### PR TITLE
Fix membrane pointerization for structured tool output

### DIFF
--- a/Sources/Swarm/Agents/Agent.swift
+++ b/Sources/Swarm/Agents/Agent.swift
@@ -1948,9 +1948,23 @@ public struct Agent: AgentRuntime, Sendable {
         }
     }
 
-    private static func toolOutputText(for output: SendableValue) -> String {
+    /// Serializes a non-string tool result as canonical JSON so downstream
+    /// consumers (Membrane pointerization, transcript replay, model context)
+    /// receive a parsable contract rather than `SendableValue.description`'s
+    /// JSON-ish format which does not escape quotes, backslashes, or newlines.
+    ///
+    /// Plain-string results pass through unchanged. Falls back to
+    /// `description` if the value contains a non-finite double — `JSONSerialization`
+    /// raises an Objective-C `NSException` (not a Swift error) on NaN/Infinity,
+    /// so we must screen the value before serializing rather than relying on
+    /// `do/catch`.
+    static func toolOutputText(for output: SendableValue) -> String {
         if let string = output.stringValue {
             return string
+        }
+
+        guard !containsNonFiniteDouble(output) else {
+            return output.description
         }
 
         do {
@@ -1962,9 +1976,24 @@ public struct Agent: AgentRuntime, Sendable {
             if let text = String(data: data, encoding: .utf8) {
                 return text
             }
-        } catch {}
+        } catch {
+            Log.agents.warning("Tool output JSON serialization failed; falling back to description: \(error)")
+        }
 
         return output.description
+    }
+
+    private static func containsNonFiniteDouble(_ value: SendableValue) -> Bool {
+        switch value {
+        case let .double(number):
+            return !number.isFinite
+        case let .array(values):
+            return values.contains(where: containsNonFiniteDouble)
+        case let .dictionary(values):
+            return values.values.contains(where: containsNonFiniteDouble)
+        case .null, .bool, .int, .string:
+            return false
+        }
     }
 
     // MARK: - Handoff Tool Schema Integration

--- a/Sources/Swarm/Agents/Agent.swift
+++ b/Sources/Swarm/Agents/Agent.swift
@@ -1885,7 +1885,7 @@ public struct Agent: AgentRuntime, Sendable {
         }
 
         if outcome.result.isSuccess {
-            var toolOutputText = outcome.result.output.stringValue ?? outcome.result.output.description
+            var toolOutputText = Self.toolOutputText(for: outcome.result.output)
             if let membraneAdapter {
                 do {
                     let currentToolOutput = toolOutputText
@@ -1946,6 +1946,25 @@ public struct Agent: AgentRuntime, Sendable {
                 throw AgentError.toolExecutionFailed(toolName: parsedCall.name, underlyingError: errorMessage)
             }
         }
+    }
+
+    private static func toolOutputText(for output: SendableValue) -> String {
+        if let string = output.stringValue {
+            return string
+        }
+
+        do {
+            let object = output.toJSONObject()
+            let data = try JSONSerialization.data(
+                withJSONObject: object,
+                options: [.sortedKeys, .fragmentsAllowed]
+            )
+            if let text = String(data: data, encoding: .utf8) {
+                return text
+            }
+        } catch {}
+
+        return output.description
     }
 
     // MARK: - Handoff Tool Schema Integration

--- a/Tests/SwarmTests/Agents/AgentToolOutputTextTests.swift
+++ b/Tests/SwarmTests/Agents/AgentToolOutputTextTests.swift
@@ -1,0 +1,102 @@
+import Foundation
+import Testing
+@testable import Swarm
+
+@Suite("Agent.toolOutputText")
+struct AgentToolOutputTextTests {
+    @Test("Plain string passes through unchanged")
+    func stringPassthrough() {
+        #expect(Agent.toolOutputText(for: .string("hello")) == "hello")
+        #expect(Agent.toolOutputText(for: .string("")) == "")
+    }
+
+    @Test("Plain string preserves embedded quotes and newlines verbatim")
+    func stringPreservesSpecialCharsLiteral() {
+        let raw = "quoted \"value\" with newline\nsecond line"
+        #expect(Agent.toolOutputText(for: .string(raw)) == raw)
+    }
+
+    @Test("Dictionary serializes as JSON with sorted keys and escaped strings")
+    func dictionaryProducesValidJSON() throws {
+        let value = SendableValue.dictionary([
+            "message": .string("quoted \"value\" with newline\nsecond line"),
+            "count": .int(42),
+            "items": .array([.string("a"), .string("b")])
+        ])
+
+        let text = Agent.toolOutputText(for: value)
+
+        // sorted keys: count, items, message
+        #expect(text.hasPrefix("{\"count\":42,\"items\":"))
+
+        let object = try JSONSerialization.jsonObject(with: Data(text.utf8)) as? [String: Any]
+        let dictionary = try #require(object)
+        #expect(dictionary["message"] as? String == "quoted \"value\" with newline\nsecond line")
+        #expect(dictionary["count"] as? Int == 42)
+        #expect(dictionary["items"] as? [String] == ["a", "b"])
+    }
+
+    @Test("Nested dictionaries and arrays round-trip through JSON")
+    func nestedRoundTrip() throws {
+        let value = SendableValue.dictionary([
+            "outer": .dictionary([
+                "inner": .array([.int(1), .int(2), .int(3)]),
+                "flag": .bool(true)
+            ])
+        ])
+
+        let text = Agent.toolOutputText(for: value)
+        let object = try JSONSerialization.jsonObject(with: Data(text.utf8)) as? [String: Any]
+        let dictionary = try #require(object)
+        let outer = try #require(dictionary["outer"] as? [String: Any])
+        #expect(outer["inner"] as? [Int] == [1, 2, 3])
+        #expect(outer["flag"] as? Bool == true)
+    }
+
+    @Test("Scalar non-string values serialize as JSON fragments")
+    func scalarFragments() {
+        #expect(Agent.toolOutputText(for: .int(42)) == "42")
+        #expect(Agent.toolOutputText(for: .double(3.5)) == "3.5")
+        #expect(Agent.toolOutputText(for: .bool(true)) == "true")
+        #expect(Agent.toolOutputText(for: .bool(false)) == "false")
+        #expect(Agent.toolOutputText(for: .null) == "null")
+    }
+
+    @Test("Top-level array serializes as JSON array")
+    func topLevelArray() throws {
+        let value = SendableValue.array([
+            .string("a\"b"),
+            .int(1),
+            .null
+        ])
+
+        let text = Agent.toolOutputText(for: value)
+        let object = try JSONSerialization.jsonObject(with: Data(text.utf8)) as? [Any]
+        let array = try #require(object)
+        #expect(array.count == 3)
+        #expect(array[0] as? String == "a\"b")
+        #expect(array[1] as? Int == 1)
+        #expect(array[2] is NSNull)
+    }
+
+    @Test("Non-finite double falls back to description without crashing")
+    func nonFiniteDoubleFallsBack() {
+        // JSONSerialization raises NSException (not a Swift error) on NaN/Infinity.
+        // The helper must screen the value before serializing — falling back to
+        // description preserves prior behavior on this edge case without crashing.
+        #expect(Agent.toolOutputText(for: .double(.nan)) == SendableValue.double(.nan).description)
+        #expect(Agent.toolOutputText(for: .double(.infinity)) == SendableValue.double(.infinity).description)
+        #expect(Agent.toolOutputText(for: .double(-.infinity)) == SendableValue.double(-.infinity).description)
+    }
+
+    @Test("Non-finite double nested inside dictionary falls back without crashing")
+    func nonFiniteNestedFallsBack() {
+        let value = SendableValue.dictionary([
+            "ok": .int(1),
+            "broken": .array([.double(.nan)])
+        ])
+        let text = Agent.toolOutputText(for: value)
+        // Falls back to description — must not be valid JSON and must not crash.
+        #expect(!text.isEmpty)
+    }
+}

--- a/Tests/SwarmTests/MCP/SwarmMCPServerServiceTests.swift
+++ b/Tests/SwarmTests/MCP/SwarmMCPServerServiceTests.swift
@@ -276,7 +276,7 @@ struct SwarmMCPServerServiceTests {
                         arguments: ["value": .int(i)]
                     )
                     guard
-                        case let .text(text)? = result.content.first,
+                        case let .text(text: text, annotations: _, _meta: _)? = result.content.first,
                         let parsed = Int(text)
                     else {
                         throw SwarmMCPServerServiceTestError.unreachable("unexpected content")

--- a/Tests/SwarmTests/MembraneIntegrationTests.swift
+++ b/Tests/SwarmTests/MembraneIntegrationTests.swift
@@ -126,6 +126,41 @@ struct MembraneIntegrationTests {
         #expect(result.metadata["membrane.fallback.error"]?.stringValue?.contains("forced membrane failure") == true)
     }
 
+    @Test("Pointerized structured tool output resolves as JSON")
+    func pointerizedStructuredToolOutputResolvesAsJSON() async throws {
+        let provider = PointerResolvingInferenceProvider()
+        let agent = try Agent(
+            tools: [StructuredPayloadTool()],
+            instructions: "Call the structured payload tool, resolve the pointer, then finish.",
+            configuration: AgentConfiguration(
+                name: "membrane-structured-tool-output",
+                maxIterations: 4,
+                defaultTracingEnabled: false
+            ),
+            inferenceProvider: provider
+        ).environment(
+            \.membrane,
+            MembraneEnvironment(
+                isEnabled: true,
+                configuration: MembraneFeatureConfiguration(
+                    jitMinToolCount: 12,
+                    defaultJITLoadCount: 2,
+                    pointerThresholdBytes: 32,
+                    pointerSummaryMaxChars: 80
+                )
+            )
+        )
+
+        let result = try await agent.run("exercise pointerized structured output")
+
+        let resolvedPointerOutput = try #require(result.toolResults.last?.output.stringValue)
+        let data = Data(resolvedPointerOutput.utf8)
+        let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let dictionary = try #require(object)
+        #expect(dictionary["message"] as? String == "quoted \"value\" with newline\nsecond line")
+        #expect(dictionary["count"] as? Int == 42)
+    }
+
     @Test("Default adapter checkpoint state roundtrips loaded tools")
     func defaultAdapterCheckpointRoundtrip() async throws {
         let adapter = DefaultMembraneAgentAdapter(
@@ -273,6 +308,101 @@ private struct MembraneTestTool: AnyJSONTool, Sendable {
 
     func execute(arguments _: [String: SendableValue]) async throws -> SendableValue {
         .string("ok")
+    }
+}
+
+private struct StructuredPayloadTool: AnyJSONTool, Sendable {
+    let name = "structured_payload"
+    let description = "Returns structured JSON-compatible data large enough to pointerize."
+    let parameters: [ToolParameter] = []
+
+    func execute(arguments _: [String: SendableValue]) async throws -> SendableValue {
+        .dictionary([
+            "message": .string("quoted \"value\" with newline\nsecond line"),
+            "count": .int(42),
+            "items": .array((0 ..< 20).map { .string("item-\($0)") })
+        ])
+    }
+}
+
+private actor PointerResolvingInferenceProvider: InferenceProvider, ConversationInferenceProvider {
+    private var turn = 0
+
+    func generate(prompt _: String, options _: InferenceOptions) async throws -> String {
+        "done"
+    }
+
+    nonisolated func stream(prompt _: String, options _: InferenceOptions) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in
+            continuation.yield("done")
+            continuation.finish()
+        }
+    }
+
+    func generateWithToolCalls(
+        prompt _: String,
+        tools _: [ToolSchema],
+        options _: InferenceOptions
+    ) async throws -> InferenceResponse {
+        try nextResponse(from: "")
+    }
+
+    func generate(messages: [InferenceMessage], options _: InferenceOptions) async throws -> String {
+        InferenceMessage.flattenPrompt(messages)
+    }
+
+    nonisolated func stream(
+        messages: [InferenceMessage],
+        options _: InferenceOptions
+    ) -> AsyncThrowingStream<String, Error> {
+        let text = InferenceMessage.flattenPrompt(messages)
+        return AsyncThrowingStream { continuation in
+            continuation.yield(text)
+            continuation.finish()
+        }
+    }
+
+    func generateWithToolCalls(
+        messages: [InferenceMessage],
+        tools _: [ToolSchema],
+        options _: InferenceOptions
+    ) async throws -> InferenceResponse {
+        try nextResponse(from: InferenceMessage.flattenPrompt(messages))
+    }
+
+    private func nextResponse(from prompt: String) throws -> InferenceResponse {
+        defer { turn += 1 }
+        switch turn {
+        case 0:
+            return InferenceResponse(
+                toolCalls: [
+                    .init(id: "call-structured", name: "structured_payload", arguments: [:])
+                ],
+                finishReason: .toolCall
+            )
+        case 1:
+            let pointerID = try Self.pointerID(from: prompt)
+            return InferenceResponse(
+                toolCalls: [
+                    .init(
+                        id: "call-resolve",
+                        name: MembraneInternalToolName.resolvePointer,
+                        arguments: ["pointer_id": .string(pointerID)]
+                    )
+                ],
+                finishReason: .toolCall
+            )
+        default:
+            return InferenceResponse(content: "done", finishReason: .completed)
+        }
+    }
+
+    private static func pointerID(from prompt: String) throws -> String {
+        guard let range = prompt.range(of: #"ptr_[0-9a-f]{12}"#, options: .regularExpression) else {
+            struct MissingPointer: Error {}
+            throw MissingPointer()
+        }
+        return String(prompt[range])
     }
 }
 


### PR DESCRIPTION
## Summary

Structured tool results were converted with `SendableValue.description` before being passed into Membrane pointerization. That representation is not a JSON contract: it does not escape `"`, `\`, or `\n`, so any structured tool output containing those characters produces a non-parsable pointer payload.

This changes the Agent tool-output boundary to serialize non-string `SendableValue` results as canonical JSON (sorted keys, proper escaping, fragments allowed) before Membrane transforms or pointerizes them. Plain string tool results still pass through unchanged.

## What changed

- `Agent.toolOutputText(for:)` — new helper. String passes through; everything else goes through `JSONSerialization` with `[.sortedKeys, .fragmentsAllowed]` so the conversation/transcript/pointer payload is parsable JSON.
- **NaN/Infinity hardening.** `JSONSerialization` raises an Objective-C `NSException` on non-finite doubles, which Swift `do/catch` cannot trap. The helper pre-screens the value tree and falls back to `description` for non-finite doubles instead of crashing the agent.
- **Diagnostic logging.** A genuine `JSONSerialization` failure now logs at `Log.agents.warning` instead of being silently swallowed.
- **MCP SDK test compatibility.** `SwarmMCPServerServiceTests` is updated to the newer `CallTool.Result.Content.text(text:annotations:_meta:)` case shape so the test target compiles against the currently-pinned MCP SDK. Without this the test target won't build, so we can't deliver the fix without it.

## Tests

Local upstream verification (CI runs are currently blocked by an Actions billing issue on the upstream account):

```
SWARM_HIVE_RUNTIME=1 SWARM_INCLUDE_HIVE=1 swift test --no-parallel
# Test run with 1708 tests in 234 suites passed after 17.297 seconds.
```

Targeted suites:

- `swift test --filter AgentToolOutputTextTests` — 8 tests, all pass (new file)
- `swift test --filter MembraneIntegrationTests` — 7 tests, all pass (includes the new `pointerizedStructuredToolOutputResolvesAsJSON` integration test)
- `swift test --filter SwarmMCPServerServiceTests` — 13 tests, all pass

The new unit tests in `AgentToolOutputTextTests` cover:

- Plain string passthrough (with embedded quotes/newlines preserved verbatim)
- Dictionary serializes as JSON with sorted keys and proper escape sequences
- Nested dictionary/array round-trip via `JSONSerialization.jsonObject`
- Scalar fragments (`Int`, `Double`, `Bool`, `null`)
- Top-level array
- Non-finite double fallback at the top level **and** nested inside a dictionary (regression guard against NSException crash)

## Notes for the reviewer

- The PR is rebased on current `main` (`02537a6`, including the Wax 0.1.20 fix from #80).
- The MCP SDK case-pattern update is technically unrelated to the membrane fix but is required for the test target to compile against the current MCP SDK pin — happy to split into a separate PR if preferred, but the fix can't be tested without it.
- Behavior change visible to the model: dictionary/array tool outputs now reach the model as canonical JSON instead of `description`'s JSON-ish format. This is strictly an improvement in correctness; full local suite passes confirm no test snapshots assumed the old representation.