### PR TITLE
Fix workspace memory layering

### DIFF
--- a/Sources/Swarm/Agents/Agent+Workspace.swift
+++ b/Sources/Swarm/Agents/Agent+Workspace.swift
@@ -15,12 +15,16 @@ public extension Agent {
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty }
             .joined(separator: "\n\n")
-        let workspaceMemory = workspace.map { WorkspaceMemory(workspace: $0, activatedSkills: []) }
+        let memory: (any Memory)? = if let workspace {
+            try Self.workspaceMemory(workspace: workspace, activatedSkills: [])
+        } else {
+            nil
+        }
         return try Agent(
             tools: builtTools,
             instructions: combinedInstructions,
             configuration: configuration,
-            memory: workspaceMemory,
+            memory: memory,
             inferenceProvider: inferenceProvider
         )
     }
@@ -47,13 +51,23 @@ public extension Agent {
             tools: filterTools(builtTools, using: skills),
             instructions: combinedInstructions,
             configuration: configuration.name(spec.title),
-            memory: WorkspaceMemory(workspace: workspace, activatedSkills: skills),
+            memory: try workspaceMemory(workspace: workspace, activatedSkills: skills),
             inferenceProvider: inferenceProvider
         )
     }
 }
 
 private extension Agent {
+    static func workspaceMemory(
+        workspace: AgentWorkspace,
+        activatedSkills: [WorkspaceSkill]
+    ) throws -> any Memory {
+        CompositeMemory([
+            try makeDefaultMemory(),
+            WorkspaceMemory(workspace: workspace, activatedSkills: activatedSkills),
+        ])
+    }
+
     static func filterTools(_ tools: [any AnyJSONTool], using skills: [WorkspaceSkill]) -> [any AnyJSONTool] {
         let constrainedSkillLists = skills
             .map(\.allowedTools)

--- a/Sources/Swarm/Agents/Agent.swift
+++ b/Sources/Swarm/Agents/Agent.swift
@@ -827,20 +827,17 @@ public struct Agent: AgentRuntime, Sendable {
             ?? (configuration.defaultTracingEnabled ? SwiftLogTracer(minimumLevel: .debug) : nil)
         let activeMemory = resolvedMemory()
         let lifecycleMemory = activeMemory as? any MemorySessionLifecycle
+        let trackedSessionMemory = activeMemory.flatMap(defaultSessionMemory)
         var defaultMemoryRunKey: ObjectIdentifier?
 
         if let session,
-           let activeMemory,
-           let defaultMemory
+           let trackedSessionMemory
         {
-            let activeMemoryObject = activeMemory as AnyObject
-            let defaultMemoryObject = defaultMemory as AnyObject
-            if activeMemoryObject === defaultMemoryObject {
-                let memoryKey = ObjectIdentifier(activeMemoryObject)
-                defaultMemoryRunKey = memoryKey
-                if try await Self.defaultMemorySessionTracker.beginRun(for: memoryKey, sessionID: session.sessionId) {
-                    await activeMemory.clear()
-                }
+            let trackedMemoryObject = trackedSessionMemory as AnyObject
+            let memoryKey = ObjectIdentifier(trackedMemoryObject)
+            defaultMemoryRunKey = memoryKey
+            if try await Self.defaultMemorySessionTracker.beginRun(for: memoryKey, sessionID: session.sessionId) {
+                await trackedSessionMemory.clear()
             }
         }
 
@@ -884,17 +881,9 @@ public struct Agent: AgentRuntime, Sendable {
             let replayTranscript = SwarmTranscript(memoryMessages: sessionHistory)
             try replayTranscript.validateReplayCompatibility()
 
-            // Seed memory with session history once (only if memory is empty and the memory allows it).
-            let importPolicy = activeMemory as? any MemorySessionImportPolicy
-            let allowsSessionSeeding = importPolicy?.allowsAutomaticSessionSeeding ?? true
-            if let activeMemory, allowsSessionSeeding, !sessionHistory.isEmpty, await activeMemory.isEmpty {
-                if let replayAware = activeMemory as? any MemorySessionReplayAware {
-                    await replayAware.importSessionHistory(sessionHistory)
-                } else {
-                    for message in sessionHistory {
-                        await activeMemory.add(message)
-                    }
-                }
+            // Seed memory with session history once when the memory is eligible.
+            if let activeMemory, session != nil {
+                await activeMemory.seedSessionHistoryIfNeeded(sessionHistory)
             }
 
             // Create user message for this turn
@@ -1108,7 +1097,23 @@ public struct Agent: AgentRuntime, Sendable {
         memory ?? AgentEnvironmentValues.current.memory ?? defaultMemory
     }
 
-    private static func makeDefaultMemory() throws -> any Memory {
+    private func defaultSessionMemory(from activeMemory: any Memory) -> (any Memory)? {
+        if let defaultMemory {
+            let activeObject = activeMemory as AnyObject
+            let defaultObject = defaultMemory as AnyObject
+            if activeObject === defaultObject {
+                return defaultMemory
+            }
+        }
+
+        if let trackingProvider = activeMemory as? any MemorySessionTrackingProvider {
+            return trackingProvider.trackedSessionMemory
+        }
+
+        return nil
+    }
+
+    static func makeDefaultMemory() throws -> any Memory {
         if SwarmRuntimeEnvironment.isRunningTests {
             let root = FileManager.default.temporaryDirectory
                 .appendingPathComponent("SwarmDefaultMemoryTests", isDirectory: true)

--- a/Sources/Swarm/Memory/CompositeMemory.swift
+++ b/Sources/Swarm/Memory/CompositeMemory.swift
@@ -1,0 +1,235 @@
+import Foundation
+
+/// A memory implementation that fans writes out to multiple memory layers and
+/// combines retrieved context from each layer.
+actor CompositeMemory: Memory, MemoryPromptDescriptor, MemorySessionLifecycle, MemorySessionReplayAware, MemoryRetrievalPolicyAware, MemorySessionImportPolicy, MemorySessionTrackingProvider, MemorySessionSeedControlling {
+    nonisolated let memoryPromptTitle: String
+    nonisolated let memoryPromptGuidance: String?
+    nonisolated let memoryPriority: MemoryPriorityHint
+    nonisolated let allowsAutomaticSessionSeeding: Bool
+    nonisolated let trackedSessionMemory: (any Memory)?
+
+    private let memories: [any Memory]
+    private let tokenEstimator: any TokenEstimator
+
+    init(
+        _ memories: [any Memory],
+        memoryPromptTitle: String = "Layered Memory Context",
+        memoryPromptGuidance: String? = "Use earlier memory sections first when context conflicts. Workspace context supplements, but does not replace, working and durable memory.",
+        memoryPriority: MemoryPriorityHint = .primary,
+        trackedSessionMemory: (any Memory)? = nil,
+        tokenEstimator: any TokenEstimator = CharacterBasedTokenEstimator.shared
+    ) {
+        self.memories = memories
+        self.memoryPromptTitle = memoryPromptTitle
+        self.memoryPromptGuidance = memoryPromptGuidance
+        self.memoryPriority = memoryPriority
+        self.tokenEstimator = tokenEstimator
+        self.trackedSessionMemory = trackedSessionMemory ?? memories.first { $0 is DefaultAgentMemory }
+        self.allowsAutomaticSessionSeeding = memories.contains(where: Self.allowsSessionSeeding)
+    }
+
+    var count: Int {
+        get async {
+            var total = 0
+            for memory in memories {
+                total += await memory.count
+            }
+            return total
+        }
+    }
+
+    var isEmpty: Bool {
+        get async {
+            for memory in memories where await !memory.isEmpty {
+                return false
+            }
+            return true
+        }
+    }
+
+    func add(_ message: MemoryMessage) async {
+        for memory in memories {
+            await memory.add(message)
+        }
+    }
+
+    func context(for query: String, tokenLimit: Int) async -> String {
+        await context(for: MemoryQuery(
+            text: query,
+            tokenLimit: tokenLimit,
+            maxItems: max(1, memories.count * 2),
+            maxItemTokens: max(1, tokenLimit)
+        ))
+    }
+
+    func context(for query: MemoryQuery) async -> String {
+        guard query.tokenLimit > 0, !memories.isEmpty else {
+            return ""
+        }
+
+        var layerContexts: [String] = []
+        for memory in memories {
+            let rawContext = await context(from: memory, query: query, tokenLimit: query.tokenLimit)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !rawContext.isEmpty else {
+                continue
+            }
+            layerContexts.append(rawContext)
+        }
+
+        return combine(layerContexts, tokenLimit: query.tokenLimit)
+    }
+
+    func allMessages() async -> [MemoryMessage] {
+        var messages: [MemoryMessage] = []
+        for memory in memories {
+            messages += await memory.allMessages()
+        }
+        return messages
+    }
+
+    func clear() async {
+        for memory in memories {
+            await memory.clear()
+        }
+    }
+
+    func beginMemorySession() async {
+        for memory in memories {
+            guard let lifecycleMemory = memory as? any MemorySessionLifecycle else {
+                continue
+            }
+            await lifecycleMemory.beginMemorySession()
+        }
+    }
+
+    func endMemorySession() async {
+        for memory in memories {
+            guard let lifecycleMemory = memory as? any MemorySessionLifecycle else {
+                continue
+            }
+            await lifecycleMemory.endMemorySession()
+        }
+    }
+
+    private func combine(_ layerContexts: [String], tokenLimit: Int) -> String {
+        guard !layerContexts.isEmpty else {
+            return ""
+        }
+
+        var sections: [String] = []
+        var usedTokens = 0
+        let separator = "\n\n"
+        let separatorTokens = tokenEstimator.estimateTokens(for: separator)
+
+        for (index, rawContext) in layerContexts.enumerated() {
+            let separatorBudget = sections.isEmpty ? 0 : separatorTokens
+            let availableTokens = tokenLimit - usedTokens - separatorBudget
+            guard availableTokens > 0 else {
+                break
+            }
+
+            let remainingLayers = max(1, layerContexts.count - index)
+            let layerLimit = max(1, availableTokens / remainingLayers)
+            let sectionTokens = tokenEstimator.estimateTokens(for: rawContext)
+            let section = sectionTokens <= layerLimit
+                ? rawContext
+                : truncate(rawContext, tokenLimit: layerLimit)
+            guard !section.isEmpty else {
+                continue
+            }
+
+            let additionalTokens = tokenEstimator.estimateTokens(for: section) + separatorBudget
+            if usedTokens + additionalTokens <= tokenLimit {
+                sections.append(section)
+                usedTokens += additionalTokens
+                continue
+            }
+
+            guard sections.isEmpty else {
+                break
+            }
+
+            let truncated = truncate(rawContext, tokenLimit: availableTokens)
+            if !truncated.isEmpty {
+                sections.append(truncated)
+            }
+            break
+        }
+
+        return sections.joined(separator: separator)
+    }
+
+    func shouldImportSessionHistory() async -> Bool {
+        for memory in memories where Self.allowsSessionSeeding(memory) {
+            if await memory.isEmpty {
+                return true
+            }
+        }
+        return false
+    }
+
+    func importSessionHistory(_ messages: [MemoryMessage]) async {
+        guard !messages.isEmpty else {
+            return
+        }
+
+        for memory in memories where Self.allowsSessionSeeding(memory) {
+            guard await memory.isEmpty else {
+                continue
+            }
+            if let replayAware = memory as? any MemorySessionReplayAware {
+                await replayAware.importSessionHistory(messages)
+            } else {
+                for message in messages {
+                    await memory.add(message)
+                }
+            }
+        }
+    }
+
+    private func context(
+        from memory: any Memory,
+        query: MemoryQuery,
+        tokenLimit: Int
+    ) async -> String {
+        if let policyAwareMemory = memory as? any MemoryRetrievalPolicyAware {
+            return await policyAwareMemory.context(for: MemoryQuery(
+                text: query.text,
+                tokenLimit: tokenLimit,
+                maxItems: query.maxItems,
+                maxItemTokens: min(query.maxItemTokens, tokenLimit)
+            ))
+        }
+
+        return await memory.context(for: query.text, tokenLimit: tokenLimit)
+    }
+
+    private func truncate(_ text: String, tokenLimit: Int) -> String {
+        guard tokenLimit > 0 else {
+            return ""
+        }
+        guard tokenEstimator.estimateTokens(for: text) > tokenLimit else {
+            return text
+        }
+
+        var result = ""
+        for word in text.split(whereSeparator: \.isWhitespace) {
+            let candidate = result.isEmpty ? String(word) : "\(result) \(word)"
+            if tokenEstimator.estimateTokens(for: candidate) > tokenLimit {
+                break
+            }
+            result = candidate
+        }
+
+        if result.isEmpty {
+            return String(text.prefix(max(1, tokenLimit * 4)))
+        }
+        return "\(result)..."
+    }
+
+    private static func allowsSessionSeeding(_ memory: any Memory) -> Bool {
+        (memory as? any MemorySessionImportPolicy)?.allowsAutomaticSessionSeeding ?? true
+    }
+}

--- a/Sources/Swarm/Memory/MemorySessionLifecycle.swift
+++ b/Sources/Swarm/Memory/MemorySessionLifecycle.swift
@@ -18,3 +18,48 @@ public protocol MemorySessionReplayAware: Memory {
     /// Imports a batch of session history messages using memory-specific logic.
     func importSessionHistory(_ messages: [MemoryMessage]) async
 }
+
+public extension Memory {
+    /// Seeds prior session messages into memory when the memory is eligible and still needs replay.
+    func seedSessionHistoryIfNeeded(_ messages: [MemoryMessage]) async {
+        guard !messages.isEmpty else {
+            return
+        }
+
+        let importPolicy = self as? any MemorySessionImportPolicy
+        guard importPolicy?.allowsAutomaticSessionSeeding ?? true else {
+            return
+        }
+
+        let shouldSeed = if let seedController = self as? any MemorySessionSeedControlling {
+            await seedController.shouldImportSessionHistory()
+        } else {
+            await isEmpty
+        }
+        guard shouldSeed else {
+            return
+        }
+
+        if let replayAware = self as? any MemorySessionReplayAware {
+            await replayAware.importSessionHistory(messages)
+        } else {
+            for message in messages {
+                await add(message)
+            }
+        }
+    }
+}
+
+/// Internal hook for composite memories that contain the agent's default memory
+/// as one layer. The agent runtime uses this to preserve the default memory's
+/// per-session clearing and serialization behavior without clearing static
+/// memory layers such as workspace context.
+protocol MemorySessionTrackingProvider: Sendable {
+    var trackedSessionMemory: (any Memory)? { get }
+}
+
+/// Internal hook for memories that need per-layer control over when session
+/// replay should be imported.
+protocol MemorySessionSeedControlling: Memory {
+    func shouldImportSessionHistory() async -> Bool
+}

--- a/Sources/SwarmMacros/AgentMacro.swift
+++ b/Sources/SwarmMacros/AgentMacro.swift
@@ -181,15 +181,9 @@ public struct AgentMacro: MemberMacro, ExtensionMacro {
 
                             // Store in memory (for AI context) if available
                             if let mem = activeMemory {
-                                // Seed session history only once for a fresh memory instance.
-                                if session != nil, await mem.isEmpty, !sessionHistory.isEmpty {
-                                    if let replayAware = mem as? any MemorySessionReplayAware {
-                                        await replayAware.importSessionHistory(sessionHistory)
-                                    } else {
-                                        for msg in sessionHistory {
-                                            await mem.add(msg)
-                                        }
-                                    }
+                                // Seed session history only once when the memory is eligible.
+                                if session != nil {
+                                    await mem.seedSessionHistoryIfNeeded(sessionHistory)
                                 }
                                 await mem.add(userMessage)
                             }

--- a/Tests/SwarmMacrosTests/AgentMacroTests.swift
+++ b/Tests/SwarmMacrosTests/AgentMacroTests.swift
@@ -129,15 +129,9 @@ final class AgentMacroTests: XCTestCase {
 
                             // Store in memory (for AI context) if available
                             if let mem = activeMemory {
-                                // Seed session history only once for a fresh memory instance.
-                                if session != nil, await mem.isEmpty, !sessionHistory.isEmpty {
-                                    if let replayAware = mem as? any MemorySessionReplayAware {
-                                        await replayAware.importSessionHistory(sessionHistory)
-                                    } else {
-                                        for msg in sessionHistory {
-                                            await mem.add(msg)
-                                        }
-                                    }
+                                // Seed session history only once when the memory is eligible.
+                                if session != nil {
+                                    await mem.seedSessionHistoryIfNeeded(sessionHistory)
                                 }
                                 await mem.add(userMessage)
                             }
@@ -429,15 +423,9 @@ final class AgentMacroTests: XCTestCase {
 
                             // Store in memory (for AI context) if available
                             if let mem = activeMemory {
-                                // Seed session history only once for a fresh memory instance.
-                                if session != nil, await mem.isEmpty, !sessionHistory.isEmpty {
-                                    if let replayAware = mem as? any MemorySessionReplayAware {
-                                        await replayAware.importSessionHistory(sessionHistory)
-                                    } else {
-                                        for msg in sessionHistory {
-                                            await mem.add(msg)
-                                        }
-                                    }
+                                // Seed session history only once when the memory is eligible.
+                                if session != nil {
+                                    await mem.seedSessionHistoryIfNeeded(sessionHistory)
                                 }
                                 await mem.add(userMessage)
                             }

--- a/Tests/SwarmTests/Macros/AgentActorMacroConformanceTests.swift
+++ b/Tests/SwarmTests/Macros/AgentActorMacroConformanceTests.swift
@@ -73,4 +73,52 @@ struct AgentActorMacroConformanceTests {
 
         #expect(agent.tools.contains { $0.name == "echo" })
     }
+
+    @Test("Generated run seeds replay into eligible composite memory layers")
+    func generatedRunSeedsReplayIntoCompositeMemoryLayer() async throws {
+        let seedable = ConversationMemory(maxMessages: 20)
+        let staticMemory = StaticMacroContextMemory(context: "Static context includes the garnet-anchor marker.")
+        let composite = CompositeMemory([seedable, staticMemory])
+        let session = InMemorySession(sessionId: "macro-composite-memory")
+        try await session.addItems([
+            .user("Replay history includes the prism-session marker.")
+        ])
+
+        let agent = MacroEchoAgent(memory: composite)
+
+        _ = try await agent.run("current turn", session: session)
+
+        let seedableContext = await seedable.context(for: "prism current", tokenLimit: 1_000)
+        #expect(seedableContext.contains("prism-session marker"))
+        #expect(seedableContext.contains("current turn"))
+    }
+}
+
+private actor StaticMacroContextMemory: Memory, MemorySessionImportPolicy {
+    nonisolated let allowsAutomaticSessionSeeding = false
+
+    private let contextText: String
+
+    init(context: String) {
+        self.contextText = context
+    }
+
+    var count: Int { get async { 1 } }
+    var isEmpty: Bool { get async { false } }
+
+    func add(_ message: MemoryMessage) async {
+        _ = message
+    }
+
+    func context(for query: String, tokenLimit: Int) async -> String {
+        _ = query
+        _ = tokenLimit
+        return contextText
+    }
+
+    func allMessages() async -> [MemoryMessage] {
+        []
+    }
+
+    func clear() async {}
 }

--- a/Tests/SwarmTests/Memory/MemoryIngestionPolicyTests.swift
+++ b/Tests/SwarmTests/Memory/MemoryIngestionPolicyTests.swift
@@ -61,4 +61,103 @@ struct MemoryIngestionPolicyTests {
         #expect(seededUserCount == 1)
         #expect(seededAssistantCount == 1)
     }
+
+    @Test("Composite memory seeds only eligible child memories")
+    func compositeMemoryRespectsChildImportPolicy() async throws {
+        let session = InMemorySession(sessionId: "composite-policy")
+        try await session.addItems([
+            .user("composite-seed-user"),
+            .assistant("composite-seed-assistant")
+        ])
+
+        let seedable = MockAgentMemory()
+        let optOut = OptOutMemory()
+        let composite = CompositeMemory([seedable, optOut])
+
+        let provider = MockInferenceProvider(responses: ["ok"])
+        let agent = try Agent(
+            memory: composite,
+            inferenceProvider: provider
+        )
+
+        _ = try await agent.run("turn", session: session)
+
+        let seedableMessages = await seedable.addCalls.map(\.content)
+        let optOutMessages = await optOut.addCalls.map(\.content)
+
+        #expect(seedableMessages.contains("composite-seed-user"))
+        #expect(seedableMessages.contains("composite-seed-assistant"))
+        #expect(optOutMessages.isEmpty)
+    }
+
+    @Test("Composite memory gives a sole matching layer the full token budget")
+    func compositeMemoryDoesNotReserveBudgetForNoHitLayers() async throws {
+        let matching = RecordingContextMemory(context: "primary context includes the obsidian-tail marker.")
+        let noHit = RecordingContextMemory(context: "", isEmpty: false)
+        let composite = CompositeMemory([matching, noHit])
+
+        let context = await composite.context(for: "obsidian", tokenLimit: 120)
+
+        #expect(context.contains("obsidian-tail marker"))
+        #expect(await matching.observedTokenLimits == [120])
+        #expect(await noHit.observedTokenLimits == [120])
+    }
+}
+
+private actor OptOutMemory: Memory, MemorySessionImportPolicy {
+    nonisolated let allowsAutomaticSessionSeeding = false
+    private(set) var addCalls: [MemoryMessage] = []
+
+    var count: Int { get async { addCalls.count } }
+    var isEmpty: Bool { get async { addCalls.isEmpty } }
+
+    func add(_ message: MemoryMessage) async {
+        addCalls.append(message)
+    }
+
+    func context(for query: String, tokenLimit: Int) async -> String {
+        _ = query
+        _ = tokenLimit
+        return addCalls.map(\.formattedContent).joined(separator: "\n")
+    }
+
+    func allMessages() async -> [MemoryMessage] {
+        addCalls
+    }
+
+    func clear() async {
+        addCalls.removeAll()
+    }
+}
+
+private actor RecordingContextMemory: Memory {
+    private let contextText: String
+    private let empty: Bool
+    private(set) var observedTokenLimits: [Int] = []
+
+    init(context: String, isEmpty: Bool = true) {
+        self.contextText = context
+        self.empty = isEmpty
+    }
+
+    var count: Int { get async { empty ? 0 : 1 } }
+    var isEmpty: Bool { get async { empty } }
+
+    func add(_ message: MemoryMessage) async {
+        _ = message
+    }
+
+    func context(for query: String, tokenLimit: Int) async -> String {
+        _ = query
+        observedTokenLimits.append(tokenLimit)
+        return contextText
+    }
+
+    func allMessages() async -> [MemoryMessage] {
+        []
+    }
+
+    func clear() async {
+        observedTokenLimits.removeAll()
+    }
 }

--- a/Tests/SwarmTests/Workspace/AgentWorkspaceTests.swift
+++ b/Tests/SwarmTests/Workspace/AgentWorkspaceTests.swift
@@ -106,6 +106,123 @@ struct AgentWorkspaceTests {
         #expect(prompt?.contains("Local agent instructions.") == true)
     }
 
+    @Test("Workspace agents layer workspace context with default memory")
+    func workspaceAgentsLayerWorkspaceContextWithDefaultMemory() async throws {
+        let workspaceRoot = try makeWorkspaceRoot()
+        defer { try? FileManager.default.removeItem(at: workspaceRoot) }
+
+        let workspace = try AgentWorkspace(
+            bundleRoot: workspaceRoot,
+            writableRoot: workspaceRoot.appendingPathComponent("Writable", isDirectory: true),
+            indexCacheRoot: workspaceRoot.appendingPathComponent("Cache", isDirectory: true)
+        )
+        _ = try await workspace.makeWriter().recordFact(
+            title: "Refund Window",
+            content: "Workspace refunds use the blue-lantern refund marker."
+        )
+
+        let agent = try Agent.onDevice(
+            "Local agent instructions.",
+            workspace: workspace,
+            configuration: AgentConfiguration(name: "workspace-memory", defaultTracingEnabled: false),
+            inferenceProvider: MockInferenceProvider(responses: ["ok"])
+        )
+
+        #expect(agent.memory != nil)
+        guard let memory = agent.memory else { return }
+
+        await memory.add(.user("Default memory remembers the ember-archive marker."))
+
+        let context = await memory.context(for: "refund ember archive", tokenLimit: 600)
+        #expect(context.contains("blue-lantern refund marker"))
+        #expect(context.contains("ember-archive marker"))
+    }
+
+    @Test("Workspace agents seed session history into the default memory layer")
+    func workspaceAgentsSeedSessionHistoryIntoDefaultMemoryLayer() async throws {
+        let workspaceRoot = try makeWorkspaceRoot()
+        defer { try? FileManager.default.removeItem(at: workspaceRoot) }
+
+        let workspace = try AgentWorkspace(
+            bundleRoot: workspaceRoot,
+            writableRoot: workspaceRoot.appendingPathComponent("Writable", isDirectory: true),
+            indexCacheRoot: workspaceRoot.appendingPathComponent("Cache", isDirectory: true)
+        )
+        _ = try await workspace.makeWriter().recordFact(
+            title: "Workspace Fact",
+            content: "Workspace memory includes the copper-lake marker."
+        )
+
+        let session = InMemorySession(sessionId: "workspace-seed")
+        try await session.addItems([
+            .user("Session history includes the violet-signal marker.")
+        ])
+
+        let agent = try Agent.onDevice(
+            "Local agent instructions.",
+            workspace: workspace,
+            configuration: AgentConfiguration(name: "workspace-seed", defaultTracingEnabled: false),
+            inferenceProvider: MockInferenceProvider(responses: ["ok"])
+        )
+
+        _ = try await agent.run("Use the remembered context.", session: session)
+
+        guard let memory = agent.memory else {
+            Issue.record("workspace agent should expose layered memory")
+            return
+        }
+
+        let context = await memory.context(for: "copper violet signal", tokenLimit: 800)
+        #expect(context.contains("copper-lake marker"))
+        #expect(context.contains("violet-signal marker"))
+    }
+
+    @Test("Workspace agents isolate default memory when switching sessions")
+    func workspaceAgentsIsolateDefaultMemoryWhenSwitchingSessions() async throws {
+        let workspaceRoot = try makeWorkspaceRoot()
+        defer { try? FileManager.default.removeItem(at: workspaceRoot) }
+
+        let workspace = try AgentWorkspace(
+            bundleRoot: workspaceRoot,
+            writableRoot: workspaceRoot.appendingPathComponent("Writable", isDirectory: true),
+            indexCacheRoot: workspaceRoot.appendingPathComponent("Cache", isDirectory: true)
+        )
+        _ = try await workspace.makeWriter().recordFact(
+            title: "Workspace Fact",
+            content: "Workspace memory includes the silver-branch marker."
+        )
+
+        let firstSession = InMemorySession(sessionId: "workspace-session-a")
+        try await firstSession.addItems([
+            .user("First session includes the amber-session marker.")
+        ])
+
+        let secondSession = InMemorySession(sessionId: "workspace-session-b")
+        try await secondSession.addItems([
+            .user("Second session includes the cobalt-session marker.")
+        ])
+
+        let agent = try Agent.onDevice(
+            "Local agent instructions.",
+            workspace: workspace,
+            configuration: AgentConfiguration(name: "workspace-switch", defaultTracingEnabled: false),
+            inferenceProvider: MockInferenceProvider(responses: ["first", "second"])
+        )
+
+        _ = try await agent.run("First turn.", session: firstSession)
+        _ = try await agent.run("Second turn.", session: secondSession)
+
+        guard let memory = agent.memory else {
+            Issue.record("workspace agent should expose layered memory")
+            return
+        }
+
+        let context = await memory.context(for: "amber cobalt silver branch", tokenLimit: 800)
+        #expect(context.contains("silver-branch marker"))
+        #expect(context.contains("cobalt-session marker"))
+        #expect(!context.contains("amber-session marker"))
+    }
+
     @Test("Agent.spec uses listed SKILL.md content as retrieved context")
     func agentSpecUsesSkillContentAsRetrievedContext() async throws {
         let workspaceRoot = try makeWorkspaceRoot()

--- a/docs/reference/api-catalog.md
+++ b/docs/reference/api-catalog.md
@@ -3,7 +3,7 @@
 Generated from `Sources/Swarm/` on 2026-04-30.
 
 - Scope: all `.swift` files under `Sources/Swarm/`, excluding `Internal/GraphRuntime/`
-- Source files scanned: 153
+- Source files scanned: 154
 - Public/open symbols cataloged: 2423
 
 ## 1. Swarm (entry point)


### PR DESCRIPTION
## Summary
- Fixes SWARM-AUDIT-001 by layering workspace memory with the default memory instead of replacing it.
- Adds an internal CompositeMemory for workspace/runtime composition with child-aware session replay, import-policy handling, lifecycle forwarding, and default-memory session tracking.
- Updates @AgentActor-generated agents to use the same memory replay helper as the handwritten Agent runtime.
- Keeps CompositeMemory internal to avoid changing the public API surface and updates the API catalog source-file count.

## Verification
- swift test --filter 'AgentActorMacroConformanceTests|AgentMacroTests|AgentWorkspaceTests|MemoryIngestionPolicyTests|ContextCoreDefaultMemoryTests|DocumentationFreshnessTests'
- swift build
- git diff --check
- swift test
- Code review agent: APPROVE, no blocking findings