### PR TITLE
Fix workspace skill tool allowlist union

### DIFF
--- a/Sources/Swarm/Agents/Agent+Workspace.swift
+++ b/Sources/Swarm/Agents/Agent+Workspace.swift
@@ -63,9 +63,7 @@ private extension Agent {
             return tools
         }
 
-        let allowedToolNames = constrainedSkillLists.dropFirst().reduce(into: Set(constrainedSkillLists[0])) { partialResult, next in
-            partialResult.formIntersection(next)
-        }
+        let allowedToolNames = Set(constrainedSkillLists.flatMap(\.self))
 
         return tools.filter { allowedToolNames.contains($0.name) }
     }

--- a/Tests/SwarmTests/Workspace/AgentWorkspaceTests.swift
+++ b/Tests/SwarmTests/Workspace/AgentWorkspaceTests.swift
@@ -155,6 +155,68 @@ struct AgentWorkspaceTests {
         #expect(prompt?.contains("refund window") == true)
     }
 
+    @Test("Agent.spec unions constrained tool allowlists across skills")
+    func agentSpecUnionsConstrainedToolAllowlists() throws {
+        let workspaceRoot = try makeWorkspaceRoot()
+        defer { try? FileManager.default.removeItem(at: workspaceRoot) }
+
+        try writeFile(
+            at: workspaceRoot.appendingPathComponent(".swarm/agents/support.md"),
+            contents: """
+            ---
+            schema_version: 1
+            id: support
+            title: Support
+            skills:
+              - refunds
+              - tickets
+            revision: 1
+            updated_at: 2026-05-13T00:00:00Z
+            ---
+            You are the support agent.
+            """
+        )
+        try writeFile(
+            at: workspaceRoot.appendingPathComponent(".swarm/skills/refunds/SKILL.md"),
+            contents: """
+            ---
+            name: refunds
+            description: Refund support
+            allowed-tools:
+              - refund_lookup
+            ---
+            Use refund_lookup for refund status.
+            """
+        )
+        try writeFile(
+            at: workspaceRoot.appendingPathComponent(".swarm/skills/tickets/SKILL.md"),
+            contents: """
+            ---
+            name: tickets
+            description: Ticket support
+            allowed-tools:
+              - ticket_create
+            ---
+            Use ticket_create for support tickets.
+            """
+        )
+
+        let workspace = try AgentWorkspace(
+            bundleRoot: workspaceRoot,
+            writableRoot: workspaceRoot.appendingPathComponent("Writable", isDirectory: true),
+            indexCacheRoot: workspaceRoot.appendingPathComponent("Cache", isDirectory: true)
+        )
+        let agent = try Agent.spec("support", in: workspace) {
+            [
+                MockTool(name: "refund_lookup"),
+                MockTool(name: "ticket_create"),
+                MockTool(name: "unlisted")
+            ]
+        }
+
+        #expect(Set(agent.tools.map(\.name)) == ["refund_lookup", "ticket_create"])
+    }
+
     @Test("Workspace validation reports malformed SKILL.md")
     func workspaceValidationReportsMalformedSkill() async throws {
         let workspaceRoot = try makeWorkspaceRoot()


### PR DESCRIPTION
## Summary
- Fixes SWARM-AUDIT-002 by unioning constrained workspace skill allowed-tools lists instead of intersecting them.
- Preserves existing behavior where unconstrained skills do not restrict tools by themselves.
- Adds a regression for two constrained skills with disjoint allowed tools, keeping both allowed tools and excluding unlisted tools.

## Verification
- swift test --filter agentSpecUnionsConstrainedToolAllowlists
- swift test --filter AgentWorkspaceTests
- git diff --check
- swift build
- swift test
- Code review agent: APPROVE, no blocking findings