### PR TITLE
Fix provider runtime audit regressions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,7 @@ var packageDependencies: [Package.Dependency] = [
     .package(url: "https://github.com/christopherkarani/Wax.git", exact: "0.1.20"),
     .package(
         url: "https://github.com/christopherkarani/Conduit",
-        exact: "0.3.14",
+        exact: "0.3.16",
         traits: [
             .trait(name: "OpenAI"),
             .trait(name: "OpenRouter"),

--- a/Sources/Swarm/Agents/Agent.swift
+++ b/Sources/Swarm/Agents/Agent.swift
@@ -1332,9 +1332,12 @@ public struct Agent: AgentRuntime, Sendable {
         let systemMessage = buildSystemMessage(memory: activeMemory, memoryContext: memoryContext)
 
         let enableStreaming = configuration.enableStreaming && observer != nil
+        let capabilities = providerCapabilities(for: provider)
         let structuredToolStreamingProvider = provider as? any ToolCallStreamingConversationInferenceProvider
         let promptToolStreamingProvider = provider as? any ToolCallStreamingInferenceProvider
-        let useToolStreaming = enableStreaming && (structuredToolStreamingProvider != nil || promptToolStreamingProvider != nil)
+        let useToolStreaming = enableStreaming
+            && capabilities.contains(.streamingToolCalls)
+            && (structuredToolStreamingProvider != nil || promptToolStreamingProvider != nil)
         let membraneAdapter = resolvedMembraneAdapter()
 
         while iteration < configuration.maxIterations {

--- a/Sources/Swarm/Agents/Agent.swift
+++ b/Sources/Swarm/Agents/Agent.swift
@@ -21,8 +21,8 @@ import Foundation
 /// 1. Apple Foundation Models when `inferencePolicy.privacyRequired` is true
 /// 2. An explicit provider passed to `Agent(...)` (including `Agent(_:)`)
 /// 3. A provider set via `.environment(\.inferenceProvider, ...)`
-/// 4. `Swarm.defaultProvider` (set via `Swarm.configure(provider:)`)
-/// 5. `Swarm.cloudProvider` (set via `Swarm.configure(cloudProvider:)`, when tool calling is required)
+/// 4. `Swarm.cloudProvider` (set via `Swarm.configure(cloudProvider:)`, when tool calling is required)
+/// 5. `Swarm.defaultProvider` (set via `Swarm.configure(provider:)`)
 /// 6. Apple Foundation Models (on-device), if available, including prompt-based tool emulation
 /// 7. Otherwise, throw `AgentError.inferenceProviderUnavailable`
 ///
@@ -131,8 +131,8 @@ public struct Agent: AgentRuntime, Sendable {
     /// 1. Apple Foundation Models when `configuration.inferencePolicy.privacyRequired` is true
     /// 2. Explicit provider passed to ``Agent`` initialization
     /// 3. Provider set via `.environment(\.inferenceProvider, ...)`
-    /// 4. ``Swarm/defaultProvider`` (configured via `Swarm.configure(provider:)`)
-    /// 5. ``Swarm/cloudProvider`` (configured via `Swarm.configure(cloudProvider:)`)
+    /// 4. ``Swarm/cloudProvider`` (configured via `Swarm.configure(cloudProvider:)`, when tool calling is required)
+    /// 5. ``Swarm/defaultProvider`` (configured via `Swarm.configure(provider:)`)
     /// 6. Apple Foundation Models (on-device), if available
     /// 7. Throws ``AgentError/inferenceProviderUnavailable``
     ///
@@ -992,16 +992,16 @@ public struct Agent: AgentRuntime, Sendable {
             return transformedInferenceProvider(environmentProvider)
         }
 
-        // 3. Swarm.defaultProvider (global)
-        if let globalProvider = await Swarm.defaultProvider {
-            return transformedInferenceProvider(globalProvider)
-        }
-
-        // 4. Swarm.cloudProvider (if tool calling is required)
+        // 3. Swarm.cloudProvider (if tool calling is required)
         let hasEnabledTools = await !toolRegistry.schemas.isEmpty
         let needsToolCallingProvider = hasEnabledTools || !_handoffs.isEmpty
         if needsToolCallingProvider, let cloudProvider = await Swarm.cloudProvider {
             return transformedInferenceProvider(cloudProvider)
+        }
+
+        // 4. Swarm.defaultProvider (global)
+        if let globalProvider = await Swarm.defaultProvider {
+            return transformedInferenceProvider(globalProvider)
         }
 
         // 5. Foundation Models (if available, on Apple platform)

--- a/Sources/Swarm/Providers/TextOnlyConversationInferenceProviderAdapter.swift
+++ b/Sources/Swarm/Providers/TextOnlyConversationInferenceProviderAdapter.swift
@@ -25,6 +25,7 @@ public struct TextOnlyConversationInferenceProviderAdapter:
 
     public var capabilities: InferenceProviderCapabilities {
         var capabilities = InferenceProviderCapabilities.resolved(for: base)
+        capabilities.remove(.streamingToolCalls)
         capabilities.insert(.conversationMessages)
         return capabilities
     }

--- a/Tests/SwarmTests/Agents/StreamingEventTests.swift
+++ b/Tests/SwarmTests/Agents/StreamingEventTests.swift
@@ -157,6 +157,28 @@ struct StreamingEventTests {
         #expect(provider.generateWithToolCallsCount == 1)
         #expect(provider.streamWithToolCallsCount == 0)
     }
+
+    @Test("Agent streaming uses providers that advertise streaming tool calls")
+    func agentStreamingUsesAdvertisedToolCallStreamingCapability() async throws {
+        let provider = CapabilityOptInToolStreamingProvider()
+        let tool = MockTool(name: "test_tool", description: "Test tool")
+        let agent = try Agent(
+            tools: [tool],
+            instructions: "You are a test assistant.",
+            inferenceProvider: provider
+        )
+
+        var sawOutput = false
+        for try await event in agent.stream("Start") {
+            if case .output(.token("Done")) = event {
+                sawOutput = true
+            }
+        }
+
+        #expect(sawOutput)
+        #expect(provider.generateWithToolCallsCount == 0)
+        #expect(provider.streamWithToolCallsCount == 1)
+    }
 }
 
 private final class CapabilityOptOutToolStreamingProvider:
@@ -212,6 +234,70 @@ private final class CapabilityOptOutToolStreamingProvider:
         }
         return AsyncThrowingStream { continuation in
             continuation.finish(throwing: AgentError.generationFailed(reason: "streaming tool calls were not advertised"))
+        }
+    }
+
+    private func withLock<T>(_ operation: () -> T) -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return operation()
+    }
+}
+
+private final class CapabilityOptInToolStreamingProvider:
+    ToolCallStreamingInferenceProvider,
+    CapabilityReportingInferenceProvider,
+    @unchecked Sendable
+{
+    var capabilities: InferenceProviderCapabilities {
+        [.nativeToolCalling, .streamingToolCalls]
+    }
+
+    var generateWithToolCallsCount: Int {
+        withLock { generateWithToolCallsCountStorage }
+    }
+
+    var streamWithToolCallsCount: Int {
+        withLock { streamWithToolCallsCountStorage }
+    }
+
+    private let lock = NSLock()
+    private var generateWithToolCallsCountStorage = 0
+    private var streamWithToolCallsCountStorage = 0
+
+    func generate(prompt _: String, options _: InferenceOptions) async throws -> String {
+        "Done"
+    }
+
+    func stream(prompt _: String, options _: InferenceOptions) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in
+            continuation.yield("Done")
+            continuation.finish()
+        }
+    }
+
+    func generateWithToolCalls(
+        prompt _: String,
+        tools _: [ToolSchema],
+        options _: InferenceOptions
+    ) async throws -> InferenceResponse {
+        withLock {
+            generateWithToolCallsCountStorage += 1
+        }
+        return InferenceResponse(content: "Done", toolCalls: [], finishReason: .completed)
+    }
+
+    func streamWithToolCalls(
+        prompt _: String,
+        tools _: [ToolSchema],
+        options _: InferenceOptions
+    ) -> AsyncThrowingStream<InferenceStreamUpdate, Error> {
+        withLock {
+            streamWithToolCallsCountStorage += 1
+        }
+        return AsyncThrowingStream { continuation in
+            continuation.yield(.outputChunk("Done"))
+            continuation.finish()
         }
     }
 

--- a/Tests/SwarmTests/Agents/StreamingEventTests.swift
+++ b/Tests/SwarmTests/Agents/StreamingEventTests.swift
@@ -141,4 +141,83 @@ struct StreamingEventTests {
         #expect(streamCount == 0)
         #expect(generateCount == 0)
     }
+
+    @Test("Agent streaming honors providers that opt out of streaming tool calls")
+    func agentStreamingHonorsToolCallStreamingCapabilityOptOut() async throws {
+        let provider = CapabilityOptOutToolStreamingProvider()
+        let tool = MockTool(name: "test_tool", description: "Test tool")
+        let agent = try Agent(
+            tools: [tool],
+            instructions: "You are a test assistant.",
+            inferenceProvider: provider
+        )
+
+        for try await _ in agent.stream("Start") {}
+
+        #expect(provider.generateWithToolCallsCount == 1)
+        #expect(provider.streamWithToolCallsCount == 0)
+    }
+}
+
+private final class CapabilityOptOutToolStreamingProvider:
+    ToolCallStreamingInferenceProvider,
+    CapabilityReportingInferenceProvider,
+    @unchecked Sendable
+{
+    var capabilities: InferenceProviderCapabilities {
+        [.nativeToolCalling]
+    }
+
+    var generateWithToolCallsCount: Int {
+        withLock { generateWithToolCallsCountStorage }
+    }
+
+    var streamWithToolCallsCount: Int {
+        withLock { streamWithToolCallsCountStorage }
+    }
+
+    private let lock = NSLock()
+    private var generateWithToolCallsCountStorage = 0
+    private var streamWithToolCallsCountStorage = 0
+
+    func generate(prompt _: String, options _: InferenceOptions) async throws -> String {
+        "Done"
+    }
+
+    func stream(prompt _: String, options _: InferenceOptions) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in
+            continuation.yield("Done")
+            continuation.finish()
+        }
+    }
+
+    func generateWithToolCalls(
+        prompt _: String,
+        tools _: [ToolSchema],
+        options _: InferenceOptions
+    ) async throws -> InferenceResponse {
+        withLock {
+            generateWithToolCallsCountStorage += 1
+        }
+        return InferenceResponse(content: "Done", toolCalls: [], finishReason: .completed)
+    }
+
+    func streamWithToolCalls(
+        prompt _: String,
+        tools _: [ToolSchema],
+        options _: InferenceOptions
+    ) -> AsyncThrowingStream<InferenceStreamUpdate, Error> {
+        withLock {
+            streamWithToolCallsCountStorage += 1
+        }
+        return AsyncThrowingStream { continuation in
+            continuation.finish(throwing: AgentError.generationFailed(reason: "streaming tool calls were not advertised"))
+        }
+    }
+
+    private func withLock<T>(_ operation: () -> T) -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return operation()
+    }
 }

--- a/Tests/SwarmTests/Core/SwarmConfigurationTests.swift
+++ b/Tests/SwarmTests/Core/SwarmConfigurationTests.swift
@@ -80,6 +80,22 @@ struct SwarmConfigurationTests {
         }
     }
 
+    @Test("cloudProvider takes priority over defaultProvider for tool agents")
+    func cloudProviderTakesPriorityOverDefaultForToolAgents() async throws {
+        try await withIsolatedConfiguration {
+            let defaultMock = MockInferenceProvider(responses: ["from default"])
+            let cloudMock = MockInferenceProvider(responses: ["from cloud"])
+            await Swarm.configure(provider: defaultMock)
+            await Swarm.configure(cloudProvider: cloudMock)
+
+            let tool = MockTool(name: "test_tool")
+            let agent = try Agent(tools: [tool], instructions: "test")
+            let result = try await agent.run("use tool")
+
+            #expect(result.output == "from cloud")
+        }
+    }
+
     @Test("defaultProvider preferred over cloudProvider for toolless agents")
     func defaultPreferredOverCloud() async throws {
         try await withIsolatedConfiguration {
@@ -98,6 +114,23 @@ struct SwarmConfigurationTests {
         try await withIsolatedConfiguration {
             let cloudMock = MockInferenceProvider(responses: ["from handoff-cloud"])
             let handoffProvider = MockInferenceProvider(responses: ["unused"])
+            await Swarm.configure(cloudProvider: cloudMock)
+
+            let handoffTarget = try Agent(instructions: "handoff target", inferenceProvider: handoffProvider)
+            let agent = try Agent(instructions: "route", handoffAgents: [handoffTarget])
+
+            let result = try await agent.run("transfer me")
+            #expect(result.output == "from handoff-cloud")
+        }
+    }
+
+    @Test("cloudProvider takes priority over defaultProvider for handoff agents")
+    func cloudProviderTakesPriorityOverDefaultForHandoffAgents() async throws {
+        try await withIsolatedConfiguration {
+            let defaultMock = MockInferenceProvider(responses: ["from default"])
+            let cloudMock = MockInferenceProvider(responses: ["from handoff-cloud"])
+            let handoffProvider = MockInferenceProvider(responses: ["unused"])
+            await Swarm.configure(provider: defaultMock)
             await Swarm.configure(cloudProvider: cloudMock)
 
             let handoffTarget = try Agent(instructions: "handoff target", inferenceProvider: handoffProvider)

--- a/Tests/SwarmTests/Providers/TextOnlyConversationInferenceProviderAdapterTests.swift
+++ b/Tests/SwarmTests/Providers/TextOnlyConversationInferenceProviderAdapterTests.swift
@@ -41,6 +41,18 @@ struct TextOnlyConversationInferenceProviderAdapterTests {
         #expect(prompts[0].contains("[User]: hello"))
     }
 
+    @Test("Text-only conversation adapter strips streaming tool-call capability")
+    func textOnlyConversationAdapterStripsStreamingToolCallCapability() {
+        let provider = ReportingTextProvider(capabilities: [.streamingToolCalls, .responseContinuation])
+        let adapter = TextOnlyConversationInferenceProviderAdapter(base: provider)
+
+        let capabilities = adapter.capabilities
+
+        #expect(capabilities.contains(.conversationMessages))
+        #expect(capabilities.contains(.responseContinuation))
+        #expect(capabilities.contains(.streamingToolCalls) == false)
+    }
+
     @Test("Agent completes tool loops with text-only providers")
     func agentCompletesToolLoopsWithTextOnlyProviders() async throws {
         let provider = CertifiedTextOnlyProvider(mode: .toolThenAnswer)
@@ -57,5 +69,20 @@ struct TextOnlyConversationInferenceProviderAdapterTests {
         #expect(prompts.count == 2)
         #expect(prompts[0].contains("\"swarm_tool_call\""))
         #expect(prompts[1].contains("[Tool Result - string]: HELLO"))
+    }
+}
+
+private struct ReportingTextProvider: InferenceProvider, CapabilityReportingInferenceProvider {
+    let capabilities: InferenceProviderCapabilities
+
+    func generate(prompt _: String, options _: InferenceOptions) async throws -> String {
+        "ok"
+    }
+
+    func stream(prompt _: String, options _: InferenceOptions) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in
+            continuation.yield("ok")
+            continuation.finish()
+        }
     }
 }


### PR DESCRIPTION
## Summary
- fixes SWARM-AUDIT-017 by gating streaming tool-call execution on advertised provider capabilities
- fixes SWARM-AUDIT-020/021 by stripping unsupported streaming tool-call capabilities from text-only adapters while preserving opt-in coverage
- fixes SWARM-AUDIT-018 by preferring the cloud provider for tool and handoff agents when the default provider cannot satisfy those behaviors
- fixes SWARM-AUDIT-016 by moving Conduit to a stable MLX dependency graph

Stacked on #94 because the base branch unblocks MCP text-content compilation.

## Verification
- swift test --filter StreamingEventTests
- swift test --filter TextOnlyConversationInferenceProviderAdapterTests
- swift test --filter SwarmConfigurationTests
- swift test --filter 'StreamingEventTests|TextOnlyConversationInferenceProviderAdapterTests|SwarmConfigurationTests'\n- CONDUIT_INCLUDE_MLX_DEPS=1 swift package resolve\n- swift package resolve\n- swift build --target Swarm\n\n## Notes\n- Each audit issue is split into its own commit except SWARM-AUDIT-021, which is covered as the positive opt-in regression for the streaming capability model.