### PR TITLE
Fix HTTP MCP lifecycle and schema regressions

### DIFF
--- a/Sources/Swarm/MCP/HTTPMCPServer.swift
+++ b/Sources/Swarm/MCP/HTTPMCPServer.swift
@@ -509,8 +509,15 @@ public actor HTTPMCPServer: MCPServer {
     /// - Parameter schema: The inputSchema value.
     /// - Returns: An array of ToolParameter objects.
     private func parseParameters(from schema: SendableValue?) -> [ToolParameter] {
-        guard let schemaDict = schema?.dictionaryValue,
-              let properties = schemaDict["properties"]?.dictionaryValue else {
+        guard let schemaDict = schema?.dictionaryValue else {
+            return []
+        }
+
+        return parseObjectProperties(from: schemaDict)
+    }
+
+    private func parseObjectProperties(from schemaDict: [String: SendableValue]) -> [ToolParameter] {
+        guard let properties = schemaDict["properties"]?.dictionaryValue else {
             return []
         }
 
@@ -521,35 +528,83 @@ public actor HTTPMCPServer: MCPServer {
             guard let propDict = propValue.dictionaryValue else { continue }
 
             let description = extractString(propDict["description"]) ?? ""
-            let typeString = extractString(propDict["type"]) ?? "any"
-            let paramType = mapParameterType(typeString)
+            let paramType = parseParameterType(from: propDict)
             let isRequired = requiredSet.contains(name)
 
             parameters.append(ToolParameter(
                 name: name,
                 description: description,
                 type: paramType,
-                isRequired: isRequired
+                isRequired: isRequired,
+                defaultValue: propDict["default"]
             ))
         }
 
         return parameters
     }
 
-    /// Maps a JSON Schema type string to a ToolParameter.ParameterType.
+    /// Maps a JSON Schema node to a ToolParameter.ParameterType.
     ///
-    /// - Parameter typeString: The JSON Schema type string.
+    /// - Parameter schemaDict: The JSON Schema node dictionary.
     /// - Returns: The corresponding ParameterType.
-    private func mapParameterType(_ typeString: String) -> ToolParameter.ParameterType {
-        switch typeString.lowercased() {
-        case "string": .string
-        case "integer": .int
-        case "number": .double
-        case "boolean": .bool
-        case "array": .array(elementType: .any)
-        case "object": .object(properties: [])
-        default: .any
+    private func parseParameterType(from schemaDict: [String: SendableValue]) -> ToolParameter.ParameterType {
+        if let options = parseStringOptions(from: schemaDict), !options.isEmpty {
+            return .oneOf(options)
         }
+
+        let typeString = extractString(schemaDict["type"]) ?? inferredTypeString(from: schemaDict)
+
+        switch typeString.lowercased() {
+        case "string":
+            return .string
+        case "integer":
+            return .int
+        case "number":
+            return .double
+        case "boolean":
+            return .bool
+        case "array":
+            if let itemsDict = schemaDict["items"]?.dictionaryValue {
+                return .array(elementType: parseParameterType(from: itemsDict))
+            } else {
+                return .array(elementType: .any)
+            }
+        case "object":
+            return .object(properties: parseObjectProperties(from: schemaDict))
+        default:
+            return .any
+        }
+    }
+
+    private func inferredTypeString(from schemaDict: [String: SendableValue]) -> String {
+        if schemaDict["properties"]?.dictionaryValue != nil {
+            return "object"
+        }
+        if schemaDict["items"]?.dictionaryValue != nil {
+            return "array"
+        }
+        return "any"
+    }
+
+    private func parseStringOptions(from schemaDict: [String: SendableValue]) -> [String]? {
+        if let values = schemaDict["enum"]?.arrayValue?.compactMap(\.stringValue), !values.isEmpty {
+            return values
+        }
+
+        guard let oneOf = schemaDict["oneOf"]?.arrayValue else {
+            return nil
+        }
+
+        let values = oneOf.compactMap { option -> String? in
+            guard let optionDict = option.dictionaryValue else {
+                return nil
+            }
+            if let constValue = optionDict["const"]?.stringValue {
+                return constValue
+            }
+            return optionDict["enum"]?.arrayValue?.compactMap(\.stringValue).first
+        }
+        return values.isEmpty ? nil : values
     }
 
     /// Parses resources from a resources/list response.

--- a/Sources/Swarm/MCP/HTTPMCPServer.swift
+++ b/Sources/Swarm/MCP/HTTPMCPServer.swift
@@ -596,14 +596,14 @@ public actor HTTPMCPServer: MCPServer {
             return nil
         }
 
-        let values = oneOf.compactMap { option -> String? in
+        let values = oneOf.flatMap { option -> [String] in
             guard let optionDict = option.dictionaryValue else {
-                return nil
+                return []
             }
             if let constValue = optionDict["const"]?.stringValue {
-                return constValue
+                return [constValue]
             }
-            return optionDict["enum"]?.arrayValue?.compactMap(\.stringValue).first
+            return optionDict["enum"]?.arrayValue?.compactMap(\.stringValue) ?? []
         }
         return values.isEmpty ? nil : values
     }

--- a/Sources/Swarm/MCP/HTTPMCPServer.swift
+++ b/Sources/Swarm/MCP/HTTPMCPServer.swift
@@ -113,6 +113,7 @@ public actor HTTPMCPServer: MCPServer {
     public func initialize() async throws -> MCPCapabilities {
         let params: [String: SendableValue] = [
             "protocolVersion": .string("2024-11-05"),
+            "capabilities": .dictionary([:]),
             "clientInfo": .dictionary([
                 "name": .string("Swarm"),
                 "version": .string("1.0.0")
@@ -131,6 +132,7 @@ public actor HTTPMCPServer: MCPServer {
         }
 
         let capabilities = try parseCapabilities(from: result)
+        try await sendNotification(try MCPNotification(method: "notifications/initialized"))
         cachedCapabilities = capabilities
         return capabilities
     }
@@ -299,11 +301,30 @@ public actor HTTPMCPServer: MCPServer {
     /// - Returns: The MCP response from the server.
     /// - Throws: `MCPError` if all retry attempts fail.
     private func sendRequest(_ mcpRequest: MCPRequest) async throws -> MCPResponse {
+        try await sendWithRetry {
+            try await self.performRequest(mcpRequest)
+        }
+    }
+
+    /// Sends an MCP notification with retry logic.
+    ///
+    /// Notifications are JSON-RPC messages without an `id`; successful HTTP responses
+    /// do not need to contain a JSON-RPC body.
+    ///
+    /// - Parameter notification: The MCP notification to send.
+    /// - Throws: `MCPError` if all retry attempts fail.
+    private func sendNotification(_ notification: MCPNotification) async throws {
+        try await sendWithRetry {
+            try await self.performNotification(notification)
+        }
+    }
+
+    private func sendWithRetry<T>(_ operation: () async throws -> T) async throws -> T {
         var lastError: Error?
 
         for attempt in 0..<(maxRetries + 1) {
             do {
-                return try await performRequest(mcpRequest)
+                return try await operation()
             } catch let error as MCPError {
                 lastError = error
 
@@ -392,6 +413,40 @@ public actor HTTPMCPServer: MCPServer {
         }
 
         return try decoder.decode(MCPResponse.self, from: data)
+    }
+
+    /// Performs a single HTTP notification request to the MCP server.
+    ///
+    /// - Parameter notification: The JSON-RPC notification to send.
+    /// - Throws: `MCPError` if the request fails.
+    private func performNotification(_ notification: MCPNotification) async throws {
+        var urlRequest = URLRequest(url: baseURL)
+        urlRequest.httpMethod = "POST"
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        urlRequest.timeoutInterval = timeout
+
+        if let apiKey {
+            urlRequest.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        }
+
+        urlRequest.httpBody = try encoder.encode(notification)
+
+        let (data, response) = try await session.data(for: urlRequest)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw MCPError.internalError("Invalid response type")
+        }
+
+        let statusCode = httpResponse.statusCode
+        guard (200 ... 299).contains(statusCode) else {
+            let errorMessage = if let bodyString = String(data: data, encoding: .utf8), !bodyString.isEmpty {
+                "HTTP \(statusCode): \(bodyString)"
+            } else {
+                "HTTP \(statusCode)"
+            }
+
+            throw MCPError(code: statusCode, message: errorMessage)
+        }
     }
 
     // MARK: - Parsing Helpers
@@ -563,5 +618,27 @@ public actor HTTPMCPServer: MCPServer {
     /// - Returns: The string value, or nil if not a string.
     private func extractString(_ value: SendableValue?) -> String? {
         value?.stringValue
+    }
+}
+
+private struct MCPNotification: Sendable, Encodable, Equatable {
+    let jsonrpc: String
+    let method: String
+    let params: [String: SendableValue]?
+
+    init(method: String, params: [String: SendableValue]? = nil) throws {
+        guard !method.isEmpty else {
+            throw MCPError.invalidRequest("MCPNotification: method must be non-empty per JSON-RPC 2.0")
+        }
+
+        jsonrpc = "2.0"
+        self.method = method
+        self.params = params
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case jsonrpc
+        case method
+        case params
     }
 }

--- a/Sources/Swarm/MCP/HTTPMCPServer.swift
+++ b/Sources/Swarm/MCP/HTTPMCPServer.swift
@@ -180,6 +180,7 @@ public actor HTTPMCPServer: MCPServer {
             throw MCPError.internalError("No result in tools/call response")
         }
 
+        try validateToolCallResult(result, toolName: name)
         return result
     }
 
@@ -665,6 +666,35 @@ public actor HTTPMCPServer: MCPServer {
             text: text,
             blob: blob
         )
+    }
+
+    private func validateToolCallResult(_ result: SendableValue, toolName: String) throws {
+        guard let resultDict = result.dictionaryValue,
+              resultDict["isError"]?.boolValue == true else {
+            return
+        }
+
+        let detail = toolCallErrorMessage(from: resultDict)
+        throw MCPError(
+            code: MCPError.internalErrorCode,
+            message: "Remote MCP tool '\(toolName)' failed: \(detail)",
+            data: result
+        )
+    }
+
+    private func toolCallErrorMessage(from resultDict: [String: SendableValue]) -> String {
+        guard let content = resultDict["content"]?.arrayValue else {
+            return "tool returned isError"
+        }
+
+        let textParts = content.compactMap { item -> String? in
+            guard let itemDict = item.dictionaryValue else {
+                return nil
+            }
+            return itemDict["text"]?.stringValue
+        }
+
+        return textParts.isEmpty ? "tool returned isError" : textParts.joined(separator: "\n")
     }
 
     /// Extracts a string from a SendableValue.

--- a/Tests/SwarmTests/MCP/HTTPMCPServerRetryTests.swift
+++ b/Tests/SwarmTests/MCP/HTTPMCPServerRetryTests.swift
@@ -151,6 +151,58 @@ struct HTTPMCPServerRetryTests {
         #expect(!values.isRequired)
         #expect(values.type == .array(elementType: .string))
     }
+
+    @Test("Call tool treats MCP isError result as execution failure")
+    func callToolTreatsIsErrorResultAsExecutionFailure() async throws {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        let session = URLSession(configuration: config)
+
+        MockURLProtocol.reset()
+        defer { MockURLProtocol.reset() }
+
+        MockURLProtocol.handler = { request in
+            let response = HTTPURLResponse(
+                url: request.url ?? URL(string: "https://mcp.example.com/api")!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            let body: [String: Any] = [
+                "jsonrpc": "2.0",
+                "id": "tool-call",
+                "result": [
+                    "content": [
+                        [
+                            "type": "text",
+                            "text": "remote tool failed"
+                        ]
+                    ],
+                    "isError": true
+                ]
+            ]
+            return (response, try JSONSerialization.data(withJSONObject: body))
+        }
+
+        let server = try HTTPMCPServer(
+            url: URL(string: "https://mcp.example.com/api")!,
+            name: "tool-error-test",
+            maxRetries: 0,
+            session: session
+        )
+
+        do {
+            _ = try await server.callTool(name: "explode", arguments: [:])
+            Issue.record("Expected remote isError tool result to throw")
+        } catch let error as MCPError {
+            #expect(error.code == MCPError.internalErrorCode)
+            #expect(error.message.contains("explode"))
+            #expect(error.message.contains("remote tool failed"))
+            #expect(error.data?.dictionaryValue?["isError"]?.boolValue == true)
+        } catch {
+            Issue.record("Expected MCPError, got \(error)")
+        }
+    }
 }
 
 private final class MockURLProtocol: URLProtocol {

--- a/Tests/SwarmTests/MCP/HTTPMCPServerRetryTests.swift
+++ b/Tests/SwarmTests/MCP/HTTPMCPServerRetryTests.swift
@@ -75,6 +75,15 @@ struct HTTPMCPServerRetryTests {
                                                 "description": "Query source",
                                                 "enum": ["docs", "news"]
                                             ],
+                                            "category": [
+                                                "type": "string",
+                                                "description": "Content category",
+                                                "oneOf": [
+                                                    ["enum": ["guide", "api"]],
+                                                    ["const": "blog"],
+                                                    ["enum": ["release", "example"]]
+                                                ]
+                                            ],
                                             "limit": [
                                                 "type": "integer",
                                                 "description": "Maximum results",
@@ -130,6 +139,10 @@ struct HTTPMCPServerRetryTests {
         let query = try #require(payloadProperties.first { $0.name == "query" })
         #expect(query.isRequired)
         #expect(query.type == .oneOf(["docs", "news"]))
+
+        let category = try #require(payloadProperties.first { $0.name == "category" })
+        #expect(!category.isRequired)
+        #expect(category.type == .oneOf(["guide", "api", "blog", "release", "example"]))
 
         let limit = try #require(payloadProperties.first { $0.name == "limit" })
         #expect(!limit.isRequired)

--- a/Tests/SwarmTests/MCP/HTTPMCPServerRetryTests.swift
+++ b/Tests/SwarmTests/MCP/HTTPMCPServerRetryTests.swift
@@ -2,7 +2,7 @@ import Foundation
 @testable import Swarm
 import Testing
 
-@Suite("HTTPMCPServer Retry Tests")
+@Suite("HTTPMCPServer Retry Tests", .serialized)
 struct HTTPMCPServerRetryTests {
     @Test("Does not retry on HTTP 4xx responses")
     func doesNotRetryOnClientErrors() async throws {
@@ -35,6 +35,121 @@ struct HTTPMCPServerRetryTests {
         }
 
         #expect(MockURLProtocol.requestCount == 1)
+    }
+
+    @Test("List tools preserves nested input schema fidelity")
+    func listToolsPreservesNestedInputSchemaFidelity() async throws {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        let session = URLSession(configuration: config)
+
+        MockURLProtocol.reset()
+        defer { MockURLProtocol.reset() }
+
+        MockURLProtocol.handler = { request in
+            let response = HTTPURLResponse(
+                url: request.url ?? URL(string: "https://mcp.example.com/api")!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            let body: [String: Any] = [
+                "jsonrpc": "2.0",
+                "id": "tools-list",
+                "result": [
+                    "tools": [
+                        [
+                            "name": "search",
+                            "description": "Search documents",
+                            "inputSchema": [
+                                "type": "object",
+                                "required": ["payload"],
+                                "properties": [
+                                    "payload": [
+                                        "type": "object",
+                                        "description": "Search payload",
+                                        "required": ["query", "filters"],
+                                        "properties": [
+                                            "query": [
+                                                "type": "string",
+                                                "description": "Query source",
+                                                "enum": ["docs", "news"]
+                                            ],
+                                            "limit": [
+                                                "type": "integer",
+                                                "description": "Maximum results",
+                                                "default": 10
+                                            ],
+                                            "filters": [
+                                                "type": "array",
+                                                "description": "Structured filters",
+                                                "items": [
+                                                    "type": "object",
+                                                    "required": ["field"],
+                                                    "properties": [
+                                                        "field": [
+                                                            "type": "string",
+                                                            "description": "Field name"
+                                                        ],
+                                                        "values": [
+                                                            "type": "array",
+                                                            "description": "Allowed values",
+                                                            "items": ["type": "string"]
+                                                        ]
+                                                    ]
+                                                ]
+                                            ]
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+            return (response, try JSONSerialization.data(withJSONObject: body))
+        }
+
+        let server = try HTTPMCPServer(
+            url: URL(string: "https://mcp.example.com/api")!,
+            name: "schema-test",
+            maxRetries: 0,
+            session: session
+        )
+
+        let tools = try await server.listTools()
+        let tool = try #require(tools.first)
+        let payload = try #require(tool.parameters.first { $0.name == "payload" })
+        #expect(payload.isRequired)
+
+        guard case let .object(payloadProperties) = payload.type else {
+            Issue.record("Expected payload to remain an object schema")
+            return
+        }
+
+        let query = try #require(payloadProperties.first { $0.name == "query" })
+        #expect(query.isRequired)
+        #expect(query.type == .oneOf(["docs", "news"]))
+
+        let limit = try #require(payloadProperties.first { $0.name == "limit" })
+        #expect(!limit.isRequired)
+        #expect(limit.defaultValue == .int(10))
+
+        let filters = try #require(payloadProperties.first { $0.name == "filters" })
+        #expect(filters.isRequired)
+        guard case let .array(elementType) = filters.type,
+              case let .object(filterProperties) = elementType else {
+            Issue.record("Expected filters to preserve array object item schema")
+            return
+        }
+
+        let field = try #require(filterProperties.first { $0.name == "field" })
+        #expect(field.isRequired)
+        #expect(field.type == .string)
+
+        let values = try #require(filterProperties.first { $0.name == "values" })
+        #expect(!values.isRequired)
+        #expect(values.type == .array(elementType: .string))
     }
 }
 

--- a/Tests/SwarmTests/MCP/HTTPMCPServerTests.swift
+++ b/Tests/SwarmTests/MCP/HTTPMCPServerTests.swift
@@ -84,6 +84,86 @@ struct HTTPMCPServerCapabilitiesTests {
     }
 }
 
+@Suite("HTTPMCPServer Lifecycle Tests", .serialized)
+struct HTTPMCPServerLifecycleTests {
+    @Test("Initialize sends client capabilities and initialized notification")
+    func initializeSendsClientCapabilitiesAndInitializedNotification() async throws {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [HTTPMCPRecordingURLProtocol.self]
+        let session = URLSession(configuration: config)
+
+        HTTPMCPRecordingURLProtocol.reset()
+        defer { HTTPMCPRecordingURLProtocol.reset() }
+
+        HTTPMCPRecordingURLProtocol.handler = { request, body in
+            guard let requestObject = try JSONSerialization.jsonObject(with: body) as? [String: Any],
+                  let method = requestObject["method"] as? String else {
+                throw MCPError.invalidRequest("Expected JSON-RPC request body")
+            }
+
+            let response = HTTPURLResponse(
+                url: request.url ?? URL(string: "https://mcp.example.com/api")!,
+                statusCode: method == "notifications/initialized" ? 202 : 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+
+            if method == "initialize" {
+                let id = requestObject["id"] as? String ?? "initialize-id"
+                let body: [String: Any] = [
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": [
+                        "protocolVersion": "2024-11-05",
+                        "serverInfo": [
+                            "name": "mock-mcp",
+                            "version": "1.0.0"
+                        ],
+                        "capabilities": [
+                            "tools": [:]
+                        ]
+                    ]
+                ]
+                return (response, try JSONSerialization.data(withJSONObject: body))
+            }
+
+            if method == "notifications/initialized" {
+                return (response, Data())
+            }
+
+            throw MCPError.methodNotFound(method)
+        }
+
+        let server = try HTTPMCPServer(
+            url: URL(string: "https://mcp.example.com/api")!,
+            name: "lifecycle-test",
+            maxRetries: 0,
+            session: session
+        )
+
+        let capabilities = try await server.initialize()
+
+        #expect(capabilities.tools)
+
+        let requestObjects = try HTTPMCPRecordingURLProtocol.requestBodies.map { body in
+            try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+        }
+        let methods = requestObjects.compactMap { $0["method"] as? String }
+        #expect(methods == ["initialize", "notifications/initialized"])
+
+        let initializeParams = try #require(requestObjects[0]["params"] as? [String: Any])
+        #expect(initializeParams["capabilities"] != nil)
+        let clientInfo = try #require(initializeParams["clientInfo"] as? [String: Any])
+        #expect(clientInfo["name"] as? String == "Swarm")
+
+        if requestObjects.count > 1 {
+            #expect(requestObjects[1]["id"] == nil)
+        } else {
+            Issue.record("Expected notifications/initialized after initialize")
+        }
+    }
+}
+
 // MARK: - HTTPMCPServerNameTests
 
 @Suite("HTTPMCPServer Name Tests")
@@ -124,5 +204,69 @@ struct HTTPMCPServerSecurityValidationTests {
         #expect(throws: MCPError.self) {
             _ = try HTTPMCPServer(url: url, name: "insecure", apiKey: "sk-test")
         }
+    }
+}
+
+private final class HTTPMCPRecordingURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var requestBodies: [Data] = []
+    nonisolated(unsafe) static var handler: ((URLRequest, Data) throws -> (HTTPURLResponse, Data))?
+
+    static func reset() {
+        requestBodies = []
+        handler = nil
+    }
+
+    override class func canInit(with _: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let handler = Self.handler else {
+            fatalError("HTTPMCPRecordingURLProtocol.handler not set")
+        }
+
+        do {
+            let body = try bodyData(from: request)
+            Self.requestBodies.append(body)
+            let (response, data) = try handler(request, body)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+
+    private func bodyData(from request: URLRequest) throws -> Data {
+        if let body = request.httpBody {
+            return body
+        }
+
+        guard let stream = request.httpBodyStream else {
+            return Data()
+        }
+
+        stream.open()
+        defer { stream.close() }
+
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while stream.hasBytesAvailable {
+            let read = stream.read(&buffer, maxLength: buffer.count)
+            if read < 0 {
+                throw stream.streamError ?? MCPError.internalError("Failed to read HTTP body stream")
+            }
+            if read == 0 {
+                break
+            }
+            data.append(buffer, count: read)
+        }
+        return data
     }
 }


### PR DESCRIPTION
## Summary
- fixes SWARM-AUDIT-039 by sending required client capabilities during initialize and following successful initialize with an id-less `notifications/initialized` message
- fixes SWARM-AUDIT-042 by preserving nested MCP input schemas, including object properties, array item schemas, required fields, string enum options, and defaults
- fixes SWARM-AUDIT-043 by converting `tools/call` results with `isError: true` into thrown MCP execution errors instead of successful tool outputs

Stacked on #94 because the base branch unblocks MCP text-content compilation.

## Verification
- swift test --filter HTTPMCPServerLifecycleTests/initializeSendsClientCapabilitiesAndInitializedNotification
- swift test --filter HTTPMCPServerRetryTests/listToolsPreservesNestedInputSchemaFidelity
- swift test --filter HTTPMCPServerRetryTests/callToolTreatsIsErrorResultAsExecutionFailure
- swift test --filter 'HTTPMCPServerLifecycleTests|HTTPMCPServerRetryTests'\n- swift test --filter 'HTTPMCPServer|MCPClient|MCPProtocol|MCPIntegration|SwarmMCPServerService'\n- swift build --target Swarm\n- git diff --check codex/fix-mcp-text-content-tests...HEAD