### PR TITLE
test(membrane): characterize MembraneAgentAdapterError code 1 + empty-args path

### DIFF
--- a/Tests/SwarmTests/MembraneIntegrationTests.swift
+++ b/Tests/SwarmTests/MembraneIntegrationTests.swift
@@ -161,6 +161,84 @@ struct MembraneIntegrationTests {
         #expect(dictionary["count"] as? Int == 42)
     }
 
+    // MARK: - one-8h1.10 characterization (OneWorkspace investigation)
+    //
+    // Manual gate transcript 2026-05-08T05:13Z saw `Tool 'Add_Tools' failed:
+    // ... (Swarm.MembraneAgentAdapterError error 1.)`. These tests prove
+    // what `error 1` actually means and how it's triggered, so callers
+    // (and forks consuming this adapter) can map the error correctly
+    // without a magic-number lookup.
+
+    @Test("Add_Tools called with missing tool_names argument throws invalidInternalToolArguments (`error 1`)")
+    func addToolsMissingArgsThrowsErrorCase1() async throws {
+        let adapter = DefaultMembraneAgentAdapter(
+            configuration: MembraneFeatureConfiguration(jitMinToolCount: 2, defaultJITLoadCount: 1)
+        )
+        await #expect(throws: MembraneAgentAdapterError.self) {
+            _ = try await adapter.handleInternalToolCall(
+                name: MembraneInternalToolName.addTools,
+                arguments: [:]  // No tool_names key at all.
+            )
+        }
+        // Empty array: same outcome (parseToolNames returns []).
+        await #expect(throws: MembraneAgentAdapterError.self) {
+            _ = try await adapter.handleInternalToolCall(
+                name: MembraneInternalToolName.addTools,
+                arguments: ["tool_names": .array([])]
+            )
+        }
+    }
+
+    @Test("membrane_load_tool_schema with missing or empty tool_name throws invalidInternalToolArguments")
+    func loadToolSchemaMissingArgThrowsErrorCase1() async throws {
+        let adapter = DefaultMembraneAgentAdapter(
+            configuration: MembraneFeatureConfiguration(jitMinToolCount: 2, defaultJITLoadCount: 1)
+        )
+        await #expect(throws: MembraneAgentAdapterError.self) {
+            _ = try await adapter.handleInternalToolCall(
+                name: MembraneInternalToolName.loadToolSchema,
+                arguments: [:]
+            )
+        }
+        await #expect(throws: MembraneAgentAdapterError.self) {
+            _ = try await adapter.handleInternalToolCall(
+                name: MembraneInternalToolName.loadToolSchema,
+                arguments: ["tool_name": .string("")]
+            )
+        }
+    }
+
+    @Test("MembraneAgentAdapterError.invalidInternalToolArguments is the second case (NSError code 1)")
+    func errorCaseOrdinalIsOne() {
+        // Swift bridges enum-with-payload to NSError using the case
+        // declaration order. unsupportedInternalTool is case 0,
+        // invalidInternalToolArguments is case 1. The 'error 1' string
+        // in production transcripts maps to invalidInternalToolArguments.
+        let error = MembraneAgentAdapterError.invalidInternalToolArguments(
+            name: "Add_Tools",
+            reason: "Missing required array argument: tool_names"
+        )
+        let nsError = error as NSError
+        #expect(nsError.code == 1)
+        // unsupportedInternalTool is the other case at code 0.
+        let other = MembraneAgentAdapterError.unsupportedInternalTool(name: "x")
+        let otherNS = other as NSError
+        #expect(otherNS.code == 0)
+    }
+
+    @Test("Add_Tools with valid tool_names succeeds and returns confirmation message")
+    func addToolsValidArgsSucceeds() async throws {
+        let adapter = DefaultMembraneAgentAdapter(
+            configuration: MembraneFeatureConfiguration(jitMinToolCount: 2, defaultJITLoadCount: 1)
+        )
+        let result = try await adapter.handleInternalToolCall(
+            name: MembraneInternalToolName.addTools,
+            arguments: ["tool_names": .array([.string("listDatabases"), .string("getSchemaModel")])]
+        )
+        #expect(result?.contains("listDatabases") == true)
+        #expect(result?.contains("getSchemaModel") == true)
+    }
+
     @Test("Default adapter checkpoint state roundtrips loaded tools")
     func defaultAdapterCheckpointRoundtrip() async throws {
         let adapter = DefaultMembraneAgentAdapter(


### PR DESCRIPTION
## Summary

Adds 4 characterization tests to `MembraneIntegrationTests` that pin down what `MembraneAgentAdapterError error 1` (the NSError-bridged form) actually means and how it's triggered. The tests don't change any production behavior — they document an existing assertion path that was previously undocumented.

## Why

Production transcripts elsewhere surface the bridged form as a string:

> Tool 'Add_Tools' failed: The operation couldn't be completed. (Swarm.MembraneAgentAdapterError error 1.)

Mapping `error 1` → `invalidInternalToolArguments` requires reading the enum source and counting case ordinal. These tests document the mapping as Swift assertions so future maintainers don't have to rediscover it.

## Tests added

- `errorCaseOrdinalIsOne` — asserts NSError code 1 = `invalidInternalToolArguments`, code 0 = `unsupportedInternalTool`. Catches future case reordering as a test failure rather than a silent runtime mapping change.
- `addToolsMissingArgsThrowsErrorCase1` — `Add_Tools` with `[:]` or `["tool_names": .array([])]` throws as expected.
- `loadToolSchemaMissingArgThrowsErrorCase1` — same for `membrane_load_tool_schema` with missing or empty `tool_name`.
- `addToolsValidArgsSucceeds` — companion happy-path: valid args → result string lists the loaded tools.

All 4 pass on top of upstream main, alongside the existing 7 tests in this suite.

## Note on the bug we were debugging

We hit `error 1` in production while building on Swarm + Conduit + a forked Anthropic provider. The investigation showed Membrane was correctly rejecting empty-args internal tool calls; the upstream cause was Conduit's pre-fix Anthropic input_schema serialization sending empty schemas to the model, so the model couldn't see the parameter contract. Conduit-side fix is at https://github.com/christopherkarani/Conduit/pull/57 (separate PR). Membrane itself was sound — these tests exist to make that conclusion debuggable next time.