### PR TITLE
Add AgentWorkspace explicit tool overloads

### DIFF
--- a/Sources/Swarm/Agents/Agent+Workspace.swift
+++ b/Sources/Swarm/Agents/Agent+Workspace.swift
@@ -6,10 +6,25 @@ public extension Agent {
         _ instructions: String,
         workspace: AgentWorkspace? = nil,
         configuration: AgentConfiguration = .onDeviceDefault,
-        inferenceProvider: (any InferenceProvider)? = nil,
-        @ToolBuilder tools: () -> ToolCollection = { .empty }
+        inferenceProvider: (any InferenceProvider)? = nil
     ) throws -> Agent {
-        let builtTools = tools().storage
+        try onDevice(
+            instructions,
+            workspace: workspace,
+            configuration: configuration,
+            inferenceProvider: inferenceProvider,
+            tools: [any AnyJSONTool]()
+        )
+    }
+
+    /// Creates an on-device agent with workspace-backed memory and explicit JSON tools.
+    static func onDevice(
+        _ instructions: String,
+        workspace: AgentWorkspace? = nil,
+        configuration: AgentConfiguration = .onDeviceDefault,
+        inferenceProvider: (any InferenceProvider)? = nil,
+        tools: [any AnyJSONTool]
+    ) throws -> Agent {
         let globalInstructions = try workspace?.loadAgentInstructions() ?? ""
         let combinedInstructions = [globalInstructions, instructions]
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
@@ -17,7 +32,7 @@ public extension Agent {
             .joined(separator: "\n\n")
         let workspaceMemory = workspace.map { WorkspaceMemory(workspace: $0, activatedSkills: []) }
         return try Agent(
-            tools: builtTools,
+            tools: tools,
             instructions: combinedInstructions,
             configuration: configuration,
             memory: workspaceMemory,
@@ -25,18 +40,50 @@ public extension Agent {
         )
     }
 
-    /// Creates an on-device agent from an AgentWorkspace spec file.
+    /// Creates an on-device agent with workspace-backed memory and typed tools.
+    static func onDevice(
+        _ instructions: String,
+        workspace: AgentWorkspace? = nil,
+        configuration: AgentConfiguration = .onDeviceDefault,
+        inferenceProvider: (any InferenceProvider)? = nil,
+        @ToolBuilder tools: () -> ToolCollection
+    ) throws -> Agent {
+        try onDevice(
+            instructions,
+            workspace: workspace,
+            configuration: configuration,
+            inferenceProvider: inferenceProvider,
+            tools: tools().storage
+        )
+    }
+
+    /// Creates an on-device agent from an AgentWorkspace spec file with no tools.
+    static func spec(
+        _ id: String,
+        in workspace: AgentWorkspace,
+        configuration: AgentConfiguration = .onDeviceDefault,
+        inferenceProvider: (any InferenceProvider)? = nil
+    ) throws -> Agent {
+        try spec(
+            id,
+            in: workspace,
+            configuration: configuration,
+            inferenceProvider: inferenceProvider,
+            tools: [any AnyJSONTool]()
+        )
+    }
+
+    /// Creates an on-device agent from an AgentWorkspace spec file with explicit JSON tools.
     static func spec(
         _ id: String,
         in workspace: AgentWorkspace,
         configuration: AgentConfiguration = .onDeviceDefault,
         inferenceProvider: (any InferenceProvider)? = nil,
-        @ToolBuilder tools: () -> ToolCollection = { .empty }
+        tools: [any AnyJSONTool]
     ) throws -> Agent {
         let spec = try workspace.loadAgentSpec(id: id)
         let skills = try workspace.loadSkills(named: spec.skills)
         let globalInstructions = try workspace.loadAgentInstructions()
-        let builtTools = tools().storage
 
         let combinedInstructions = [globalInstructions, spec.body]
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
@@ -44,11 +91,28 @@ public extension Agent {
             .joined(separator: "\n\n")
 
         return try Agent(
-            tools: filterTools(builtTools, using: skills),
+            tools: filterTools(tools, using: skills),
             instructions: combinedInstructions,
             configuration: configuration.name(spec.title),
             memory: WorkspaceMemory(workspace: workspace, activatedSkills: skills),
             inferenceProvider: inferenceProvider
+        )
+    }
+
+    /// Creates an on-device agent from an AgentWorkspace spec file with typed tools.
+    static func spec(
+        _ id: String,
+        in workspace: AgentWorkspace,
+        configuration: AgentConfiguration = .onDeviceDefault,
+        inferenceProvider: (any InferenceProvider)? = nil,
+        @ToolBuilder tools: () -> ToolCollection
+    ) throws -> Agent {
+        try spec(
+            id,
+            in: workspace,
+            configuration: configuration,
+            inferenceProvider: inferenceProvider,
+            tools: tools().storage
         )
     }
 }

--- a/Tests/SwarmTests/Workspace/AgentWorkspaceTests.swift
+++ b/Tests/SwarmTests/Workspace/AgentWorkspaceTests.swift
@@ -106,6 +106,26 @@ struct AgentWorkspaceTests {
         #expect(prompt?.contains("Local agent instructions.") == true)
     }
 
+    @Test("Agent.onDevice accepts explicit JSON tools without ToolBuilder")
+    func agentOnDeviceAcceptsExplicitJSONTools() async throws {
+        let workspaceRoot = try makeWorkspaceRoot()
+        defer { try? FileManager.default.removeItem(at: workspaceRoot) }
+
+        let workspace = try AgentWorkspace(
+            bundleRoot: workspaceRoot,
+            writableRoot: workspaceRoot.appendingPathComponent("Writable", isDirectory: true),
+            indexCacheRoot: workspaceRoot.appendingPathComponent("Cache", isDirectory: true)
+        )
+
+        let agent = try Agent.onDevice(
+            "Local agent instructions.",
+            workspace: workspace,
+            tools: [WorkspaceProbeTool()]
+        )
+
+        #expect(agent.tools.map(\.name) == ["workspace_probe"])
+    }
+
     @Test("Agent.spec uses listed SKILL.md content as retrieved context")
     func agentSpecUsesSkillContentAsRetrievedContext() async throws {
         let workspaceRoot = try makeWorkspaceRoot()
@@ -153,6 +173,40 @@ struct AgentWorkspaceTests {
 
         let prompt = await capturedPromptText(from: provider)
         #expect(prompt?.contains("refund window") == true)
+    }
+
+    @Test("Agent.spec accepts explicit JSON tools without ToolBuilder")
+    func agentSpecAcceptsExplicitJSONTools() async throws {
+        let workspaceRoot = try makeWorkspaceRoot()
+        defer { try? FileManager.default.removeItem(at: workspaceRoot) }
+        try writeFile(
+            at: workspaceRoot.appendingPathComponent(".swarm/agents/support.md"),
+            contents: """
+            ---
+            schema_version: 1
+            id: support
+            title: Support
+            skills: []
+            revision: 1
+            updated_at: 2026-03-20T00:00:00Z
+            ---
+            You are the support agent.
+            """
+        )
+
+        let workspace = try AgentWorkspace(
+            bundleRoot: workspaceRoot,
+            writableRoot: workspaceRoot.appendingPathComponent("Writable", isDirectory: true),
+            indexCacheRoot: workspaceRoot.appendingPathComponent("Cache", isDirectory: true)
+        )
+
+        let agent = try Agent.spec(
+            "support",
+            in: workspace,
+            tools: [WorkspaceProbeTool()]
+        )
+
+        #expect(agent.tools.map(\.name) == ["workspace_probe"])
     }
 
     @Test("Workspace validation reports malformed SKILL.md")
@@ -204,6 +258,16 @@ struct AgentWorkspaceTests {
         let secondContents = try String(contentsOf: secondURL, encoding: .utf8)
         #expect(firstContents.contains("First fact"))
         #expect(secondContents.contains("Second fact"))
+    }
+}
+
+private struct WorkspaceProbeTool: AnyJSONTool {
+    let name = "workspace_probe"
+    let description = "A tiny probe tool for workspace API tests."
+    let parameters: [ToolParameter] = []
+
+    func execute(arguments: [String: SendableValue]) async throws -> SendableValue {
+        .string("ok")
     }
 }
 


### PR DESCRIPTION
## Summary

- add no-tool AgentWorkspace helpers that do not rely on the `@ToolBuilder` default closure
- add explicit `[any AnyJSONTool]` overloads for `Agent.onDevice` and `Agent.spec`
- keep the existing `@ToolBuilder` overloads for typed-tool callers
- cover the explicit-tool path in workspace tests

## Why

Downstream framework consumers can hit linker failures when the public workspace helpers expose default `@ToolBuilder` symbols such as `ToolCollection.empty` or `ToolBuilder.buildBlock`. Providing non-builder entry points gives those consumers a stable exported API while preserving the source-friendly builder API.

## Validation

- `swift test --package-path Vendor/Swarm --filter AgentWorkspaceTests`
