### PR TITLE
Add workflow timeout regression guard

### DIFF
--- a/Tests/SwarmTests/Regression/FrameworkDXRegressionTests.swift
+++ b/Tests/SwarmTests/Regression/FrameworkDXRegressionTests.swift
@@ -190,15 +190,7 @@ struct FrameworkDXRegressionTests {
                 .run("input")
         }
 
-        var agentIsBlocked = false
-        for _ in 0 ..< 100 {
-            if await agent.isBlocked {
-                agentIsBlocked = true
-                break
-            }
-            try await Task.sleep(for: .milliseconds(1))
-        }
-        #expect(agentIsBlocked)
+        await agent.waitUntilBlocked()
 
         do {
             _ = try await task.value
@@ -456,14 +448,27 @@ private actor BlockingWorkflowAgent: AgentRuntime {
     nonisolated let instructions = "Block until released."
     nonisolated let configuration = AgentConfiguration.default
     private var continuation: CheckedContinuation<Void, Never>?
+    private var blockedWaiters: [CheckedContinuation<Void, Never>] = []
 
     var isBlocked: Bool {
         continuation != nil
     }
 
+    func waitUntilBlocked() async {
+        if continuation != nil {
+            return
+        }
+        await withCheckedContinuation { waiter in
+            blockedWaiters.append(waiter)
+        }
+    }
+
     func run(_ input: String, session _: (any Session)?, observer _: (any AgentObserver)?) async throws -> AgentResult {
         await withCheckedContinuation { continuation in
             self.continuation = continuation
+            let waiters = blockedWaiters
+            blockedWaiters.removeAll()
+            waiters.forEach { $0.resume() }
         }
         return AgentResult(output: input)
     }

--- a/Tests/SwarmTests/Regression/FrameworkDXRegressionTests.swift
+++ b/Tests/SwarmTests/Regression/FrameworkDXRegressionTests.swift
@@ -180,13 +180,33 @@ struct FrameworkDXRegressionTests {
     @Test("Workflow timeout returns without waiting for non-cooperative work")
     func workflowTimeoutReturnsWithoutWaitingForNonCooperativeWork() async throws {
         let agent = BlockingWorkflowAgent()
+        let timeout: Duration = .milliseconds(200)
         let start = ContinuousClock.now
 
-        await #expect(throws: AgentError.self) {
-            _ = try await Workflow()
+        let task = Task {
+            try await Workflow()
                 .step(agent)
-                .timeout(.milliseconds(50))
+                .timeout(timeout)
                 .run("input")
+        }
+
+        var agentIsBlocked = false
+        for _ in 0 ..< 100 {
+            if await agent.isBlocked {
+                agentIsBlocked = true
+                break
+            }
+            try await Task.sleep(for: .milliseconds(1))
+        }
+        #expect(agentIsBlocked)
+
+        do {
+            _ = try await task.value
+            Issue.record("Expected workflow timeout")
+        } catch AgentError.timeout(let duration) {
+            #expect(duration == timeout)
+        } catch {
+            Issue.record("Expected workflow timeout, got \(error)")
         }
 
         let elapsed = ContinuousClock.now - start
@@ -436,6 +456,10 @@ private actor BlockingWorkflowAgent: AgentRuntime {
     nonisolated let instructions = "Block until released."
     nonisolated let configuration = AgentConfiguration.default
     private var continuation: CheckedContinuation<Void, Never>?
+
+    var isBlocked: Bool {
+        continuation != nil
+    }
 
     func run(_ input: String, session _: (any Session)?, observer _: (any AgentObserver)?) async throws -> AgentResult {
         await withCheckedContinuation { continuation in


### PR DESCRIPTION
## Summary
- Adds a regression test proving workflow timeouts return promptly even when branch work is non-cooperative.
- Keeps the current runtime behavior locked without changing workflow implementation.

## Audit item
- Closes SWARM-AUDIT-009.

## Verification
- swift test --filter 'FrameworkDXRegressionTests/workflowTimeoutReturnsWithoutWaitingForNonCooperativeWork'

## Stack
- Stacked on PR #94 because current main test compilation is blocked by the MCP text content API fix there.