### PR TITLE
Bump Wax pin from 0.1.19 to 0.1.20 (Swift 6.2 strict-concurrency fix)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ var packageDependencies: [Package.Dependency] = [
     .package(url: "https://github.com/open-telemetry/opentelemetry-swift-core.git", from: "2.3.0"),
     .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.13.2"),
     // Production graph must resolve to the published tag set that is known to build together.
-    .package(url: "https://github.com/christopherkarani/Wax.git", exact: "0.1.19"),
+    .package(url: "https://github.com/christopherkarani/Wax.git", exact: "0.1.20"),
     .package(
         url: "https://github.com/christopherkarani/Conduit",
         exact: "0.3.14",


### PR DESCRIPTION
The `Package.swift` on `main` (and 0.4.8 / 0.5.1) specifies:

```swift
.package(url: "https://github.com/christopherkarani/Wax.git", exact: "0.1.19"),
```

Wax 0.1.19 has a strict-concurrency bug in `WaxVectorSearchMiniLM/CoreML/MiniLMEmbeddings.swift` — the `prediction(...)` async helper passes a non-`Sendable` `all_MiniLM_L6_v2Output` value across an actor boundary via `withCheckedContinuation`. Under Swift 6.2 strict concurrency the build fails:

```
WaxVectorSearchMiniLM/CoreML/MiniLMEmbeddings.swift:148:30: error: sending 'output' risks causing data races
note: task-isolated 'output' is passed as a 'sending' parameter; Uses in callee may race with later task-isolated uses
```

This was fixed in Wax 0.1.20 (commit `15bf81b4`, "Fix CoreML continuation send for embedding runtimes (closes #61)", April 13 2026): the function was rewritten to decode embeddings inside the `predictionQueue` closure and return `[[Float]]?` rather than handing a non-Sendable CoreML output across the continuation. Wax 0.1.20 was tagged 15 days before Swarm 0.4.8, so this is just pin-lag — Swarm hasn't picked up the published fix yet.

**Repro:** Build any Swarm consumer with the Xcode 26 / Swift 6.2 toolchain. Even a trivial `import Swarm` in a static framework target is enough to trigger the WaxVectorSearchMiniLM compile path.

**This PR:** One-line bump.

```swift
.package(url: "https://github.com/christopherkarani/Wax.git", exact: "0.1.20"),
```

(Or widen to `from: "0.1.20"` if you want to pick up subsequent patches automatically.)

I've verified locally that the bumped pin builds clean against the OneApp/OneWorkspace consumer's xcframework build path.