### PR TITLE
Honor default memory retrieval policy

### DIFF
--- a/Sources/Swarm/Integration/Wax/WaxMemory.swift
+++ b/Sources/Swarm/Integration/Wax/WaxMemory.swift
@@ -3,7 +3,7 @@ import Wax
 import WaxVectorSearch
 
 /// Wax-backed memory implementation using the public Memory API.
-public actor WaxMemory: Memory, MemoryPromptDescriptor, MemorySessionLifecycle {
+public actor WaxMemory: Memory, MemoryPromptDescriptor, MemorySessionLifecycle, MemoryRetrievalPolicyAware {
     // MARK: Public
 
     /// Configuration for Wax memory behavior.
@@ -98,6 +98,16 @@ public actor WaxMemory: Memory, MemoryPromptDescriptor, MemorySessionLifecycle {
         do {
             let rag = try await store.search(query)
             return formatRAGContext(rag, tokenLimit: tokenLimit)
+        } catch {
+            Log.memory.error("WaxMemory: Failed to recall context: \(error.localizedDescription)")
+            return ""
+        }
+    }
+
+    public func context(for query: MemoryQuery) async -> String {
+        do {
+            let rag = try await store.search(query.text)
+            return formatRAGContext(rag, query: query)
         } catch {
             Log.memory.error("WaxMemory: Failed to recall context: \(error.localizedDescription)")
             return ""
@@ -257,6 +267,101 @@ public actor WaxMemory: Memory, MemoryPromptDescriptor, MemorySessionLifecycle {
         }
 
         return lines.joined(separator: "\n")
+    }
+
+    private func formatRAGContext(_ rag: RAGContext, query: MemoryQuery) -> String {
+        guard query.tokenLimit > 0 else { return "" }
+
+        var lines: [String] = []
+        var usedTokens = 0
+
+        for item in rag.items {
+            guard lines.count < query.maxItems else { break }
+
+            let candidate = formatRAGItem(item)
+            let itemLimit = min(query.maxItemTokens, query.tokenLimit)
+            let trimmedCandidate = trimToTokenLimit(candidate, tokenLimit: itemLimit)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedCandidate.isEmpty else {
+                continue
+            }
+
+            let tokens = configuration.tokenEstimator.estimateTokens(for: trimmedCandidate)
+            if usedTokens + tokens > query.tokenLimit {
+                if lines.isEmpty {
+                    let fallback = trimToTokenLimit(trimmedCandidate, tokenLimit: query.tokenLimit)
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                    if !fallback.isEmpty {
+                        lines.append(fallback)
+                    }
+                }
+                break
+            }
+
+            usedTokens += tokens
+            lines.append(trimmedCandidate)
+        }
+
+        return lines.joined(separator: "\n")
+    }
+
+    private func formatRAGItem(_ item: RAGContext.Item) -> String {
+        let kind = switch item.kind {
+        case .expanded: "expanded"
+        case .surrogate: "surrogate"
+        case .snippet: "snippet"
+        }
+
+        let sources = item.sources.map { source in
+            switch source {
+            case .text: return "text"
+            case .vector: return "vector"
+            case .timeline: return "timeline"
+            case .structured: return "structured"
+            case .unknown: return "unknown"
+            }
+        }.joined(separator: ",")
+
+        let prefix = "[\(kind) frame:\(item.frameId) score:\(String(format: "%.2f", item.score)) sources:\(sources)]"
+        return "\(prefix) \(item.text)"
+    }
+
+    private func trimToTokenLimit(_ text: String, tokenLimit: Int) -> String {
+        guard tokenLimit > 0 else {
+            return ""
+        }
+
+        if configuration.tokenEstimator.estimateTokens(for: text) <= tokenLimit {
+            return text
+        }
+
+        var lower = 0
+        var upper = text.count
+        var best = ""
+
+        while lower <= upper {
+            let mid = (lower + upper) / 2
+            let candidate = prefix(text, maxCharacters: mid)
+            if configuration.tokenEstimator.estimateTokens(for: candidate) <= tokenLimit {
+                best = candidate
+                lower = mid + 1
+            } else {
+                upper = mid - 1
+            }
+        }
+
+        if !best.isEmpty {
+            return best
+        }
+
+        return prefix(text, maxCharacters: max(1, min(text.count, tokenLimit)))
+    }
+
+    private func prefix(_ text: String, maxCharacters: Int) -> String {
+        guard maxCharacters > 0 else { return "" }
+        guard text.count > maxCharacters else { return text }
+        let end = text.index(text.startIndex, offsetBy: maxCharacters)
+        return String(text[..<end])
     }
 
     private func persistedMessagesMatchingQueryText(query: String) -> [MemoryMessage] {

--- a/Sources/Swarm/Memory/DefaultAgentMemory.swift
+++ b/Sources/Swarm/Memory/DefaultAgentMemory.swift
@@ -82,7 +82,48 @@ public actor DefaultAgentMemory: Memory, MemoryPromptDescriptor, MemorySessionLi
     }
 
     public func context(for query: MemoryQuery) async -> String {
-        await context(for: query.text, tokenLimit: query.tokenLimit)
+        guard query.tokenLimit > 0 else {
+            return ""
+        }
+
+        let primaryBudget = max(1, Int(Double(query.tokenLimit) * 0.7))
+        let secondaryBudget = query.tokenLimit
+
+        async let primaryContextTask = contextMemory.context(
+            for: query.text,
+            tokenLimit: primaryBudget
+        )
+        let secondaryContextStr = await waxContext(
+            for: MemoryQuery(
+                text: query.text,
+                tokenLimit: secondaryBudget,
+                maxItems: query.maxItems,
+                maxItemTokens: query.maxItemTokens
+            )
+        )
+        let primaryContextStr = await primaryContextTask
+
+        let primaryAllowance = query.maxItems == 1 ? 1 : max(1, query.maxItems - 1)
+        let primary = await limitContextItems(
+            primaryContextStr,
+            maxItems: primaryAllowance,
+            maxItemTokens: query.maxItemTokens,
+            tokenLimit: primaryBudget
+        )
+
+        let secondaryAllowance = max(0, query.maxItems - primary.count)
+        let secondary = await limitContextItems(
+            secondaryContextStr,
+            maxItems: secondaryAllowance,
+            maxItemTokens: query.maxItemTokens,
+            tokenLimit: secondaryBudget
+        )
+
+        return await formatContext(
+            primary: primary.text.trimmingCharacters(in: .whitespacesAndNewlines),
+            secondary: secondary.text.trimmingCharacters(in: .whitespacesAndNewlines),
+            tokenLimit: query.tokenLimit
+        )
     }
 
     public func allMessages() async -> [MemoryMessage] {
@@ -176,6 +217,20 @@ public actor DefaultAgentMemory: Memory, MemoryPromptDescriptor, MemorySessionLi
         }
     }
 
+    private func waxContext(for query: MemoryQuery) async -> String {
+        guard query.tokenLimit > 0 else {
+            return ""
+        }
+
+        do {
+            let wax = try await ensureWaxMemory()
+            return await wax.context(for: query)
+        } catch {
+            Log.memory.warning("DefaultAgentMemory: Failed to retrieve Wax context: \(error.localizedDescription)")
+            return ""
+        }
+    }
+
     private func formatContext(primary: String, secondary: String, tokenLimit: Int) async -> String {
         let primarySection = makeSection(
             title: contextMemory.memoryPromptTitle,
@@ -251,6 +306,90 @@ public actor DefaultAgentMemory: Memory, MemoryPromptDescriptor, MemorySessionLi
         }
 
         return rendered.joined(separator: "\n")
+    }
+
+    private func limitContextItems(
+        _ context: String,
+        maxItems: Int,
+        maxItemTokens: Int,
+        tokenLimit: Int
+    ) async -> (text: String, count: Int) {
+        guard maxItems > 0, tokenLimit > 0 else {
+            return ("", 0)
+        }
+
+        var rendered: [String] = []
+        rendered.reserveCapacity(maxItems)
+
+        for item in contextItems(from: context) {
+            guard rendered.count < maxItems else {
+                break
+            }
+
+            let itemLimit = min(maxItemTokens, tokenLimit)
+            let trimmedItem = await trimToTokenLimit(item, tokenLimit: itemLimit)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedItem.isEmpty else {
+                continue
+            }
+
+            let candidate = (rendered + [trimmedItem]).joined(separator: "\n\n")
+            if await tokenCount(for: candidate) <= tokenLimit {
+                rendered.append(trimmedItem)
+            } else {
+                if rendered.isEmpty {
+                    let fallback = await trimToTokenLimit(trimmedItem, tokenLimit: tokenLimit)
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                    if !fallback.isEmpty {
+                        rendered.append(fallback)
+                    }
+                }
+                break
+            }
+        }
+
+        return (rendered.joined(separator: "\n\n"), rendered.count)
+    }
+
+    private func contextItems(from context: String) -> [String] {
+        var items: [String] = []
+        var current: [String] = []
+
+        for line in context.split(separator: "\n", omittingEmptySubsequences: false).map(String.init) {
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.isEmpty {
+                if !current.isEmpty {
+                    current.append(line)
+                }
+                continue
+            }
+
+            if isContextItemHeader(trimmed), !current.isEmpty {
+                items.append(current.joined(separator: "\n"))
+                current = [line]
+            } else {
+                current.append(line)
+            }
+        }
+
+        if !current.isEmpty {
+            items.append(current.joined(separator: "\n"))
+        }
+
+        return items
+    }
+
+    private func isContextItemHeader(_ line: String) -> Bool {
+        if line.hasPrefix("[user]:")
+            || line.hasPrefix("[assistant]:")
+            || line.hasPrefix("[system]:")
+            || line.hasPrefix("[tool]:") {
+            return true
+        }
+
+        return line.hasPrefix("[expanded frame:")
+            || line.hasPrefix("[surrogate frame:")
+            || line.hasPrefix("[snippet frame:")
     }
 
     private func trimToTokenLimit(_ text: String, tokenLimit: Int) async -> String {

--- a/Tests/SwarmTests/MCP/SwarmMCPServerServiceTests.swift
+++ b/Tests/SwarmTests/MCP/SwarmMCPServerServiceTests.swift
@@ -276,7 +276,7 @@ struct SwarmMCPServerServiceTests {
                         arguments: ["value": .int(i)]
                     )
                     guard
-                        case let .text(text: text, annotations: _, _meta: _)? = result.content.first,
+                        case let .text(text, _, _)? = result.content.first,
                         let parsed = Int(text)
                     else {
                         throw SwarmMCPServerServiceTestError.unreachable("unexpected content")

--- a/Tests/SwarmTests/Memory/ContextCoreDefaultMemoryTests.swift
+++ b/Tests/SwarmTests/Memory/ContextCoreDefaultMemoryTests.swift
@@ -160,6 +160,150 @@ struct ContextCoreDefaultMemoryTests {
         #expect(context.isEmpty == false)
     }
 
+    @Test("DefaultAgentMemory policy query limits retrieved items")
+    func defaultCompositeMemoryPolicyQueryLimitsRetrievedItems() async throws {
+        let url = try makeTemporaryWaxURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+
+        let counter = CountingPromptTokenCounter()
+        let memory = try DefaultAgentMemory(
+            configuration: .init(
+                waxStoreURL: url
+            )
+        )
+
+        await memory.add(.user("policytopic policytopic policytopic keep-most-relevant"))
+        await memory.add(.assistant("policytopic drop-secondary"))
+        await memory.add(.user("policytopic drop-tertiary"))
+
+        let context = await AgentEnvironmentValues.$current.withValue(
+            AgentEnvironment(promptTokenCounter: counter)
+        ) {
+            await memory.context(
+                for: MemoryQuery(
+                    text: "policytopic",
+                    tokenLimit: 1_000,
+                    maxItems: 1,
+                    maxItemTokens: 300
+                )
+            )
+        }
+
+        #expect(context.contains("keep-most-relevant"))
+        #expect(!context.contains("drop-secondary"))
+        #expect(!context.contains("drop-tertiary"))
+    }
+
+    @Test("DefaultAgentMemory policy query limits tokens per retrieved item")
+    func defaultCompositeMemoryPolicyQueryLimitsItemTokens() async throws {
+        let url = try makeTemporaryWaxURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+
+        let counter = CountingPromptTokenCounter()
+        let memory = try DefaultAgentMemory(
+            configuration: .init(
+                waxStoreURL: url
+            )
+        )
+
+        await memory.add(.user("policytopic \(String(repeating: "x", count: 180)) tail-not-allowed"))
+
+        let context = await AgentEnvironmentValues.$current.withValue(
+            AgentEnvironment(promptTokenCounter: counter)
+        ) {
+            await memory.context(
+                for: MemoryQuery(
+                    text: "policytopic",
+                    tokenLimit: 800,
+                    maxItems: 1,
+                    maxItemTokens: 80
+                )
+            )
+        }
+
+        #expect(context.contains("policytopic"))
+        #expect(!context.contains("tail-not-allowed"))
+    }
+
+    @Test("DefaultAgentMemory policy query preserves bracket-prefixed body lines")
+    func defaultCompositeMemoryPolicyQueryPreservesBracketPrefixedBodyLines() async throws {
+        let url = try makeTemporaryWaxURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+
+        let counter = CountingPromptTokenCounter()
+        let memory = try DefaultAgentMemory(
+            configuration: .init(
+                waxStoreURL: url
+            )
+        )
+
+        await memory.add(.user("""
+        brackettopic
+        [dependencies]
+        body-kept
+        """))
+        await memory.add(.assistant("brackettopic drop-secondary"))
+
+        let context = await AgentEnvironmentValues.$current.withValue(
+            AgentEnvironment(promptTokenCounter: counter)
+        ) {
+            await memory.context(
+                for: MemoryQuery(
+                    text: "brackettopic",
+                    tokenLimit: 1_000,
+                    maxItems: 1,
+                    maxItemTokens: 600
+                )
+            )
+        }
+
+        #expect(context.contains("brackettopic"))
+        #expect(context.contains("[dependencies]"))
+        #expect(context.contains("body-kept"))
+        #expect(!context.contains("drop-secondary"))
+    }
+
+    @Test("DefaultAgentMemory policy query trims durable-only oversized items after reopen")
+    func defaultCompositeMemoryPolicyQueryTrimsDurableOnlyOversizedItemsAfterReopen() async throws {
+        let url = try makeTemporaryWaxURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+
+        let counter = CountingPromptTokenCounter()
+        let longPayload = String(repeating: "durable body ", count: 120)
+
+        do {
+            let seed = try DefaultAgentMemory(
+                configuration: .init(
+                    waxStoreURL: url
+                )
+            )
+            await seed.add(.user("durable-policytopic \(longPayload) tail-not-allowed"))
+        }
+
+        let reopened = try DefaultAgentMemory(
+            configuration: .init(
+                waxStoreURL: url
+            )
+        )
+
+        let context = await AgentEnvironmentValues.$current.withValue(
+            AgentEnvironment(promptTokenCounter: counter)
+        ) {
+            await reopened.context(
+                for: MemoryQuery(
+                    text: "durable-policytopic",
+                    tokenLimit: 180,
+                    maxItems: 1,
+                    maxItemTokens: 80
+                )
+            )
+        }
+
+        #expect((await reopened.workingMessages()).isEmpty)
+        #expect(context.contains("durable-policytopic"))
+        #expect(!context.contains("tail-not-allowed"))
+    }
+
     @Test("DefaultAgentMemory skips duplicate replay entries against an existing Wax store")
     func defaultCompositeMemorySkipsDuplicateReplayEntries() async throws {
         let url = try makeTemporaryWaxURL()


### PR DESCRIPTION
## Summary
- honor MemoryQuery maxItems/maxItemTokens in DefaultAgentMemory instead of delegating to the string-only path
- add policy-aware Wax durable recall so oversized durable items are trimmed before rejection
- harden composite item splitting for bracket-prefixed body lines and add regressions

Fixes SWARM-AUDIT-004.

## Verification
- red proof: durable-only oversized item test failed before Wax policy path
- red proof: bracket-prefixed body-line test failed before splitter hardening
- swift test --filter 'ContextCoreDefaultMemoryTests/defaultCompositeMemoryPolicyQueryPreservesBracketPrefixedBodyLines|ContextCoreDefaultMemoryTests/defaultCompositeMemoryPolicyQueryTrimsDurableOnlyOversizedItemsAfterReopen|ContextCoreDefaultMemoryTests/defaultCompositeMemoryPolicyQueryLimitsRetrievedItems|ContextCoreDefaultMemoryTests/defaultCompositeMemoryPolicyQueryLimitsItemTokens'
- swift test --filter 'ContextCoreDefaultMemoryTests|WaxMemoryTests|Strict4kPromptEnvelopeTests|AgentWorkspaceTests/agentUsesPolicyAwareMemoryQuery'
- git diff --check
- swift build
- swift test

## Review
- code-reviewer final pass: no findings