### PR TITLE
Update Agent runtime defaults and rename ToolCallingAgent

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7a07e6e502fc0903cb09c1931f3a4cdde3de2ce6d9d1a9c979a49ae2c7d0fd54",
+  "originHash" : "eaf5d2c5cab8724988b35439d611d50962386df59dedfd80a4682732a70e4254",
   "pins" : [
     {
       "identity" : "conduit",

--- a/Sources/SwiftAgents/Agents/Chat.swift
+++ b/Sources/SwiftAgents/Agents/Chat.swift
@@ -7,7 +7,7 @@ import Foundation
 
 /// A simple chat-only agent that calls an inference provider once per request.
 ///
-/// Unlike `ReActAgent` or `ToolCallingAgent`, `ChatAgent` does not invoke tools.
+/// Unlike `ReActAgent` or `Agent`, `ChatAgent` does not invoke tools.
 /// It is useful for the common "instructions + user input" chat pattern.
 public actor ChatAgent: AgentRuntime {
     // MARK: Public

--- a/Sources/SwiftAgents/Agents/RelayAgent.swift
+++ b/Sources/SwiftAgents/Agents/RelayAgent.swift
@@ -1,9 +1,9 @@
 // RelayAgent.swift
 // SwiftAgents Framework
 //
-// Unified agent runtime alias backed by ToolCallingAgent.
+// Unified agent runtime alias backed by Agent.
 
 import Foundation
 
 /// Unified agent runtime that performs a single model turn with tool calling.
-public typealias RelayAgent = ToolCallingAgent
+public typealias RelayAgent = Agent

--- a/Sources/SwiftAgents/Core/AgentRuntime.swift
+++ b/Sources/SwiftAgents/Core/AgentRuntime.swift
@@ -1,7 +1,7 @@
 // AgentRuntime.swift
 // SwiftAgents Framework
 //
-// Core AgentRuntime protocol defining the fundamental agent behavior contract.
+// Core AgentRuntime protocol and related inference types.
 
 import Foundation
 

--- a/Sources/SwiftAgents/Orchestration/OrchestrationHiveEngine.swift
+++ b/Sources/SwiftAgents/Orchestration/OrchestrationHiveEngine.swift
@@ -1,0 +1,285 @@
+// OrchestrationHiveEngine.swift
+// SwiftAgents Framework
+//
+// Hive-backed orchestration executor.
+
+#if SWIFTAGENTS_HIVE_RUNTIME && canImport(HiveCore)
+
+import Dispatch
+import Foundation
+import HiveCore
+import Logging
+
+enum OrchestrationHiveEngine {
+    struct Accumulator: Codable, Sendable, Equatable {
+        var toolCalls: [ToolCall]
+        var toolResults: [ToolResult]
+        var iterationCount: Int
+        var metadata: [String: SendableValue]
+
+        init(
+            toolCalls: [ToolCall] = [],
+            toolResults: [ToolResult] = [],
+            iterationCount: Int = 0,
+            metadata: [String: SendableValue] = [:]
+        ) {
+            self.toolCalls = toolCalls
+            self.toolResults = toolResults
+            self.iterationCount = iterationCount
+            self.metadata = metadata
+        }
+
+        static func reduce(current: Accumulator, update: Accumulator) throws -> Accumulator {
+            var merged = current
+            merged.toolCalls.append(contentsOf: update.toolCalls)
+            merged.toolResults.append(contentsOf: update.toolResults)
+            merged.iterationCount += update.iterationCount
+
+            let sortedKeys = update.metadata.keys.sorted { lhs, rhs in
+                lhs.utf8.lexicographicallyPrecedes(rhs.utf8)
+            }
+            for key in sortedKeys {
+                if let value = update.metadata[key] {
+                    merged.metadata[key] = value
+                }
+            }
+            return merged
+        }
+    }
+
+    enum Schema: HiveSchema {
+        typealias Context = OrchestrationStepContext
+        typealias Input = String
+        typealias InterruptPayload = String
+        typealias ResumePayload = String
+
+        static let currentInputKey = HiveChannelKey<Self, String>(HiveChannelID("currentInput"))
+        static let accumulatorKey = HiveChannelKey<Self, Accumulator>(HiveChannelID("accumulator"))
+
+        static var channelSpecs: [AnyHiveChannelSpec<Self>] {
+            [
+                AnyHiveChannelSpec(
+                    HiveChannelSpec(
+                        key: currentInputKey,
+                        scope: .global,
+                        reducer: .lastWriteWins(),
+                        updatePolicy: .single,
+                        initial: { "" },
+                        persistence: .untracked
+                    )
+                ),
+                AnyHiveChannelSpec(
+                    HiveChannelSpec(
+                        key: accumulatorKey,
+                        scope: .global,
+                        reducer: HiveReducer(Accumulator.reduce),
+                        updatePolicy: .single,
+                        initial: { Accumulator() },
+                        persistence: .untracked
+                    )
+                )
+            ]
+        }
+
+        static func inputWrites(_ input: String, inputContext _: HiveInputContext) throws -> [AnyHiveWrite<Self>] {
+            [
+                AnyHiveWrite(currentInputKey, input),
+                AnyHiveWrite(accumulatorKey, Accumulator())
+            ]
+        }
+    }
+
+    static func execute(
+        steps: [OrchestrationStep],
+        input: String,
+        session: (any Session)?,
+        hooks: (any RunHooks)?,
+        orchestrator: (any AgentRuntime)?,
+        orchestratorName: String,
+        handoffs: [AnyHandoffConfiguration],
+        onIterationStart: ((Int) -> Void)?,
+        onIterationEnd: ((Int) -> Void)?
+    ) async throws -> AgentResult {
+        let startTime = ContinuousClock.now
+
+        let context = AgentContext(input: input)
+        let stepContext = OrchestrationStepContext(
+            agentContext: context,
+            session: session,
+            hooks: hooks,
+            orchestrator: orchestrator,
+            orchestratorName: orchestratorName,
+            handoffs: handoffs
+        )
+        await context.recordExecution(agentName: orchestratorName)
+
+        let graph = try makeGraph(steps: steps)
+        let environment = HiveEnvironment<Schema>(
+            context: stepContext,
+            clock: SwiftAgentsHiveClock(),
+            logger: SwiftAgentsHiveLogger()
+        )
+
+        let runtime = HiveRuntime(graph: graph, environment: environment)
+        let threadID = HiveThreadID(UUID().uuidString)
+
+        let options = HiveRunOptions(
+            maxSteps: steps.count,
+            maxConcurrentTasks: 1,
+            checkpointPolicy: .disabled,
+            debugPayloads: false,
+            deterministicTokenStreaming: false,
+            eventBufferCapacity: max(64, steps.count * 8),
+            outputProjectionOverride: .fullStore
+        )
+
+        let handle = await runtime.run(threadID: threadID, input: input, options: options)
+
+        do {
+            for try await event in handle.events {
+                switch event.kind {
+                case .stepStarted(let stepIndex, _):
+                    onIterationStart?(stepIndex + 1)
+                case .stepFinished(let stepIndex, _):
+                    onIterationEnd?(stepIndex + 1)
+                default:
+                    break
+                }
+            }
+        } catch {
+            // Ignore stream errors; outcome handles the terminal error path.
+        }
+
+        let outcome = try await handle.outcome.value
+
+        switch outcome {
+        case .finished(let output, _):
+            let store = try requireFullStore(output)
+            let currentInput = try store.get(Schema.currentInputKey)
+            let accumulator = try store.get(Schema.accumulatorKey)
+
+            let duration = ContinuousClock.now - startTime
+            var metadata = accumulator.metadata
+            metadata["orchestration.engine"] = .string("hive")
+            metadata["orchestration.total_steps"] = .int(steps.count)
+            metadata["orchestration.total_duration"] = .double(
+                Double(duration.components.seconds) +
+                    Double(duration.components.attoseconds) / 1e18
+            )
+
+            return AgentResult(
+                output: currentInput,
+                toolCalls: accumulator.toolCalls,
+                toolResults: accumulator.toolResults,
+                iterationCount: accumulator.iterationCount,
+                duration: duration,
+                tokenUsage: nil,
+                metadata: metadata
+            )
+
+        case .cancelled:
+            throw AgentError.cancelled
+
+        case .outOfSteps(let maxSteps, _, _):
+            throw AgentError.internalError(reason: "Hive orchestration exceeded maxSteps=\(maxSteps).")
+
+        case .interrupted:
+            throw AgentError.internalError(reason: "Hive orchestration interrupted unexpectedly.")
+        }
+    }
+
+    private static func makeGraph(steps: [OrchestrationStep]) throws -> CompiledHiveGraph<Schema> {
+        precondition(!steps.isEmpty)
+
+        let nodeIDs = steps.indices.map { HiveNodeID("orchestration.step_\($0)") }
+
+        var builder = HiveGraphBuilder<Schema>(start: [nodeIDs[0]])
+
+        for (index, step) in steps.enumerated() {
+            let nodeID = nodeIDs[index]
+            builder.addNode(nodeID) { input in
+                let stepContext = input.context
+                let currentInput = try input.store.get(Schema.currentInputKey)
+                let result = try await step.execute(currentInput, context: stepContext)
+
+                var metadataUpdate = result.metadata
+                for (key, value) in result.metadata {
+                    metadataUpdate["orchestration.step_\(index).\(key)"] = value
+                }
+
+                let delta = Accumulator(
+                    toolCalls: result.toolCalls,
+                    toolResults: result.toolResults,
+                    iterationCount: result.iterationCount,
+                    metadata: metadataUpdate
+                )
+
+                await stepContext.agentContext.setPreviousOutput(result)
+
+                return HiveNodeOutput(
+                    writes: [
+                        AnyHiveWrite(Schema.currentInputKey, result.output),
+                        AnyHiveWrite(Schema.accumulatorKey, delta)
+                    ]
+                )
+            }
+
+            if index > 0 {
+                builder.addEdge(from: nodeIDs[index - 1], to: nodeID)
+            }
+        }
+
+        builder.setOutputProjection(.fullStore)
+        return try builder.compile()
+    }
+
+    private static func requireFullStore(_ output: HiveRunOutput<Schema>) throws -> HiveGlobalStore<Schema> {
+        switch output {
+        case .fullStore(let store):
+            return store
+        case .channels:
+            throw AgentError.internalError(reason: "Hive orchestration output projection mismatch.")
+        }
+    }
+}
+
+private struct SwiftAgentsHiveClock: HiveClock {
+    func nowNanoseconds() -> UInt64 {
+        DispatchTime.now().uptimeNanoseconds
+    }
+
+    func sleep(nanoseconds: UInt64) async throws {
+        try await Task.sleep(nanoseconds: nanoseconds)
+    }
+}
+
+private struct SwiftAgentsHiveLogger: HiveLogger {
+    private let logger: Logger
+
+    init(logger: Logger = Log.orchestration) {
+        self.logger = logger
+    }
+
+    func debug(_ message: String, metadata: [String: String]) {
+        logger.debug(Logger.Message(stringLiteral: message), metadata: swiftLogMetadata(metadata))
+    }
+
+    func info(_ message: String, metadata: [String: String]) {
+        logger.info(Logger.Message(stringLiteral: message), metadata: swiftLogMetadata(metadata))
+    }
+
+    func error(_ message: String, metadata: [String: String]) {
+        logger.error(Logger.Message(stringLiteral: message), metadata: swiftLogMetadata(metadata))
+    }
+
+    private func swiftLogMetadata(_ metadata: [String: String]) -> Logger.Metadata {
+        var swiftMetadata: Logger.Metadata = [:]
+        swiftMetadata.reserveCapacity(metadata.count)
+        for (key, value) in metadata {
+            swiftMetadata[key] = .string(value)
+        }
+        return swiftMetadata
+    }
+}
+
+#endif

--- a/Sources/SwiftAgents/Providers/Conduit/LLM.swift
+++ b/Sources/SwiftAgents/Providers/Conduit/LLM.swift
@@ -5,7 +5,7 @@ import Foundation
 ///
 /// Use with any API that accepts an `InferenceProvider`:
 /// ```swift
-/// let agent = ToolCallingAgent(inferenceProvider: .openAI(apiKey: "..."))
+/// let agent = Agent(.openAI(key: "..."))
 /// ```
 ///
 /// Advanced customization is intentionally hidden behind `.advanced { ... }`.
@@ -23,6 +23,13 @@ public enum LLM: Sendable, InferenceProvider {
         .openAI(OpenAIConfig(apiKey: apiKey, model: model))
     }
 
+    public static func openAI(
+        key: String,
+        model: String = "gpt-4o-mini"
+    ) -> LLM {
+        openAI(apiKey: key, model: model)
+    }
+
     public static func anthropic(
         apiKey: String,
         model: String = AnthropicModelID.claude35Sonnet.rawValue
@@ -30,11 +37,25 @@ public enum LLM: Sendable, InferenceProvider {
         .anthropic(AnthropicConfig(apiKey: apiKey, model: model))
     }
 
+    public static func anthropic(
+        key: String,
+        model: String = AnthropicModelID.claude35Sonnet.rawValue
+    ) -> LLM {
+        anthropic(apiKey: key, model: model)
+    }
+
     public static func openRouter(
         apiKey: String,
         model: String = "anthropic/claude-3.5-sonnet"
     ) -> LLM {
         .openRouter(OpenRouterConfig(apiKey: apiKey, model: model))
+    }
+
+    public static func openRouter(
+        key: String,
+        model: String = "anthropic/claude-3.5-sonnet"
+    ) -> LLM {
+        openRouter(apiKey: key, model: model)
     }
 
     // MARK: - Progressive Disclosure
@@ -141,12 +162,24 @@ public extension InferenceProvider where Self == LLM {
         LLM.openAI(apiKey: apiKey, model: model)
     }
 
+    static func openAI(key: String, model: String = "gpt-4o-mini") -> LLM {
+        LLM.openAI(key: key, model: model)
+    }
+
     static func anthropic(apiKey: String, model: String = AnthropicModelID.claude35Sonnet.rawValue) -> LLM {
         LLM.anthropic(apiKey: apiKey, model: model)
     }
 
+    static func anthropic(key: String, model: String = AnthropicModelID.claude35Sonnet.rawValue) -> LLM {
+        LLM.anthropic(key: key, model: model)
+    }
+
     static func openRouter(apiKey: String, model: String = "anthropic/claude-3.5-sonnet") -> LLM {
         LLM.openRouter(apiKey: apiKey, model: model)
+    }
+
+    static func openRouter(key: String, model: String = "anthropic/claude-3.5-sonnet") -> LLM {
+        LLM.openRouter(key: key, model: model)
     }
 }
 

--- a/Sources/SwiftAgents/Providers/DefaultInferenceProviderFactory.swift
+++ b/Sources/SwiftAgents/Providers/DefaultInferenceProviderFactory.swift
@@ -1,0 +1,54 @@
+// DefaultInferenceProviderFactory.swift
+// SwiftAgents Framework
+//
+// Opinionated default inference provider selection.
+//
+// Agent (the default tool-calling runtime) uses this factory to attempt
+// Apple Foundation Models when no explicit inference provider is configured.
+
+import Foundation
+
+#if canImport(FoundationModels)
+import FoundationModels
+#endif
+
+enum DefaultInferenceProviderFactory {
+    static func makeFoundationModelsProviderIfAvailable() -> (any InferenceProvider)? {
+        #if canImport(FoundationModels)
+        if #available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *) {
+            let model = SystemLanguageModel.default
+            guard model.availability == .available else {
+                return nil
+            }
+            return FoundationModelsInferenceProvider()
+        }
+        #endif
+
+        return nil
+    }
+}
+
+#if canImport(FoundationModels)
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+private struct FoundationModelsInferenceProvider: InferenceProvider {
+    func generate(prompt: String, options: InferenceOptions) async throws -> String {
+        let session = LanguageModelSession()
+        return try await session.generate(prompt: prompt, options: options)
+    }
+
+    func stream(prompt: String, options: InferenceOptions) -> AsyncThrowingStream<String, Error> {
+        let session = LanguageModelSession()
+        return session.stream(prompt: prompt, options: options)
+    }
+
+    func generateWithToolCalls(
+        prompt: String,
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) async throws -> InferenceResponse {
+        let session = LanguageModelSession()
+        return try await session.generateWithToolCalls(prompt: prompt, tools: tools, options: options)
+    }
+}
+#endif
+

--- a/Tests/SwiftAgentsTests/Agents/AgentConduitProviderSelectionStreamingTests.swift
+++ b/Tests/SwiftAgentsTests/Agents/AgentConduitProviderSelectionStreamingTests.swift
@@ -1,8 +1,8 @@
 import Testing
 @testable import SwiftAgents
 
-@Suite("ToolCallingAgent ConduitProviderSelection Streaming")
-struct ToolCallingAgentConduitProviderSelectionStreamingTests {
+@Suite("Agent ConduitProviderSelection Streaming")
+struct AgentConduitProviderSelectionStreamingTests {
     @Test("Uses tool-call streaming when provider is wrapped in ConduitProviderSelection")
     func usesToolStreamingThroughProviderSelectionWrapper() async throws {
         struct EchoTool: AnyJSONTool, Sendable {
@@ -36,7 +36,7 @@ struct ToolCallingAgentConduitProviderSelectionStreamingTests {
                 tools _: [ToolSchema],
                 options _: InferenceOptions
             ) async throws -> InferenceResponse {
-                // If this is called, ToolCallingAgent did not take the streaming tool-call path.
+                // If this is called, Agent did not take the streaming tool-call path.
                 throw AgentError.generationFailed(reason: "Unexpected call to generateWithToolCalls() in provider-selection streaming test")
             }
 
@@ -70,7 +70,7 @@ struct ToolCallingAgentConduitProviderSelectionStreamingTests {
         let provider = ScriptedStreamingProvider()
         let wrapped: ConduitProviderSelection = .provider(provider)
 
-        let agent = ToolCallingAgent(
+        let agent = Agent(
             tools: [EchoTool()],
             configuration: .default.maxIterations(3),
             inferenceProvider: wrapped

--- a/Tests/SwiftAgentsTests/Agents/AgentDefaultInferenceProviderTests.swift
+++ b/Tests/SwiftAgentsTests/Agents/AgentDefaultInferenceProviderTests.swift
@@ -1,0 +1,30 @@
+import Testing
+@testable import SwiftAgents
+
+@Suite("Agent Defaults")
+struct AgentDefaultInferenceProviderTests {
+    @Test("Throws if no inference provider is set and Foundation Models are unavailable")
+    func throwsIfNoProviderAndFoundationModelsUnavailable() async {
+        // Keep this deterministic across environments: if Foundation Models are available at runtime,
+        // Agent may run without an explicit provider.
+        if DefaultInferenceProviderFactory.makeFoundationModelsProviderIfAvailable() != nil {
+            return
+        }
+
+        do {
+            _ = try await Agent().run("hi")
+            Issue.record("Expected inference provider unavailable error")
+        } catch let error as AgentError {
+            switch error {
+            case .inferenceProviderUnavailable(let reason):
+                #expect(reason.contains("Foundation Models"))
+                #expect(reason.contains("inference provider"))
+            default:
+                Issue.record("Unexpected AgentError: \(error)")
+            }
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+}
+

--- a/Tests/SwiftAgentsTests/Agents/AgentLiveToolCallStreamingTests.swift
+++ b/Tests/SwiftAgentsTests/Agents/AgentLiveToolCallStreamingTests.swift
@@ -2,8 +2,8 @@ import Foundation
 import Testing
 @testable import SwiftAgents
 
-@Suite("ToolCallingAgent Live Tool Call Streaming")
-struct ToolCallingAgentLiveToolCallStreamingTests {
+@Suite("Agent Live Tool Call Streaming")
+struct AgentLiveToolCallStreamingTests {
     @Test("Emits toolCallPartial before toolCallStarted when provider streams tool-call assembly")
     func emitsPartialUpdatesBeforeToolExecution() async throws {
         struct EchoTool: AnyJSONTool, Sendable {
@@ -105,7 +105,7 @@ struct ToolCallingAgentLiveToolCallStreamingTests {
             ],
         ])
 
-        let agent = ToolCallingAgent(
+        let agent = Agent(
             tools: [EchoTool()],
             configuration: .default.maxIterations(3),
             inferenceProvider: provider
@@ -199,8 +199,8 @@ struct ToolCallingAgentLiveToolCallStreamingTests {
                 tools _: [ToolSchema],
                 options _: InferenceOptions
             ) async throws -> InferenceResponse {
-                // If ToolCallingAgent falls back to the non-streaming path, this is called (and the test should fail).
-                throw AgentError.generationFailed(reason: "Expected ToolCallingAgent to use streamWithToolCalls(), but it called generateWithToolCalls()")
+                // If Agent falls back to the non-streaming path, this is called (and the test should fail).
+                throw AgentError.generationFailed(reason: "Expected Agent to use streamWithToolCalls(), but it called generateWithToolCalls()")
             }
 
             func streamWithToolCalls(
@@ -238,7 +238,7 @@ struct ToolCallingAgentLiveToolCallStreamingTests {
             ],
         ])
 
-        let agent = ToolCallingAgent(
+        let agent = Agent(
             tools: [EchoTool()],
             configuration: .default.maxIterations(3),
             inferenceProvider: ConduitProviderSelection.provider(provider)

--- a/Tests/SwiftAgentsTests/Agents/StreamingEventTests.swift
+++ b/Tests/SwiftAgentsTests/Agents/StreamingEventTests.swift
@@ -53,14 +53,14 @@ struct StreamingEventTests {
         #expect(events.contains { if case .completed = $0 { return true }; return false })
     }
     
-    @Test("ToolCallingAgent stream emits iteration events")
+    @Test("Agent stream emits iteration events")
     func agentStreamEvents() async throws {
-        // 1. Setup mock provider (ToolCallingAgent uses generateWithToolCalls)
+        // 1. Setup mock provider (Agent uses generateWithToolCalls)
         let mockProvider = MockInferenceProvider()
         await mockProvider.setResponses(["Final answer directly"])
         
         // 2. Setup agent
-        let agent = ToolCallingAgent(
+        let agent = Agent(
             tools: [],
             instructions: "You are a test assistant.",
             inferenceProvider: mockProvider
@@ -78,15 +78,15 @@ struct StreamingEventTests {
         #expect(events.contains { if case .completed = $0 { return true }; return false })
     }
 
-    @Test("ToolCallingAgent streaming avoids second request without tool-call streaming")
-    func toolCallingAgentStreamingAvoidsSecondRequest() async throws {
+    @Test("Agent streaming avoids second request without tool-call streaming")
+    func agentStreamingAvoidsSecondRequest() async throws {
         let mockProvider = MockInferenceProvider()
         await mockProvider.setToolCallResponses([
             InferenceResponse(content: "Final answer directly", toolCalls: [], finishReason: .completed)
         ])
 
         let tool = MockTool(name: "test_tool", description: "Test tool")
-        let agent = ToolCallingAgent(
+        let agent = Agent(
             tools: [tool],
             instructions: "You are a test assistant.",
             inferenceProvider: mockProvider

--- a/Tests/SwiftAgentsTests/Memory/MemoryIngestionPolicyTests.swift
+++ b/Tests/SwiftAgentsTests/Memory/MemoryIngestionPolicyTests.swift
@@ -3,8 +3,8 @@ import Testing
 
 @Suite("Memory Ingestion Policy")
 struct MemoryIngestionPolicyTests {
-    @Test("ToolCallingAgent stores tool results in memory")
-    func toolCallingAgentStoresToolResults() async throws {
+    @Test("Agent stores tool results in memory")
+    func agentStoresToolResults() async throws {
         let tool = MockTool(name: "mock_tool", result: .string("ok"))
 
         let provider = MockInferenceProvider()
@@ -17,7 +17,7 @@ struct MemoryIngestionPolicyTests {
         ])
 
         let memory = MockAgentMemory()
-        let agent = ToolCallingAgent(
+        let agent = Agent(
             tools: [tool],
             configuration: .default.maxIterations(3),
             memory: memory,
@@ -46,7 +46,7 @@ struct MemoryIngestionPolicyTests {
         let provider = MockInferenceProvider(responses: ["Final Answer: ok"])
         let memory = MockAgentMemory()
 
-        let agent = ToolCallingAgent(
+        let agent = Agent(
             memory: memory,
             inferenceProvider: provider
         )

--- a/Tests/SwiftAgentsTests/Providers/LLMPresetsTests.swift
+++ b/Tests/SwiftAgentsTests/Providers/LLMPresetsTests.swift
@@ -6,9 +6,7 @@ import Testing
 struct LLMPresetsTests {
     @Test("OpenAI preset builds Conduit OpenAI provider")
     func openAIPresetBuildsProvider() {
-        let agent = ToolCallingAgent(
-            inferenceProvider: .openAI(apiKey: "test-key", model: "gpt-4o-mini")
-        )
+        let agent = Agent(.openAI(key: "test-key", model: "gpt-4o-mini"))
 
         let provider = agent.inferenceProvider
         #expect(provider != nil)
@@ -22,9 +20,7 @@ struct LLMPresetsTests {
 
     @Test("Anthropic preset builds Conduit Anthropic provider")
     func anthropicPresetBuildsProvider() {
-        let agent = ToolCallingAgent(
-            inferenceProvider: .anthropic(apiKey: "test-key", model: "claude-3-opus-20240229")
-        )
+        let agent = Agent(.anthropic(key: "test-key", model: "claude-3-opus-20240229"))
 
         let provider = agent.inferenceProvider
         #expect(provider != nil)
@@ -38,9 +34,7 @@ struct LLMPresetsTests {
 
     @Test("OpenRouter preset builds Conduit OpenAI-compatible provider")
     func openRouterPresetBuildsProvider() {
-        let agent = ToolCallingAgent(
-            inferenceProvider: .openRouter(apiKey: "test-key", model: "anthropic/claude-3-opus")
-        )
+        let agent = Agent(.openRouter(key: "test-key", model: "anthropic/claude-3-opus"))
 
         let provider = agent.inferenceProvider
         #expect(provider != nil)

--- a/Tests/SwiftAgentsTests/Tools/ToolSchemaIntegrationTests.swift
+++ b/Tests/SwiftAgentsTests/Tools/ToolSchemaIntegrationTests.swift
@@ -36,9 +36,9 @@ struct ToolSchemaIntegrationTests {
     func agentsAcceptTypedTools() {
         let tool = SchemaEchoTool()
 
-        let toolCalling = ToolCallingAgent(tools: [tool])
-        #expect(toolCalling.tools.count == 1)
-        #expect(toolCalling.tools.first?.name == "echo")
+        let agent = Agent(tools: [tool])
+        #expect(agent.tools.count == 1)
+        #expect(agent.tools.first?.name == "echo")
 
         let react = ReActAgent(tools: [tool])
         #expect(react.tools.count == 1)

--- a/docs/Handoffs.md
+++ b/docs/Handoffs.md
@@ -161,7 +161,7 @@ inputFilter: { data in
 Dynamically enables or disables the handoff based on runtime conditions:
 
 ```swift
-public typealias IsEnabledCallback = @Sendable (AgentContext, any Agent) async -> Bool
+public typealias IsEnabledCallback = @Sendable (AgentContext, any AgentRuntime) async -> Bool
 ```
 
 Example:

--- a/docs/MIGRATION_GUIDE.md
+++ b/docs/MIGRATION_GUIDE.md
@@ -1,5 +1,27 @@
 # Migration Guide
 
+## ToolCallingAgent → Agent (Breaking)
+
+The default tool-calling runtime agent has been renamed for ergonomics.
+
+### Breaking Change
+
+- `ToolCallingAgent` → `Agent`
+
+### Migration
+
+```swift
+// Before
+let agent = ToolCallingAgent(inferenceProvider: .anthropic(apiKey: "ANTHROPIC_API_KEY"))
+
+// After
+let agent = Agent(.anthropic(key: "ANTHROPIC_API_KEY"))
+```
+
+> Note: If you don't provide an inference provider, `Agent` will try Apple Foundation Models (on-device) when available. If Foundation Models are unavailable, `Agent.run(...)` throws `AgentError.inferenceProviderUnavailable`.
+
+---
+
 ## SwiftAgents 2.x → 2.x (Agent Macro Rename)
 
 The public macro used to generate agent boilerplate has been renamed.
@@ -133,7 +155,7 @@ extension ToolRegistry {
     func execute<T>(
         ofType type: T.Type,
         arguments: [String: SendableValue],
-        agent: (any Agent)? = nil,
+        agent: (any AgentRuntime)? = nil,
         context: AgentContext? = nil,
         hooks: (any RunHooks)? = nil
     ) async throws -> SendableValue where T: Tool

--- a/docs/guardrails.md
+++ b/docs/guardrails.md
@@ -125,7 +125,7 @@ public protocol OutputGuardrail: Sendable {
     var name: String { get }
 
     /// Validates an agent's output.
-    func validate(_ output: String, agent: any Agent, context: AgentContext?) async throws -> GuardrailResult
+    func validate(_ output: String, agent: any AgentRuntime, context: AgentContext?) async throws -> GuardrailResult
 }
 ```
 
@@ -137,7 +137,7 @@ public protocol OutputGuardrail: Sendable {
 struct ContentFilterGuardrail: OutputGuardrail {
     let name = "ContentFilter"
 
-    func validate(_ output: String, agent: any Agent, context: AgentContext?) async throws -> GuardrailResult {
+    func validate(_ output: String, agent: any AgentRuntime, context: AgentContext?) async throws -> GuardrailResult {
         if output.contains("inappropriate") {
             return .tripwire(message: "Inappropriate content detected")
         }
@@ -226,7 +226,7 @@ public struct ToolGuardrailData: Sendable {
     public let arguments: [String: SendableValue]
 
     /// The agent executing the tool, if available.
-    public let agent: (any Agent)?
+    public let agent: (any AgentRuntime)?
 
     /// The orchestration context, if available.
     public let context: AgentContext?

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -585,7 +585,7 @@ Memory systems integrate seamlessly with SwiftAgents' agent infrastructure.
 let memory = ConversationMemory(maxMessages: 50)
 
 // Create agent with memory
-let agent = ToolCallingAgent(
+let agent = Agent(
     instructions: "You are a helpful assistant",
     configuration: AgentConfiguration(name: "Assistant"),
     memory: memory
@@ -616,8 +616,8 @@ let context = await erasedMemory.context(for: "query", tokenLimit: 1000)
 // Shared memory between agents
 let sharedMemory = ConversationMemory(maxMessages: 100)
 
-let agent1 = ToolCallingAgent(configuration: AgentConfiguration(name: "Researcher"), memory: sharedMemory)
-let agent2 = ToolCallingAgent(configuration: AgentConfiguration(name: "Writer"), memory: sharedMemory)
+let agent1 = Agent(configuration: AgentConfiguration(name: "Researcher"), memory: sharedMemory)
+let agent2 = Agent(configuration: AgentConfiguration(name: "Writer"), memory: sharedMemory)
 
 // Both agents can access and contribute to the same memory
 ```

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -674,6 +674,6 @@ public func trace(_ event: TraceEvent) async {
 Disable tracing overhead in unit tests:
 
 ```swift
-let agent = ToolCallingAgent(tracer: NoOpTracer())
+let agent = Agent(tracer: NoOpTracer())
 // Tests run without tracing overhead
 ```

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -365,7 +365,7 @@ Supported operations:
 
 ```swift
 // Platform-specific: includes CalculatorTool on Apple platforms
-let agent = ToolCallingAgent(
+let agent = Agent(
     tools: BuiltInTools.all,
     instructions: "You are a helpful assistant with access to tools."
 )
@@ -463,7 +463,7 @@ default:
 ### Direct Initialization
 
 ```swift
-let agent = ToolCallingAgent(
+let agent = Agent(
     tools: [
         WeatherTool(),
         CalculatorTool(),
@@ -481,7 +481,7 @@ runtime `AnyJSONTool` ABI automatically.
 ### Using Builder Pattern
 
 ```swift
-let agent = try ToolCallingAgent.Builder()
+let agent = Agent.Builder()
     .tools([WeatherTool(), CalculatorTool()])
     .instructions("You are a helpful math and weather assistant")
     .configuration(.default)
@@ -505,12 +505,12 @@ let result = try await reactAgent.run("Calculate 15% tip on $45.50")
 // Agent will reason about using calculator tool, then execute it
 ```
 
-### ToolCallingAgent Example
+### Agent Example
 
-ToolCallingAgent uses the LLM's native tool calling API for more reliable execution:
+Agent uses the LLM's native tool calling API for more reliable execution:
 
 ```swift
-let toolAgent = ToolCallingAgent(
+let toolAgent = Agent(
     tools: [WeatherTool(), StocksTool()],
     instructions: "You are a financial and weather assistant.",
     configuration: AgentConfiguration(
@@ -824,7 +824,7 @@ func createToolsFromConfig(_ config: ToolConfiguration) async -> [any AnyJSONToo
     return tools
 }
 
-let agent = ToolCallingAgent(
+let agent = Agent(
     tools: await createToolsFromConfig(config),
     instructions: "You are a configurable assistant"
 )


### PR DESCRIPTION
**Summary**
- Replace `ToolCallingAgent` with `Agent`, keep behavior intact, and document the breaking change across README/docs.
- Add opinionated provider resolution for Agent (environment value → Foundation Models fallback → error) plus the new `Agent(.anthropic(key: "…"))` initializer and LLM key-based helpers.
- Ensure defaults/test coverage reflect the new initializer, fallback behavior, and rename across Swift sources/tests.

**Testing**
- Not run (not requested)