### PR TITLE
Cover indexed workflow merge ordering

### DIFF
--- a/Tests/SwarmTests/Regression/FrameworkDXRegressionTests.swift
+++ b/Tests/SwarmTests/Regression/FrameworkDXRegressionTests.swift
@@ -63,6 +63,18 @@ struct FrameworkDXRegressionTests {
         #expect(object["1"] == "fast-one")
     }
 
+    @Test("Workflow indexed parallel merge preserves agent input order")
+    func workflowParallelIndexedMergePreservesInputOrder() async throws {
+        let slow = OrderedWorkflowAgent(output: "slow-zero", delay: .milliseconds(120))
+        let fast = OrderedWorkflowAgent(output: "fast-one", delay: .milliseconds(10))
+
+        let result = try await Workflow()
+            .parallel([slow, fast], merge: .indexed)
+            .run("input")
+
+        #expect(result.output == "[0]: slow-zero\n[1]: fast-one")
+    }
+
     @Test("MCP tool cache invalidation wins over in-flight refresh")
     func mcpToolCacheInvalidationWinsOverInflightRefresh() async throws {
         let client = MCPClient()


### PR DESCRIPTION
## Summary
- add regression coverage for `.indexed` workflow parallel merge ordering
- keep this item test-only because current `origin/main` already sorts non-`.first` parallel results by original agent index before merging
- complements the existing `.structured` ordering regression so both audit-identified merge modes are guarded

## Verification
- static proof: `Workflow.execute(step:)` collects `(index, AgentResult)` pairs and sorts non-`.first` results by original index before `mergeResults`
- `swift test --filter FrameworkDXRegressionTests/workflowParallelStructuredMergePreservesInputOrder`
- `swift test --filter 'FrameworkDXRegressionTests/workflowParallelStructuredMergePreservesInputOrder|FrameworkDXRegressionTests/workflowParallelIndexedMergePreservesInputOrder'`
- `swift test --filter FrameworkDXRegressionTests`
- `git diff --check`
- `swift build`
- `swift test` (1713 tests)
- code review agent: no blocking findings
