### PR TITLE
Fix oversized memory context gaps

### DIFF
--- a/Sources/Swarm/Integration/Wax/WaxMemory.swift
+++ b/Sources/Swarm/Integration/Wax/WaxMemory.swift
@@ -222,6 +222,10 @@ public actor WaxMemory: Memory, MemoryPromptDescriptor, MemorySessionLifecycle {
         var usedTokens = 0
 
         for item in rag.items {
+            if isStoredMessageOverBudget(for: item, tokenLimit: tokenLimit) {
+                continue
+            }
+
             let kind = switch item.kind {
             case .expanded: "expanded"
             case .surrogate: "surrogate"
@@ -242,12 +246,58 @@ public actor WaxMemory: Memory, MemoryPromptDescriptor, MemorySessionLifecycle {
             let candidate = "\(prefix) \(item.text)"
             let tokens = configuration.tokenEstimator.estimateTokens(for: candidate)
 
+            if tokens > tokenLimit { continue }
             if usedTokens + tokens > tokenLimit { break }
             usedTokens += tokens
             lines.append(candidate)
         }
 
+        if lines.isEmpty, rag.items.isEmpty == false {
+            return MemoryMessage.formatContext(
+                persistedMessagesMatchingQueryText(query: rag.query),
+                tokenLimit: tokenLimit,
+                tokenEstimator: configuration.tokenEstimator
+            )
+        }
+
         return lines.joined(separator: "\n")
+    }
+
+    private func isStoredMessageOverBudget(for item: RAGContext.Item, tokenLimit: Int) -> Bool {
+        guard let messageIDString = item.metadata["message_id"],
+              let messageID = UUID(uuidString: messageIDString),
+              let message = persistedMessages.first(where: { $0.id == messageID }) else {
+            return false
+        }
+
+        return configuration.tokenEstimator.estimateTokens(for: message.formattedContent) > tokenLimit
+    }
+
+    private func persistedMessagesMatchingQueryText(query: String) -> [MemoryMessage] {
+        let terms = Self.distinctiveSearchTerms(in: query)
+        guard terms.isEmpty == false else { return [] }
+
+        return persistedMessages.filter { message in
+            let content = message.content.lowercased()
+            return terms.allSatisfy { content.contains($0) }
+        }
+    }
+
+    private static func distinctiveSearchTerms(in text: String) -> [String] {
+        let stopWords: Set<String> = [
+            "about", "after", "again", "agent", "answer", "before", "context", "memory",
+            "message", "messages", "please", "question", "status", "their", "there",
+            "these", "those", "through", "using", "where", "which", "would"
+        ]
+
+        return Array(
+            Set(
+                text
+                    .lowercased()
+                    .components(separatedBy: CharacterSet.alphanumerics.inverted)
+                    .filter { $0.count >= 8 && stopWords.contains($0) == false }
+            )
+        ).sorted()
     }
 }
 

--- a/Sources/Swarm/Integration/Wax/WaxMemory.swift
+++ b/Sources/Swarm/Integration/Wax/WaxMemory.swift
@@ -222,10 +222,6 @@ public actor WaxMemory: Memory, MemoryPromptDescriptor, MemorySessionLifecycle {
         var usedTokens = 0
 
         for item in rag.items {
-            if isStoredMessageOverBudget(for: item, tokenLimit: tokenLimit) {
-                continue
-            }
-
             let kind = switch item.kind {
             case .expanded: "expanded"
             case .surrogate: "surrogate"
@@ -263,16 +259,6 @@ public actor WaxMemory: Memory, MemoryPromptDescriptor, MemorySessionLifecycle {
         return lines.joined(separator: "\n")
     }
 
-    private func isStoredMessageOverBudget(for item: RAGContext.Item, tokenLimit: Int) -> Bool {
-        guard let messageIDString = item.metadata["message_id"],
-              let messageID = UUID(uuidString: messageIDString),
-              let message = persistedMessages.first(where: { $0.id == messageID }) else {
-            return false
-        }
-
-        return configuration.tokenEstimator.estimateTokens(for: message.formattedContent) > tokenLimit
-    }
-
     private func persistedMessagesMatchingQueryText(query: String) -> [MemoryMessage] {
         let terms = Self.distinctiveSearchTerms(in: query)
         guard terms.isEmpty == false else { return [] }
@@ -283,7 +269,7 @@ public actor WaxMemory: Memory, MemoryPromptDescriptor, MemorySessionLifecycle {
         }
     }
 
-    private static func distinctiveSearchTerms(in text: String) -> [String] {
+    static func distinctiveSearchTerms(in text: String) -> [String] {
         let stopWords: Set<String> = [
             "about", "after", "again", "agent", "answer", "before", "context", "memory",
             "message", "messages", "please", "question", "status", "their", "there",
@@ -295,7 +281,7 @@ public actor WaxMemory: Memory, MemoryPromptDescriptor, MemorySessionLifecycle {
                 text
                     .lowercased()
                     .components(separatedBy: CharacterSet.alphanumerics.inverted)
-                    .filter { $0.count >= 8 && stopWords.contains($0) == false }
+                    .filter { $0.count >= 4 && stopWords.contains($0) == false }
             )
         ).sorted()
     }

--- a/Sources/Swarm/Memory/AgentMemory.swift
+++ b/Sources/Swarm/Memory/AgentMemory.swift
@@ -214,6 +214,8 @@ public extension MemoryMessage {
         tokenLimit: Int,
         tokenEstimator: any TokenEstimator = CharacterBasedTokenEstimator.shared
     ) -> String {
+        guard tokenLimit > 0 else { return "" }
+
         var result: [String] = []
         var currentTokens = 0
 
@@ -221,6 +223,10 @@ public extension MemoryMessage {
         for message in messages.reversed() {
             let formatted = message.formattedContent
             let messageTokens = tokenEstimator.estimateTokens(for: formatted)
+
+            if messageTokens > tokenLimit {
+                continue
+            }
 
             if currentTokens + messageTokens <= tokenLimit {
                 result.append(formatted)
@@ -251,6 +257,8 @@ public extension MemoryMessage {
         separator: String,
         tokenEstimator: any TokenEstimator = CharacterBasedTokenEstimator.shared
     ) -> String {
+        guard tokenLimit > 0 else { return "" }
+
         var result: [String] = []
         var currentTokens = 0
         let separatorTokens = tokenEstimator.estimateTokens(for: separator)
@@ -259,6 +267,10 @@ public extension MemoryMessage {
             let formatted = message.formattedContent
             let messageTokens = tokenEstimator.estimateTokens(for: formatted)
             let totalNeeded = messageTokens + (result.isEmpty ? 0 : separatorTokens)
+
+            if messageTokens > tokenLimit {
+                continue
+            }
 
             if currentTokens + totalNeeded <= tokenLimit {
                 result.append(formatted)

--- a/Tests/SwarmTests/Memory/MemoryMessageTests.swift
+++ b/Tests/SwarmTests/Memory/MemoryMessageTests.swift
@@ -185,4 +185,105 @@ struct MemoryMessageTests {
         #expect(description.contains("..."))
         #expect(description.count < 100)
     }
+
+    // MARK: - Context Formatting Tests
+
+    @Test("Context formatting skips oversized newest message")
+    func contextFormattingSkipsOversizedNewestMessage() {
+        let estimator = CharacterBasedTokenEstimator(charactersPerToken: 1)
+        let messages = [
+            MemoryMessage.user("first-fit"),
+            MemoryMessage.assistant("second-fit"),
+            MemoryMessage.user(String(repeating: "x", count: 120))
+        ]
+
+        let context = MemoryMessage.formatContext(
+            messages,
+            tokenLimit: 60,
+            tokenEstimator: estimator
+        )
+
+        #expect(context.contains("[user]: first-fit"))
+        #expect(context.contains("[assistant]: second-fit"))
+        #expect(!context.contains(String(repeating: "x", count: 120)))
+    }
+
+    @Test("Context formatting with custom separator skips oversized newest message")
+    func contextFormattingWithCustomSeparatorSkipsOversizedNewestMessage() {
+        let estimator = CharacterBasedTokenEstimator(charactersPerToken: 1)
+        let messages = [
+            MemoryMessage.user("first-fit"),
+            MemoryMessage.assistant("second-fit"),
+            MemoryMessage.user(String(repeating: "x", count: 120))
+        ]
+
+        let context = MemoryMessage.formatContext(
+            messages,
+            tokenLimit: 64,
+            separator: "\n---\n",
+            tokenEstimator: estimator
+        )
+
+        #expect(context == "[user]: first-fit\n---\n[assistant]: second-fit")
+    }
+
+    @Test("Context formatting skips oversized middle message")
+    func contextFormattingSkipsOversizedMiddleMessage() {
+        let estimator = CharacterBasedTokenEstimator(charactersPerToken: 1)
+        let oversized = String(repeating: "x", count: 120)
+        let messages = [
+            MemoryMessage.user("older-fit"),
+            MemoryMessage.user(oversized),
+            MemoryMessage.assistant("newer-fit")
+        ]
+
+        let context = MemoryMessage.formatContext(
+            messages,
+            tokenLimit: 64,
+            tokenEstimator: estimator
+        )
+
+        #expect(context.contains("[user]: older-fit"))
+        #expect(context.contains("[assistant]: newer-fit"))
+        #expect(!context.contains(oversized))
+    }
+
+    @Test("Context formatting stops at non-oversized message that exhausts remaining budget")
+    func contextFormattingStopsAtNonOversizedBudgetExhaustion() {
+        let estimator = CharacterBasedTokenEstimator(charactersPerToken: 1)
+        let fittingButTooLargeAfterNewest = String(repeating: "m", count: 40)
+        let messages = [
+            MemoryMessage.user("older-fit"),
+            MemoryMessage.user(fittingButTooLargeAfterNewest),
+            MemoryMessage.assistant("new")
+        ]
+
+        let context = MemoryMessage.formatContext(
+            messages,
+            tokenLimit: 48,
+            tokenEstimator: estimator
+        )
+
+        #expect(context == "[assistant]: new")
+    }
+
+    @Test("Context formatting with custom separator stops at non-oversized budget exhaustion")
+    func contextFormattingWithCustomSeparatorStopsAtNonOversizedBudgetExhaustion() {
+        let estimator = CharacterBasedTokenEstimator(charactersPerToken: 1)
+        let fittingButTooLargeAfterNewest = String(repeating: "m", count: 40)
+        let messages = [
+            MemoryMessage.user("older-fit"),
+            MemoryMessage.user(fittingButTooLargeAfterNewest),
+            MemoryMessage.assistant("new")
+        ]
+
+        let context = MemoryMessage.formatContext(
+            messages,
+            tokenLimit: 48,
+            separator: "\n---\n",
+            tokenEstimator: estimator
+        )
+
+        #expect(context == "[assistant]: new")
+    }
 }

--- a/Tests/SwarmTests/Memory/MemoryMessageTests.swift
+++ b/Tests/SwarmTests/Memory/MemoryMessageTests.swift
@@ -286,4 +286,74 @@ struct MemoryMessageTests {
 
         #expect(context == "[assistant]: new")
     }
+
+    @Test("Context formatting returns empty when token limit is zero")
+    func contextFormattingReturnsEmptyWhenTokenLimitIsZero() {
+        let estimator = CharacterBasedTokenEstimator(charactersPerToken: 1)
+        let messages = [
+            MemoryMessage.user("first"),
+            MemoryMessage.assistant("second")
+        ]
+
+        let context = MemoryMessage.formatContext(
+            messages,
+            tokenLimit: 0,
+            tokenEstimator: estimator
+        )
+
+        #expect(context.isEmpty)
+    }
+
+    @Test("Context formatting returns empty when all messages are oversized")
+    func contextFormattingReturnsEmptyWhenAllMessagesAreOversized() {
+        let estimator = CharacterBasedTokenEstimator(charactersPerToken: 1)
+        let messages = [
+            MemoryMessage.user(String(repeating: "x", count: 120)),
+            MemoryMessage.assistant(String(repeating: "y", count: 200))
+        ]
+
+        let context = MemoryMessage.formatContext(
+            messages,
+            tokenLimit: 60,
+            tokenEstimator: estimator
+        )
+
+        #expect(context.isEmpty)
+    }
+
+    @Test("Context formatting with custom separator returns empty when token limit is zero")
+    func contextFormattingWithSeparatorReturnsEmptyWhenTokenLimitIsZero() {
+        let estimator = CharacterBasedTokenEstimator(charactersPerToken: 1)
+        let messages = [
+            MemoryMessage.user("first"),
+            MemoryMessage.assistant("second")
+        ]
+
+        let context = MemoryMessage.formatContext(
+            messages,
+            tokenLimit: 0,
+            separator: "\n---\n",
+            tokenEstimator: estimator
+        )
+
+        #expect(context.isEmpty)
+    }
+
+    @Test("Context formatting with custom separator returns empty when all messages are oversized")
+    func contextFormattingWithSeparatorReturnsEmptyWhenAllMessagesAreOversized() {
+        let estimator = CharacterBasedTokenEstimator(charactersPerToken: 1)
+        let messages = [
+            MemoryMessage.user(String(repeating: "x", count: 120)),
+            MemoryMessage.assistant(String(repeating: "y", count: 200))
+        ]
+
+        let context = MemoryMessage.formatContext(
+            messages,
+            tokenLimit: 60,
+            separator: "\n---\n",
+            tokenEstimator: estimator
+        )
+
+        #expect(context.isEmpty)
+    }
 }

--- a/Tests/SwarmTests/Memory/SlidingWindowMemoryTests.swift
+++ b/Tests/SwarmTests/Memory/SlidingWindowMemoryTests.swift
@@ -126,6 +126,60 @@ struct SlidingWindowMemoryTests {
         #expect(!context.isEmpty)
     }
 
+    @Test("Context skips oversized newest message and keeps older context")
+    func contextSkipsOversizedNewestMessage() async {
+        let memory = SlidingWindowMemory(
+            maxTokens: 200,
+            tokenEstimator: CharacterBasedTokenEstimator(charactersPerToken: 1)
+        )
+
+        await memory.add(.user("older-fit"))
+        await memory.add(.assistant("still-fits"))
+        await memory.add(.user(String(repeating: "x", count: 120)))
+
+        let context = await memory.context(for: "test", tokenLimit: 64)
+
+        #expect(context.contains("[user]: older-fit"))
+        #expect(context.contains("[assistant]: still-fits"))
+        #expect(!context.contains(String(repeating: "x", count: 120)))
+    }
+
+    @Test("Context skips oversized middle message and keeps surrounding context")
+    func contextSkipsOversizedMiddleMessage() async {
+        let memory = SlidingWindowMemory(
+            maxTokens: 300,
+            tokenEstimator: CharacterBasedTokenEstimator(charactersPerToken: 1)
+        )
+        let oversized = String(repeating: "x", count: 120)
+
+        await memory.add(.user("older-fit"))
+        await memory.add(.user(oversized))
+        await memory.add(.assistant("newer-fit"))
+
+        let context = await memory.context(for: "test", tokenLimit: 64)
+
+        #expect(context.contains("[user]: older-fit"))
+        #expect(context.contains("[assistant]: newer-fit"))
+        #expect(!context.contains(oversized))
+    }
+
+    @Test("Context stops at non-oversized message that exhausts remaining budget")
+    func contextStopsAtNonOversizedBudgetExhaustion() async {
+        let memory = SlidingWindowMemory(
+            maxTokens: 300,
+            tokenEstimator: CharacterBasedTokenEstimator(charactersPerToken: 1)
+        )
+        let fittingButTooLargeAfterNewest = String(repeating: "m", count: 40)
+
+        await memory.add(.user("older-fit"))
+        await memory.add(.user(fittingButTooLargeAfterNewest))
+        await memory.add(.assistant("new"))
+
+        let context = await memory.context(for: "test", tokenLimit: 48)
+
+        #expect(context == "[assistant]: new")
+    }
+
     // MARK: - Clear Tests
 
     @Test("Clear resets both messages and token count")

--- a/Tests/SwarmTests/Memory/WaxMemoryTests.swift
+++ b/Tests/SwarmTests/Memory/WaxMemoryTests.swift
@@ -94,7 +94,9 @@ struct WaxMemoryTests {
         await memory.add(.user(String(repeating: "\(key) oversized ", count: 160)))
         await memory.add(.assistant("unrelated-recent-fits"))
 
-        let context = await memory.context(for: key, tokenLimit: 800)
+        // Use a tight token limit so even Wax-truncated representations of the
+        // large message exceed the budget and are skipped by per-item token checks.
+        let context = await memory.context(for: key, tokenLimit: 50)
 
         #expect(context.contains("concise-fit"))
         #expect(!context.contains("oversized"))
@@ -120,6 +122,56 @@ struct WaxMemoryTests {
 
         #expect(context.contains("first-fit"))
         #expect(!context.contains("third-fit"))
+    }
+
+    @Test("distinctive search terms include four character words")
+    func distinctiveSearchTermsIncludeFourCharacterWords() {
+        let terms = WaxMemory.distinctiveSearchTerms(in: "The quick brown fox jumps")
+        #expect(terms.contains("quick"))
+        #expect(terms.contains("brown"))
+        #expect(terms.contains("jumps"))
+    }
+
+    @Test("fallback triggers when all RAG items exceed token limit individually")
+    func fallbackTriggersWhenAllRAGItemsAreOversized() async throws {
+        let url = try makeTemporaryWaxURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let memory = try await WaxMemory(
+            url: url,
+            configuration: .init(tokenEstimator: CharacterBasedTokenEstimator(charactersPerToken: 1))
+        )
+
+        // Use a tight token limit so RAG items (with their heavy prefix) exceed
+        // the budget, but the fallback via MemoryMessage.formatContext (which
+        // uses a much smaller `[user]: ` prefix) can still fit the message.
+        await memory.add(.user("alpha"))
+        await memory.add(.user("beta is on hold until further notice"))
+
+        let context = await memory.context(for: "alpha", tokenLimit: 20)
+
+        // Fallback should find the persisted message via keyword search and
+        // MemoryMessage.formatContext should fit it within the smaller prefix.
+        #expect(context.contains("alpha"))
+    }
+
+    @Test("context returns empty when token limit is zero")
+    func contextReturnsEmptyWhenTokenLimitIsZero() async throws {
+        let url = try makeTemporaryWaxURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let memory = try await WaxMemory(url: url)
+        await memory.add(.user("hello world"))
+
+        let context = await memory.context(for: "hello", tokenLimit: 0)
+
+        #expect(context.isEmpty)
+    }
+
+    @Test("distinctive search terms returns empty for stop words only")
+    func distinctiveSearchTermsReturnsEmptyForStopWordsOnly() {
+        let terms = WaxMemory.distinctiveSearchTerms(in: "the a an about using")
+        #expect(terms.isEmpty)
     }
 }
 

--- a/Tests/SwarmTests/Memory/WaxMemoryTests.swift
+++ b/Tests/SwarmTests/Memory/WaxMemoryTests.swift
@@ -78,6 +78,49 @@ struct WaxMemoryTests {
         #expect(await reopened.count == 1)
         #expect((await reopened.allMessages()).map(\.id) == [message.id])
     }
+
+    @Test("context skips oversized ranked item and keeps fitting RAG context")
+    func contextSkipsOversizedRankedItem() async throws {
+        let url = try makeTemporaryWaxURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let key = "waxbudget\(UUID().uuidString.replacingOccurrences(of: "-", with: ""))"
+        let memory = try await WaxMemory(
+            url: url,
+            configuration: .init(tokenEstimator: CharacterBasedTokenEstimator(charactersPerToken: 4))
+        )
+
+        await memory.add(.user("\(key) concise-fit"))
+        await memory.add(.user(String(repeating: "\(key) oversized ", count: 160)))
+        await memory.add(.assistant("unrelated-recent-fits"))
+
+        let context = await memory.context(for: key, tokenLimit: 800)
+
+        #expect(context.contains("concise-fit"))
+        #expect(!context.contains("oversized"))
+        #expect(!context.contains("unrelated-recent-fits"))
+    }
+
+    @Test("context stops at non-oversized ranked item that exhausts remaining budget")
+    func contextStopsAtNonOversizedRankedBudgetExhaustion() async throws {
+        let url = try makeTemporaryWaxURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let key = "waxcutoff\(UUID().uuidString.replacingOccurrences(of: "-", with: ""))"
+        let memory = try await WaxMemory(
+            url: url,
+            configuration: .init(tokenEstimator: CharacterBasedTokenEstimator(charactersPerToken: 1))
+        )
+
+        await memory.add(.user("\(Array(repeating: key, count: 10).joined(separator: " ")) first-fit"))
+        await memory.add(.user("\(Array(repeating: key, count: 8).joined(separator: " ")) \(String(repeating: "m", count: 200)) second-wide"))
+        await memory.add(.user("\(key) third-fit"))
+
+        let context = await memory.context(for: key, tokenLimit: 700)
+
+        #expect(context.contains("first-fit"))
+        #expect(!context.contains("third-fit"))
+    }
 }
 
 private func makeTemporaryWaxURL() throws -> URL {


### PR DESCRIPTION
## Summary
- skip individually oversized memory messages instead of letting them erase fitting context
- preserve sliding-window and ranked-retrieval cutoff semantics when normal items exhaust remaining budget
- harden Wax fallback so unrelated persisted messages are not pulled in by broad query overlap

## Audit Item
- Fixes SWARM-AUDIT-003

## Verification
- swift test --filter 'MemoryMessageTests/contextFormatting|SlidingWindowMemoryTests/contextSkipsOversized|SlidingWindowMemoryTests/contextStopsAtNonOversizedBudgetExhaustion|WaxMemoryTests/contextSkipsOversizedRankedItem|WaxMemoryTests/contextStopsAtNonOversizedRankedBudgetExhaustion'
- swift test --filter 'MemoryMessageTests|SlidingWindowMemoryTests|WaxMemoryTests'
- git diff --check
- swift build
- swift test

## Review
- Code review agent approved after the budget-exhaustion regression fix.