### PR TITLE
Fix MCP text content API usage

### DIFF
--- a/Sources/SwarmMCP/SwarmMCPErrorMapper.swift
+++ b/Sources/SwarmMCP/SwarmMCPErrorMapper.swift
@@ -271,6 +271,6 @@ enum SwarmMCPErrorMapper {
     }
 
     private static func textContent(_ text: String) -> MCP.Tool.Content {
-        .text(text)
+        .text(text: text, annotations: nil, _meta: nil)
     }
 }

--- a/Tests/SwarmTests/MCP/SwarmMCPServerServiceTests.swift
+++ b/Tests/SwarmTests/MCP/SwarmMCPServerServiceTests.swift
@@ -46,7 +46,7 @@ struct SwarmMCPServerServiceTests {
         )
 
         #expect(result.isError != true)
-        #expect(result.content == [.text("HELLO")])
+        #expect(textContent(from: result.content) == "HELLO")
     }
 
     @Test("ListTools returns deterministic stable ordering and schemas")
@@ -109,7 +109,7 @@ struct SwarmMCPServerServiceTests {
         )
 
         #expect(result.isError != true)
-        #expect(result.content == [.text("hello")])
+        #expect(textContent(from: result.content) == "hello")
 
         let invocations = await executor.invocationsSnapshot()
         #expect(invocations.count == 1)
@@ -276,7 +276,7 @@ struct SwarmMCPServerServiceTests {
                         arguments: ["value": .int(i)]
                     )
                     guard
-                        case let .text(text)? = result.content.first,
+                        let text = textContent(from: result.content),
                         let parsed = Int(text)
                     else {
                         throw SwarmMCPServerServiceTestError.unreachable("unexpected content")
@@ -410,6 +410,13 @@ struct SwarmMCPServerServiceTests {
         try await firstStart
         await service.stop()
     }
+}
+
+private func textContent(from content: [MCP.Tool.Content]) -> String? {
+    guard case let .text(text: text, annotations: _, _meta: _)? = content.first else {
+        return nil
+    }
+    return text
 }
 
 private func metadataObject(from content: [MCP.Tool.Content]) throws -> [String: Value] {


### PR DESCRIPTION
## Summary
- Updates SwarmMCP text content construction to the current MCP labeled API.
- Updates SwarmMCPServerService tests to extract text payloads from the new labeled tuple shape instead of comparing/deconstructing deprecated shorthand cases.

## Verification
- swift test --filter SwarmMCPServerServiceTests

## Notes
- This is a prerequisite baseline compile fix discovered while verifying SWARM-AUDIT-009 against current origin/main.