### PR TITLE
fix: unblock Xcode 26 / Swift 6.2 builds (swift-syntax range)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,7 +200,7 @@ swift package plugin --allow-writing-to-package-directory swiftformat
 
 - All inference goes through `InferenceProvider` adapters in
   `Sources/Swarm/Providers/`. Production providers are routed through
-  [Conduit](https://github.com/christopherkarani/Conduit) (pinned to `0.3.13`
+  [Conduit](https://github.com/christopherkarani/Conduit) (pinned to `0.3.14`
   in `Package.swift`) with traits enabled for OpenAI, OpenRouter, Anthropic,
   and MLX.
 - Foundation Models are now also routed through Conduit (see commits

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,19 @@ if includeDemo {
 }
 
 var packageDependencies: [Package.Dependency] = [
-    .package(url: "https://github.com/swiftlang/swift-syntax.git", "600.0.0"..<"601.0.0"),
+    // swift-syntax range is intentionally widened to include 601/602 lines.
+    //
+    // Background: Xcode 26 (Swift 6.2.x) ships implicit SwiftPM prebuilts for
+    // swift-syntax via the swiftlang "MacroSupport" prebuilt server. The 600.0.1
+    // prebuilt is built against an older macOS SDK and fails to load on consumer
+    // machines with "SDK does not match" warnings followed by
+    // "Unable to find module dependency: 'SwiftSyntax'" errors. That prebuilt
+    // download cannot be disabled from a consumer project (SWIFT_USE_PREBUILT_MACROS=NO,
+    // IDESwiftPackageEnablePrebuilts=NO, SWIFTPM_DISABLE_PREBUILTS=1 and
+    // -skipMacroValidation all fail to suppress it). Widening the range here lets
+    // SwiftPM resolve to 601+ on Swift 6.2 toolchains, which does not ship the
+    // broken prebuilt.
+    .package(url: "https://github.com/swiftlang/swift-syntax.git", "600.0.0"..<"603.0.0"),
     .package(url: "https://github.com/apple/swift-log.git", from: "1.10.1"),
     .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.11.0"),
     .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.13.2"),
@@ -25,7 +37,7 @@ var packageDependencies: [Package.Dependency] = [
     .package(url: "https://github.com/christopherkarani/Wax.git", exact: "0.1.19"),
     .package(
         url: "https://github.com/christopherkarani/Conduit",
-        exact: "0.3.13",
+        exact: "0.3.14",
         traits: [
             .trait(name: "OpenAI"),
             .trait(name: "OpenRouter"),

--- a/Sources/Swarm/Swarm.swift
+++ b/Sources/Swarm/Swarm.swift
@@ -49,7 +49,7 @@
 ///
 public enum Swarm {
     /// The current version of the Swarm framework.
-    public static let version = "0.5.0"
+    public static let version = "0.5.2"
 
     /// The minimum macOS platform version required by Swarm.
     public static let minimumMacOSVersion = "15.0"

--- a/Tests/SwarmTests/V2SurfaceAuditTests.swift
+++ b/Tests/SwarmTests/V2SurfaceAuditTests.swift
@@ -22,9 +22,9 @@ struct V2SurfaceAuditTests {
 
     // MARK: - Version
 
-    @Test("Swarm.version is 0.5.0")
+    @Test("Swarm.version is 0.5.2")
     func versionIsV2() {
-        #expect(Swarm.version == "0.5.0")
+        #expect(Swarm.version == "0.5.2")
     }
 
     // MARK: - TokenUsage (module-level, not nested)


### PR DESCRIPTION
## Summary

Downstream apps consuming Swarm via SwiftPM fail to build on Xcode 26.3 (17C528) / Swift 6.2.4 / macOS SDK 26.2 with:

```
warning: module file '.../swift-syntax/600.0.1/.../SwiftSyntax.swiftmodule' is
  incompatible with this Swift compiler: SDK does not match
error: Unable to find module dependency: 'SwiftSyntax' (in target 'SwarmMacros')
```

Xcode 26 ships implicit SwiftPM "MacroSupport" prebuilts for `swift-syntax`. The `600.0.1` prebuilt is built against an older macOS SDK and fails to load. The download cannot be disabled from consumer build settings (`SWIFT_USE_PREBUILT_MACROS=NO`, `IDESwiftPackageEnablePrebuilts=NO`, `SWIFTPM_DISABLE_PREBUILTS=1`, `-skipMacroValidation` — none have any effect in Xcode 26), so the fix has to live in the package manifests.

### What changed

- Widened `swift-syntax` range: `"600.0.0"..<"601.0.0"` → `"600.0.0"..<"603.0.0"`
- Bumped Conduit dependency: `0.3.13` → `0.3.14` (prerequisite release that widens its own `swift-syntax` range; was the transitive blocker). See christopherkarani/Conduit@0.3.14.
- Bumped `Swarm.version`: `0.5.0` → `0.5.2` (skipping `0.5.1` because source was behind the published tag before this change).
- Updated pinned-value test (`V2SurfaceAuditTests`) and the `CLAUDE.md` Conduit version reference.

With both manifests widened, SwiftPM now resolves `swift-syntax` to **`602.0.0`**, whose prebuilts load cleanly against the current macOS SDK.

### Why a Conduit release was needed

Conduit `0.3.13` declared `swift-syntax` as `from: "600.0.0"` which SwiftPM interprets as `[600.0.0, 601.0.0)`. Because Swarm pins Conduit exact, the intersection of Swarm's local range and Conduit's transitive range was still locked to `600.x` — so widening Swarm alone had no effect. Conduit was updated and tagged `0.3.14` (and also `1.0.2` on the same commit for future 1.x adopters; Hive 0.1.9 pins Conduit `<1.0.0`, hence the `0.3.x` re-tag).

### Non-goals

- Does not drop `SwarmMacros` — downstream `@Tool` / `@Agent` users depend on it.
- Does not vendor `swift-syntax` as a local path dep.
- Does not add consumer-side workarounds (verified none work in Xcode 26).

## Test plan

Validated locally on Swift 6.2.4 / macOS 26 / Apple Silicon:

- [x] `swift build --target SwarmMacros` — clean, no API drift between swift-syntax 600 and 602
- [x] `swift build` (full) — 3113 products linked, 0 errors
- [x] `swift test --no-parallel` — 1614/1614 tests across 219 suites pass
- [x] `SWARM_HIVE_RUNTIME=1 SWARM_INCLUDE_HIVE=1 swift test --no-parallel` — matches CI env, all green
- [x] `swift test --filter SwarmMacrosTests` — 40/40 pass
- [x] `swift run SwarmCapabilityShowcase matrix` — all 13 scenarios pass (fresh `.build`)
- [ ] Consumer-side verification on Xcode 26.3: scratch iOS app depending on this branch / tag `0.5.2`, `rm -rf ~/Library/Developer/Xcode/DerivedData/*`, `xcodebuild -sdk iphonesimulator build`. Expected: zero `error:` lines, no "SDK does not match" warnings. **Must be run from a machine with Xcode 26.3 before tagging a release.**
- [ ] CI green (this PR)