### PR TITLE
Fix Swift 6 async let actor isolation crash

### DIFF
--- a/Sources/Swarm/Memory/DefaultAgentMemory.swift
+++ b/Sources/Swarm/Memory/DefaultAgentMemory.swift
@@ -69,14 +69,15 @@ public actor DefaultAgentMemory: Memory, MemoryPromptDescriptor, MemorySessionLi
             return ""
         }
 
-        async let primaryContext = contextMemory.context(
+        async let primaryContextTask = contextMemory.context(
             for: query,
             tokenLimit: max(1, Int(Double(tokenLimit) * 0.7))
         )
-        async let secondaryContext = waxContext(for: query, tokenLimit: max(1, tokenLimit / 3))
+        let secondaryContextStr = await waxContext(for: query, tokenLimit: max(1, tokenLimit / 3))
+        let primaryContextStr = await primaryContextTask
 
-        let primary = (await primaryContext).trimmingCharacters(in: .whitespacesAndNewlines)
-        let secondary = (await secondaryContext).trimmingCharacters(in: .whitespacesAndNewlines)
+        let primary = primaryContextStr.trimmingCharacters(in: .whitespacesAndNewlines)
+        let secondary = secondaryContextStr.trimmingCharacters(in: .whitespacesAndNewlines)
         return await formatContext(primary: primary, secondary: secondary, tokenLimit: tokenLimit)
     }
 


### PR DESCRIPTION
Replaces async let calls to actor-isolated methods with sequential awaits to fix a known compiler bug on macOS ARM64 that causes a swift_task_dealloc heap corruption. The async let task lowering in Swift 6 occasionally triggers a double-free of the task context when capturing self on an actor. Moving to sequential await avoids the compiler miscompilation.