### PR TITLE
Fix low-risk audit regressions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -94,7 +94,7 @@ Please check the relevant option(s):
 - [ ] I have performed a self-review of my own code
 - [ ] I have run `swift build` and ensured no compilation errors
 - [ ] I have run `swift test` and all tests pass
-- [ ] I have run SwiftFormat: `swift package plugin --allow-writing-to-package-directory swiftformat`
+- [ ] I have run SwiftFormat: `swiftformat Sources Tests --lint --config .swiftformat`
 - [ ] I have run SwiftLint and fixed any warnings: `swiftlint lint`
 
 ### Concurrency & Safety

--- a/Sources/Swarm/Integration/Wax/WaxEmbeddingProviderAdapters.swift
+++ b/Sources/Swarm/Integration/Wax/WaxEmbeddingProviderAdapters.swift
@@ -59,6 +59,7 @@ public struct WaxEmbeddingProviderAdapter: WaxVectorSearch.EmbeddingProvider {
     public var dimensions: Int { base.dimensions }
 
     public func embed(_ text: String) async throws -> [Float] {
-        try await base.embed(text)
+        let embedding = try await base.embed(text)
+        return normalize ? EmbeddingUtils.normalize(embedding) : embedding
     }
 }

--- a/Sources/Swarm/Memory/ContextCoreMemory.swift
+++ b/Sources/Swarm/Memory/ContextCoreMemory.swift
@@ -51,6 +51,18 @@ public actor ContextCoreMemory: Memory, MemoryPromptDescriptor, MemorySessionLif
     }
 
     public init(configuration: ContextCoreMemoryConfiguration = .default) throws {
+        try self.init(
+            configuration: configuration,
+            endSession: { context in
+                try await context.endSession()
+            }
+        )
+    }
+
+    init(
+        configuration: ContextCoreMemoryConfiguration = .default,
+        endSession: @escaping @Sendable (ContextCore.AgentContext) async throws -> Void
+    ) throws {
         self.configuration = configuration
         self.memoryPromptTitle = configuration.promptTitle
         self.memoryPromptGuidance = configuration.promptGuidance
@@ -59,6 +71,7 @@ public actor ContextCoreMemory: Memory, MemoryPromptDescriptor, MemorySessionLif
             try ContextCore.AgentContext(configuration: configuration.contextConfiguration)
         }
         self.context = try contextFactory()
+        self.endSession = endSession
     }
 
     public func add(_ message: MemoryMessage) async {
@@ -91,6 +104,14 @@ public actor ContextCoreMemory: Memory, MemoryPromptDescriptor, MemorySessionLif
     }
 
     public func clear() async {
+        if sessionIsReady {
+            do {
+                try await endSession(context)
+            } catch {
+                // Best-effort shutdown. Clearing Swarm's local buffer remains authoritative.
+            }
+        }
+
         messages.removeAll()
         sessionIsReady = false
     }
@@ -105,7 +126,7 @@ public actor ContextCoreMemory: Memory, MemoryPromptDescriptor, MemorySessionLif
         }
 
         do {
-            try await context.endSession()
+            try await endSession(context)
         } catch {
             // Best-effort shutdown. The local buffer stays authoritative.
         }
@@ -122,6 +143,7 @@ public actor ContextCoreMemory: Memory, MemoryPromptDescriptor, MemorySessionLif
 
     private let configuration: ContextCoreMemoryConfiguration
     private let contextFactory: @Sendable () throws -> ContextCore.AgentContext
+    private let endSession: @Sendable (ContextCore.AgentContext) async throws -> Void
     private var context: ContextCore.AgentContext
     private var sessionIsReady = false
     private var messages: [MemoryMessage] = []

--- a/Sources/SwarmMacros/ToolMacro.swift
+++ b/Sources/SwarmMacros/ToolMacro.swift
@@ -84,7 +84,7 @@ public struct ToolMacro: MemberMacro, ExtensionMacro {
         }
         let typeName = structDecl.name.text
 
-        // Derive tool name from type name (lowercase, remove "Tool" suffix)
+        // Derive tool name from type name (snake_case, remove "Tool" suffix)
         let toolName = deriveToolName(from: typeName)
 
         // Find all @Parameter annotated properties
@@ -168,8 +168,18 @@ public struct ToolMacro: MemberMacro, ExtensionMacro {
         if name.hasSuffix("Tool") {
             name = String(name.dropLast(4))
         }
-        // Convert to lowercase
-        return name.lowercased()
+        var output = ""
+        for character in name {
+            if character.isUppercase {
+                if !output.isEmpty {
+                    output.append("_")
+                }
+                output.append(character.lowercased())
+            } else {
+                output.append(character)
+            }
+        }
+        return output
     }
 
     /// Extracts @Parameter annotated properties from the declaration.

--- a/Sources/SwarmMacros/ToolMacro.swift
+++ b/Sources/SwarmMacros/ToolMacro.swift
@@ -155,11 +155,10 @@ public struct ToolMacro: MemberMacro, ExtensionMacro {
     private static func extractDescription(from node: AttributeSyntax) -> String? {
         guard let arguments = node.arguments?.as(LabeledExprListSyntax.self),
               let firstArg = arguments.first,
-              let stringLiteral = firstArg.expression.as(StringLiteralExprSyntax.self),
-              let segment = stringLiteral.segments.first?.as(StringSegmentSyntax.self) else {
+              let stringLiteral = firstArg.expression.as(StringLiteralExprSyntax.self) else {
             return nil
         }
-        return segment.content.text
+        return extractStaticStringLiteral(from: stringLiteral)
     }
 
     /// Derives the tool name from the type name.
@@ -237,9 +236,8 @@ public struct ToolMacro: MemberMacro, ExtensionMacro {
         // First unlabeled argument is the description
         for arg in arguments {
             if arg.label == nil,
-               let stringLiteral = arg.expression.as(StringLiteralExprSyntax.self),
-               let segment = stringLiteral.segments.first?.as(StringSegmentSyntax.self) {
-                return segment.content.text
+               let stringLiteral = arg.expression.as(StringLiteralExprSyntax.self) {
+                return extractStaticStringLiteral(from: stringLiteral)
             }
         }
         return nil
@@ -265,8 +263,8 @@ public struct ToolMacro: MemberMacro, ExtensionMacro {
                 var options: [String] = []
                 for element in arrayExpr.elements {
                     if let stringLiteral = element.expression.as(StringLiteralExprSyntax.self),
-                       let segment = stringLiteral.segments.first?.as(StringSegmentSyntax.self) {
-                        options.append(segment.content.text)
+                       let option = extractStaticStringLiteral(from: stringLiteral) {
+                        options.append(option)
                     }
                 }
                 return options
@@ -300,8 +298,8 @@ public struct ToolMacro: MemberMacro, ExtensionMacro {
 
             return """
                 ToolParameter(
-                    name: "\(param.name)",
-                    description: "\(param.description)",
+                    name: \(stringLiteral(param.name)),
+                    description: \(stringLiteral(param.description)),
                     type: \(paramType),
                     isRequired: \(isRequired)\(defaultValueStr)
                 )
@@ -315,7 +313,7 @@ public struct ToolMacro: MemberMacro, ExtensionMacro {
     private static func mapSwiftTypeToParameterType(_ swiftType: String, oneOf: [String]?) -> String {
         // Handle oneOf first
         if let options = oneOf, !options.isEmpty {
-            let optionsStr = options.map { "\"\($0)\"" }.joined(separator: ", ")
+            let optionsStr = options.map(stringLiteral).joined(separator: ", ")
             return ".oneOf([\(optionsStr)])"
         }
 
@@ -351,7 +349,7 @@ public struct ToolMacro: MemberMacro, ExtensionMacro {
     /// Converts a default value to SendableValue syntax.
     private static func convertToSendableValue(_ value: String, type: String) -> String {
         let cleanValue = value.trimmingCharacters(in: .whitespaces)
-        
+
         if cleanValue == "nil" {
             return "nil"
         }
@@ -370,6 +368,110 @@ public struct ToolMacro: MemberMacro, ExtensionMacro {
         default:
             return ".string(\(cleanValue))"
         }
+    }
+
+    private static func stringLiteral(_ value: String) -> String {
+        String(reflecting: value)
+    }
+
+    private static func extractStaticStringLiteral(from stringLiteral: StringLiteralExprSyntax) -> String? {
+        let rawDelimiterCount = stringLiteral.openingQuote.text.prefix { $0 == "#" }.count
+        var value = ""
+
+        for segment in stringLiteral.segments {
+            guard let stringSegment = segment.as(StringSegmentSyntax.self) else {
+                return nil
+            }
+            value += decodeStringLiteralSegment(stringSegment.content.text, rawDelimiterCount: rawDelimiterCount)
+        }
+
+        return value
+    }
+
+    private static func decodeStringLiteralSegment(_ text: String, rawDelimiterCount: Int) -> String {
+        var decoded = ""
+        var index = text.startIndex
+
+        while index < text.endIndex {
+            let character = text[index]
+            guard character == "\\" else {
+                decoded.append(character)
+                index = text.index(after: index)
+                continue
+            }
+
+            index = text.index(after: index)
+            var hashCount = 0
+            var scanIndex = index
+            while scanIndex < text.endIndex, text[scanIndex] == "#" {
+                hashCount += 1
+                scanIndex = text.index(after: scanIndex)
+            }
+
+            guard hashCount == rawDelimiterCount, scanIndex < text.endIndex else {
+                decoded.append("\\")
+                continue
+            }
+
+            index = scanIndex
+            let escaped = text[index]
+            switch escaped {
+            case "\"":
+                decoded.append("\"")
+            case "\\":
+                decoded.append("\\")
+            case "0":
+                decoded.append("\0")
+            case "n":
+                decoded.append("\n")
+            case "r":
+                decoded.append("\r")
+            case "t":
+                decoded.append("\t")
+            case "u":
+                if decodeUnicodeEscape(from: text, index: &index, into: &decoded) {
+                    continue
+                }
+                decoded += rawEscape(escaped, rawDelimiterCount: rawDelimiterCount)
+            default:
+                decoded += rawEscape(escaped, rawDelimiterCount: rawDelimiterCount)
+            }
+            index = text.index(after: index)
+        }
+
+        return decoded
+    }
+
+    private static func decodeUnicodeEscape(
+        from text: String,
+        index: inout String.Index,
+        into decoded: inout String
+    ) -> Bool {
+        var scanIndex = text.index(after: index)
+        guard scanIndex < text.endIndex, text[scanIndex] == "{" else {
+            return false
+        }
+
+        scanIndex = text.index(after: scanIndex)
+        var hex = ""
+        while scanIndex < text.endIndex, text[scanIndex] != "}" {
+            hex.append(text[scanIndex])
+            scanIndex = text.index(after: scanIndex)
+        }
+
+        guard scanIndex < text.endIndex,
+              let scalarValue = UInt32(hex, radix: 16),
+              let scalar = UnicodeScalar(scalarValue) else {
+            return false
+        }
+
+        decoded.append(Character(scalar))
+        index = scanIndex
+        return true
+    }
+
+    private static func rawEscape(_ escaped: Character, rawDelimiterCount: Int) -> String {
+        "\\" + String(repeating: "#", count: rawDelimiterCount) + String(escaped)
     }
 
     /// Generates the execute(arguments:) wrapper method.

--- a/Sources/SwarmMacros/ToolMacro.swift
+++ b/Sources/SwarmMacros/ToolMacro.swift
@@ -476,7 +476,7 @@ public struct ToolMacro: MemberMacro, ExtensionMacro {
         }
 
         decoded.append(Character(scalar))
-        index = scanIndex
+        index = text.index(after: scanIndex)
         return true
     }
 

--- a/Tests/SwarmMacrosTests/ToolMacroTests.swift
+++ b/Tests/SwarmMacrosTests/ToolMacroTests.swift
@@ -220,6 +220,67 @@ final class ToolMacroTests: XCTestCase {
         #endif
     }
 
+    func testToolParameterLiteralsAreEscaped() throws {
+        #if canImport(SwarmMacros)
+            assertMacroExpansion(
+                #"""
+                @Tool("Finds \"quoted\" text")
+                struct SearchTool {
+                    @Parameter("Search for a \"quoted\" phrase", oneOf: ["exact \"phrase\"", "loose"])
+                    var query: String
+
+                    func execute() async throws -> String {
+                        return query
+                    }
+                }
+                """#,
+                expandedSource: """
+                struct SearchTool {
+                    var query: String
+
+                    func execute() async throws -> String {
+                        return query
+                    }
+
+                    public let name: String = "search"
+
+                    public let description: String = #"Finds "quoted" text"#
+
+                    public let parameters: [ToolParameter] = [
+                                ToolParameter(
+                            name: "query",
+                            description: "Search for a \\"quoted\\" phrase",
+                            type: .oneOf(["exact \\"phrase\\"", "loose"]),
+                            isRequired: true
+                        )
+                        ]
+
+                    public init() {
+                    }
+
+                    public struct Input: Codable, Sendable {
+                        public var query: String
+                    }
+
+                    public typealias Output = String
+
+                    public func execute(_ input: Input) async throws -> Output {
+                        var toolCopy = self
+                        toolCopy.query = input.query
+                        return try await toolCopy.execute()
+                    }
+                }
+
+                extension SearchTool: Tool, Sendable {
+                }
+                """,
+                macros: toolMacros()
+            )
+        #else
+            throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
     func testToolWithIntParameter() throws {
         #if canImport(SwarmMacros)
             assertMacroExpansion(

--- a/Tests/SwarmMacrosTests/ToolMacroTests.swift
+++ b/Tests/SwarmMacrosTests/ToolMacroTests.swift
@@ -281,6 +281,67 @@ final class ToolMacroTests: XCTestCase {
         #endif
     }
 
+    func testToolParameterUnicodeEscapesDoNotKeepClosingBrace() throws {
+        #if canImport(SwarmMacros)
+            assertMacroExpansion(
+                #"""
+                @Tool("Smile \u{1F600}")
+                struct EmojiTool {
+                    @Parameter("Mood \u{1F600}")
+                    var mood: String
+
+                    func execute() async throws -> String {
+                        return mood
+                    }
+                }
+                """#,
+                expandedSource: """
+                struct EmojiTool {
+                    var mood: String
+
+                    func execute() async throws -> String {
+                        return mood
+                    }
+
+                    public let name: String = "emoji"
+
+                    public let description: String = "Smile 😀"
+
+                    public let parameters: [ToolParameter] = [
+                                ToolParameter(
+                            name: "mood",
+                            description: "Mood 😀",
+                            type: .string,
+                            isRequired: true
+                        )
+                        ]
+
+                    public init() {
+                    }
+
+                    public struct Input: Codable, Sendable {
+                        public var mood: String
+                    }
+
+                    public typealias Output = String
+
+                    public func execute(_ input: Input) async throws -> Output {
+                        var toolCopy = self
+                        toolCopy.mood = input.mood
+                        return try await toolCopy.execute()
+                    }
+                }
+
+                extension EmojiTool: Tool, Sendable {
+                }
+                """,
+                macros: toolMacros()
+            )
+        #else
+            throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
     func testToolWithIntParameter() throws {
         #if canImport(SwarmMacros)
             assertMacroExpansion(

--- a/Tests/SwarmMacrosTests/ToolMacroTests.swift
+++ b/Tests/SwarmMacrosTests/ToolMacroTests.swift
@@ -480,7 +480,7 @@ final class ToolMacroTests: XCTestCase {
                         return ""
                     }
 
-                    public let name: String = "myawesome"
+                    public let name: String = "my_awesome"
 
                     public let description: String = "Simple tool"
 

--- a/Tests/SwarmTests/ContextCoreIntegrationTests.swift
+++ b/Tests/SwarmTests/ContextCoreIntegrationTests.swift
@@ -24,4 +24,35 @@ struct ContextCoreIntegrationTests {
         #expect(context.contains("alpha"))
         #expect(context.contains("beta"))
     }
+
+    @Test("ContextCoreMemory clear ends an active session")
+    func contextCoreMemoryClearEndsActiveSession() async throws {
+        let recorder = EndSessionRecorder()
+        let memory = try ContextCoreMemory(
+            configuration: ContextCoreMemoryConfiguration(
+                promptTitle: "ContextCore Test Memory",
+                promptGuidance: "Test guidance"
+            ),
+            endSession: { _ in
+                await recorder.record()
+            }
+        )
+
+        await memory.beginMemorySession()
+        await memory.clear()
+
+        #expect(await recorder.count == 1)
+    }
+}
+
+private actor EndSessionRecorder {
+    private var recordedCount = 0
+
+    var count: Int {
+        recordedCount
+    }
+
+    func record() {
+        recordedCount += 1
+    }
 }

--- a/Tests/SwarmTests/Integration/WaxIntegrationTests.swift
+++ b/Tests/SwarmTests/Integration/WaxIntegrationTests.swift
@@ -15,4 +15,41 @@ struct WaxIntegrationTests {
         #expect(integration.isEnabled == true)
         #expect(WaxIntegration.debugDescription == "Wax integration is enabled")
     }
+
+    @Test("Wax embedding adapter normalizes vectors when requested")
+    func waxEmbeddingAdapterNormalizesVectorsWhenRequested() async throws {
+        let adapter = WaxEmbeddingProviderAdapter(FixedEmbeddingProvider(vector: [3, 4]), normalize: true)
+
+        let embedding = try await adapter.embed("query")
+
+        #expect(embedding.count == 2)
+        #expect(abs(embedding[0] - 0.6) < 0.0001)
+        #expect(abs(embedding[1] - 0.8) < 0.0001)
+        #expect(adapter.identity?.normalized == true)
+    }
+
+    @Test("Wax embedding adapter preserves raw vectors by default")
+    func waxEmbeddingAdapterPreservesRawVectorsByDefault() async throws {
+        let adapter = WaxEmbeddingProviderAdapter(FixedEmbeddingProvider(vector: [3, 4]))
+
+        let embedding = try await adapter.embed("query")
+
+        #expect(embedding == [3, 4])
+        #expect(adapter.identity?.normalized == false)
+    }
+}
+
+private struct FixedEmbeddingProvider: EmbeddingProvider {
+    let vector: [Float]
+    let dimensions: Int
+    let modelIdentifier = "fixed"
+
+    init(vector: [Float]) {
+        self.vector = vector
+        self.dimensions = vector.count
+    }
+
+    func embed(_: String) async throws -> [Float] {
+        vector
+    }
 }

--- a/docs/guide/opentelemetry-tracing.md
+++ b/docs/guide/opentelemetry-tracing.md
@@ -38,7 +38,7 @@ URLSession instrumentation modules:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/christopherkarani/Swarm.git", from: "0.5.0"),
+    .package(url: "https://github.com/christopherkarani/Swarm.git", from: "0.5.1"),
     .package(url: "https://github.com/open-telemetry/opentelemetry-swift-core.git", from: "2.3.0"),
     .package(url: "https://github.com/open-telemetry/opentelemetry-swift.git", from: "2.3.0"),
 ],


### PR DESCRIPTION
## Summary
- fixes PR checklist SwiftFormat command drift and tracing guide install version drift
- fixes Tool macro literal escaping and snake_case derived tool names
- honors Wax embedding normalization and ends active ContextCore sessions on clear

## Verification
- swift test --filter ToolMacroTests
- swift test --filter WaxIntegrationTests
- swift test --filter ContextCoreIntegrationTests
- swift test --filter 'ToolMacroTests|WaxIntegrationTests|ContextCoreIntegrationTests'
- swift build --target Swarm

Stacked on #94 because current main needs the MCP text-content compile fix first.