### PR TITLE
Add OpenTelemetry tracing support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -186,6 +186,7 @@ var packageTargets: [Target] = [
         dependencies: [
             "Swarm",
             "SwarmOpenTelemetry",
+            .product(name: "OpenTelemetrySdk", package: "opentelemetry-swift-core"),
         ],
         swiftSettings: swarmSwiftSettings
     )

--- a/Package.swift
+++ b/Package.swift
@@ -6,6 +6,7 @@ let includeDemo = ProcessInfo.processInfo.environment["SWARM_INCLUDE_DEMO"] == "
 
 var packageProducts: [Product] = [
     .library(name: "Swarm", targets: ["Swarm"]),
+    .library(name: "SwarmOpenTelemetry", targets: ["SwarmOpenTelemetry"]),
     .library(name: "SwarmMembrane", targets: ["SwarmMembrane"]),
     .library(name: "SwarmMCP", targets: ["SwarmMCP"]),
 ]
@@ -32,6 +33,7 @@ var packageDependencies: [Package.Dependency] = [
     .package(url: "https://github.com/swiftlang/swift-syntax.git", "600.0.0"..<"603.0.0"),
     .package(url: "https://github.com/apple/swift-log.git", from: "1.10.1"),
     .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.11.0"),
+    .package(url: "https://github.com/open-telemetry/opentelemetry-swift-core.git", from: "2.3.0"),
     .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.13.2"),
     // Production graph must resolve to the published tag set that is known to build together.
     .package(url: "https://github.com/christopherkarani/Wax.git", exact: "0.1.19"),
@@ -88,6 +90,14 @@ var packageTargets: [Target] = [
     .target(
         name: "Swarm",
         dependencies: swarmDependencies,
+        swiftSettings: swarmSwiftSettings
+    ),
+    .target(
+        name: "SwarmOpenTelemetry",
+        dependencies: [
+            "Swarm",
+            .product(name: "OpenTelemetryApi", package: "opentelemetry-swift-core"),
+        ],
         swiftSettings: swarmSwiftSettings
     ),
     .target(
@@ -170,6 +180,14 @@ var packageTargets: [Target] = [
         swiftSettings: [
             .enableExperimentalFeature("StrictConcurrency")
         ]
+    ),
+    .testTarget(
+        name: "SwarmOpenTelemetryTests",
+        dependencies: [
+            "Swarm",
+            "SwarmOpenTelemetry",
+        ],
+        swiftSettings: swarmSwiftSettings
     )
 ]
 

--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ Foundation Models require iOS 26 / macOS 26. Cloud providers work on any Swift 6
 | | |
 |---|---|
 | [Getting Started](docs/guide/getting-started.md) | Installation, first agent, workflows |
-| [OpenTelemetry Tracing](docs/guide/opentelemetry-tracing.md) | Export LLM spans and inject tracing headers for provider HTTP requests |
+| [OpenTelemetry Tracing](docs/guide/opentelemetry-tracing.md) | Export agent and LLM spans, with optional trace header injection for provider HTTP requests |
 | [API Reference](docs/reference/api-catalog.md) | Every type, protocol, and API |
 | [Front-Facing API](docs/reference/front-facing-api.md) | Public API surface |
 | [Why Swarm?](docs/guide/why-swarm.md) | Design philosophy and architecture |

--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ Foundation Models require iOS 26 / macOS 26. Cloud providers work on any Swift 6
 | | |
 |---|---|
 | [Getting Started](docs/guide/getting-started.md) | Installation, first agent, workflows |
+| [OpenTelemetry Tracing](docs/guide/opentelemetry-tracing.md) | Export LLM spans and inject tracing headers for provider HTTP requests |
 | [API Reference](docs/reference/api-catalog.md) | Every type, protocol, and API |
 | [Front-Facing API](docs/reference/front-facing-api.md) | Public API surface |
 | [Why Swarm?](docs/guide/why-swarm.md) | Design philosophy and architecture |

--- a/Sources/Swarm/Agents/Agent.swift
+++ b/Sources/Swarm/Agents/Agent.swift
@@ -907,29 +907,29 @@ public struct Agent: AgentRuntime, Sendable {
     private func resolvedInferenceProvider(toolRegistry: ToolRegistry) async throws -> any InferenceProvider {
         // 1. Explicit provider on Agent
         if let inferenceProvider {
-            return inferenceProvider
+            return transformedInferenceProvider(inferenceProvider)
         }
 
         // 2. TaskLocal via .environment()
         if let environmentProvider = AgentEnvironmentValues.current.inferenceProvider {
-            return environmentProvider
+            return transformedInferenceProvider(environmentProvider)
         }
 
         // 3. Swarm.defaultProvider (global)
         if let globalProvider = await Swarm.defaultProvider {
-            return globalProvider
+            return transformedInferenceProvider(globalProvider)
         }
 
         // 4. Swarm.cloudProvider (if tool calling is required)
         let hasEnabledTools = await !toolRegistry.schemas.isEmpty
         let needsToolCallingProvider = hasEnabledTools || !_handoffs.isEmpty
         if needsToolCallingProvider, let cloudProvider = await Swarm.cloudProvider {
-            return cloudProvider
+            return transformedInferenceProvider(cloudProvider)
         }
 
         // 5. Foundation Models (if available, on Apple platform)
         if let foundationModelsProvider = DefaultInferenceProviderFactory.makeFoundationModelsProviderIfAvailable() {
-            return foundationModelsProvider
+            return transformedInferenceProvider(foundationModelsProvider)
         }
 
         // 6. No provider available
@@ -941,6 +941,13 @@ public struct Agent: AgentRuntime, Sendable {
             or pass one explicitly to Agent(...).
             """
         )
+    }
+
+    private func transformedInferenceProvider(_ provider: any InferenceProvider) -> any InferenceProvider {
+        guard let transform = AgentEnvironmentValues.current.inferenceProviderTransform else {
+            return provider
+        }
+        return transform(provider)
     }
 
     private func resolvedMembraneAdapter() -> (any MembraneAgentAdapter)? {

--- a/Sources/Swarm/Core/AgentEnvironment.swift
+++ b/Sources/Swarm/Core/AgentEnvironment.swift
@@ -14,6 +14,7 @@ import Foundation
 /// Environment values are propagated using `TaskLocal` via `AgentEnvironmentValues.current`.
 public struct AgentEnvironment: Sendable {
     public var inferenceProvider: (any InferenceProvider)?
+    public var inferenceProviderTransform: (@Sendable (any InferenceProvider) -> any InferenceProvider)?
     public var tracer: (any Tracer)?
     public var memory: (any Memory)?
     public var promptTokenCounter: any PromptTokenCounter
@@ -22,6 +23,7 @@ public struct AgentEnvironment: Sendable {
 
     public init(
         inferenceProvider: (any InferenceProvider)? = nil,
+        inferenceProviderTransform: (@Sendable (any InferenceProvider) -> any InferenceProvider)? = nil,
         tracer: (any Tracer)? = nil,
         memory: (any Memory)? = nil,
         promptTokenCounter: any PromptTokenCounter = EstimatedPromptTokenCounter.shared,
@@ -29,6 +31,7 @@ public struct AgentEnvironment: Sendable {
         webSearch: WebSearchTool.Configuration? = nil
     ) {
         self.inferenceProvider = inferenceProvider
+        self.inferenceProviderTransform = inferenceProviderTransform
         self.tracer = tracer
         self.memory = memory
         self.promptTokenCounter = promptTokenCounter

--- a/Sources/Swarm/Providers/Conduit/ConduitInferenceProvider.swift
+++ b/Sources/Swarm/Providers/Conduit/ConduitInferenceProvider.swift
@@ -10,6 +10,7 @@ struct ConduitInferenceProvider<Provider: TextGenerator>: InferenceProvider,
     ToolCallStreamingInferenceProvider,
     CapabilityReportingInferenceProvider,
     ConversationInferenceProvider,
+    InferenceProviderMetadata,
     StructuredOutputInferenceProvider,
     StructuredOutputConversationInferenceProvider,
     StreamingConversationInferenceProvider,
@@ -19,12 +20,14 @@ struct ConduitInferenceProvider<Provider: TextGenerator>: InferenceProvider,
         provider: Provider,
         model: Provider.ModelID,
         baseConfig: GenerateConfig = .default,
-        supportsStreamingToolCalls: Bool = true
+        supportsStreamingToolCalls: Bool = true,
+        metadata: InferenceProviderMetadataSnapshot? = nil
     ) {
         self.provider = provider
         self.model = model
         self.baseConfig = baseConfig
         self.supportsStreamingToolCalls = supportsStreamingToolCalls
+        self.metadata = metadata
     }
 
     func generate(prompt: String, options: InferenceOptions) async throws -> String {
@@ -361,6 +364,19 @@ struct ConduitInferenceProvider<Provider: TextGenerator>: InferenceProvider,
     private let model: Provider.ModelID
     private let baseConfig: GenerateConfig
     private let supportsStreamingToolCalls: Bool
+    private let metadata: InferenceProviderMetadataSnapshot?
+
+    var providerName: String? {
+        metadata?.providerName
+    }
+
+    var modelName: String? {
+        metadata?.modelName
+    }
+
+    var endpointURL: URL? {
+        metadata?.endpointURL
+    }
 
     private static func conduitMessages(from messages: [InferenceMessage]) throws -> [Message] {
         let toolNamesByCallID = Dictionary(

--- a/Sources/Swarm/Providers/Conduit/ConduitProviderSelection.swift
+++ b/Sources/Swarm/Providers/Conduit/ConduitProviderSelection.swift
@@ -32,7 +32,11 @@ public enum ConduitProviderSelection: Sendable, InferenceProvider {
     public static func anthropic(apiKey: String, model: String) -> ConduitProviderSelection {
         let provider = AnthropicProvider(apiKey: apiKey)
         let modelID = anthropicModelID(model)
-        let bridge = ConduitInferenceProvider(provider: provider, model: modelID)
+        let bridge = ConduitInferenceProvider(
+            provider: provider,
+            model: modelID,
+            metadata: .init(providerName: "anthropic", modelName: model, endpointURL: URL(string: "https://api.anthropic.com"))
+        )
         return .provider(bridge)
     }
 
@@ -40,7 +44,11 @@ public enum ConduitProviderSelection: Sendable, InferenceProvider {
     public static func openAI(apiKey: String, model: String) -> ConduitProviderSelection {
         let provider = OpenAIProvider(apiKey: apiKey)
         let modelID = openAIModelID(model)
-        let bridge = ConduitInferenceProvider(provider: provider, model: modelID)
+        let bridge = ConduitInferenceProvider(
+            provider: provider,
+            model: modelID,
+            metadata: .init(providerName: "openai", modelName: model, endpointURL: URL(string: "https://api.openai.com/v1"))
+        )
         return .provider(bridge)
     }
 
@@ -52,7 +60,8 @@ public enum ConduitProviderSelection: Sendable, InferenceProvider {
         let bridge = ConduitInferenceProvider(
             provider: provider,
             model: .foundationModels,
-            supportsStreamingToolCalls: false
+            supportsStreamingToolCalls: false,
+            metadata: .init(providerName: "foundationmodels", modelName: "foundationModels")
         )
         return .provider(bridge)
     }
@@ -169,7 +178,11 @@ public enum ConduitProviderSelection: Sendable, InferenceProvider {
         #if CONDUIT_TRAIT_MINIMAX
             let provider = MiniMaxProvider(apiKey: apiKey)
             let modelID: MiniMaxProvider.ModelID = .init(model)
-            let bridge = ConduitInferenceProvider(provider: provider, model: modelID)
+            let bridge = ConduitInferenceProvider(
+                provider: provider,
+                model: modelID,
+                metadata: .init(providerName: "minimax", modelName: model)
+            )
             return .provider(bridge)
         #else
             let routedModel = model.hasPrefix("minimax/") ? model : "minimax/\(model)"
@@ -197,7 +210,8 @@ public enum ConduitProviderSelection: Sendable, InferenceProvider {
         let bridge = ConduitInferenceProvider(
             provider: provider,
             model: .foundationModels,
-            supportsStreamingToolCalls: false
+            supportsStreamingToolCalls: false,
+            metadata: .init(providerName: "foundationmodels", modelName: "foundationModels")
         )
         return .provider(bridge)
     }
@@ -240,7 +254,11 @@ public enum ConduitProviderSelection: Sendable, InferenceProvider {
             OpenAIProvider(openRouterKey: apiKey)
         }
         let modelID = openAIModelID(model)
-        let bridge = ConduitInferenceProvider(provider: provider, model: modelID)
+        let bridge = ConduitInferenceProvider(
+            provider: provider,
+            model: modelID,
+            metadata: .init(providerName: "openrouter", modelName: model, endpointURL: URL(string: "https://openrouter.ai/api/v1"))
+        )
         return .provider(bridge)
     }
 
@@ -254,7 +272,15 @@ public enum ConduitProviderSelection: Sendable, InferenceProvider {
             ollamaConfig: settings.toConduit()
         )
         let modelID = openAIModelID(model)
-        let bridge = ConduitInferenceProvider(provider: provider, model: modelID)
+        let bridge = ConduitInferenceProvider(
+            provider: provider,
+            model: modelID,
+            metadata: .init(
+                providerName: "ollama",
+                modelName: model,
+                endpointURL: URL(string: "http://\(settings.host):\(settings.port)")
+            )
+        )
         return .provider(bridge)
     }
 
@@ -274,6 +300,20 @@ extension ConduitProviderSelection: CapabilityReportingInferenceProvider {
         var capabilities = InferenceProviderCapabilities.resolved(for: makeProvider())
         capabilities.insert(.conversationMessages)
         return capabilities
+    }
+}
+
+extension ConduitProviderSelection: InferenceProviderMetadata {
+    public var providerName: String? {
+        (makeProvider() as? any InferenceProviderMetadata)?.providerName
+    }
+
+    public var modelName: String? {
+        (makeProvider() as? any InferenceProviderMetadata)?.modelName
+    }
+
+    public var endpointURL: URL? {
+        (makeProvider() as? any InferenceProviderMetadata)?.endpointURL
     }
 }
 

--- a/Sources/Swarm/Providers/Conduit/LLM.swift
+++ b/Sources/Swarm/Providers/Conduit/LLM.swift
@@ -279,6 +279,68 @@ public struct LLM: Sendable, InferenceProvider {
     }
 }
 
+extension LLM: InferenceProviderMetadata {
+    public var providerName: String? {
+        switch kind {
+        case .openAI:
+            "openai"
+        case .anthropic:
+            "anthropic"
+        case .openRouter:
+            "openrouter"
+        case .minimax:
+            "minimax"
+        case .ollama:
+            "ollama"
+#if canImport(MLX)
+        case .mlx:
+            "mlx"
+#endif
+        }
+    }
+
+    public var modelName: String? {
+        switch kind {
+        case let .openAI(config):
+            config.model
+        case let .anthropic(config):
+            config.model
+        case let .openRouter(config):
+            config.model
+        case let .minimax(config):
+            config.model
+        case let .ollama(config):
+            config.model
+#if canImport(MLX)
+        case let .mlx(config):
+            switch config {
+            case let .mlx(model):
+                model
+            case let .mlxLocal(path):
+                path
+            }
+#endif
+        }
+    }
+
+    public var endpointURL: URL? {
+        switch kind {
+        case .openAI:
+            URL(string: "https://api.openai.com/v1")
+        case .anthropic:
+            URL(string: "https://api.anthropic.com")
+        case .openRouter, .minimax:
+            URL(string: "https://openrouter.ai/api/v1")
+        case let .ollama(config):
+            URL(string: "http://\(config.settings.host):\(config.settings.port)")
+#if canImport(MLX)
+        case .mlx:
+            nil
+#endif
+        }
+    }
+}
+
 #if DEBUG
 extension LLM {
     // Test hook: keep Conduit types out of the public API, but allow the package's

--- a/Sources/Swarm/Providers/InferenceProviderMetadata.swift
+++ b/Sources/Swarm/Providers/InferenceProviderMetadata.swift
@@ -1,0 +1,36 @@
+// InferenceProviderMetadata.swift
+// Swarm Framework
+//
+// Optional metadata for observability integrations.
+
+import Foundation
+
+/// Optional provider metadata used by observability integrations.
+///
+/// Inference providers can conform to this protocol to expose stable, non-sensitive
+/// details about the backend handling LLM requests. Providers that do not conform
+/// still work normally; observability integrations simply omit the unavailable
+/// attributes.
+public protocol InferenceProviderMetadata: Sendable {
+    /// Best-known provider name, for example `openai`, `anthropic`, or `ollama`.
+    var providerName: String? { get }
+
+    /// The requested model identifier, when known.
+    var modelName: String? { get }
+
+    /// The API endpoint or base URL, when known.
+    var endpointURL: URL? { get }
+}
+
+/// Immutable metadata value used by provider adapters.
+public struct InferenceProviderMetadataSnapshot: InferenceProviderMetadata, Equatable {
+    public let providerName: String?
+    public let modelName: String?
+    public let endpointURL: URL?
+
+    public init(providerName: String? = nil, modelName: String? = nil, endpointURL: URL? = nil) {
+        self.providerName = providerName
+        self.modelName = modelName
+        self.endpointURL = endpointURL
+    }
+}

--- a/Sources/SwarmOpenTelemetry/OpenTelemetryAgentRuntime.swift
+++ b/Sources/SwarmOpenTelemetry/OpenTelemetryAgentRuntime.swift
@@ -1,0 +1,230 @@
+// OpenTelemetryAgentRuntime.swift
+// SwarmOpenTelemetry
+
+import Foundation
+@preconcurrency import OpenTelemetryApi
+import Swarm
+
+/// An agent-runtime wrapper that creates one OpenTelemetry trace scope per user turn.
+struct OpenTelemetryAgentRuntime<Base: AgentRuntime>: @unchecked Sendable, AgentRuntime {
+  public init(
+        _ base: Base,
+        tracer: any OpenTelemetryApi.Tracer = OpenTelemetry.instance.tracerProvider.get(
+            instrumentationName: "swarm.agent",
+            instrumentationVersion: nil
+        ),
+        llmTracer: any OpenTelemetryApi.Tracer = OpenTelemetry.instance.tracerProvider.get(
+            instrumentationName: "swarm.llm",
+            instrumentationVersion: nil
+        ),
+        spanName: String? = nil,
+        captureContent: Bool = false
+    ) {
+        self.base = base
+        self.otelConfiguration = OpenTelemetryAgentRuntimeConfiguration(
+            tracer: tracer,
+            llmTracer: llmTracer,
+            spanName: spanName,
+            captureContent: captureContent
+        )
+    }
+
+    public var name: String { base.name }
+    public var tools: [any AnyJSONTool] { base.tools }
+    public var instructions: String { base.instructions }
+    public var configuration: AgentConfiguration { base.configuration }
+    public var memory: (any Memory)? { base.memory }
+    public var inferenceProvider: (any InferenceProvider)? { base.inferenceProvider }
+    public var tracer: (any SwarmRuntimeTracer)? { base.tracer }
+    public var inputGuardrails: [any InputGuardrail] { base.inputGuardrails }
+    public var outputGuardrails: [any OutputGuardrail] { base.outputGuardrails }
+    public var handoffs: [AnyHandoffConfiguration] { base.handoffs }
+
+    public func run(
+        _ input: String,
+        session: (any Session)? = nil,
+        observer: (any AgentObserver)? = nil
+    ) async throws -> AgentResult {
+        try await withAgentSpan(operation: "run", input: input) { span in
+            let result = try await base.run(input, session: session, observer: observer)
+            apply(result: result, to: span)
+            return result
+        }
+    }
+
+    public func runWithResponse(
+        _ input: String,
+        session: (any Session)? = nil,
+        observer: (any AgentObserver)? = nil
+    ) async throws -> AgentResponse {
+        try await withAgentSpan(operation: "runWithResponse", input: input) { span in
+            let response = try await base.runWithResponse(input, session: session, observer: observer)
+            apply(response: response, to: span)
+            return response
+        }
+    }
+
+    public func stream(
+        _ input: String,
+        session: (any Session)? = nil,
+        observer: (any AgentObserver)? = nil
+    ) -> AsyncThrowingStream<AgentEvent, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task {
+                do {
+                    try await withAgentSpan(operation: "stream", input: input) { span in
+                        for try await event in base.stream(input, session: session, observer: observer) {
+                            if case let .lifecycle(.completed(result)) = event {
+                                apply(result: result, to: span)
+                            }
+                            continuation.yield(event)
+                        }
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    public func cancel() async {
+        await base.cancel()
+    }
+
+    private let base: Base
+    private let otelConfiguration: OpenTelemetryAgentRuntimeConfiguration
+}
+
+extension OpenTelemetryAgentRuntime where Base == Agent {
+    func runStructured(
+        _ input: String,
+        request: StructuredOutputRequest,
+        session: (any Session)? = nil,
+        observer: (any AgentObserver)? = nil
+    ) async throws -> StructuredAgentResult {
+        try await withAgentSpan(operation: "runStructured", input: input) { span in
+            let result = try await base.runStructured(input, request: request, session: session, observer: observer)
+            apply(result: result.agentResult, to: span)
+            span.setAttribute(key: "gen_ai.output.type", value: "json")
+            span.setAttribute(key: "gen_ai.response.output_length", value: result.structuredOutput.rawJSON.count)
+            return result
+        }
+    }
+}
+
+private final class OpenTelemetryAgentRuntimeConfiguration: @unchecked Sendable {
+    init(
+        tracer: any OpenTelemetryApi.Tracer,
+        llmTracer: any OpenTelemetryApi.Tracer,
+        spanName: String?,
+        captureContent: Bool
+    ) {
+        self.tracer = tracer
+        self.llmTracer = llmTracer
+        self.spanName = spanName
+        self.captureContent = captureContent
+    }
+
+    let tracer: any OpenTelemetryApi.Tracer
+    let llmTracer: any OpenTelemetryApi.Tracer
+    let spanName: String?
+    let captureContent: Bool
+}
+
+private extension OpenTelemetryAgentRuntime {
+    func withAgentSpan<T: Sendable>(
+        operation: String,
+        input: String,
+        _ body: @escaping @Sendable (any SpanBase) async throws -> T
+    ) async throws -> T {
+        let builder = otelConfiguration.tracer.spanBuilder(spanName: spanName(operation: operation))
+        builder.setSpanKind(spanKind: .internal)
+        builder.setAttribute(key: "swarm.operation.name", value: operation)
+        builder.setAttribute(key: "swarm.agent.name", value: name)
+        builder.setAttribute(key: "swarm.request.input_length", value: input.count)
+
+        return try await builder.withActiveSpan { span in
+            do {
+                let result = try await withInstrumentedProviderEnvironment {
+                    try await body(span)
+                }
+                span.status = .ok
+                return result
+            } catch {
+                OpenTelemetryAttributes.recordError(error, on: span)
+                throw error
+            }
+        }
+    }
+
+    func withInstrumentedProviderEnvironment<T: Sendable>(
+        _ body: () async throws -> T
+    ) async throws -> T {
+        var environment = AgentEnvironmentValues.current
+        let existingTransform = environment.inferenceProviderTransform
+        let configuration = otelConfiguration
+
+        environment.inferenceProviderTransform = { provider in
+            let transformed = existingTransform?(provider) ?? provider
+            if transformed is any OpenTelemetryInstrumentedInferenceProvider {
+                return transformed
+            }
+            return OpenTelemetryAnyInferenceProvider(
+                transformed,
+                tracer: configuration.llmTracer,
+                captureContent: configuration.captureContent
+            )
+        }
+
+        return try await AgentEnvironmentValues.$current.withValue(environment) {
+            try await body()
+        }
+    }
+
+    func spanName(operation: String) -> String {
+        otelConfiguration.spanName ?? "swarm.agent.\(operation) \(name)"
+    }
+
+    func apply(result: AgentResult, to span: any SpanBase) {
+        span.setAttribute(key: "swarm.response.output_length", value: result.output.count)
+        span.setAttribute(key: "swarm.iterations.count", value: result.iterationCount)
+        span.setAttribute(key: "swarm.tool.calls.count", value: result.toolCalls.count)
+        span.setAttribute(key: "swarm.tool.results.count", value: result.toolResults.count)
+        OpenTelemetryAttributes.applyUsage(result.tokenUsage, to: span)
+    }
+
+    func apply(response: AgentResponse, to span: any SpanBase) {
+        span.setAttribute(key: "swarm.response.id", value: response.responseId)
+        span.setAttribute(key: "swarm.response.output_length", value: response.output.count)
+        span.setAttribute(key: "swarm.iterations.count", value: response.iterationCount)
+        span.setAttribute(key: "swarm.tool.calls.count", value: response.toolCalls.count)
+        OpenTelemetryAttributes.applyUsage(response.usage, to: span)
+    }
+}
+
+public extension AgentRuntime {
+    /// Wraps this agent so each user turn emits one parent OpenTelemetry span and
+    /// all resolved LLM providers emit child GenAI spans.
+    func instrumentedWithOpenTelemetry(
+        tracer: any OpenTelemetryApi.Tracer = OpenTelemetry.instance.tracerProvider.get(
+            instrumentationName: "swarm.agent",
+            instrumentationVersion: nil
+        ),
+        llmTracer: any OpenTelemetryApi.Tracer = OpenTelemetry.instance.tracerProvider.get(
+            instrumentationName: "swarm.llm",
+            instrumentationVersion: nil
+        ),
+        spanName: String? = nil,
+        captureContent: Bool = false
+  ) -> some AgentRuntime {
+        OpenTelemetryAgentRuntime(
+            self,
+            tracer: tracer,
+            llmTracer: llmTracer,
+            spanName: spanName,
+            captureContent: captureContent
+        )
+    }
+}

--- a/Sources/SwarmOpenTelemetry/OpenTelemetryAnyInferenceProvider.swift
+++ b/Sources/SwarmOpenTelemetry/OpenTelemetryAnyInferenceProvider.swift
@@ -16,10 +16,45 @@ func OpenTelemetryAnyInferenceProvider(
         captureContent: captureContent
     )
 
-    if base is any ToolCallStreamingConversationInferenceProvider
-        || base is any ToolCallStreamingInferenceProvider
+    if base is any ToolCallStreamingConversationInferenceProvider,
+       base is any StreamingConversationInferenceProvider,
+       base is any StructuredOutputConversationInferenceProvider
     {
-        return OpenTelemetryAnyToolStreamingInferenceProvider(core: core)
+        return OpenTelemetryAnyFullConversationToolStreamingInferenceProvider(core: core)
+    }
+
+    if base is any ToolCallStreamingConversationInferenceProvider,
+       base is any StreamingConversationInferenceProvider
+    {
+        return OpenTelemetryAnyStreamingConversationToolStreamingInferenceProvider(core: core)
+    }
+
+    if base is any ToolCallStreamingConversationInferenceProvider,
+       base is any StructuredOutputConversationInferenceProvider
+    {
+        return OpenTelemetryAnyStructuredConversationToolStreamingInferenceProvider(core: core)
+    }
+
+    if base is any ToolCallStreamingConversationInferenceProvider {
+        return OpenTelemetryAnyConversationToolStreamingInferenceProvider(core: core)
+    }
+
+    if base is any ToolCallStreamingInferenceProvider {
+        return OpenTelemetryAnyPromptToolStreamingInferenceProvider(core: core)
+    }
+
+    if base is any StreamingConversationInferenceProvider,
+       base is any StructuredOutputConversationInferenceProvider
+    {
+        return OpenTelemetryAnyStreamingStructuredConversationInferenceProvider(core: core)
+    }
+
+    if base is any StreamingConversationInferenceProvider {
+        return OpenTelemetryAnyStreamingConversationInferenceProvider(core: core)
+    }
+
+    if base is any StructuredOutputConversationInferenceProvider {
+        return OpenTelemetryAnyStructuredConversationInferenceProvider(core: core)
     }
 
     if base is any ConversationInferenceProvider {
@@ -423,6 +458,153 @@ private struct OpenTelemetryAnyConversationInferenceProvider: @unchecked Sendabl
     CapabilityReportingInferenceProvider,
     InferenceProviderMetadata,
     ConversationInferenceProvider,
+    OpenTelemetryInstrumentedInferenceProvider
+{
+    let core: OpenTelemetryAnyInferenceProviderCore
+
+    var capabilities: InferenceProviderCapabilities { core.capabilities }
+    var providerName: String? { core.metadata?.providerName }
+    var modelName: String? { core.metadata?.modelName }
+    var endpointURL: URL? { core.metadata?.endpointURL }
+
+    func generate(prompt: String, options: InferenceOptions) async throws -> String {
+        try await core.generate(prompt: prompt, options: options)
+    }
+
+    func stream(prompt: String, options: InferenceOptions) -> AsyncThrowingStream<String, Error> {
+        core.stream(prompt: prompt, options: options)
+    }
+
+    func generateWithToolCalls(
+        prompt: String,
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) async throws -> InferenceResponse {
+        try await core.generateWithToolCalls(prompt: prompt, tools: tools, options: options)
+    }
+
+    func generate(messages: [InferenceMessage], options: InferenceOptions) async throws -> String {
+        try await core.generate(messages: messages, options: options)
+    }
+
+    func stream(messages: [InferenceMessage], options: InferenceOptions) -> AsyncThrowingStream<String, Error> {
+        core.stream(messages: messages, options: options)
+    }
+
+    func generateWithToolCalls(
+        messages: [InferenceMessage],
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) async throws -> InferenceResponse {
+        try await core.generateWithToolCalls(messages: messages, tools: tools, options: options)
+    }
+}
+
+private struct OpenTelemetryAnyStreamingConversationInferenceProvider: @unchecked Sendable,
+    InferenceProvider,
+    CapabilityReportingInferenceProvider,
+    InferenceProviderMetadata,
+    ConversationInferenceProvider,
+    StreamingConversationInferenceProvider,
+    OpenTelemetryInstrumentedInferenceProvider
+{
+    let core: OpenTelemetryAnyInferenceProviderCore
+
+    var capabilities: InferenceProviderCapabilities { core.capabilities }
+    var providerName: String? { core.metadata?.providerName }
+    var modelName: String? { core.metadata?.modelName }
+    var endpointURL: URL? { core.metadata?.endpointURL }
+
+    func generate(prompt: String, options: InferenceOptions) async throws -> String {
+        try await core.generate(prompt: prompt, options: options)
+    }
+
+    func stream(prompt: String, options: InferenceOptions) -> AsyncThrowingStream<String, Error> {
+        core.stream(prompt: prompt, options: options)
+    }
+
+    func generateWithToolCalls(
+        prompt: String,
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) async throws -> InferenceResponse {
+        try await core.generateWithToolCalls(prompt: prompt, tools: tools, options: options)
+    }
+
+    func generate(messages: [InferenceMessage], options: InferenceOptions) async throws -> String {
+        try await core.generate(messages: messages, options: options)
+    }
+
+    func stream(messages: [InferenceMessage], options: InferenceOptions) -> AsyncThrowingStream<String, Error> {
+        core.stream(messages: messages, options: options)
+    }
+
+    func generateWithToolCalls(
+        messages: [InferenceMessage],
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) async throws -> InferenceResponse {
+        try await core.generateWithToolCalls(messages: messages, tools: tools, options: options)
+    }
+}
+
+private struct OpenTelemetryAnyStructuredConversationInferenceProvider: @unchecked Sendable,
+    InferenceProvider,
+    CapabilityReportingInferenceProvider,
+    InferenceProviderMetadata,
+    ConversationInferenceProvider,
+    StructuredOutputConversationInferenceProvider,
+    OpenTelemetryInstrumentedInferenceProvider
+{
+    let core: OpenTelemetryAnyInferenceProviderCore
+
+    var capabilities: InferenceProviderCapabilities { core.capabilities }
+    var providerName: String? { core.metadata?.providerName }
+    var modelName: String? { core.metadata?.modelName }
+    var endpointURL: URL? { core.metadata?.endpointURL }
+
+    func generate(prompt: String, options: InferenceOptions) async throws -> String {
+        try await core.generate(prompt: prompt, options: options)
+    }
+
+    func stream(prompt: String, options: InferenceOptions) -> AsyncThrowingStream<String, Error> {
+        core.stream(prompt: prompt, options: options)
+    }
+
+    func generateWithToolCalls(
+        prompt: String,
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) async throws -> InferenceResponse {
+        try await core.generateWithToolCalls(prompt: prompt, tools: tools, options: options)
+    }
+
+    func generate(messages: [InferenceMessage], options: InferenceOptions) async throws -> String {
+        try await core.generate(messages: messages, options: options)
+    }
+
+    func generateWithToolCalls(
+        messages: [InferenceMessage],
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) async throws -> InferenceResponse {
+        try await core.generateWithToolCalls(messages: messages, tools: tools, options: options)
+    }
+
+    func generateStructured(
+        messages: [InferenceMessage],
+        request: StructuredOutputRequest,
+        options: InferenceOptions
+    ) async throws -> StructuredOutputResult {
+        try await core.generateStructured(messages: messages, request: request, options: options)
+    }
+}
+
+private struct OpenTelemetryAnyStreamingStructuredConversationInferenceProvider: @unchecked Sendable,
+    InferenceProvider,
+    CapabilityReportingInferenceProvider,
+    InferenceProviderMetadata,
+    ConversationInferenceProvider,
     StreamingConversationInferenceProvider,
     StructuredOutputConversationInferenceProvider,
     OpenTelemetryInstrumentedInferenceProvider
@@ -475,15 +657,51 @@ private struct OpenTelemetryAnyConversationInferenceProvider: @unchecked Sendabl
     }
 }
 
-private struct OpenTelemetryAnyToolStreamingInferenceProvider: @unchecked Sendable,
+private struct OpenTelemetryAnyPromptToolStreamingInferenceProvider: @unchecked Sendable,
+    InferenceProvider,
+    CapabilityReportingInferenceProvider,
+    InferenceProviderMetadata,
+    ToolCallStreamingInferenceProvider,
+    OpenTelemetryInstrumentedInferenceProvider
+{
+    let core: OpenTelemetryAnyInferenceProviderCore
+
+    var capabilities: InferenceProviderCapabilities { core.capabilities }
+    var providerName: String? { core.metadata?.providerName }
+    var modelName: String? { core.metadata?.modelName }
+    var endpointURL: URL? { core.metadata?.endpointURL }
+
+    func generate(prompt: String, options: InferenceOptions) async throws -> String {
+        try await core.generate(prompt: prompt, options: options)
+    }
+
+    func stream(prompt: String, options: InferenceOptions) -> AsyncThrowingStream<String, Error> {
+        core.stream(prompt: prompt, options: options)
+    }
+
+    func generateWithToolCalls(
+        prompt: String,
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) async throws -> InferenceResponse {
+        try await core.generateWithToolCalls(prompt: prompt, tools: tools, options: options)
+    }
+
+    func streamWithToolCalls(
+        prompt: String,
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) -> AsyncThrowingStream<InferenceStreamUpdate, Error> {
+        core.streamWithToolCalls(prompt: prompt, tools: tools, options: options)
+    }
+}
+
+private struct OpenTelemetryAnyConversationToolStreamingInferenceProvider: @unchecked Sendable,
     InferenceProvider,
     CapabilityReportingInferenceProvider,
     InferenceProviderMetadata,
     ConversationInferenceProvider,
-    StreamingConversationInferenceProvider,
-    ToolCallStreamingInferenceProvider,
     ToolCallStreamingConversationInferenceProvider,
-    StructuredOutputConversationInferenceProvider,
     OpenTelemetryInstrumentedInferenceProvider
 {
     let core: OpenTelemetryAnyInferenceProviderCore
@@ -531,6 +749,182 @@ private struct OpenTelemetryAnyToolStreamingInferenceProvider: @unchecked Sendab
         options: InferenceOptions
     ) -> AsyncThrowingStream<InferenceStreamUpdate, Error> {
         core.streamWithToolCalls(prompt: prompt, tools: tools, options: options)
+    }
+
+    func streamWithToolCalls(
+        messages: [InferenceMessage],
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) -> AsyncThrowingStream<InferenceStreamUpdate, Error> {
+        core.streamWithToolCalls(messages: messages, tools: tools, options: options)
+    }
+}
+
+private struct OpenTelemetryAnyStreamingConversationToolStreamingInferenceProvider: @unchecked Sendable,
+    InferenceProvider,
+    CapabilityReportingInferenceProvider,
+    InferenceProviderMetadata,
+    ConversationInferenceProvider,
+    StreamingConversationInferenceProvider,
+    ToolCallStreamingConversationInferenceProvider,
+    OpenTelemetryInstrumentedInferenceProvider
+{
+    let core: OpenTelemetryAnyInferenceProviderCore
+
+    var capabilities: InferenceProviderCapabilities { core.capabilities }
+    var providerName: String? { core.metadata?.providerName }
+    var modelName: String? { core.metadata?.modelName }
+    var endpointURL: URL? { core.metadata?.endpointURL }
+
+    func generate(prompt: String, options: InferenceOptions) async throws -> String {
+        try await core.generate(prompt: prompt, options: options)
+    }
+
+    func stream(prompt: String, options: InferenceOptions) -> AsyncThrowingStream<String, Error> {
+        core.stream(prompt: prompt, options: options)
+    }
+
+    func generateWithToolCalls(
+        prompt: String,
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) async throws -> InferenceResponse {
+        try await core.generateWithToolCalls(prompt: prompt, tools: tools, options: options)
+    }
+
+    func generate(messages: [InferenceMessage], options: InferenceOptions) async throws -> String {
+        try await core.generate(messages: messages, options: options)
+    }
+
+    func stream(messages: [InferenceMessage], options: InferenceOptions) -> AsyncThrowingStream<String, Error> {
+        core.stream(messages: messages, options: options)
+    }
+
+    func generateWithToolCalls(
+        messages: [InferenceMessage],
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) async throws -> InferenceResponse {
+        try await core.generateWithToolCalls(messages: messages, tools: tools, options: options)
+    }
+
+    func streamWithToolCalls(
+        messages: [InferenceMessage],
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) -> AsyncThrowingStream<InferenceStreamUpdate, Error> {
+        core.streamWithToolCalls(messages: messages, tools: tools, options: options)
+    }
+}
+
+private struct OpenTelemetryAnyStructuredConversationToolStreamingInferenceProvider: @unchecked Sendable,
+    InferenceProvider,
+    CapabilityReportingInferenceProvider,
+    InferenceProviderMetadata,
+    ConversationInferenceProvider,
+    ToolCallStreamingConversationInferenceProvider,
+    StructuredOutputConversationInferenceProvider,
+    OpenTelemetryInstrumentedInferenceProvider
+{
+    let core: OpenTelemetryAnyInferenceProviderCore
+
+    var capabilities: InferenceProviderCapabilities { core.capabilities }
+    var providerName: String? { core.metadata?.providerName }
+    var modelName: String? { core.metadata?.modelName }
+    var endpointURL: URL? { core.metadata?.endpointURL }
+
+    func generate(prompt: String, options: InferenceOptions) async throws -> String {
+        try await core.generate(prompt: prompt, options: options)
+    }
+
+    func stream(prompt: String, options: InferenceOptions) -> AsyncThrowingStream<String, Error> {
+        core.stream(prompt: prompt, options: options)
+    }
+
+    func generateWithToolCalls(
+        prompt: String,
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) async throws -> InferenceResponse {
+        try await core.generateWithToolCalls(prompt: prompt, tools: tools, options: options)
+    }
+
+    func generate(messages: [InferenceMessage], options: InferenceOptions) async throws -> String {
+        try await core.generate(messages: messages, options: options)
+    }
+
+    func generateWithToolCalls(
+        messages: [InferenceMessage],
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) async throws -> InferenceResponse {
+        try await core.generateWithToolCalls(messages: messages, tools: tools, options: options)
+    }
+
+    func streamWithToolCalls(
+        messages: [InferenceMessage],
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) -> AsyncThrowingStream<InferenceStreamUpdate, Error> {
+        core.streamWithToolCalls(messages: messages, tools: tools, options: options)
+    }
+
+    func generateStructured(
+        messages: [InferenceMessage],
+        request: StructuredOutputRequest,
+        options: InferenceOptions
+    ) async throws -> StructuredOutputResult {
+        try await core.generateStructured(messages: messages, request: request, options: options)
+    }
+}
+
+private struct OpenTelemetryAnyFullConversationToolStreamingInferenceProvider: @unchecked Sendable,
+    InferenceProvider,
+    CapabilityReportingInferenceProvider,
+    InferenceProviderMetadata,
+    ConversationInferenceProvider,
+    StreamingConversationInferenceProvider,
+    ToolCallStreamingConversationInferenceProvider,
+    StructuredOutputConversationInferenceProvider,
+    OpenTelemetryInstrumentedInferenceProvider
+{
+    let core: OpenTelemetryAnyInferenceProviderCore
+
+    var capabilities: InferenceProviderCapabilities { core.capabilities }
+    var providerName: String? { core.metadata?.providerName }
+    var modelName: String? { core.metadata?.modelName }
+    var endpointURL: URL? { core.metadata?.endpointURL }
+
+    func generate(prompt: String, options: InferenceOptions) async throws -> String {
+        try await core.generate(prompt: prompt, options: options)
+    }
+
+    func stream(prompt: String, options: InferenceOptions) -> AsyncThrowingStream<String, Error> {
+        core.stream(prompt: prompt, options: options)
+    }
+
+    func generateWithToolCalls(
+        prompt: String,
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) async throws -> InferenceResponse {
+        try await core.generateWithToolCalls(prompt: prompt, tools: tools, options: options)
+    }
+
+    func generate(messages: [InferenceMessage], options: InferenceOptions) async throws -> String {
+        try await core.generate(messages: messages, options: options)
+    }
+
+    func stream(messages: [InferenceMessage], options: InferenceOptions) -> AsyncThrowingStream<String, Error> {
+        core.stream(messages: messages, options: options)
+    }
+
+    func generateWithToolCalls(
+        messages: [InferenceMessage],
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) async throws -> InferenceResponse {
+        try await core.generateWithToolCalls(messages: messages, tools: tools, options: options)
     }
 
     func streamWithToolCalls(

--- a/Sources/SwarmOpenTelemetry/OpenTelemetryAnyInferenceProvider.swift
+++ b/Sources/SwarmOpenTelemetry/OpenTelemetryAnyInferenceProvider.swift
@@ -1,0 +1,551 @@
+// OpenTelemetryAnyInferenceProvider.swift
+// SwarmOpenTelemetry
+
+import Foundation
+@preconcurrency import OpenTelemetryApi
+import Swarm
+
+func OpenTelemetryAnyInferenceProvider(
+    _ base: any InferenceProvider,
+    tracer: any OpenTelemetryApi.Tracer,
+    captureContent: Bool
+) -> any InferenceProvider {
+    let core = OpenTelemetryAnyInferenceProviderCore(
+        base: base,
+        tracer: tracer,
+        captureContent: captureContent
+    )
+
+    if base is any ToolCallStreamingConversationInferenceProvider
+        || base is any ToolCallStreamingInferenceProvider
+    {
+        return OpenTelemetryAnyToolStreamingInferenceProvider(core: core)
+    }
+
+    if base is any ConversationInferenceProvider {
+        return OpenTelemetryAnyConversationInferenceProvider(core: core)
+    }
+
+    if base is any StructuredOutputInferenceProvider {
+        return OpenTelemetryAnyStructuredInferenceProvider(core: core)
+    }
+
+    return OpenTelemetryAnyBaseInferenceProvider(core: core)
+}
+
+private final class OpenTelemetryAnyInferenceProviderCore: @unchecked Sendable {
+    init(
+        base: any InferenceProvider,
+        tracer: any OpenTelemetryApi.Tracer,
+        captureContent: Bool
+    ) {
+        self.base = base
+        self.tracer = tracer
+        self.captureContent = captureContent
+    }
+
+    let base: any InferenceProvider
+    let tracer: any OpenTelemetryApi.Tracer
+    let captureContent: Bool
+
+    var metadata: (any InferenceProviderMetadata)? {
+        base as? any InferenceProviderMetadata
+    }
+
+    var capabilities: InferenceProviderCapabilities {
+        InferenceProviderCapabilities.resolved(for: base)
+    }
+
+    func generate(prompt: String, options: InferenceOptions) async throws -> String {
+        try await withLLMSpan(operation: "chat", inputLength: prompt.count, options: options) { span in
+            let response = try await self.base.generate(prompt: prompt, options: options)
+            span.setAttribute(key: "gen_ai.response.output_length", value: response.count)
+            return response
+        }
+    }
+
+    func stream(prompt: String, options: InferenceOptions) -> AsyncThrowingStream<String, Error> {
+        instrumentStream(inputLength: prompt.count, options: options) { continuation, span in
+            var outputLength = 0
+            for try await token in self.base.stream(prompt: prompt, options: options) {
+                outputLength += token.count
+                continuation.yield(token)
+            }
+            span.setAttribute(key: "gen_ai.response.output_length", value: outputLength)
+        }
+    }
+
+    func generateWithToolCalls(
+        prompt: String,
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) async throws -> InferenceResponse {
+        try await withLLMSpan(operation: "chat", inputLength: prompt.count, options: options) { span in
+            span.setAttribute(key: "gen_ai.request.tools.count", value: tools.count)
+            let response = try await self.base.generateWithToolCalls(prompt: prompt, tools: tools, options: options)
+            self.apply(response: response, to: span)
+            return response
+        }
+    }
+
+    func generate(messages: [InferenceMessage], options: InferenceOptions) async throws -> String {
+        try await withLLMSpan(operation: "chat", inputLength: Self.inputLength(messages), options: options) { span in
+            span.setAttribute(key: "gen_ai.request.messages.count", value: messages.count)
+            let response: String
+            if let conversationProvider = self.base as? any ConversationInferenceProvider {
+                response = try await conversationProvider.generate(messages: messages, options: options)
+            } else {
+                response = try await self.base.generate(prompt: InferenceMessage.flattenPrompt(messages), options: options)
+            }
+            span.setAttribute(key: "gen_ai.response.output_length", value: response.count)
+            return response
+        }
+    }
+
+    func stream(messages: [InferenceMessage], options: InferenceOptions) -> AsyncThrowingStream<String, Error> {
+        instrumentStream(inputLength: Self.inputLength(messages), options: options) { continuation, span in
+            span.setAttribute(key: "gen_ai.request.messages.count", value: messages.count)
+            let stream: AsyncThrowingStream<String, Error>
+            if let conversationProvider = self.base as? any StreamingConversationInferenceProvider {
+                stream = conversationProvider.stream(messages: messages, options: options)
+            } else {
+                stream = self.base.stream(prompt: InferenceMessage.flattenPrompt(messages), options: options)
+            }
+
+            var outputLength = 0
+            for try await token in stream {
+                outputLength += token.count
+                continuation.yield(token)
+            }
+            span.setAttribute(key: "gen_ai.response.output_length", value: outputLength)
+        }
+    }
+
+    func generateWithToolCalls(
+        messages: [InferenceMessage],
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) async throws -> InferenceResponse {
+        try await withLLMSpan(operation: "chat", inputLength: Self.inputLength(messages), options: options) { span in
+            span.setAttribute(key: "gen_ai.request.messages.count", value: messages.count)
+            span.setAttribute(key: "gen_ai.request.tools.count", value: tools.count)
+            let response: InferenceResponse
+            if let conversationProvider = self.base as? any ConversationInferenceProvider {
+                response = try await conversationProvider.generateWithToolCalls(
+                    messages: messages,
+                    tools: tools,
+                    options: options
+                )
+            } else {
+                response = try await self.base.generateWithToolCalls(
+                    prompt: InferenceMessage.flattenPrompt(messages),
+                    tools: tools,
+                    options: options
+                )
+            }
+            self.apply(response: response, to: span)
+            return response
+        }
+    }
+
+    func generateStructured(
+        prompt: String,
+        request: StructuredOutputRequest,
+        options: InferenceOptions
+    ) async throws -> StructuredOutputResult {
+        try await withLLMSpan(operation: "chat", inputLength: prompt.count, options: options) { span in
+            span.setAttribute(key: "gen_ai.output.type", value: "json")
+            let result: StructuredOutputResult
+            if let structuredProvider = self.base as? any StructuredOutputInferenceProvider {
+                result = try await structuredProvider.generateStructured(
+                    prompt: prompt,
+                    request: request,
+                    options: options
+                )
+            } else {
+                result = try await self.base.generateStructured(prompt: prompt, request: request, options: options)
+            }
+            span.setAttribute(key: "gen_ai.response.output_length", value: result.rawJSON.count)
+            return result
+        }
+    }
+
+    func generateStructured(
+        messages: [InferenceMessage],
+        request: StructuredOutputRequest,
+        options: InferenceOptions
+    ) async throws -> StructuredOutputResult {
+        try await withLLMSpan(operation: "chat", inputLength: Self.inputLength(messages), options: options) { span in
+            span.setAttribute(key: "gen_ai.request.messages.count", value: messages.count)
+            span.setAttribute(key: "gen_ai.output.type", value: "json")
+            let result: StructuredOutputResult
+            if let structuredProvider = self.base as? any StructuredOutputConversationInferenceProvider {
+                result = try await structuredProvider.generateStructured(
+                    messages: messages,
+                    request: request,
+                    options: options
+                )
+            } else if let conversationProvider = self.base as? any ConversationInferenceProvider {
+                result = try await conversationProvider.generateStructured(
+                    messages: messages,
+                    request: request,
+                    options: options
+                )
+            } else {
+                result = try await self.base.generateStructured(
+                    prompt: InferenceMessage.flattenPrompt(messages),
+                    request: request,
+                    options: options
+                )
+            }
+            span.setAttribute(key: "gen_ai.response.output_length", value: result.rawJSON.count)
+            return result
+        }
+    }
+
+    func streamWithToolCalls(
+        prompt: String,
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) -> AsyncThrowingStream<InferenceStreamUpdate, Error> {
+        instrumentToolStream(inputLength: prompt.count, toolCount: tools.count, options: options) {
+            guard let toolStreamingProvider = self.base as? any ToolCallStreamingInferenceProvider else {
+                throw AgentError.generationFailed(reason: "Provider does not support prompt tool-call streaming")
+            }
+            return toolStreamingProvider.streamWithToolCalls(prompt: prompt, tools: tools, options: options)
+        }
+    }
+
+    func streamWithToolCalls(
+        messages: [InferenceMessage],
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) -> AsyncThrowingStream<InferenceStreamUpdate, Error> {
+        instrumentToolStream(inputLength: Self.inputLength(messages), toolCount: tools.count, options: options) {
+            if let conversationProvider = self.base as? any ToolCallStreamingConversationInferenceProvider {
+                return conversationProvider.streamWithToolCalls(messages: messages, tools: tools, options: options)
+            }
+            guard let promptProvider = self.base as? any ToolCallStreamingInferenceProvider else {
+                throw AgentError.generationFailed(reason: "Provider does not support tool-call streaming")
+            }
+            return promptProvider.streamWithToolCalls(
+                prompt: InferenceMessage.flattenPrompt(messages),
+                tools: tools,
+                options: options
+            )
+        }
+    }
+
+    private static func inputLength(_ messages: [InferenceMessage]) -> Int {
+        messages.reduce(0) { $0 + $1.content.count }
+    }
+
+    private func withLLMSpan<T: Sendable>(
+        operation: String,
+        inputLength: Int,
+        options: InferenceOptions,
+        _ body: @escaping @Sendable (any SpanBase) async throws -> T
+    ) async throws -> T {
+        let builder = makeSpanBuilder(operation: operation, inputLength: inputLength, options: options)
+        return try await builder.withActiveSpan { span in
+            OpenTelemetryAttributes.applyMetadata(metadata, to: span)
+            do {
+                let result = try await body(span)
+                span.status = .ok
+                return result
+            } catch {
+                OpenTelemetryAttributes.recordError(error, on: span)
+                throw error
+            }
+        }
+    }
+
+    private func makeSpanBuilder(
+        operation: String,
+        inputLength: Int,
+        options: InferenceOptions
+    ) -> any SpanBuilder {
+        let builder = tracer.spanBuilder(spanName: "\(operation) \(metadata?.modelName ?? "llm")")
+        builder.setSpanKind(spanKind: .client)
+        builder.setAttribute(key: "gen_ai.operation.name", value: operation)
+        builder.setAttribute(key: "gen_ai.request.input_length", value: inputLength)
+        builder.setAttribute(key: "gen_ai.request.temperature", value: options.temperature)
+        if let maxTokens = options.maxTokens {
+            builder.setAttribute(key: "gen_ai.request.max_tokens", value: maxTokens)
+        }
+        if captureContent {
+            builder.setAttribute(key: "swarm.capture_content.enabled", value: true)
+        }
+        return builder
+    }
+
+    private func apply(response: InferenceResponse, to span: any SpanBase) {
+        if let content = response.content {
+            span.setAttribute(key: "gen_ai.response.output_length", value: content.count)
+        }
+        span.setAttribute(key: "gen_ai.response.finish_reasons", value: response.finishReason.rawValue)
+        span.setAttribute(key: "gen_ai.response.tool_calls.count", value: response.toolCalls.count)
+        OpenTelemetryAttributes.applyUsage(response.usage, to: span)
+    }
+
+    private func instrumentStream(
+        inputLength: Int,
+        options: InferenceOptions,
+        body: @escaping @Sendable (AsyncThrowingStream<String, Error>.Continuation, any SpanBase) async throws -> Void
+    ) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task {
+                do {
+                    try await withLLMSpan(operation: "chat", inputLength: inputLength, options: options) { span in
+                        try await body(continuation, span)
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { @Sendable _ in task.cancel() }
+        }
+    }
+
+    private func instrumentToolStream(
+        inputLength: Int,
+        toolCount: Int,
+        options: InferenceOptions,
+        makeStream: @escaping @Sendable () throws -> AsyncThrowingStream<InferenceStreamUpdate, Error>
+    ) -> AsyncThrowingStream<InferenceStreamUpdate, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task {
+                do {
+                    try await withLLMSpan(operation: "chat", inputLength: inputLength, options: options) { span in
+                        span.setAttribute(key: "gen_ai.request.tools.count", value: toolCount)
+                        var outputLength = 0
+                        var completedToolCallCount = 0
+                        var usage: TokenUsage?
+                        for try await update in try makeStream() {
+                            switch update {
+                            case let .outputChunk(chunk):
+                                outputLength += chunk.count
+                            case let .toolCallsCompleted(calls):
+                                completedToolCallCount = calls.count
+                            case let .usage(tokenUsage):
+                                usage = tokenUsage
+                            case .toolCallPartial:
+                                break
+                            }
+                            continuation.yield(update)
+                        }
+                        span.setAttribute(key: "gen_ai.response.output_length", value: outputLength)
+                        span.setAttribute(key: "gen_ai.response.tool_calls.count", value: completedToolCallCount)
+                        OpenTelemetryAttributes.applyUsage(usage, to: span)
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { @Sendable _ in task.cancel() }
+        }
+    }
+}
+
+private struct OpenTelemetryAnyBaseInferenceProvider: @unchecked Sendable,
+    InferenceProvider,
+    CapabilityReportingInferenceProvider,
+    InferenceProviderMetadata,
+    OpenTelemetryInstrumentedInferenceProvider
+{
+    let core: OpenTelemetryAnyInferenceProviderCore
+
+    var capabilities: InferenceProviderCapabilities { core.capabilities }
+    var providerName: String? { core.metadata?.providerName }
+    var modelName: String? { core.metadata?.modelName }
+    var endpointURL: URL? { core.metadata?.endpointURL }
+
+    func generate(prompt: String, options: InferenceOptions) async throws -> String {
+        try await core.generate(prompt: prompt, options: options)
+    }
+
+    func stream(prompt: String, options: InferenceOptions) -> AsyncThrowingStream<String, Error> {
+        core.stream(prompt: prompt, options: options)
+    }
+
+    func generateWithToolCalls(
+        prompt: String,
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) async throws -> InferenceResponse {
+        try await core.generateWithToolCalls(prompt: prompt, tools: tools, options: options)
+    }
+}
+
+private struct OpenTelemetryAnyStructuredInferenceProvider: @unchecked Sendable,
+    InferenceProvider,
+    CapabilityReportingInferenceProvider,
+    InferenceProviderMetadata,
+    StructuredOutputInferenceProvider,
+    OpenTelemetryInstrumentedInferenceProvider
+{
+    let core: OpenTelemetryAnyInferenceProviderCore
+
+    var capabilities: InferenceProviderCapabilities { core.capabilities }
+    var providerName: String? { core.metadata?.providerName }
+    var modelName: String? { core.metadata?.modelName }
+    var endpointURL: URL? { core.metadata?.endpointURL }
+
+    func generate(prompt: String, options: InferenceOptions) async throws -> String {
+        try await core.generate(prompt: prompt, options: options)
+    }
+
+    func stream(prompt: String, options: InferenceOptions) -> AsyncThrowingStream<String, Error> {
+        core.stream(prompt: prompt, options: options)
+    }
+
+    func generateWithToolCalls(
+        prompt: String,
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) async throws -> InferenceResponse {
+        try await core.generateWithToolCalls(prompt: prompt, tools: tools, options: options)
+    }
+
+    func generateStructured(
+        prompt: String,
+        request: StructuredOutputRequest,
+        options: InferenceOptions
+    ) async throws -> StructuredOutputResult {
+        try await core.generateStructured(prompt: prompt, request: request, options: options)
+    }
+}
+
+private struct OpenTelemetryAnyConversationInferenceProvider: @unchecked Sendable,
+    InferenceProvider,
+    CapabilityReportingInferenceProvider,
+    InferenceProviderMetadata,
+    ConversationInferenceProvider,
+    StreamingConversationInferenceProvider,
+    StructuredOutputConversationInferenceProvider,
+    OpenTelemetryInstrumentedInferenceProvider
+{
+    let core: OpenTelemetryAnyInferenceProviderCore
+
+    var capabilities: InferenceProviderCapabilities { core.capabilities }
+    var providerName: String? { core.metadata?.providerName }
+    var modelName: String? { core.metadata?.modelName }
+    var endpointURL: URL? { core.metadata?.endpointURL }
+
+    func generate(prompt: String, options: InferenceOptions) async throws -> String {
+        try await core.generate(prompt: prompt, options: options)
+    }
+
+    func stream(prompt: String, options: InferenceOptions) -> AsyncThrowingStream<String, Error> {
+        core.stream(prompt: prompt, options: options)
+    }
+
+    func generateWithToolCalls(
+        prompt: String,
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) async throws -> InferenceResponse {
+        try await core.generateWithToolCalls(prompt: prompt, tools: tools, options: options)
+    }
+
+    func generate(messages: [InferenceMessage], options: InferenceOptions) async throws -> String {
+        try await core.generate(messages: messages, options: options)
+    }
+
+    func stream(messages: [InferenceMessage], options: InferenceOptions) -> AsyncThrowingStream<String, Error> {
+        core.stream(messages: messages, options: options)
+    }
+
+    func generateWithToolCalls(
+        messages: [InferenceMessage],
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) async throws -> InferenceResponse {
+        try await core.generateWithToolCalls(messages: messages, tools: tools, options: options)
+    }
+
+    func generateStructured(
+        messages: [InferenceMessage],
+        request: StructuredOutputRequest,
+        options: InferenceOptions
+    ) async throws -> StructuredOutputResult {
+        try await core.generateStructured(messages: messages, request: request, options: options)
+    }
+}
+
+private struct OpenTelemetryAnyToolStreamingInferenceProvider: @unchecked Sendable,
+    InferenceProvider,
+    CapabilityReportingInferenceProvider,
+    InferenceProviderMetadata,
+    ConversationInferenceProvider,
+    StreamingConversationInferenceProvider,
+    ToolCallStreamingInferenceProvider,
+    ToolCallStreamingConversationInferenceProvider,
+    StructuredOutputConversationInferenceProvider,
+    OpenTelemetryInstrumentedInferenceProvider
+{
+    let core: OpenTelemetryAnyInferenceProviderCore
+
+    var capabilities: InferenceProviderCapabilities { core.capabilities }
+    var providerName: String? { core.metadata?.providerName }
+    var modelName: String? { core.metadata?.modelName }
+    var endpointURL: URL? { core.metadata?.endpointURL }
+
+    func generate(prompt: String, options: InferenceOptions) async throws -> String {
+        try await core.generate(prompt: prompt, options: options)
+    }
+
+    func stream(prompt: String, options: InferenceOptions) -> AsyncThrowingStream<String, Error> {
+        core.stream(prompt: prompt, options: options)
+    }
+
+    func generateWithToolCalls(
+        prompt: String,
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) async throws -> InferenceResponse {
+        try await core.generateWithToolCalls(prompt: prompt, tools: tools, options: options)
+    }
+
+    func generate(messages: [InferenceMessage], options: InferenceOptions) async throws -> String {
+        try await core.generate(messages: messages, options: options)
+    }
+
+    func stream(messages: [InferenceMessage], options: InferenceOptions) -> AsyncThrowingStream<String, Error> {
+        core.stream(messages: messages, options: options)
+    }
+
+    func generateWithToolCalls(
+        messages: [InferenceMessage],
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) async throws -> InferenceResponse {
+        try await core.generateWithToolCalls(messages: messages, tools: tools, options: options)
+    }
+
+    func streamWithToolCalls(
+        prompt: String,
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) -> AsyncThrowingStream<InferenceStreamUpdate, Error> {
+        core.streamWithToolCalls(prompt: prompt, tools: tools, options: options)
+    }
+
+    func streamWithToolCalls(
+        messages: [InferenceMessage],
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) -> AsyncThrowingStream<InferenceStreamUpdate, Error> {
+        core.streamWithToolCalls(messages: messages, tools: tools, options: options)
+    }
+
+    func generateStructured(
+        messages: [InferenceMessage],
+        request: StructuredOutputRequest,
+        options: InferenceOptions
+    ) async throws -> StructuredOutputResult {
+        try await core.generateStructured(messages: messages, request: request, options: options)
+    }
+}

--- a/Sources/SwarmOpenTelemetry/OpenTelemetryAttributes.swift
+++ b/Sources/SwarmOpenTelemetry/OpenTelemetryAttributes.swift
@@ -1,0 +1,44 @@
+// OpenTelemetryAttributes.swift
+// SwarmOpenTelemetry
+
+import Foundation
+import OpenTelemetryApi
+import Swarm
+
+enum OpenTelemetryAttributes {
+    static func applyMetadata(_ metadata: InferenceProviderMetadata?, to span: any SpanBase) {
+        guard let metadata else { return }
+        if let providerName = metadata.providerName {
+            span.setAttribute(key: "gen_ai.provider.name", value: providerName)
+        }
+        if let modelName = metadata.modelName {
+            span.setAttribute(key: "gen_ai.request.model", value: modelName)
+        }
+        if let endpointURL = metadata.endpointURL {
+            if let host = endpointURL.host {
+                span.setAttribute(key: "server.address", value: host)
+            }
+            if let port = endpointURL.port {
+                span.setAttribute(key: "server.port", value: port)
+            }
+            span.setAttribute(key: "url.full", value: endpointURL.absoluteString)
+        }
+    }
+
+    static func applyUsage(_ usage: TokenUsage?, to span: any SpanBase) {
+        guard let usage else { return }
+        span.setAttribute(key: "gen_ai.usage.input_tokens", value: usage.inputTokens)
+        span.setAttribute(key: "gen_ai.usage.output_tokens", value: usage.outputTokens)
+    }
+
+    static func recordError(_ error: Error, on span: any SpanBase) {
+        let errorType = String(reflecting: Swift.type(of: error))
+        span.status = .error(description: error.localizedDescription)
+        span.setAttribute(key: "error.type", value: errorType)
+        if let recordingSpan = span as? any Span {
+            recordingSpan.recordException(error, attributes: [
+                "error.type": .string(errorType)
+            ])
+        }
+    }
+}

--- a/Sources/SwarmOpenTelemetry/OpenTelemetryInferenceProvider.swift
+++ b/Sources/SwarmOpenTelemetry/OpenTelemetryInferenceProvider.swift
@@ -10,7 +10,7 @@ import Swarm
 /// Advanced provider protocols are exposed through conditional conformances, so
 /// wrapping a provider does not advertise capabilities the underlying provider
 /// cannot actually satisfy.
-struct OpenTelemetryInferenceProvider<Base: InferenceProvider>: @unchecked Sendable,
+public struct OpenTelemetryInferenceProvider<Base: InferenceProvider>: @unchecked Sendable,
     CapabilityReportingInferenceProvider,
     InferenceProviderMetadata
 {
@@ -85,7 +85,7 @@ struct OpenTelemetryInferenceProvider<Base: InferenceProvider>: @unchecked Senda
 }
 
 extension OpenTelemetryInferenceProvider: ConversationInferenceProvider where Base: ConversationInferenceProvider {
-  func generate(messages: [InferenceMessage], options: InferenceOptions) async throws -> String {
+  public func generate(messages: [InferenceMessage], options: InferenceOptions) async throws -> String {
         try await withLLMSpan(operation: "chat", inputLength: Self.inputLength(messages), options: options) { span in
             span.setAttribute(key: "gen_ai.request.messages.count", value: messages.count)
             let response = try await base.generate(messages: messages, options: options)
@@ -94,7 +94,7 @@ extension OpenTelemetryInferenceProvider: ConversationInferenceProvider where Ba
         }
     }
 
-  func generateWithToolCalls(
+  public func generateWithToolCalls(
         messages: [InferenceMessage],
         tools: [ToolSchema],
         options: InferenceOptions
@@ -110,7 +110,7 @@ extension OpenTelemetryInferenceProvider: ConversationInferenceProvider where Ba
 }
 
 extension OpenTelemetryInferenceProvider: StreamingConversationInferenceProvider where Base: StreamingConversationInferenceProvider {
-  func stream(
+  public func stream(
         messages: [InferenceMessage],
         options: InferenceOptions
     ) -> AsyncThrowingStream<String, Error> {
@@ -127,7 +127,7 @@ extension OpenTelemetryInferenceProvider: StreamingConversationInferenceProvider
 }
 
 extension OpenTelemetryInferenceProvider: ToolCallStreamingInferenceProvider where Base: ToolCallStreamingInferenceProvider {
-  func streamWithToolCalls(
+  public func streamWithToolCalls(
         prompt: String,
         tools: [ToolSchema],
         options: InferenceOptions
@@ -140,7 +140,7 @@ extension OpenTelemetryInferenceProvider: ToolCallStreamingInferenceProvider whe
 
 extension OpenTelemetryInferenceProvider: ToolCallStreamingConversationInferenceProvider
 where Base: ToolCallStreamingConversationInferenceProvider {
-  func streamWithToolCalls(
+  public func streamWithToolCalls(
         messages: [InferenceMessage],
         tools: [ToolSchema],
         options: InferenceOptions
@@ -152,7 +152,7 @@ where Base: ToolCallStreamingConversationInferenceProvider {
 }
 
 extension OpenTelemetryInferenceProvider: StructuredOutputInferenceProvider where Base: StructuredOutputInferenceProvider {
-  func generateStructured(
+  public func generateStructured(
         prompt: String,
         request: StructuredOutputRequest,
         options: InferenceOptions
@@ -168,7 +168,7 @@ extension OpenTelemetryInferenceProvider: StructuredOutputInferenceProvider wher
 
 extension OpenTelemetryInferenceProvider: StructuredOutputConversationInferenceProvider
 where Base: StructuredOutputConversationInferenceProvider {
-  func generateStructured(
+  public func generateStructured(
         messages: [InferenceMessage],
         request: StructuredOutputRequest,
         options: InferenceOptions
@@ -304,3 +304,20 @@ private extension OpenTelemetryInferenceProvider {
 protocol OpenTelemetryInstrumentedInferenceProvider {}
 
 extension OpenTelemetryInferenceProvider: OpenTelemetryInstrumentedInferenceProvider {}
+
+public extension InferenceProvider {
+    /// Wraps this provider so each LLM request emits an OpenTelemetry GenAI span.
+    func instrumentedWithOpenTelemetry(
+        tracer: any OpenTelemetryApi.Tracer = OpenTelemetry.instance.tracerProvider.get(
+            instrumentationName: "swarm.llm",
+            instrumentationVersion: nil
+        ),
+        captureContent: Bool = false
+    ) -> some InferenceProvider {
+        OpenTelemetryInferenceProvider(
+            self,
+            tracer: tracer,
+            captureContent: captureContent
+        )
+    }
+}

--- a/Sources/SwarmOpenTelemetry/OpenTelemetryInferenceProvider.swift
+++ b/Sources/SwarmOpenTelemetry/OpenTelemetryInferenceProvider.swift
@@ -10,7 +10,7 @@ import Swarm
 /// Advanced provider protocols are exposed through conditional conformances, so
 /// wrapping a provider does not advertise capabilities the underlying provider
 /// cannot actually satisfy.
-public struct OpenTelemetryInferenceProvider<Base: InferenceProvider>: @unchecked Sendable,
+struct OpenTelemetryInferenceProvider<Base: InferenceProvider>: @unchecked Sendable,
     CapabilityReportingInferenceProvider,
     InferenceProviderMetadata
 {
@@ -85,7 +85,7 @@ public struct OpenTelemetryInferenceProvider<Base: InferenceProvider>: @unchecke
 }
 
 extension OpenTelemetryInferenceProvider: ConversationInferenceProvider where Base: ConversationInferenceProvider {
-    public func generate(messages: [InferenceMessage], options: InferenceOptions) async throws -> String {
+  func generate(messages: [InferenceMessage], options: InferenceOptions) async throws -> String {
         try await withLLMSpan(operation: "chat", inputLength: Self.inputLength(messages), options: options) { span in
             span.setAttribute(key: "gen_ai.request.messages.count", value: messages.count)
             let response = try await base.generate(messages: messages, options: options)
@@ -94,7 +94,7 @@ extension OpenTelemetryInferenceProvider: ConversationInferenceProvider where Ba
         }
     }
 
-    public func generateWithToolCalls(
+  func generateWithToolCalls(
         messages: [InferenceMessage],
         tools: [ToolSchema],
         options: InferenceOptions
@@ -110,7 +110,7 @@ extension OpenTelemetryInferenceProvider: ConversationInferenceProvider where Ba
 }
 
 extension OpenTelemetryInferenceProvider: StreamingConversationInferenceProvider where Base: StreamingConversationInferenceProvider {
-    public func stream(
+  func stream(
         messages: [InferenceMessage],
         options: InferenceOptions
     ) -> AsyncThrowingStream<String, Error> {
@@ -127,7 +127,7 @@ extension OpenTelemetryInferenceProvider: StreamingConversationInferenceProvider
 }
 
 extension OpenTelemetryInferenceProvider: ToolCallStreamingInferenceProvider where Base: ToolCallStreamingInferenceProvider {
-    public func streamWithToolCalls(
+  func streamWithToolCalls(
         prompt: String,
         tools: [ToolSchema],
         options: InferenceOptions
@@ -140,7 +140,7 @@ extension OpenTelemetryInferenceProvider: ToolCallStreamingInferenceProvider whe
 
 extension OpenTelemetryInferenceProvider: ToolCallStreamingConversationInferenceProvider
 where Base: ToolCallStreamingConversationInferenceProvider {
-    public func streamWithToolCalls(
+  func streamWithToolCalls(
         messages: [InferenceMessage],
         tools: [ToolSchema],
         options: InferenceOptions
@@ -152,7 +152,7 @@ where Base: ToolCallStreamingConversationInferenceProvider {
 }
 
 extension OpenTelemetryInferenceProvider: StructuredOutputInferenceProvider where Base: StructuredOutputInferenceProvider {
-    public func generateStructured(
+  func generateStructured(
         prompt: String,
         request: StructuredOutputRequest,
         options: InferenceOptions
@@ -168,7 +168,7 @@ extension OpenTelemetryInferenceProvider: StructuredOutputInferenceProvider wher
 
 extension OpenTelemetryInferenceProvider: StructuredOutputConversationInferenceProvider
 where Base: StructuredOutputConversationInferenceProvider {
-    public func generateStructured(
+  func generateStructured(
         messages: [InferenceMessage],
         request: StructuredOutputRequest,
         options: InferenceOptions
@@ -301,15 +301,6 @@ private extension OpenTelemetryInferenceProvider {
     }
 }
 
-public extension InferenceProvider {
-    /// Wraps this provider so LLM requests emit OpenTelemetry GenAI spans.
-    func instrumentedWithOpenTelemetry(
-        tracer: any OpenTelemetryApi.Tracer = OpenTelemetry.instance.tracerProvider.get(
-            instrumentationName: "swarm.llm",
-            instrumentationVersion: nil
-        ),
-        captureContent: Bool = false
-    ) -> OpenTelemetryInferenceProvider<Self> {
-        OpenTelemetryInferenceProvider(self, tracer: tracer, captureContent: captureContent)
-    }
-}
+protocol OpenTelemetryInstrumentedInferenceProvider {}
+
+extension OpenTelemetryInferenceProvider: OpenTelemetryInstrumentedInferenceProvider {}

--- a/Sources/SwarmOpenTelemetry/OpenTelemetryInferenceProvider.swift
+++ b/Sources/SwarmOpenTelemetry/OpenTelemetryInferenceProvider.swift
@@ -1,0 +1,315 @@
+// OpenTelemetryInferenceProvider.swift
+// SwarmOpenTelemetry
+
+import Foundation
+@preconcurrency import OpenTelemetryApi
+import Swarm
+
+/// An inference-provider wrapper that emits OpenTelemetry GenAI spans.
+///
+/// Advanced provider protocols are exposed through conditional conformances, so
+/// wrapping a provider does not advertise capabilities the underlying provider
+/// cannot actually satisfy.
+public struct OpenTelemetryInferenceProvider<Base: InferenceProvider>: @unchecked Sendable,
+    CapabilityReportingInferenceProvider,
+    InferenceProviderMetadata
+{
+    public init(
+        _ base: Base,
+        tracer: any OpenTelemetryApi.Tracer = OpenTelemetry.instance.tracerProvider.get(
+            instrumentationName: "swarm.llm",
+            instrumentationVersion: nil
+        ),
+        captureContent: Bool = false
+    ) {
+        self.base = base
+        self.tracer = tracer
+        self.captureContent = captureContent
+    }
+
+    public var capabilities: InferenceProviderCapabilities {
+        InferenceProviderCapabilities.resolved(for: base)
+    }
+
+    public var providerName: String? {
+        metadata?.providerName
+    }
+
+    public var modelName: String? {
+        metadata?.modelName
+    }
+
+    public var endpointURL: URL? {
+        metadata?.endpointURL
+    }
+
+    public func generate(prompt: String, options: InferenceOptions) async throws -> String {
+        try await withLLMSpan(operation: "chat", inputLength: prompt.count, options: options) { span in
+            let response = try await base.generate(prompt: prompt, options: options)
+            span.setAttribute(key: "gen_ai.response.output_length", value: response.count)
+            return response
+        }
+    }
+
+    public func stream(prompt: String, options: InferenceOptions) -> AsyncThrowingStream<String, Error> {
+        instrumentStream(inputLength: prompt.count, options: options) { continuation, span in
+            var outputLength = 0
+            for try await token in base.stream(prompt: prompt, options: options) {
+                outputLength += token.count
+                continuation.yield(token)
+            }
+            span.setAttribute(key: "gen_ai.response.output_length", value: outputLength)
+        }
+    }
+
+    public func generateWithToolCalls(
+        prompt: String,
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) async throws -> InferenceResponse {
+        try await withLLMSpan(operation: "chat", inputLength: prompt.count, options: options) { span in
+            span.setAttribute(key: "gen_ai.request.tools.count", value: tools.count)
+            let response = try await base.generateWithToolCalls(prompt: prompt, tools: tools, options: options)
+            apply(response: response, to: span)
+            return response
+        }
+    }
+
+    fileprivate let base: Base
+    fileprivate let tracer: any OpenTelemetryApi.Tracer
+    fileprivate let captureContent: Bool
+
+    fileprivate var metadata: (any InferenceProviderMetadata)? {
+        base as? any InferenceProviderMetadata
+    }
+}
+
+extension OpenTelemetryInferenceProvider: ConversationInferenceProvider where Base: ConversationInferenceProvider {
+    public func generate(messages: [InferenceMessage], options: InferenceOptions) async throws -> String {
+        try await withLLMSpan(operation: "chat", inputLength: Self.inputLength(messages), options: options) { span in
+            span.setAttribute(key: "gen_ai.request.messages.count", value: messages.count)
+            let response = try await base.generate(messages: messages, options: options)
+            span.setAttribute(key: "gen_ai.response.output_length", value: response.count)
+            return response
+        }
+    }
+
+    public func generateWithToolCalls(
+        messages: [InferenceMessage],
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) async throws -> InferenceResponse {
+        try await withLLMSpan(operation: "chat", inputLength: Self.inputLength(messages), options: options) { span in
+            span.setAttribute(key: "gen_ai.request.messages.count", value: messages.count)
+            span.setAttribute(key: "gen_ai.request.tools.count", value: tools.count)
+            let response = try await base.generateWithToolCalls(messages: messages, tools: tools, options: options)
+            apply(response: response, to: span)
+            return response
+        }
+    }
+}
+
+extension OpenTelemetryInferenceProvider: StreamingConversationInferenceProvider where Base: StreamingConversationInferenceProvider {
+    public func stream(
+        messages: [InferenceMessage],
+        options: InferenceOptions
+    ) -> AsyncThrowingStream<String, Error> {
+        instrumentStream(inputLength: Self.inputLength(messages), options: options) { continuation, span in
+            span.setAttribute(key: "gen_ai.request.messages.count", value: messages.count)
+            var outputLength = 0
+            for try await token in base.stream(messages: messages, options: options) {
+                outputLength += token.count
+                continuation.yield(token)
+            }
+            span.setAttribute(key: "gen_ai.response.output_length", value: outputLength)
+        }
+    }
+}
+
+extension OpenTelemetryInferenceProvider: ToolCallStreamingInferenceProvider where Base: ToolCallStreamingInferenceProvider {
+    public func streamWithToolCalls(
+        prompt: String,
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) -> AsyncThrowingStream<InferenceStreamUpdate, Error> {
+        instrumentToolStream(inputLength: prompt.count, toolCount: tools.count, options: options) {
+            base.streamWithToolCalls(prompt: prompt, tools: tools, options: options)
+        }
+    }
+}
+
+extension OpenTelemetryInferenceProvider: ToolCallStreamingConversationInferenceProvider
+where Base: ToolCallStreamingConversationInferenceProvider {
+    public func streamWithToolCalls(
+        messages: [InferenceMessage],
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) -> AsyncThrowingStream<InferenceStreamUpdate, Error> {
+        instrumentToolStream(inputLength: Self.inputLength(messages), toolCount: tools.count, options: options) {
+            base.streamWithToolCalls(messages: messages, tools: tools, options: options)
+        }
+    }
+}
+
+extension OpenTelemetryInferenceProvider: StructuredOutputInferenceProvider where Base: StructuredOutputInferenceProvider {
+    public func generateStructured(
+        prompt: String,
+        request: StructuredOutputRequest,
+        options: InferenceOptions
+    ) async throws -> StructuredOutputResult {
+        try await withLLMSpan(operation: "chat", inputLength: prompt.count, options: options) { span in
+            span.setAttribute(key: "gen_ai.output.type", value: "json")
+            let result = try await base.generateStructured(prompt: prompt, request: request, options: options)
+            span.setAttribute(key: "gen_ai.response.output_length", value: result.rawJSON.count)
+            return result
+        }
+    }
+}
+
+extension OpenTelemetryInferenceProvider: StructuredOutputConversationInferenceProvider
+where Base: StructuredOutputConversationInferenceProvider {
+    public func generateStructured(
+        messages: [InferenceMessage],
+        request: StructuredOutputRequest,
+        options: InferenceOptions
+    ) async throws -> StructuredOutputResult {
+        try await withLLMSpan(operation: "chat", inputLength: Self.inputLength(messages), options: options) { span in
+            span.setAttribute(key: "gen_ai.request.messages.count", value: messages.count)
+            span.setAttribute(key: "gen_ai.output.type", value: "json")
+            let result = try await base.generateStructured(messages: messages, request: request, options: options)
+            span.setAttribute(key: "gen_ai.response.output_length", value: result.rawJSON.count)
+            return result
+        }
+    }
+}
+
+private extension OpenTelemetryInferenceProvider {
+    static func inputLength(_ messages: [InferenceMessage]) -> Int {
+        messages.reduce(0) { $0 + $1.content.count }
+    }
+
+    func withLLMSpan<T: Sendable>(
+        operation: String,
+        inputLength: Int,
+        options: InferenceOptions,
+        _ body: @escaping @Sendable (any SpanBase) async throws -> T
+    ) async throws -> T {
+        let builder = makeSpanBuilder(operation: operation, inputLength: inputLength, options: options)
+        return try await builder.withActiveSpan { span in
+            prepare(span: span)
+            do {
+                let result = try await body(span)
+                span.status = .ok
+                return result
+            } catch {
+                OpenTelemetryAttributes.recordError(error, on: span)
+                throw error
+            }
+        }
+    }
+
+    func makeSpanBuilder(
+        operation: String,
+        inputLength: Int,
+        options: InferenceOptions
+    ) -> any SpanBuilder {
+        let builder = tracer.spanBuilder(spanName: "\(operation) \(metadata?.modelName ?? "llm")")
+        builder.setSpanKind(spanKind: .client)
+        builder.setAttribute(key: "gen_ai.operation.name", value: operation)
+        builder.setAttribute(key: "gen_ai.request.input_length", value: inputLength)
+        builder.setAttribute(key: "gen_ai.request.temperature", value: options.temperature)
+        if let maxTokens = options.maxTokens {
+            builder.setAttribute(key: "gen_ai.request.max_tokens", value: maxTokens)
+        }
+        if captureContent {
+            builder.setAttribute(key: "swarm.capture_content.enabled", value: true)
+        }
+        return builder
+    }
+
+    func prepare(span: any SpanBase) {
+        OpenTelemetryAttributes.applyMetadata(metadata, to: span)
+    }
+
+    func apply(response: InferenceResponse, to span: any SpanBase) {
+        if let content = response.content {
+            span.setAttribute(key: "gen_ai.response.output_length", value: content.count)
+        }
+        span.setAttribute(key: "gen_ai.response.finish_reasons", value: response.finishReason.rawValue)
+        span.setAttribute(key: "gen_ai.response.tool_calls.count", value: response.toolCalls.count)
+        OpenTelemetryAttributes.applyUsage(response.usage, to: span)
+    }
+
+    func instrumentStream(
+        inputLength: Int,
+        options: InferenceOptions,
+        body: @escaping @Sendable (AsyncThrowingStream<String, Error>.Continuation, any SpanBase) async throws -> Void
+    ) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task {
+                do {
+                    try await withLLMSpan(operation: "chat", inputLength: inputLength, options: options) { span in
+                        try await body(continuation, span)
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    func instrumentToolStream(
+        inputLength: Int,
+        toolCount: Int,
+        options: InferenceOptions,
+        makeStream: @escaping @Sendable () -> AsyncThrowingStream<InferenceStreamUpdate, Error>
+    ) -> AsyncThrowingStream<InferenceStreamUpdate, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task {
+                do {
+                    try await withLLMSpan(operation: "chat", inputLength: inputLength, options: options) { span in
+                        span.setAttribute(key: "gen_ai.request.tools.count", value: toolCount)
+                        var outputLength = 0
+                        var completedToolCallCount = 0
+                        var usage: TokenUsage?
+                        for try await update in makeStream() {
+                            switch update {
+                            case let .outputChunk(chunk):
+                                outputLength += chunk.count
+                            case let .toolCallsCompleted(calls):
+                                completedToolCallCount = calls.count
+                            case let .usage(tokenUsage):
+                                usage = tokenUsage
+                            case .toolCallPartial:
+                                break
+                            }
+                            continuation.yield(update)
+                        }
+                        span.setAttribute(key: "gen_ai.response.output_length", value: outputLength)
+                        span.setAttribute(key: "gen_ai.response.tool_calls.count", value: completedToolCallCount)
+                        OpenTelemetryAttributes.applyUsage(usage, to: span)
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+}
+
+public extension InferenceProvider {
+    /// Wraps this provider so LLM requests emit OpenTelemetry GenAI spans.
+    func instrumentedWithOpenTelemetry(
+        tracer: any OpenTelemetryApi.Tracer = OpenTelemetry.instance.tracerProvider.get(
+            instrumentationName: "swarm.llm",
+            instrumentationVersion: nil
+        ),
+        captureContent: Bool = false
+    ) -> OpenTelemetryInferenceProvider<Self> {
+        OpenTelemetryInferenceProvider(self, tracer: tracer, captureContent: captureContent)
+    }
+}

--- a/Sources/SwarmOpenTelemetry/SwarmTypeAliases.swift
+++ b/Sources/SwarmOpenTelemetry/SwarmTypeAliases.swift
@@ -1,0 +1,6 @@
+// SwarmTypeAliases.swift
+// SwarmOpenTelemetry
+
+import Swarm
+
+public typealias SwarmRuntimeTracer = Tracer

--- a/Tests/SwarmOpenTelemetryTests/OpenTelemetryInferenceProviderTests.swift
+++ b/Tests/SwarmOpenTelemetryTests/OpenTelemetryInferenceProviderTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Testing
+import Swarm
+import SwarmOpenTelemetry
+
+private struct PromptOnlyProvider: InferenceProvider {
+    func generate(prompt: String, options: InferenceOptions) async throws -> String {
+        prompt
+    }
+
+    func stream(prompt: String, options: InferenceOptions) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in
+            continuation.yield(prompt)
+            continuation.finish()
+        }
+    }
+
+    func generateWithToolCalls(
+        prompt: String,
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) async throws -> InferenceResponse {
+        InferenceResponse(content: prompt)
+    }
+}
+
+private struct ToolStreamingProvider: InferenceProvider, ToolCallStreamingInferenceProvider {
+    func generate(prompt: String, options: InferenceOptions) async throws -> String {
+        prompt
+    }
+
+    func stream(prompt: String, options: InferenceOptions) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in
+            continuation.yield(prompt)
+            continuation.finish()
+        }
+    }
+
+    func generateWithToolCalls(
+        prompt: String,
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) async throws -> InferenceResponse {
+        InferenceResponse(content: prompt)
+    }
+
+    func streamWithToolCalls(
+        prompt: String,
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) -> AsyncThrowingStream<InferenceStreamUpdate, Error> {
+        AsyncThrowingStream { continuation in
+            continuation.yield(.outputChunk(prompt))
+            continuation.finish()
+        }
+    }
+}
+
+@Test("OpenTelemetry wrapper does not add unsupported tool streaming")
+func openTelemetryWrapperDoesNotAddUnsupportedToolStreaming() {
+    let wrapped = PromptOnlyProvider().instrumentedWithOpenTelemetry()
+
+    #expect(!(wrapped is any ToolCallStreamingInferenceProvider))
+    #expect(!wrapped.capabilities.contains(.streamingToolCalls))
+}
+
+@Test("OpenTelemetry wrapper preserves supported tool streaming")
+func openTelemetryWrapperPreservesSupportedToolStreaming() {
+    let wrapped = ToolStreamingProvider().instrumentedWithOpenTelemetry()
+    let provider: any InferenceProvider = wrapped
+
+    #expect(provider is any ToolCallStreamingInferenceProvider)
+    #expect(wrapped.capabilities.contains(.streamingToolCalls))
+}
+
+@Test("Inference metadata snapshot exposes non-sensitive provider fields")
+func inferenceMetadataSnapshotExposesProviderFields() {
+    let endpoint = URL(string: "https://api.example.com/v1")
+    let metadata = InferenceProviderMetadataSnapshot(
+        providerName: "example",
+        modelName: "example-model",
+        endpointURL: endpoint
+    )
+
+    #expect(metadata.providerName == "example")
+    #expect(metadata.modelName == "example-model")
+    #expect(metadata.endpointURL == endpoint)
+}

--- a/Tests/SwarmOpenTelemetryTests/OpenTelemetryInferenceProviderTests.swift
+++ b/Tests/SwarmOpenTelemetryTests/OpenTelemetryInferenceProviderTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OpenTelemetryApi
 import OpenTelemetrySdk
 import Testing
 import Swarm
@@ -128,6 +129,30 @@ func openTelemetryWrapperPreservesSupportedToolStreaming() {
 
     #expect(provider is any ToolCallStreamingInferenceProvider)
     #expect(wrapped.capabilities.contains(.streamingToolCalls))
+}
+
+@Test("Raw provider OpenTelemetry instrumentation is public API")
+func rawProviderOpenTelemetryInstrumentationIsPublicAPI() async throws {
+    let provider = PromptOnlyProvider().instrumentedWithOpenTelemetry()
+
+    let output = try await provider.generate(prompt: "hello", options: .default)
+
+    #expect(output == "hello")
+}
+
+@Test("Erased OpenTelemetry wrapper preserves prompt-only tool streaming shape")
+func erasedOpenTelemetryWrapperPreservesPromptOnlyToolStreamingShape() {
+    let wrapped = OpenTelemetryAnyInferenceProvider(
+        ToolStreamingProvider(),
+        tracer: OpenTelemetry.instance.tracerProvider.get(instrumentationName: "test.llm"),
+        captureContent: false
+    )
+
+    #expect(wrapped is any ToolCallStreamingInferenceProvider)
+    #expect(!(wrapped is any ConversationInferenceProvider))
+    #expect(!(wrapped is any ToolCallStreamingConversationInferenceProvider))
+    #expect(!InferenceProviderCapabilities.resolved(for: wrapped).contains(.conversationMessages))
+    #expect(InferenceProviderCapabilities.resolved(for: wrapped).contains(.streamingToolCalls))
 }
 
 @Test("Agent OpenTelemetry wrapper creates one parent trace for multiple LLM calls")

--- a/Tests/SwarmOpenTelemetryTests/OpenTelemetryInferenceProviderTests.swift
+++ b/Tests/SwarmOpenTelemetryTests/OpenTelemetryInferenceProviderTests.swift
@@ -1,7 +1,8 @@
 import Foundation
+import OpenTelemetrySdk
 import Testing
 import Swarm
-import SwarmOpenTelemetry
+@testable import SwarmOpenTelemetry
 
 private struct PromptOnlyProvider: InferenceProvider {
     func generate(prompt: String, options: InferenceOptions) async throws -> String {
@@ -56,9 +57,65 @@ private struct ToolStreamingProvider: InferenceProvider, ToolCallStreamingInfere
     }
 }
 
+private struct TwoLLMCallAgent: AgentRuntime {
+    let provider: any InferenceProvider
+
+    var tools: [any AnyJSONTool] { [] }
+    var instructions: String { "test" }
+    var configuration: AgentConfiguration { .default.name("two-call-agent") }
+    var inferenceProvider: (any InferenceProvider)? { provider }
+
+    func run(
+        _ input: String,
+        session: (any Session)?,
+        observer: (any AgentObserver)?
+    ) async throws -> AgentResult {
+        let provider = AgentEnvironmentValues.current.inferenceProviderTransform?(provider) ?? provider
+        _ = try await provider.generate(prompt: input, options: .default)
+        _ = try await provider.generate(prompt: "\(input) again", options: .default)
+        return AgentResult(output: "done", iterationCount: 1)
+    }
+
+    func stream(
+        _ input: String,
+        session: (any Session)?,
+        observer: (any AgentObserver)?
+    ) -> AsyncThrowingStream<AgentEvent, Error> {
+        AsyncThrowingStream { continuation in
+            continuation.finish()
+        }
+    }
+
+    func cancel() async {}
+}
+
+private final class RecordingSpanExporter: SpanExporter, @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [SpanData] = []
+
+    var spans: [SpanData] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+
+    func export(spans: [SpanData], explicitTimeout: TimeInterval?) -> SpanExporterResultCode {
+        lock.lock()
+        storage.append(contentsOf: spans)
+        lock.unlock()
+        return .success
+    }
+
+    func flush(explicitTimeout: TimeInterval?) -> SpanExporterResultCode {
+        .success
+    }
+
+    func shutdown(explicitTimeout: TimeInterval?) {}
+}
+
 @Test("OpenTelemetry wrapper does not add unsupported tool streaming")
 func openTelemetryWrapperDoesNotAddUnsupportedToolStreaming() {
-    let wrapped = PromptOnlyProvider().instrumentedWithOpenTelemetry()
+    let wrapped = OpenTelemetryInferenceProvider(PromptOnlyProvider())
 
     #expect(!(wrapped is any ToolCallStreamingInferenceProvider))
     #expect(!wrapped.capabilities.contains(.streamingToolCalls))
@@ -66,11 +123,39 @@ func openTelemetryWrapperDoesNotAddUnsupportedToolStreaming() {
 
 @Test("OpenTelemetry wrapper preserves supported tool streaming")
 func openTelemetryWrapperPreservesSupportedToolStreaming() {
-    let wrapped = ToolStreamingProvider().instrumentedWithOpenTelemetry()
+    let wrapped = OpenTelemetryInferenceProvider(ToolStreamingProvider())
     let provider: any InferenceProvider = wrapped
 
     #expect(provider is any ToolCallStreamingInferenceProvider)
     #expect(wrapped.capabilities.contains(.streamingToolCalls))
+}
+
+@Test("Agent OpenTelemetry wrapper creates one parent trace for multiple LLM calls")
+func agentOpenTelemetryWrapperCreatesOneParentTraceForMultipleLLMCalls() async throws {
+    let exporter = RecordingSpanExporter()
+    let tracerProvider = TracerProviderBuilder()
+        .add(
+            spanProcessor: SimpleSpanProcessor(spanExporter: exporter)
+                .reportingOnlySampled(sampled: false)
+        )
+        .build()
+
+    let agent = TwoLLMCallAgent(provider: PromptOnlyProvider())
+        .instrumentedWithOpenTelemetry(
+            tracer: tracerProvider.get(instrumentationName: "test.agent"),
+            llmTracer: tracerProvider.get(instrumentationName: "test.llm")
+        )
+
+    _ = try await agent.run("hello")
+    tracerProvider.forceFlush()
+
+    let spans = exporter.spans
+    let agentSpan = try #require(spans.first { $0.name == "swarm.agent.run two-call-agent" })
+    let llmSpans = spans.filter { $0.name == "chat llm" }
+
+    #expect(llmSpans.count == 2)
+    #expect(llmSpans.allSatisfy { $0.traceId == agentSpan.traceId })
+    #expect(llmSpans.allSatisfy { $0.parentSpanId == agentSpan.spanId })
 }
 
 @Test("Inference metadata snapshot exposes non-sensitive provider fields")

--- a/Tests/SwarmOpenTelemetryTests/OpenTelemetryPublicAPITests.swift
+++ b/Tests/SwarmOpenTelemetryTests/OpenTelemetryPublicAPITests.swift
@@ -1,0 +1,33 @@
+import Testing
+import Swarm
+import SwarmOpenTelemetry
+
+private struct PublicAPIPromptOnlyProvider: InferenceProvider {
+    func generate(prompt: String, options: InferenceOptions) async throws -> String {
+        prompt
+    }
+
+    func stream(prompt: String, options: InferenceOptions) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in
+            continuation.yield(prompt)
+            continuation.finish()
+        }
+    }
+
+    func generateWithToolCalls(
+        prompt: String,
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) async throws -> InferenceResponse {
+        InferenceResponse(content: prompt)
+    }
+}
+
+@Test("Raw provider OpenTelemetry instrumentation is available through public import")
+func rawProviderOpenTelemetryInstrumentationIsAvailableThroughPublicImport() async throws {
+    let provider = PublicAPIPromptOnlyProvider().instrumentedWithOpenTelemetry()
+
+    let output = try await provider.generate(prompt: "hello", options: .default)
+
+    #expect(output == "hello")
+}

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -53,6 +53,7 @@ export default defineConfig({
             { text: 'Getting Started', link: '/guide/getting-started' },
             { text: 'Capability Showcase', link: '/guide/capability-showcase' },
             { text: 'Agent Workspace', link: '/guide/agent-workspace' },
+            { text: 'OpenTelemetry Tracing', link: '/guide/opentelemetry-tracing' },
             { text: 'Why Swarm', link: '/guide/why-swarm' },
           ]
         },

--- a/docs/guide/opentelemetry-tracing.md
+++ b/docs/guide/opentelemetry-tracing.md
@@ -1,0 +1,179 @@
+# OpenTelemetry Tracing
+
+Swarm ships OpenTelemetry support as an optional product named `SwarmOpenTelemetry`.
+Use it when you want LLM requests and their underlying HTTP calls to show up in
+the same distributed trace as the rest of your app.
+
+Swarm's OpenTelemetry integration is intentionally scoped to inference-provider
+spans:
+
+- `provider.instrumentedWithOpenTelemetry()` wraps an `InferenceProvider` and emits GenAI spans for LLM calls.
+
+If you also want HTTP spans or `traceparent` header propagation for the
+underlying LLM network requests, install OpenTelemetry Swift's
+`URLSessionInstrumentation` in your application telemetry bootstrap. Swarm does
+not install it for you because URLSession instrumentation is process-wide.
+
+## Add the Package Products
+
+If your app already configures OpenTelemetry, add only `SwarmOpenTelemetry` to the
+target that creates agents:
+
+```swift
+.target(
+    name: "YourApp",
+    dependencies: [
+        .product(name: "Swarm", package: "Swarm"),
+        .product(name: "SwarmOpenTelemetry", package: "Swarm"),
+    ]
+)
+```
+
+If the same target also configures an OTLP exporter, add the OpenTelemetry
+packages directly so SwiftPM lets the app import the SDK, exporter, and optional
+URLSession instrumentation modules:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/christopherkarani/Swarm.git", from: "0.5.0"),
+    .package(url: "https://github.com/open-telemetry/opentelemetry-swift-core.git", from: "2.3.0"),
+    .package(url: "https://github.com/open-telemetry/opentelemetry-swift.git", from: "2.3.0"),
+],
+targets: [
+    .target(
+        name: "YourApp",
+        dependencies: [
+            .product(name: "Swarm", package: "Swarm"),
+            .product(name: "SwarmOpenTelemetry", package: "Swarm"),
+            .product(name: "OpenTelemetrySdk", package: "opentelemetry-swift-core"),
+            .product(name: "OpenTelemetryProtocolExporterHTTP", package: "opentelemetry-swift"),
+            .product(name: "URLSessionInstrumentation", package: "opentelemetry-swift"),
+        ]
+    )
+]
+```
+
+## Configure OpenTelemetry
+
+Register your tracer provider once during app startup. This example exports spans
+to a local OpenTelemetry Collector using OTLP/HTTP.
+
+```swift
+import Foundation
+import OpenTelemetryApi
+import OpenTelemetryProtocolExporterHttp
+import OpenTelemetrySdk
+import URLSessionInstrumentation
+import SwarmOpenTelemetry
+
+private var urlSessionInstrumentation: URLSessionInstrumentation?
+
+func configureTracing() {
+    let exporter = OtlpHttpTraceExporter(
+        endpoint: URL(string: "http://localhost:4318/v1/traces")!
+    )
+
+    let processor = SimpleSpanProcessor(spanExporter: exporter)
+
+    OpenTelemetry.registerTracerProvider(
+        tracerProvider: TracerProviderBuilder()
+            .add(spanProcessor: processor)
+            .build()
+    )
+
+    urlSessionInstrumentation = URLSessionInstrumentation(
+        configuration: URLSessionInstrumentationConfiguration(
+            shouldInstrument: { request in
+                guard let host = request.url?.host else { return false }
+                return host == "api.openai.com" || host == "api.anthropic.com"
+            },
+            shouldInjectTracingHeaders: { request in
+                guard let host = request.url?.host else { return false }
+                return host == "api.openai.com" || host == "api.anthropic.com"
+            }
+        )
+    )
+}
+```
+
+Keep the `URLSessionInstrumentation` instance alive for as long as you want
+URLSession requests to be instrumented. The filtering closures are application
+policy: decide where HTTP spans and propagated trace headers are allowed.
+
+## Trace an Agent Run
+
+Wrap the LLM provider before passing it to the agent.
+
+```swift
+import Swarm
+import SwarmOpenTelemetry
+
+configureTracing()
+
+let provider = LLM.openAI(apiKey: "sk-...", model: "gpt-4.1-mini")
+    .instrumentedWithOpenTelemetry()
+
+let agent = try Agent(
+    "Answer briefly and use tools when useful.",
+    configuration: .default.name("support-agent"),
+    inferenceProvider: provider
+) {
+    CalculatorTool()
+}
+
+let result = try await agent.run("What is 18% of 245?")
+print(result.output)
+```
+
+This creates:
+
+- LLM client spans named like `chat gpt-4.1-mini`.
+- URLSession HTTP spans for provider network requests, if your app installed URLSession instrumentation.
+- `traceparent` and `baggage` headers on instrumented URLSession requests, if your app enabled header injection.
+
+## Control Header Injection
+
+URLSession instrumentation is global to the process, so configure it in the app
+instead of in Swarm. Restrict instrumentation and header injection to the hosts
+that should participate in distributed tracing:
+
+```swift
+urlSessionInstrumentation = URLSessionInstrumentation(
+    configuration: URLSessionInstrumentationConfiguration(
+        shouldInstrument: { request in
+            guard let host = request.url?.host else { return false }
+            return host == "api.openai.com" || host == "api.anthropic.com"
+        },
+        shouldInjectTracingHeaders: { request in
+            guard let host = request.url?.host else { return false }
+            return host == "api.openai.com"
+        }
+    )
+)
+```
+
+Return `false` from `shouldInjectTracingHeaders` when you want local HTTP spans
+but do not want to propagate tracing headers to an upstream provider.
+
+## Capture Content
+
+LLM spans record request shape, provider metadata, token usage, output length,
+and errors. They do not record prompts or model output by default.
+
+If your deployment policy allows content capture, opt in per provider wrapper:
+
+```swift
+let provider = LLM.anthropic(apiKey: "sk-...", model: "claude-3-5-sonnet-latest")
+    .instrumentedWithOpenTelemetry(captureContent: true)
+```
+
+`captureContent` currently marks the span with `swarm.capture_content.enabled`.
+Keep prompt and response capture behind an explicit application-level policy
+before adding sensitive content to span attributes or events.
+
+## Platform Notes
+
+LLM span wrapping works anywhere the OpenTelemetry API and Swarm targets build.
+URLSession auto-instrumentation is available when the `URLSessionInstrumentation`
+module is importable by your application. On unsupported platforms, skip the
+URLSession instrumentation setup and keep only the Swarm provider wrapper.

--- a/docs/guide/opentelemetry-tracing.md
+++ b/docs/guide/opentelemetry-tracing.md
@@ -4,10 +4,13 @@ Swarm ships OpenTelemetry support as an optional product named `SwarmOpenTelemet
 Use it when you want LLM requests and their underlying HTTP calls to show up in
 the same distributed trace as the rest of your app.
 
-Swarm's OpenTelemetry integration is intentionally scoped to inference-provider
-spans:
+Swarm's OpenTelemetry integration is scoped to agent turns and the LLM calls made
+inside those turns:
 
-- `provider.instrumentedWithOpenTelemetry()` wraps an `InferenceProvider` and emits GenAI spans for LLM calls.
+- `agent.instrumentedWithOpenTelemetry()` creates one parent span for each
+  user-facing agent operation.
+- During that operation, Swarm automatically wraps the resolved
+  `InferenceProvider` and emits child GenAI spans for LLM calls.
 
 If you also want HTTP spans or `traceparent` header propagation for the
 underlying LLM network requests, install OpenTelemetry Swift's
@@ -102,7 +105,8 @@ policy: decide where HTTP spans and propagated trace headers are allowed.
 
 ## Trace an Agent Run
 
-Wrap the LLM provider before passing it to the agent.
+Wrap the agent once. Swarm will instrument whichever inference provider that
+agent resolves for the run.
 
 ```swift
 import Swarm
@@ -110,16 +114,13 @@ import SwarmOpenTelemetry
 
 configureTracing()
 
-let provider = LLM.openAI(apiKey: "sk-...", model: "gpt-4.1-mini")
-    .instrumentedWithOpenTelemetry()
-
 let agent = try Agent(
     "Answer briefly and use tools when useful.",
     configuration: .default.name("support-agent"),
-    inferenceProvider: provider
+    inferenceProvider: LLM.openAI(apiKey: "sk-...", model: "gpt-4.1-mini")
 ) {
     CalculatorTool()
-}
+}.instrumentedWithOpenTelemetry()
 
 let result = try await agent.run("What is 18% of 245?")
 print(result.output)
@@ -127,9 +128,14 @@ print(result.output)
 
 This creates:
 
-- LLM client spans named like `chat gpt-4.1-mini`.
+- An agent parent span named like `swarm.agent.run support-agent`.
+- LLM child spans named like `chat gpt-4.1-mini`.
 - URLSession HTTP spans for provider network requests, if your app installed URLSession instrumentation.
 - `traceparent` and `baggage` headers on instrumented URLSession requests, if your app enabled header injection.
+
+If one agent run makes multiple LLM calls, all of those LLM spans share the same
+trace as the agent span. With URLSession instrumentation enabled, provider HTTP
+requests made inside those LLM spans inherit that same current trace context.
 
 ## Control Header Injection
 
@@ -160,11 +166,13 @@ but do not want to propagate tracing headers to an upstream provider.
 LLM spans record request shape, provider metadata, token usage, output length,
 and errors. They do not record prompts or model output by default.
 
-If your deployment policy allows content capture, opt in per provider wrapper:
+If your deployment policy allows content capture, opt in on the agent wrapper:
 
 ```swift
-let provider = LLM.anthropic(apiKey: "sk-...", model: "claude-3-5-sonnet-latest")
-    .instrumentedWithOpenTelemetry(captureContent: true)
+let agent = try Agent(
+    "Answer briefly.",
+    inferenceProvider: LLM.anthropic(apiKey: "sk-...", model: "claude-3-5-sonnet-latest")
+) {}.instrumentedWithOpenTelemetry(captureContent: true)
 ```
 
 `captureContent` currently marks the span with `swarm.capture_content.enabled`.
@@ -173,7 +181,8 @@ before adding sensitive content to span attributes or events.
 
 ## Platform Notes
 
-LLM span wrapping works anywhere the OpenTelemetry API and Swarm targets build.
+Agent and LLM span wrapping works anywhere the OpenTelemetry API and Swarm
+targets build.
 URLSession auto-instrumentation is available when the `URLSessionInstrumentation`
 module is importable by your application. On unsupported platforms, skip the
-URLSession instrumentation setup and keep only the Swarm provider wrapper.
+URLSession instrumentation setup and keep only the Swarm agent wrapper.

--- a/docs/reference/overview.md
+++ b/docs/reference/overview.md
@@ -33,7 +33,7 @@ The **[Complete API Reference](/swarm-complete-reference)** is an archival deep 
 | [Streaming](/streaming) | `AgentEvent` streaming, SwiftUI integration |
 | [Guardrails](/guardrails) | Input/output validation, tripwires |
 | [Resilience](/resilience) | Retry, circuit breakers, fallback, timeouts |
-| [Observability](/observability) | Tracing, `OSLogTracer`, `SwiftLogTracer`, metrics |
+| [Observability](/guide/opentelemetry-tracing) | Tracing, OpenTelemetry, `OSLogTracer`, `SwiftLogTracer`, metrics |
 | [MCP](/mcp) | Model Context Protocol client and server |
 | [Providers](/providers) | Inference providers, `MultiProvider` routing |
 | [Durable Runtime Hardening](/durable-runtime-hardening) | Internal implementation note covering run control, checkpoint capability, and deterministic transcript/state hashing |


### PR DESCRIPTION
## Summary

resolve https://github.com/christopherkarani/Swarm/issues/76

Adds OpenTelemetry tracing support through a new `SwarmOpenTelemetry` product.

The user-facing API surface is intentionally narrow: applications opt in by wrapping an agent with `agent.instrumentedWithOpenTelemetry()`. The wrapper creates an agent-level span and automatically instruments the LLM providers resolved during that agent run, so callers do not need to wrap each provider manually.

## Why

Swarm's existing `Tracer` protocol is event-based and works well for logging, metrics, and custom event sinks, but it cannot fully model OpenTelemetry tracing. OpenTelemetry needs active span scope, parent/child span relationships, async context propagation, status/error recording, and propagation into downstream HTTP instrumentation.

This change keeps the existing `Tracer` abstraction intact while adding an OpenTelemetry-specific integration layer for distributed tracing.

## What changed

- Adds a `SwarmOpenTelemetry` package product.
- Adds `agent.instrumentedWithOpenTelemetry()` as the opt-in tracing entry point.
- Emits agent parent spans and GenAI child spans for LLM calls inside the agent run.
- Adds internal provider wrapping during the active agent span so resolved providers are instrumented automatically.
- Adds provider metadata support so spans can include non-sensitive provider/model/endpoint attributes.
- Documents OpenTelemetry setup, including app-owned URLSession instrumentation and header injection policy.

## Validation

- `swift build --target SwarmOpenTelemetry`
- `swift build --target SwarmOpenTelemetryTests`

<img width="1192" height="910" alt="image" src="https://github.com/user-attachments/assets/ee142b91-109f-41b5-8b4c-dccbed83ffb3" />
