### PR TITLE
Persist no-session default memory turns

### DIFF
--- a/Sources/Swarm/Agents/Agent.swift
+++ b/Sources/Swarm/Agents/Agent.swift
@@ -942,11 +942,16 @@ public struct Agent: AgentRuntime, Sendable {
                 if let transcriptHash = try? persistedTranscript.transcriptHash() {
                     _ = resultBuilder.setMetadata(Self.transcriptHashMetadataKey, .string(transcriptHash))
                 }
+            } else if let activeMemory, shouldPersistNoSessionTurn(to: activeMemory) {
+                await persistNoSessionTurn(
+                    userMessage: userMessage,
+                    transcriptMessages: toolLoopOutcome.transcriptMessages,
+                    to: activeMemory
+                )
             }
 
-            // Memory provides additional context (RAG, summaries) - NOT for conversation storage
-            // This avoids duplication: session stores conversation, memory provides context
-            // Note: If using memory for conversation context, populate it from session on demand
+            // Session remains the transcript source of truth. When no session is supplied,
+            // the default memory keeps user/assistant turns available for subsequent runs.
 
             _ = resultBuilder.setMetadata(RuntimeMetadata.runtimeEngineKey, .string(RuntimeMetadata.graphRuntimeEngineName))
             let result = resultBuilder.build()
@@ -1106,6 +1111,28 @@ public struct Agent: AgentRuntime, Sendable {
 
     private func resolvedMemory() -> (any Memory)? {
         memory ?? AgentEnvironmentValues.current.memory ?? defaultMemory
+    }
+
+    private func shouldPersistNoSessionTurn(to activeMemory: any Memory) -> Bool {
+        guard let defaultMemory else {
+            return false
+        }
+
+        return activeMemory as AnyObject === defaultMemory as AnyObject
+    }
+
+    private func persistNoSessionTurn(
+        userMessage: MemoryMessage,
+        transcriptMessages: [MemoryMessage],
+        to memory: any Memory
+    ) async {
+        let messages = ([userMessage] + transcriptMessages).filter { message in
+            message.role == .user || message.role == .assistant
+        }
+
+        for message in messages {
+            await memory.add(message)
+        }
     }
 
     private static func makeDefaultMemory() throws -> any Memory {

--- a/Tests/SwarmTests/Memory/ContextCoreDefaultMemoryTests.swift
+++ b/Tests/SwarmTests/Memory/ContextCoreDefaultMemoryTests.swift
@@ -34,6 +34,35 @@ struct ContextCoreDefaultMemoryTests {
         #expect(systemMessage?.content.contains("First reply") == true)
     }
 
+    @Test("No-session agent run persists default memory for subsequent turns")
+    func noSessionAgentRunPersistsDefaultMemoryForSubsequentTurns() async throws {
+        let provider = MockInferenceProvider(responses: [
+            "First no-session reply",
+            "Second no-session reply"
+        ])
+
+        let agent = try Agent(
+            tools: [],
+            instructions: "You are a helpful assistant.",
+            inferenceProvider: provider
+        )
+
+        _ = try await agent.run("Remember this no-session fact")
+        _ = try await agent.run("What did I ask you to remember?")
+
+        let messageCalls = await provider.generateMessageCalls
+        #expect(messageCalls.count == 2)
+
+        let secondMessages = messageCalls[1].messages
+        let systemMessage = secondMessages.first(where: { $0.role == .system })
+
+        #expect(systemMessage != nil)
+        #expect(systemMessage?.content.contains("ContextCore Memory Context (primary)") == true)
+        #expect(systemMessage?.content.contains("Wax Memory Context (secondary)") == true)
+        #expect(systemMessage?.content.contains("Remember this no-session fact") == true)
+        #expect(systemMessage?.content.contains("First no-session reply") == true)
+    }
+
     @Test("DefaultAgentMemory seeds replayed history into both layers")
     func defaultCompositeMemorySeedsReplayIntoBothLayers() async throws {
         let url = try makeTemporaryWaxURL()

--- a/Tests/SwarmTests/Memory/MemoryIngestionPolicyTests.swift
+++ b/Tests/SwarmTests/Memory/MemoryIngestionPolicyTests.swift
@@ -35,6 +35,22 @@ struct MemoryIngestionPolicyTests {
         }))
     }
 
+    @Test("No-session runs do not store transcript turns in explicit memory")
+    func noSessionRunDoesNotStoreTranscriptTurnsInExplicitMemory() async throws {
+        let provider = MockInferenceProvider(responses: ["Final Answer: ok"])
+        let memory = MockAgentMemory()
+
+        let agent = try Agent(
+            memory: memory,
+            inferenceProvider: provider
+        )
+
+        _ = try await agent.run("hi")
+
+        let added = await memory.addCalls
+        #expect(!added.contains(where: { $0.role == .user || $0.role == .assistant }))
+    }
+
     @Test("Session history is seeded only when memory is empty")
     func sessionHistorySeedsOnce() async throws {
         let session = InMemorySession(sessionId: "test")


### PR DESCRIPTION
## Summary
- persist no-session user and assistant turns into the agent-owned default memory
- keep explicit memory from becoming implicit transcript storage
- cover no-session recall and explicit-memory exclusion with regressions

## Verification
- red proof before fix: `swift test --filter 'ContextCoreDefaultMemoryTests/noSessionAgentRunPersistsDefaultMemoryForSubsequentTurns'` failed because the second no-session run had no memory context\n- `swift test --filter 'ContextCoreDefaultMemoryTests/noSessionAgentRunPersistsDefaultMemoryForSubsequentTurns|MemoryIngestionPolicyTests/noSessionRunDoesNotStoreTranscriptTurnsInExplicitMemory'`\n- `swift test --filter 'ContextCoreDefaultMemoryTests|MemoryIngestionPolicyTests|AgentTranscriptContractTests|SessionIntegrationTests'`\n- `git diff --check`\n- `swift build`\n- `swift test`\n\n## Audit Item\nSWARM-AUDIT-005