### PR TITLE
Plumb ReasoningConfig from ModelSettings → InferenceOptions → Conduit

### DIFF
--- a/Sources/Swarm/Core/AgentConfiguration+InferenceOptions.swift
+++ b/Sources/Swarm/Core/AgentConfiguration+InferenceOptions.swift
@@ -35,7 +35,8 @@ package extension AgentConfiguration {
                 truncation: settings.truncation,
                 verbosity: settings.verbosity,
                 providerSettings: settings.providerSettings,
-                previousResponseId: previousResponseId
+                previousResponseId: previousResponseId,
+                reasoning: settings.reasoning
             )
         }
 

--- a/Sources/Swarm/Core/AgentRuntime.swift
+++ b/Sources/Swarm/Core/AgentRuntime.swift
@@ -346,6 +346,11 @@ public struct InferenceOptions: Sendable, Equatable {
     /// Optional structured output contract for the request.
     public var structuredOutput: StructuredOutputRequest?
 
+    /// Configuration for extended thinking / reasoning mode (OpenAI o-series,
+    /// OpenRouter `:thinking`, etc.). Without this, reasoning models can run
+    /// unbounded — see one-fhx.
+    public var reasoning: ReasoningConfig?
+
     /// Creates inference options.
     /// - Parameters:
     ///   - temperature: Generation temperature. Default: 1.0
@@ -362,6 +367,7 @@ public struct InferenceOptions: Sendable, Equatable {
     ///   - verbosity: Verbosity preference. Default: nil
     ///   - providerSettings: Provider-specific pass-through settings. Default: nil
     ///   - previousResponseId: Previous response identifier for conversation continuation. Default: nil
+    ///   - reasoning: Reasoning configuration for thinking-capable models. Default: nil
     public init(
         temperature: Double = 1.0,
         maxTokens: Int? = nil,
@@ -377,7 +383,8 @@ public struct InferenceOptions: Sendable, Equatable {
         verbosity: Verbosity? = nil,
         providerSettings: [String: SendableValue]? = nil,
         previousResponseId: String? = nil,
-        structuredOutput: StructuredOutputRequest? = nil
+        structuredOutput: StructuredOutputRequest? = nil,
+        reasoning: ReasoningConfig? = nil
     ) {
         self.temperature = temperature
         self.maxTokens = maxTokens
@@ -394,6 +401,7 @@ public struct InferenceOptions: Sendable, Equatable {
         self.providerSettings = providerSettings
         self.previousResponseId = previousResponseId
         self.structuredOutput = structuredOutput
+        self.reasoning = reasoning
     }
 
     // MARK: - Special Builder Methods

--- a/Sources/Swarm/Core/ModelSettings.swift
+++ b/Sources/Swarm/Core/ModelSettings.swift
@@ -355,7 +355,8 @@ public extension ModelSettings {
             promptCacheRetention: other.promptCacheRetention ?? promptCacheRetention,
             repetitionPenalty: other.repetitionPenalty ?? repetitionPenalty,
             minP: other.minP ?? minP,
-            providerSettings: mergeProviderSettings(with: other.providerSettings)
+            providerSettings: mergeProviderSettings(with: other.providerSettings),
+            reasoning: other.reasoning ?? reasoning
         )
 
         // Validate the merged settings to catch invalid combinations

--- a/Sources/Swarm/Core/ModelSettings.swift
+++ b/Sources/Swarm/Core/ModelSettings.swift
@@ -155,6 +155,14 @@ public struct ModelSettings: Sendable, Equatable {
     /// ```
     public var providerSettings: [String: SendableValue]?
 
+    /// Configuration for extended thinking / reasoning mode.
+    ///
+    /// Used by OpenAI o-series, OpenRouter `:thinking`, and similar providers.
+    /// Without this, reasoning models may run unbounded — see one-fhx for the
+    /// production failure mode (gpt-5 returning response_bytes=0 after 800-1000
+    /// reasoning tokens).
+    public var reasoning: ReasoningConfig?
+
     // MARK: - Initialization
 
     /// Creates a new model settings configuration.
@@ -177,7 +185,8 @@ public struct ModelSettings: Sendable, Equatable {
         promptCacheRetention: CacheRetention? = nil,
         repetitionPenalty: Double? = nil,
         minP: Double? = nil,
-        providerSettings: [String: SendableValue]? = nil
+        providerSettings: [String: SendableValue]? = nil,
+        reasoning: ReasoningConfig? = nil
     ) {
         self.temperature = temperature
         self.topP = topP
@@ -195,6 +204,7 @@ public struct ModelSettings: Sendable, Equatable {
         self.repetitionPenalty = repetitionPenalty
         self.minP = minP
         self.providerSettings = providerSettings
+        self.reasoning = reasoning
     }
 }
 

--- a/Sources/Swarm/Core/ModelSettings.swift
+++ b/Sources/Swarm/Core/ModelSettings.swift
@@ -309,6 +309,12 @@ public extension ModelSettings {
                 throw ModelSettingsValidationError.invalidRepetitionPenalty(repetitionPenalty)
             }
         }
+
+        if let reasoningMaxTokens = reasoning?.maxTokens {
+            guard reasoningMaxTokens > 0 else {
+                throw ModelSettingsValidationError.invalidReasoningMaxTokens(reasoningMaxTokens)
+            }
+        }
     }
 }
 
@@ -401,6 +407,8 @@ public enum ModelSettingsValidationError: Error, Sendable, LocalizedError {
             "Invalid minP \(value): must be a finite number between 0.0 and 1.0"
         case let .invalidRepetitionPenalty(value):
             "Invalid repetitionPenalty \(value): must be a finite number >= 0.0"
+        case let .invalidReasoningMaxTokens(value):
+            "Invalid reasoning maxTokens \(value): must be greater than 0"
         }
     }
 
@@ -427,6 +435,9 @@ public enum ModelSettingsValidationError: Error, Sendable, LocalizedError {
 
     /// Repetition penalty must be a finite number >= 0.0.
     case invalidRepetitionPenalty(Double)
+
+    /// Reasoning max tokens must be greater than 0.
+    case invalidReasoningMaxTokens(Int)
 }
 
 // MARK: - ToolChoice

--- a/Sources/Swarm/Core/ReasoningConfig.swift
+++ b/Sources/Swarm/Core/ReasoningConfig.swift
@@ -1,0 +1,61 @@
+// ReasoningConfig.swift
+// Swarm Framework
+//
+// Swarm-level mirror of Conduit's ReasoningConfig. Lives at the Swarm boundary
+// so consumers don't need to depend on Conduit types directly. Translated to
+// Conduit's ReasoningConfig at the ConduitInferenceProvider boundary.
+
+import Foundation
+
+/// Reasoning effort level for models that support extended thinking / chain-of-
+/// thought reasoning (e.g. OpenAI o-series, OpenRouter `:thinking` variants).
+///
+/// Maps directly to Conduit's `ReasoningEffort`. Anthropic uses a separate
+/// `ThinkingConfig` mechanism not covered by this enum.
+public enum ReasoningEffort: String, Sendable, Hashable, Codable, CaseIterable {
+    /// Maximum reasoning time.
+    case xhigh
+    /// Extensive reasoning.
+    case high
+    /// Balanced reasoning.
+    case medium
+    /// Light reasoning.
+    case low
+    /// Very brief reasoning.
+    case minimal
+}
+
+/// Configuration for extended thinking / reasoning mode.
+///
+/// Use `effort` for providers that accept a qualitative level (OpenAI o1,
+/// OpenRouter `:thinking`). Use `maxTokens` to allocate a token budget
+/// directly. Use `enabled` for simple on/off providers (e.g. some o1 endpoints).
+/// Use `exclude` to suppress reasoning details from the response payload.
+///
+/// Mirrors Conduit's `ReasoningConfig` (Vendor/Conduit/Sources/Conduit/Core/Types/GenerateConfig.swift)
+/// so Swarm consumers don't import Conduit directly.
+public struct ReasoningConfig: Sendable, Hashable, Codable {
+    /// Reasoning effort level (qualitative).
+    public var effort: ReasoningEffort?
+
+    /// Maximum tokens for reasoning. Alternative to `effort`.
+    public var maxTokens: Int?
+
+    /// Whether to exclude reasoning details from the response.
+    public var exclude: Bool?
+
+    /// Whether reasoning is enabled. Used by simple-flag providers.
+    public var enabled: Bool?
+
+    public init(
+        effort: ReasoningEffort? = nil,
+        maxTokens: Int? = nil,
+        exclude: Bool? = nil,
+        enabled: Bool? = nil
+    ) {
+        self.effort = effort
+        self.maxTokens = maxTokens
+        self.exclude = exclude
+        self.enabled = enabled
+    }
+}

--- a/Sources/Swarm/Core/ReasoningConfig.swift
+++ b/Sources/Swarm/Core/ReasoningConfig.swift
@@ -23,6 +23,12 @@ public enum ReasoningEffort: String, Sendable, Hashable, Codable, CaseIterable {
     case low
     /// Very brief reasoning.
     case minimal
+    /// No reasoning — standard generation. Use this to explicitly
+    /// disable reasoning when the base/provider config has it enabled;
+    /// `nil` means "preserve base config", which can't override an
+    /// inherited reasoning setting. Mirrors Conduit's `ReasoningEffort.none`,
+    /// which serializes as `effort: "none"` on the wire.
+    case none
 }
 
 /// Configuration for extended thinking / reasoning mode.

--- a/Sources/Swarm/Providers/Conduit/ConduitInferenceProvider.swift
+++ b/Sources/Swarm/Providers/Conduit/ConduitInferenceProvider.swift
@@ -498,11 +498,28 @@ struct ConduitInferenceProvider<Provider: TextGenerator>: InferenceProvider,
             updated = updated.responseFormat(try Self.conduitResponseFormat(from: structuredOutput.format))
         }
 
+        if let reasoning = options.reasoning {
+            updated = updated.reasoning(Self.conduitReasoning(from: reasoning))
+        }
+
         if let providerSettings = options.providerSettings, !providerSettings.isEmpty {
             updated = try applyProviderRuntimeSettings(providerSettings, to: updated)
         }
 
         return updated
+    }
+
+    /// Translates Swarm's `ReasoningConfig` to Conduit's matching type.
+    ///
+    /// Swarm keeps its own mirror so consumers don't import Conduit directly;
+    /// the translation lives here at the provider boundary.
+    private static func conduitReasoning(from reasoning: ReasoningConfig) -> ConduitAdvanced.ReasoningConfig {
+        ConduitAdvanced.ReasoningConfig(
+            effort: reasoning.effort.flatMap { ConduitAdvanced.ReasoningEffort(rawValue: $0.rawValue) },
+            maxTokens: reasoning.maxTokens,
+            exclude: reasoning.exclude,
+            enabled: reasoning.enabled
+        )
     }
 
     private func applyProviderRuntimeSettings(

--- a/Tests/SwarmTests/Core/AgentConfigurationInferenceOptionsTests.swift
+++ b/Tests/SwarmTests/Core/AgentConfigurationInferenceOptionsTests.swift
@@ -80,6 +80,20 @@ struct AgentConfigurationInferenceOptionsTests {
         #expect(config.inferenceOptions.reasoning == nil)
     }
 
+    @Test("ReasoningEffort.none mirrors Conduit and is distinct from nil")
+    func reasoningEffortNoneIsExpressible() {
+        // Regression for PR #83 Codex feedback: callers need a way to
+        // explicitly disable reasoning when the base/provider config has
+        // it on. `nil` means "preserve base"; `.none` means "off".
+        let reasoning = ReasoningConfig(effort: .none)
+        let settings = ModelSettings().reasoning(reasoning)
+        let config = AgentConfiguration.default.modelSettings(settings)
+
+        #expect(config.inferenceOptions.reasoning?.effort == .none)
+        #expect(ReasoningEffort.none.rawValue == "none",
+                "raw value must match Conduit's ReasoningEffort.none for the bridge to round-trip")
+    }
+
     @Test("Context mode strict4k overrides adaptive profile")
     func strict4kContextModeUsesStrictProfile() {
         let config = AgentConfiguration.default

--- a/Tests/SwarmTests/Core/AgentConfigurationInferenceOptionsTests.swift
+++ b/Tests/SwarmTests/Core/AgentConfigurationInferenceOptionsTests.swift
@@ -61,6 +61,25 @@ struct AgentConfigurationInferenceOptionsTests {
         #expect(options.providerSettings == nil)
     }
 
+    @Test("ModelSettings reasoning config propagates to InferenceOptions")
+    func reasoningConfigPropagation() {
+        let reasoning = ReasoningConfig(effort: .low, maxTokens: 4096, exclude: true)
+        let settings = ModelSettings().reasoning(reasoning)
+        let config = AgentConfiguration.default.modelSettings(settings)
+
+        let options = config.inferenceOptions
+        #expect(options.reasoning?.effort == .low)
+        #expect(options.reasoning?.maxTokens == 4096)
+        #expect(options.reasoning?.exclude == true)
+        #expect(options.reasoning?.enabled == nil)
+    }
+
+    @Test("Reasoning is nil when model settings absent")
+    func reasoningNilWithoutModelSettings() {
+        let config = AgentConfiguration.default
+        #expect(config.inferenceOptions.reasoning == nil)
+    }
+
     @Test("Context mode strict4k overrides adaptive profile")
     func strict4kContextModeUsesStrictProfile() {
         let config = AgentConfiguration.default

--- a/Tests/SwarmTests/Core/ModelSettingsTests+Validation.swift
+++ b/Tests/SwarmTests/Core/ModelSettingsTests+Validation.swift
@@ -107,6 +107,31 @@ struct ModelSettingsValidationTests {
         }
     }
 
+    @Test("Valid reasoning maxTokens positive value")
+    func validReasoningMaxTokens() throws {
+        let settings = ModelSettings()
+            .reasoning(ReasoningConfig(maxTokens: 1000))
+        try settings.validate()
+    }
+
+    @Test("Invalid reasoning maxTokens zero throws")
+    func invalidReasoningMaxTokensZero() {
+        let settings = ModelSettings()
+            .reasoning(ReasoningConfig(maxTokens: 0))
+        #expect(throws: ModelSettingsValidationError.self) {
+            try settings.validate()
+        }
+    }
+
+    @Test("Invalid reasoning maxTokens negative throws")
+    func invalidReasoningMaxTokensNegative() {
+        let settings = ModelSettings()
+            .reasoning(ReasoningConfig(maxTokens: -100))
+        #expect(throws: ModelSettingsValidationError.self) {
+            try settings.validate()
+        }
+    }
+
     @Test("Valid frequencyPenalty at lower bound")
     func validFrequencyPenaltyLowerBound() throws {
         let settings = ModelSettings().frequencyPenalty(-2.0)
@@ -363,7 +388,8 @@ struct ModelSettingsValidationErrorTests {
             .invalidMaxTokens(-1),
             .invalidFrequencyPenalty(3.0),
             .invalidPresencePenalty(-3.0),
-            .invalidMinP(2.0)
+            .invalidMinP(2.0),
+            .invalidReasoningMaxTokens(0)
         ]
 
         for error in errors {

--- a/Tests/SwarmTests/Core/ModelSettingsTests.swift
+++ b/Tests/SwarmTests/Core/ModelSettingsTests.swift
@@ -252,6 +252,45 @@ struct ModelSettingsMergeTests {
 
         #expect(merged.providerSettings?["key"] == .string("value"))
     }
+
+    // MARK: - Reasoning merge (PR #83 Codex feedback)
+
+    @Test("Merge preserves reasoning from base when override has none")
+    func mergePreservesBaseReasoning() throws {
+        let base = ModelSettings()
+            .reasoning(ReasoningConfig(effort: .high, maxTokens: 4096))
+        let overrides = ModelSettings().temperature(0.5)
+
+        let merged = try base.merged(with: overrides)
+
+        #expect(merged.reasoning?.effort == .high)
+        #expect(merged.reasoning?.maxTokens == 4096)
+        #expect(merged.temperature == 0.5)
+    }
+
+    @Test("Merge prefers override reasoning over base")
+    func mergePrefersOverrideReasoning() throws {
+        let base = ModelSettings()
+            .reasoning(ReasoningConfig(effort: .low))
+        let overrides = ModelSettings()
+            .reasoning(ReasoningConfig(effort: .xhigh, maxTokens: 8192))
+
+        let merged = try base.merged(with: overrides)
+
+        #expect(merged.reasoning?.effort == .xhigh)
+        #expect(merged.reasoning?.maxTokens == 8192)
+    }
+
+    @Test("Merge keeps reasoning from override when base has none")
+    func mergeAddsOverrideReasoning() throws {
+        let base = ModelSettings().temperature(0.7)
+        let overrides = ModelSettings()
+            .reasoning(ReasoningConfig(effort: .medium))
+
+        let merged = try base.merged(with: overrides)
+
+        #expect(merged.reasoning?.effort == .medium)
+    }
 }
 
 // MARK: - ModelSettingsCodableTests


### PR DESCRIPTION
## Summary

Conduit fully supports `ReasoningConfig` ([Sources/Conduit/Core/Types/GenerateConfig.swift](https://github.com/christopherkarani/Conduit/blob/main/Sources/Conduit/Core/Types/GenerateConfig.swift)) with `effort` / `maxTokens` / `enabled` / `exclude` knobs, and the OpenAI provider serializes it as the `reasoning` body field. But Swarm's factories (`ConduitProviderSelection.openRouter` / `.openAI`) never propagate it, so consumers can't pass reasoning controls through to reasoning-capable models (gpt-5, o-series, OpenRouter `:thinking` variants).

Without this, reasoning models run unbounded — production transcripts on our side showed gpt-5 consuming 800-1000 reasoning tokens per call returning `response_bytes=0` and hitting agent max iterations. The OpenRouter docs flag this as the documented failure mode for reasoning models without bounded effort: https://openrouter.ai/docs/guides/best-practices/reasoning-tokens.

## Changes

- New `Sources/Swarm/Core/ReasoningConfig.swift` — Swarm-level mirror of Conduit's `ReasoningConfig` + `ReasoningEffort`. Mirroring keeps Swarm consumers free of a direct Conduit-types import; the translation lives at the `ConduitInferenceProvider` boundary.
- `ModelSettings.reasoning: ReasoningConfig?` — added to the existing `@Builder` struct + initializer.
- `InferenceOptions.reasoning: ReasoningConfig?` — same, threaded through.
- `AgentConfiguration+InferenceOptions.swift` — bridge passes `settings.reasoning` into `InferenceOptions`.
- `ConduitInferenceProvider.apply(options:to:)` — translates `Swarm.ReasoningConfig` → `ConduitAdvanced.ReasoningConfig` and calls Conduit's `GenerateConfig.reasoning(_:)` builder.

Tests in `AgentConfigurationInferenceOptionsTests` exercise the propagation (settings → options → config) and the absent-settings fallback.

## Behavior

```swift
let settings = ModelSettings()
    .reasoning(ReasoningConfig(effort: .low, maxTokens: 4096))
let config = AgentConfiguration.default.modelSettings(settings)
// config.inferenceOptions.reasoning.effort == .low
// → translates to GenerateConfig.reasoning at provider apply time
```

No behavior change when `reasoning` is unset.

## Compatibility

- Source-compatible: all existing call sites continue to work unchanged.
- Conduit pin in this PR is unchanged (still 0.3.14); the `ReasoningConfig` types this PR uses have been in Conduit since 0.3.x.

Discovered while building an agent pipeline on Swarm; happy to adjust the API shape (e.g. if you'd prefer to import Conduit's `ReasoningConfig` directly rather than mirror it).