### PR TITLE
Harden workflow resume signatures

### DIFF
--- a/Sources/Swarm/Workflow/Workflow.swift
+++ b/Sources/Swarm/Workflow/Workflow.swift
@@ -87,10 +87,24 @@ import Foundation
 /// ### Durable Execution
 /// - ``durable``
 public struct Workflow: Sendable {
+    struct OpaqueBehaviorSignature: Sendable, Equatable {
+        let value: String
+
+        init(kind: String, explicit: String?, fileID: StaticString, line: UInt) {
+            let trimmed = explicit?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let identity = if let trimmed, !trimmed.isEmpty {
+                "explicit:\(workflowSignatureComponent(trimmed))"
+            } else {
+                "source:\(workflowSignatureComponent("\(fileID):\(line)"))"
+            }
+            value = "\(kind):\(identity)"
+        }
+    }
+
     enum Step: Sendable {
         case single(any AgentRuntime)
-        case parallel([any AgentRuntime], merge: MergeStrategy)
-        case route(@Sendable (String) -> (any AgentRuntime)?)
+        case parallel([any AgentRuntime], merge: MergeStrategy, mergeBehaviorSignature: OpaqueBehaviorSignature?)
+        case route(OpaqueBehaviorSignature, @Sendable (String) -> (any AgentRuntime)?)
         case fallback(primary: any AgentRuntime, backup: any AgentRuntime, retries: Int)
     }
 
@@ -227,6 +241,7 @@ public struct Workflow: Sendable {
     /// - Parameters:
     ///   - agents: An array of agents to execute in parallel.
     ///   - merge: The strategy for combining results. Defaults to `.structured`.
+    ///   - customMergeSignature: Optional stable durable identity to change when `.custom` merge behavior changes.
     /// - Returns: A new workflow with the added parallel step.
     ///
     /// ## Example
@@ -235,15 +250,36 @@ public struct Workflow: Sendable {
     /// // Analyze from multiple perspectives
     /// let result = try await Workflow()
     ///     .parallel(
-        ///         [technicalAgent, businessAgent, userAgent],
+    ///         [technicalAgent, businessAgent, userAgent],
     ///         merge: .indexed
     ///     )
     ///     .step(synthesizerAgent)
     ///     .run("Evaluate new feature proposal")
     /// ```
-    public func parallel(_ agents: [any AgentRuntime], merge: MergeStrategy = .structured) -> Workflow {
+    public func parallel(
+        _ agents: [any AgentRuntime],
+        merge: MergeStrategy = .structured,
+        customMergeSignature: String? = nil,
+        fileID: StaticString = #fileID,
+        line: UInt = #line
+    ) -> Workflow {
         var copy = self
-        copy.steps.append(.parallel(agents, merge: merge))
+        let mergeBehaviorSignature: OpaqueBehaviorSignature?
+        if case .custom = merge {
+            mergeBehaviorSignature = OpaqueBehaviorSignature(
+                kind: "customMerge",
+                explicit: customMergeSignature,
+                fileID: fileID,
+                line: line
+            )
+        } else {
+            mergeBehaviorSignature = nil
+        }
+        copy.steps.append(.parallel(
+            agents,
+            merge: merge,
+            mergeBehaviorSignature: mergeBehaviorSignature
+        ))
         return copy
     }
 
@@ -254,6 +290,7 @@ public struct Workflow: Sendable {
     ///
     /// - Parameter condition: A closure that receives the current input string
     ///   and returns the agent to execute, or `nil` if routing fails.
+    /// - Parameter signature: Optional stable durable identity to change when route behavior changes.
     /// - Returns: A new workflow with the added routing step.
     ///
     /// ## Example
@@ -271,10 +308,28 @@ public struct Workflow: Sendable {
     ///     }
     ///     .run("Review this code snippet")
     /// ```
-    public func route(_ condition: @escaping @Sendable (String) -> (any AgentRuntime)?) -> Workflow {
+    public func route(
+        _ condition: @escaping @Sendable (String) -> (any AgentRuntime)?,
+        signature: String? = nil,
+        fileID: StaticString = #fileID,
+        line: UInt = #line
+    ) -> Workflow {
         var copy = self
-        copy.steps.append(.route(condition))
+        copy.steps.append(.route(
+            OpaqueBehaviorSignature(kind: "route", explicit: signature, fileID: fileID, line: line),
+            condition
+        ))
         return copy
+    }
+
+    /// Adds a dynamic routing step with an explicit durable identity for the routing behavior.
+    public func route(
+        signature: String,
+        fileID: StaticString = #fileID,
+        line: UInt = #line,
+        _ condition: @escaping @Sendable (String) -> (any AgentRuntime)?
+    ) -> Workflow {
+        route(condition, signature: signature, fileID: fileID, line: line)
     }
 
     /// Configures the workflow to repeat until a condition is met.
@@ -288,6 +343,7 @@ public struct Workflow: Sendable {
     ///     Defaults to 100.
     ///   - condition: A closure that receives the ``AgentResult`` from each
     ///     iteration and returns `true` when the workflow should stop.
+    ///   - signature: Optional stable durable identity to change when repeat predicate behavior changes.
     /// - Returns: A new workflow configured with the repeat condition.
     ///
     /// ## Example
@@ -304,12 +360,32 @@ public struct Workflow: Sendable {
     /// ```
     public func repeatUntil(
         maxIterations: Int = 100,
-        _ condition: @escaping @Sendable (AgentResult) -> Bool
+        _ condition: @escaping @Sendable (AgentResult) -> Bool,
+        signature: String? = nil,
+        fileID: StaticString = #fileID,
+        line: UInt = #line
     ) -> Workflow {
         var copy = self
         copy.repeatCondition = condition
+        copy.repeatConditionSignature = OpaqueBehaviorSignature(
+            kind: "repeat",
+            explicit: signature,
+            fileID: fileID,
+            line: line
+        )
         copy.maxRepeatIterations = maxIterations
         return copy
+    }
+
+    /// Configures repetition with an explicit durable identity for the repeat predicate.
+    public func repeatUntil(
+        maxIterations: Int = 100,
+        signature: String,
+        fileID: StaticString = #fileID,
+        line: UInt = #line,
+        _ condition: @escaping @Sendable (AgentResult) -> Bool
+    ) -> Workflow {
+        repeatUntil(maxIterations: maxIterations, condition, signature: signature, fileID: fileID, line: line)
     }
 
     /// Sets a timeout for workflow execution.
@@ -443,6 +519,7 @@ public struct Workflow: Sendable {
 
     var steps: [Step] = []
     var repeatCondition: (@Sendable (AgentResult) -> Bool)?
+    var repeatConditionSignature: OpaqueBehaviorSignature?
     var maxRepeatIterations = 100
     var timeoutDuration: Duration?
     var observer: (any AgentObserver)?
@@ -524,7 +601,7 @@ public struct Workflow: Sendable {
         case .single(let agent):
             return try await agent.run(input, session: nil, observer: observer)
 
-        case .parallel(let agents, let merge):
+        case .parallel(let agents, let merge, _):
             let inputSnapshot = input
             let completedResults = try await withThrowingTaskGroup(
                 of: (Int, AgentResult).self,
@@ -553,7 +630,7 @@ public struct Workflow: Sendable {
             let mergedOutput = mergeResults(results, strategy: merge)
             return AgentResult(output: mergedOutput)
 
-        case .route(let route):
+        case .route(_, let route):
             guard let selected = route(input) else {
                 throw WorkflowError.routingFailed(reason: "Workflow route did not match any agent for input")
             }
@@ -618,9 +695,9 @@ public struct Workflow: Sendable {
         let parts: [String] = steps.enumerated().map { index, step in
             switch step {
             case .single(let agent):
-                return "\(index):single:\(agent.name)"
-            case .parallel(let agents, let merge):
-                let names = agents.map(\.name).joined(separator: ",")
+                return "\(index):single:\(workflowAgentSignature(agent))"
+            case .parallel(let agents, let merge, let mergeBehaviorSignature):
+                let agentsSignature = agents.map(workflowAgentSignature).joined(separator: ",")
                 let mergeSignature: String
                 switch merge {
                 case .structured:
@@ -630,19 +707,134 @@ public struct Workflow: Sendable {
                 case .first:
                     mergeSignature = "first"
                 case .custom:
-                    mergeSignature = "custom"
+                    mergeSignature = mergeBehaviorSignature?.value ?? "custom:opaque"
                 }
-                return "\(index):parallel:\(names):\(mergeSignature)"
-            case .route:
-                return "\(index):route"
+                return "\(index):parallel:\(agentsSignature):\(mergeSignature)"
+            case .route(let signature, _):
+                return "\(index):route:\(signature.value)"
             case .fallback(let primary, let backup, let retries):
-                return "\(index):fallback:\(primary.name):\(backup.name):\(retries)"
+                return "\(index):fallback:\(workflowAgentSignature(primary)):\(workflowAgentSignature(backup)):\(retries)"
             }
         }
 
-        let repeatSignature = "repeat:\(repeatCondition != nil):\(maxRepeatIterations)"
-        return (parts + [repeatSignature]).joined(separator: "|")
+        let repeatSignature = if repeatCondition != nil {
+            "repeat:true:\(maxRepeatIterations):\(repeatConditionSignature?.value ?? "repeat:opaque")"
+        } else {
+            "repeat:false:\(maxRepeatIterations)"
+        }
+        return (["workflowSignature:v2"] + parts + [repeatSignature]).joined(separator: "|")
     }
+}
+
+private func workflowAgentSignature(_ agent: any AgentRuntime) -> String {
+    [
+        "type=\(workflowSignatureComponent(String(reflecting: type(of: agent))))",
+        "name=\(workflowSignatureComponent(agent.name))",
+        "instructions=\(workflowSignatureComponent(agent.instructions))",
+        "configuration=\(workflowConfigurationSignature(agent.configuration))",
+        "tools=\(agent.tools.map(workflowToolSignature).joined(separator: ","))",
+        "memory=\(workflowOptionalTypeSignature(agent.memory))",
+        "provider=\(workflowInferenceProviderSignature(agent.inferenceProvider))",
+        "tracer=\(workflowOptionalTypeSignature(agent.tracer))",
+        "inputGuardrails=\(agent.inputGuardrails.map(workflowGuardrailSignature).joined(separator: ","))",
+        "outputGuardrails=\(agent.outputGuardrails.map(workflowGuardrailSignature).joined(separator: ","))",
+        "handoffs=\(agent.handoffs.map(workflowHandoffSignature).joined(separator: ","))",
+    ].joined(separator: ";")
+}
+
+private func workflowConfigurationSignature(_ configuration: AgentConfiguration) -> String {
+    let timeout = configuration.timeout.components
+    let parts = [
+        "name=\(workflowSignatureComponent(configuration.name))",
+        "maxIterations=\(configuration.maxIterations)",
+        "timeout=\(timeout.seconds):\(timeout.attoseconds)",
+        "temperature=\(configuration.temperature)",
+        "maxTokens=\(configuration.maxTokens.map(String.init) ?? "nil")",
+        "stopSequences=\(workflowSignatureComponent(String(reflecting: configuration.stopSequences)))",
+        "modelSettings=\(workflowSignatureComponent(String(reflecting: configuration.modelSettings)))",
+        "contextProfile=\(workflowSignatureComponent(String(reflecting: configuration.contextProfile)))",
+        "contextMode=\(workflowSignatureComponent(String(reflecting: configuration.contextMode)))",
+        "inferencePolicy=\(workflowSignatureComponent(String(reflecting: configuration.inferencePolicy)))",
+        "enableStreaming=\(configuration.enableStreaming)",
+        "includeToolCallDetails=\(configuration.includeToolCallDetails)",
+        "stopOnToolError=\(configuration.stopOnToolError)",
+        "includeReasoning=\(configuration.includeReasoning)",
+        "sessionHistoryLimit=\(configuration.sessionHistoryLimit.map(String.init) ?? "nil")",
+        "parallelToolCalls=\(configuration.parallelToolCalls)",
+        "previousResponseId=\(workflowSignatureComponent(configuration.previousResponseId ?? "nil"))",
+        "autoPreviousResponseId=\(configuration.autoPreviousResponseId)",
+        "defaultTracingEnabled=\(configuration.defaultTracingEnabled)",
+        "graphRunOptionsOverride=\(workflowSignatureComponent(String(reflecting: configuration.graphRunOptionsOverride)))",
+    ]
+    return parts.joined(separator: ";")
+}
+
+private func workflowToolSignature(_ tool: any AnyJSONTool) -> String {
+    [
+        "type=\(workflowSignatureComponent(String(reflecting: type(of: tool))))",
+        "name=\(workflowSignatureComponent(tool.name))",
+        "description=\(workflowSignatureComponent(tool.description))",
+        "parameters=\(workflowSignatureComponent(String(reflecting: tool.parameters)))",
+        "semantics=\(workflowSignatureComponent(String(reflecting: tool.executionSemantics)))",
+        "enabled=\(tool.isEnabled)",
+        "inputGuardrails=\(tool.inputGuardrails.map(workflowToolInputGuardrailSignature).joined(separator: ","))",
+        "outputGuardrails=\(tool.outputGuardrails.map(workflowToolOutputGuardrailSignature).joined(separator: ","))",
+    ].joined(separator: ";")
+}
+
+private func workflowHandoffSignature(_ handoff: AnyHandoffConfiguration) -> String {
+    [
+        "target=\(workflowAgentSignature(handoff.targetAgent))",
+        "toolName=\(workflowSignatureComponent(handoff.toolNameOverride ?? "nil"))",
+        "toolDescription=\(workflowSignatureComponent(handoff.toolDescription ?? "nil"))",
+        "onTransfer=\(handoff.onTransfer == nil ? "nil" : "present")",
+        "transform=\(handoff.transform == nil ? "nil" : "present")",
+        "when=\(handoff.when == nil ? "nil" : "present")",
+        "nestHistory=\(handoff.nestHandoffHistory)",
+    ].joined(separator: ";")
+}
+
+private func workflowGuardrailSignature(_ guardrail: any Guardrail) -> String {
+    [
+        "type=\(workflowSignatureComponent(String(reflecting: type(of: guardrail))))",
+        "name=\(workflowSignatureComponent(guardrail.name))",
+    ].joined(separator: ";")
+}
+
+private func workflowToolInputGuardrailSignature(_ guardrail: any ToolInputGuardrail) -> String {
+    [
+        "type=\(workflowSignatureComponent(String(reflecting: type(of: guardrail))))",
+        "name=\(workflowSignatureComponent(guardrail.name))",
+    ].joined(separator: ";")
+}
+
+private func workflowToolOutputGuardrailSignature(_ guardrail: any ToolOutputGuardrail) -> String {
+    [
+        "type=\(workflowSignatureComponent(String(reflecting: type(of: guardrail))))",
+        "name=\(workflowSignatureComponent(guardrail.name))",
+    ].joined(separator: ";")
+}
+
+private func workflowInferenceProviderSignature(_ provider: (any InferenceProvider)?) -> String {
+    guard let provider else {
+        return "nil"
+    }
+    let capabilities = InferenceProviderCapabilities.resolved(for: provider)
+    return [
+        "type=\(workflowSignatureComponent(String(reflecting: type(of: provider))))",
+        "capabilities=\(capabilities.rawValue)",
+    ].joined(separator: ";")
+}
+
+private func workflowOptionalTypeSignature(_ value: Any?) -> String {
+    guard let value else {
+        return "nil"
+    }
+    return workflowSignatureComponent(String(reflecting: type(of: value)))
+}
+
+private func workflowSignatureComponent(_ value: String) -> String {
+    "\(value.utf8.count)#\(value)"
 }
 
 private final class WorkflowTimedOperationCoordinator<T: Sendable>: @unchecked Sendable {

--- a/Tests/SwarmTests/Workflow/WorkflowDurableTests.swift
+++ b/Tests/SwarmTests/Workflow/WorkflowDurableTests.swift
@@ -81,6 +81,113 @@ struct WorkflowDurableTests {
         }
     }
 
+    @Test("durable resume rejects same-name agent configuration mismatch")
+    func resumeRejectsSameNameAgentConfigurationMismatch() async throws {
+        let checkpointing = WorkflowCheckpointing.inMemory()
+
+        let original = Workflow()
+            .step(MockAgentRuntime(
+                response: "done",
+                configuration: AgentConfiguration(name: "Worker", maxIterations: 1, temperature: 0.1)
+            ))
+            .durable
+            .checkpoint(id: "wf-agent-config-mismatch", policy: .everyStep)
+            .durable
+            .checkpointing(checkpointing)
+
+        _ = try await original.durable.execute("start")
+
+        let changed = Workflow()
+            .step(MockAgentRuntime(
+                response: "done",
+                configuration: AgentConfiguration(name: "Worker", maxIterations: 5, temperature: 0.1)
+            ))
+            .durable
+            .checkpoint(id: "wf-agent-config-mismatch", policy: .everyStep)
+            .durable
+            .checkpointing(checkpointing)
+
+        await #expect(throws: WorkflowError.self) {
+            _ = try await changed.durable.execute("resume", resumeFrom: "wf-agent-config-mismatch")
+        }
+    }
+
+    @Test("durable resume rejects changed route closure identity")
+    func resumeRejectsChangedRouteClosureIdentity() async throws {
+        let checkpointing = WorkflowCheckpointing.inMemory()
+
+        let original = Workflow()
+            .step(MockAgentRuntime(response: "seed"))
+            .route { _ in nil as (any AgentRuntime)? }
+            .durable
+            .checkpoint(id: "wf-route-closure-mismatch", policy: .everyStep)
+            .durable
+            .checkpointing(checkpointing)
+
+        await #expect(throws: WorkflowError.self) {
+            _ = try await original.durable.execute("start")
+        }
+        #expect(try await checkpointing.containsCheckpoint(for: "wf-route-closure-mismatch"))
+
+        let changed = Workflow()
+            .step(MockAgentRuntime(response: "seed"))
+            .route { _ in MockAgentRuntime(response: "changed-route") }
+            .durable
+            .checkpoint(id: "wf-route-closure-mismatch", policy: .everyStep)
+            .durable
+            .checkpointing(checkpointing)
+
+        await #expect(throws: WorkflowError.self) {
+            _ = try await changed.durable.execute("resume", resumeFrom: "wf-route-closure-mismatch")
+        }
+    }
+
+    @Test("durable resume rejects changed custom merge closure identity")
+    func resumeRejectsChangedCustomMergeClosureIdentity() async throws {
+        let checkpointing = WorkflowCheckpointing.inMemory()
+
+        let original = Workflow()
+            .parallel([MockAgentRuntime(response: "branch")], merge: .custom { _ in "original-merge" })
+            .durable
+            .checkpoint(id: "wf-custom-merge-mismatch", policy: .everyStep)
+            .durable
+            .checkpointing(checkpointing)
+
+        _ = try await original.durable.execute("start")
+
+        let changed = Workflow()
+            .parallel([MockAgentRuntime(response: "branch")], merge: .custom { _ in "changed-merge" })
+            .durable
+            .checkpoint(id: "wf-custom-merge-mismatch", policy: .everyStep)
+            .durable
+            .checkpointing(checkpointing)
+
+        await #expect(throws: WorkflowError.self) {
+            _ = try await changed.durable.execute("resume", resumeFrom: "wf-custom-merge-mismatch")
+        }
+    }
+
+    @Test("durable resume rejects changed repeat closure identity")
+    func resumeRejectsChangedRepeatClosureIdentity() async throws {
+        let checkpointing = WorkflowCheckpointing.inMemory()
+
+        let original = repeatClosureIdentityWorkflow(
+            checkpointing: checkpointing,
+            signature: "repeat-predicate:v1"
+        ) { _ in false }
+
+        _ = try await original.durable.execute("start")
+
+        let changed = repeatClosureIdentityWorkflow(
+            checkpointing: checkpointing,
+            signature: "repeat-predicate:v2"
+        ) { _ in true }
+
+        await #expect(throws: WorkflowError.self) {
+            _ = try await changed.durable.execute("resume", resumeFrom: "wf-repeat-closure-mismatch")
+        }
+    }
+
     @Test("durable fallback executes backup after retries exhausted")
     func fallbackUsesBackup() async throws {
         let result = try await Workflow()
@@ -91,6 +198,20 @@ struct WorkflowDurableTests {
         #expect(result.output == "backup")
         #expect(result.metadata["workflow.fallback.used"] == .bool(true))
     }
+}
+
+private func repeatClosureIdentityWorkflow(
+    checkpointing: WorkflowCheckpointing,
+    signature: String,
+    condition: @escaping @Sendable (AgentResult) -> Bool
+) -> Workflow {
+    Workflow()
+        .step(MockAgentRuntime(response: "draft"))
+        .repeatUntil(maxIterations: 1, condition, signature: signature)
+        .durable
+        .checkpoint(id: "wf-repeat-closure-mismatch", policy: .everyStep)
+        .durable
+        .checkpointing(checkpointing)
 }
 
 private actor FailingAgent: AgentRuntime {

--- a/docs/reference/api-catalog.md
+++ b/docs/reference/api-catalog.md
@@ -2494,21 +2494,23 @@ Generated from `Sources/Swarm/` on 2026-04-30.
 
 | Line | Kind | Access | Name | Signature |
 |------|------|--------|------|-----------|
-| 4 | struct | public | Workflow | `public struct Workflow` |
-| 12 | enum | public | Workflow.MergeStrategy | `public enum MergeStrategy` |
-| 15 | case | public | Workflow.MergeStrategy.structured | `public case structured` |
-| 18 | case | public | Workflow.MergeStrategy.indexed | `public case indexed` |
-| 20 | case | public | Workflow.MergeStrategy.first | `public case first` |
-| 22 | case | public | Workflow.MergeStrategy.custom(_:) | `public case custom(([AgentResult]) -> String)` |
-| 25 | func | public | Workflow.init() | `public init()` |
-| 27 | func | public | Workflow.step(_:) | `public func step(_ agent: some AgentRuntime) -> Workflow` |
-| 33 | func | public | Workflow.parallel(_:merge:) | `public func parallel(_ agents: [any AgentRuntime], merge: Workflow.MergeStrategy = .structured) -> Workflow` |
-| 39 | func | public | Workflow.route(_:) | `public func route(_ condition: @escaping (String) -> (any AgentRuntime)?) -> Workflow` |
-| 45 | func | public | Workflow.repeatUntil(maxIterations:_:) | `public func repeatUntil(maxIterations: Int = 100, _ condition: @escaping (AgentResult) -> Bool) -> Workflow` |
-| 55 | func | public | Workflow.timeout(_:) | `public func timeout(_ duration: Duration) -> Workflow` |
-| 61 | func | public | Workflow.observed(by:) | `public func observed(by observer: some AgentObserver) -> Workflow` |
-| 67 | func | public | Workflow.run(_:) | `public func run(_ input: String) async throws -> AgentResult` |
-| 418 | func | public | Workflow.stream(_:) | `public func stream(_ input: String) -> AsyncThrowingStream<AgentEvent, any Error>` |
+| 89 | struct | public | Workflow | `public struct Workflow` |
+| 125 | enum | public | Workflow.MergeStrategy | `public enum MergeStrategy` |
+| 140 | case | public | Workflow.MergeStrategy.structured | `public case structured` |
+| 157 | case | public | Workflow.MergeStrategy.indexed | `public case indexed` |
+| 173 | case | public | Workflow.MergeStrategy.first | `public case first` |
+| 193 | case | public | Workflow.MergeStrategy.custom(_:) | `public case custom(@Sendable ([AgentResult]) -> String)` |
+| 209 | func | public | Workflow.init() | `public init()` |
+| 229 | func | public | Workflow.step(_:) | `public func step(_ agent: some AgentRuntime) -> Workflow` |
+| 259 | func | public | Workflow.parallel(_:merge:customMergeSignature:fileID:line:) | `public func parallel(_ agents: [any AgentRuntime], merge: Workflow.MergeStrategy = .structured, customMergeSignature: String? = nil, fileID: StaticString = #fileID, line: UInt = #line) -> Workflow` |
+| 311 | func | public | Workflow.route(_:signature:fileID:line:) | `public func route(_ condition: @escaping @Sendable (String) -> (any AgentRuntime)?, signature: String? = nil, fileID: StaticString = #fileID, line: UInt = #line) -> Workflow` |
+| 326 | func | public | Workflow.route(signature:fileID:line:_:) | `public func route(signature: String, fileID: StaticString = #fileID, line: UInt = #line, _ condition: @escaping @Sendable (String) -> (any AgentRuntime)?) -> Workflow` |
+| 361 | func | public | Workflow.repeatUntil(maxIterations:_:signature:fileID:line:) | `public func repeatUntil(maxIterations: Int = 100, _ condition: @escaping @Sendable (AgentResult) -> Bool, signature: String? = nil, fileID: StaticString = #fileID, line: UInt = #line) -> Workflow` |
+| 381 | func | public | Workflow.repeatUntil(maxIterations:signature:fileID:line:_:) | `public func repeatUntil(maxIterations: Int = 100, signature: String, fileID: StaticString = #fileID, line: UInt = #line, _ condition: @escaping @Sendable (AgentResult) -> Bool) -> Workflow` |
+| 407 | func | public | Workflow.timeout(_:) | `public func timeout(_ duration: Duration) -> Workflow` |
+| 433 | func | public | Workflow.observed(by:) | `public func observed(by observer: some AgentObserver) -> Workflow` |
+| 459 | func | public | Workflow.run(_:) | `public func run(_ input: String) async throws -> AgentResult` |
+| 494 | func | public | Workflow.stream(_:) | `public func stream(_ input: String) -> AsyncThrowingStream<AgentEvent, Error>` |
 
 ### Workflow/WorkflowCheckpointing.swift
 

--- a/docs/reference/front-facing-api.md
+++ b/docs/reference/front-facing-api.md
@@ -258,9 +258,39 @@ public struct Workflow: Sendable {
 
     // Composition
     public func step(_ agent: some AgentRuntime) -> Workflow
-    public func parallel(_ agents: [any AgentRuntime], merge: MergeStrategy = .structured) -> Workflow
-    public func route(_ condition: @escaping @Sendable (String) -> (any AgentRuntime)?) -> Workflow
-    public func repeatUntil(maxIterations: Int = 100, _ condition: @escaping @Sendable (AgentResult) -> Bool) -> Workflow
+    public func parallel(
+        _ agents: [any AgentRuntime],
+        merge: MergeStrategy = .structured,
+        customMergeSignature: String? = nil,
+        fileID: StaticString = #fileID,
+        line: UInt = #line
+    ) -> Workflow
+    public func route(
+        _ condition: @escaping @Sendable (String) -> (any AgentRuntime)?,
+        signature: String? = nil,
+        fileID: StaticString = #fileID,
+        line: UInt = #line
+    ) -> Workflow
+    public func route(
+        signature: String,
+        fileID: StaticString = #fileID,
+        line: UInt = #line,
+        _ condition: @escaping @Sendable (String) -> (any AgentRuntime)?
+    ) -> Workflow
+    public func repeatUntil(
+        maxIterations: Int = 100,
+        _ condition: @escaping @Sendable (AgentResult) -> Bool,
+        signature: String? = nil,
+        fileID: StaticString = #fileID,
+        line: UInt = #line
+    ) -> Workflow
+    public func repeatUntil(
+        maxIterations: Int = 100,
+        signature: String,
+        fileID: StaticString = #fileID,
+        line: UInt = #line,
+        _ condition: @escaping @Sendable (AgentResult) -> Bool
+    ) -> Workflow
     public func timeout(_ duration: Duration) -> Workflow
     public func observed(by observer: some AgentObserver) -> Workflow
 


### PR DESCRIPTION
## Summary
- harden durable workflow resume signatures with agent configuration, tools, memory/provider/tracer types, guardrails, handoffs, and merge/repeat/route identity
- add durable identity for custom merge, route, and repeat predicate closures while preserving existing trailing-closure call sites
- refresh Workflow public API reference docs after the new identity parameters/overloads

## Verification
- red proof before fix: focused workflow durability tests failed because changed same-name agent config, route closure, and custom merge closure resumed without mismatch
- `swift test --filter WorkflowDurableTests/resumeRejectsChangedRepeatClosureIdentity`
- `swift test --filter 'WorkflowDurableTests|WorkflowResumeIntegrationTests|WorkflowCoreTests|FrameworkDXRegressionTests|DocumentationFreshnessTests/apiCatalogHeaderAndWorkflowStreamLineStayFresh'`
- `git diff --check`
- `swift build`
- `swift test` (1716 tests)

## Notes
- Default closure identity uses source location for route/custom merge/repeat behavior.
- Explicit signatures are available for durable workflows when a closure body changes without moving the call site.
