### PR TITLE
fix recursive debugDescription

### DIFF
--- a/Sources/SwiftAgents/Core/AgentError.swift
+++ b/Sources/SwiftAgents/Core/AgentError.swift
@@ -126,6 +126,6 @@ extension AgentError: LocalizedError {
 
 extension AgentError: CustomDebugStringConvertible {
     public var debugDescription: String {
-        "AgentError.\(self)"
+      "AgentError.\(self.errorDescription ?? "Unknown")"
     }
 }


### PR DESCRIPTION
The following code leads to recursive calls and stack overflow:

```
extension AgentError: CustomDebugStringConvertible {
    public var debugDescription: String {
      "AgentError.\(self)"
    }
}
```