### PR TITLE
Fix handoff runtime behavior and result accounting

### DIFF
--- a/Sources/Swarm/Agents/Agent.swift
+++ b/Sources/Swarm/Agents/Agent.swift
@@ -2114,10 +2114,35 @@ public struct Agent: AgentRuntime, Sendable {
             // Check if this is a handoff tool call
             if let handoffConfig = handoffMap[parsedCall.name] {
                 if let when = handoffConfig.when, await !when(context, handoffConfig.targetAgent) {
-                    throw AgentError.toolExecutionFailed(
+                    let message = "Handoff is not enabled"
+                    let handoffCall = ToolCall(
+                        providerCallId: parsedCall.id,
                         toolName: parsedCall.name,
-                        underlyingError: "Handoff is not enabled"
+                        arguments: parsedCall.arguments
                     )
+                    _ = resultBuilder.addToolCall(handoffCall)
+                    let result = ToolResult.failure(callId: handoffCall.id, error: message, duration: .zero)
+                    _ = resultBuilder.addToolResult(result)
+
+                    if configuration.stopOnToolError {
+                        throw AgentError.toolExecutionFailed(toolName: parsedCall.name, underlyingError: message)
+                    }
+
+                    let toolError = "[TOOL ERROR] Execution failed: \(message). Please try a different approach or tool."
+                    conversationHistory.append(.toolResult(
+                        toolName: parsedCall.name,
+                        result: toolError,
+                        toolCallID: parsedCall.id
+                    ))
+                    transcriptMessages.append(
+                        SwarmTranscriptCodec.encodeMessage(
+                            role: .tool,
+                            content: toolError,
+                            toolName: parsedCall.name,
+                            toolCallID: parsedCall.id
+                        )
+                    )
+                    continue
                 }
 
                 let reason = parsedCall.arguments["reason"]?.stringValue ?? ""

--- a/Sources/Swarm/Agents/Agent.swift
+++ b/Sources/Swarm/Agents/Agent.swift
@@ -2144,7 +2144,7 @@ public struct Agent: AgentRuntime, Sendable {
                     reason.isEmpty ? "Continue the conversation" : reason
                 }
 
-                let handoffData = HandoffInputData(
+                let initialHandoffData = HandoffInputData(
                     sourceAgentName: name,
                     targetAgentName: targetAgent.name,
                     input: handoffInput,
@@ -2154,15 +2154,24 @@ public struct Agent: AgentRuntime, Sendable {
 
                 if let onTransfer = handoffConfig.onTransfer {
                     do {
-                        try await onTransfer(context, handoffData)
+                        try await onTransfer(context, initialHandoffData)
                     } catch {
                         Log.agents.warning("Handoff onTransfer callback failed for \(parsedCall.name): \(error)")
                     }
                 }
 
+                let handoffData = HandoffInputData(
+                    sourceAgentName: initialHandoffData.sourceAgentName,
+                    targetAgentName: initialHandoffData.targetAgentName,
+                    input: initialHandoffData.input,
+                    context: await context.snapshot,
+                    metadata: initialHandoffData.metadata
+                )
                 let transformedData = handoffConfig.transform?(handoffData) ?? handoffData
                 let requestContext = transformedData.context.merging(transformedData.metadata) { _, new in new }
                 let handoffContext = await context.copy(additionalValues: requestContext)
+                await applyContextValues(requestContext, to: handoffContext)
+                await preserveExecutionPath(from: context, in: handoffContext)
                 if handoffConfig.nestHandoffHistory {
                     await addNestedHandoffHistory(conversationHistory, to: handoffContext)
                 }
@@ -2179,9 +2188,17 @@ public struct Agent: AgentRuntime, Sendable {
                 do {
                     result = try await executeWithinRemainingTimeout(startTime: startTime) {
                         if let receiver = targetAgent as? any HandoffReceiver {
-                            try await receiver.handleHandoff(handoffRequest, context: handoffContext)
+                            return try await receiver.handleHandoff(handoffRequest, context: handoffContext)
                         } else {
-                            try await targetAgent.run(transformedData.input, session: nil, observer: observer)
+                            let handoffSession = try await makeNestedHandoffSession(
+                                from: handoffContext,
+                                enabled: handoffConfig.nestHandoffHistory
+                            )
+                            return try await targetAgent.run(
+                                transformedData.input,
+                                session: handoffSession,
+                                observer: observer
+                            )
                         }
                     }
                 } catch {
@@ -2260,6 +2277,40 @@ public struct Agent: AgentRuntime, Sendable {
         return nil
     }
 
+    private func applyContextValues(
+        _ values: [String: SendableValue],
+        to context: AgentContext
+    ) async {
+        for (key, value) in values {
+            await context.set(key, value: value)
+        }
+    }
+
+    private func preserveExecutionPath(from source: AgentContext, in target: AgentContext) async {
+        let executionPath = await source.getExecutionPath()
+        for agentName in executionPath {
+            await target.recordExecution(agentName: agentName)
+        }
+    }
+
+    private func makeNestedHandoffSession(
+        from context: AgentContext,
+        enabled: Bool
+    ) async throws -> (any Session)? {
+        guard enabled else {
+            return nil
+        }
+
+        let messages = await context.getMessages()
+        guard !messages.isEmpty else {
+            return nil
+        }
+
+        let session = InMemorySession()
+        try await session.addItems(messages)
+        return session
+    }
+
     private func addNestedHandoffHistory(
         _ conversationHistory: [ConversationMessage],
         to context: AgentContext
@@ -2271,6 +2322,9 @@ public struct Agent: AgentRuntime, Sendable {
             case let .user(content):
                 await context.addMessage(SwarmTranscriptCodec.encodeMessage(role: .user, content: content))
             case let .assistant(content, toolCalls):
+                guard toolCalls.isEmpty else {
+                    continue
+                }
                 await context.addMessage(
                     SwarmTranscriptCodec.encodeMessage(
                         role: .assistant,

--- a/Sources/Swarm/Agents/Agent.swift
+++ b/Sources/Swarm/Agents/Agent.swift
@@ -2125,6 +2125,12 @@ public struct Agent: AgentRuntime, Sendable {
 
                 let handoffStart = ContinuousClock.now
                 let spanId = await tracing?.traceToolCall(name: parsedCall.name, arguments: parsedCall.arguments)
+                let handoffCall = ToolCall(
+                    providerCallId: parsedCall.id,
+                    toolName: parsedCall.name,
+                    arguments: parsedCall.arguments
+                )
+                _ = resultBuilder.addToolCall(handoffCall)
                 await observer?.onHandoff(context: context, fromAgent: self, toAgent: targetAgent)
 
                 // Find the last user message to use as handoff input
@@ -2169,12 +2175,28 @@ public struct Agent: AgentRuntime, Sendable {
                     context: requestContext
                 )
 
-                let result = try await executeWithinRemainingTimeout(startTime: startTime) {
-                    if let receiver = targetAgent as? any HandoffReceiver {
-                        try await receiver.handleHandoff(handoffRequest, context: handoffContext)
-                    } else {
-                        try await targetAgent.run(transformedData.input, session: nil, observer: observer)
+                let result: AgentResult
+                do {
+                    result = try await executeWithinRemainingTimeout(startTime: startTime) {
+                        if let receiver = targetAgent as? any HandoffReceiver {
+                            try await receiver.handleHandoff(handoffRequest, context: handoffContext)
+                        } else {
+                            try await targetAgent.run(transformedData.input, session: nil, observer: observer)
+                        }
                     }
+                } catch {
+                    let handoffDuration = ContinuousClock.now - handoffStart
+                    _ = resultBuilder.addToolResult(
+                        ToolResult.failure(
+                            callId: handoffCall.id,
+                            error: error.localizedDescription,
+                            duration: handoffDuration
+                        )
+                    )
+                    if let spanId {
+                        await tracing?.traceToolError(spanId: spanId, name: parsedCall.name, error: error)
+                    }
+                    throw error
                 }
                 conversationHistory.append(.toolResult(
                     toolName: parsedCall.name,
@@ -2190,8 +2212,15 @@ public struct Agent: AgentRuntime, Sendable {
                     )
                 )
 
+                let handoffDuration = ContinuousClock.now - handoffStart
+                _ = resultBuilder.addToolResult(
+                    ToolResult.success(
+                        callId: handoffCall.id,
+                        output: .string(result.output),
+                        duration: handoffDuration
+                    )
+                )
                 if let spanId {
-                    let handoffDuration = ContinuousClock.now - handoffStart
                     await tracing?.traceToolResult(spanId: spanId, name: parsedCall.name, result: result.output, duration: handoffDuration)
                 }
 

--- a/Sources/Swarm/Agents/Agent.swift
+++ b/Sources/Swarm/Agents/Agent.swift
@@ -2173,7 +2173,11 @@ public struct Agent: AgentRuntime, Sendable {
                 await applyContextValues(requestContext, to: handoffContext)
                 await preserveExecutionPath(from: context, in: handoffContext)
                 if handoffConfig.nestHandoffHistory {
-                    await addNestedHandoffHistory(conversationHistory, to: handoffContext)
+                    await addNestedHandoffHistory(
+                        conversationHistory,
+                        to: handoffContext,
+                        skippingToolCallID: parsedCall.id
+                    )
                 }
 
                 let handoffRequest = HandoffRequest(
@@ -2313,7 +2317,8 @@ public struct Agent: AgentRuntime, Sendable {
 
     private func addNestedHandoffHistory(
         _ conversationHistory: [ConversationMessage],
-        to context: AgentContext
+        to context: AgentContext,
+        skippingToolCallID skippedToolCallID: String?
     ) async {
         for message in conversationHistory {
             switch message {
@@ -2322,17 +2327,21 @@ public struct Agent: AgentRuntime, Sendable {
             case let .user(content):
                 await context.addMessage(SwarmTranscriptCodec.encodeMessage(role: .user, content: content))
             case let .assistant(content, toolCalls):
-                guard toolCalls.isEmpty else {
+                let nestedToolCalls = toolCalls.filter { $0.id != skippedToolCallID }
+                guard toolCalls.isEmpty || !nestedToolCalls.isEmpty else {
                     continue
                 }
                 await context.addMessage(
                     SwarmTranscriptCodec.encodeMessage(
                         role: .assistant,
                         content: content,
-                        toolCalls: toolCalls
+                        toolCalls: nestedToolCalls
                     )
                 )
             case let .toolResult(toolName, result, toolCallID):
+                guard toolCallID != skippedToolCallID else {
+                    continue
+                }
                 await context.addMessage(
                     SwarmTranscriptCodec.encodeMessage(
                         role: .tool,

--- a/Sources/Swarm/Agents/Agent.swift
+++ b/Sources/Swarm/Agents/Agent.swift
@@ -1330,6 +1330,8 @@ public struct Agent: AgentRuntime, Sendable {
         )
         var transcriptMessages: [MemoryMessage] = []
         let systemMessage = buildSystemMessage(memory: activeMemory, memoryContext: memoryContext)
+        let executionContext = AgentContext(input: input)
+        await executionContext.recordExecution(agentName: name)
 
         let enableStreaming = configuration.enableStreaming && observer != nil
         let structuredToolStreamingProvider = provider as? any ToolCallStreamingConversationInferenceProvider
@@ -1420,7 +1422,10 @@ public struct Agent: AgentRuntime, Sendable {
                 } else {
                     rawPrompt = buildPrompt(from: conversationHistory)
                 }
-                let unplannedSchemas = await buildToolSchemasWithHandoffs(toolRegistry: toolRegistry)
+                let unplannedSchemas = await buildToolSchemasWithHandoffs(
+                    toolRegistry: toolRegistry,
+                    context: executionContext
+                )
                 var plannedPrompt = rawPrompt
                 var plannedSchemas = MembraneInternalTools.sortedSchemas(unplannedSchemas)
 
@@ -1534,6 +1539,7 @@ public struct Agent: AgentRuntime, Sendable {
                         observer: observer,
                         tracing: tracing,
                         membraneAdapter: membraneAdapter,
+                        context: executionContext,
                         startTime: startTime
                     )
                     // If a handoff occurred, return the target agent's result
@@ -2034,10 +2040,13 @@ public struct Agent: AgentRuntime, Sendable {
     ///
     /// This merges regular tool schemas with handoff-generated schemas,
     /// allowing handoffs to appear as callable tools in the LLM prompt.
-    private func buildToolSchemasWithHandoffs(toolRegistry: ToolRegistry) async -> [ToolSchema] {
+    private func buildToolSchemasWithHandoffs(
+        toolRegistry: ToolRegistry,
+        context: AgentContext
+    ) async -> [ToolSchema] {
         var schemas = await toolRegistry.schemas
 
-        for handoff in _handoffs {
+        for handoff in await activeHandoffs(context: context) {
             let handoffSchema = ToolSchema(
                 name: handoff.effectiveToolName,
                 description: handoff.effectiveToolDescription,
@@ -2056,6 +2065,19 @@ public struct Agent: AgentRuntime, Sendable {
         return MembraneInternalTools.sortedSchemas(schemas)
     }
 
+    private func activeHandoffs(context: AgentContext) async -> [AnyHandoffConfiguration] {
+        var active: [AnyHandoffConfiguration] = []
+
+        for handoff in _handoffs {
+            if let when = handoff.when, await !when(context, handoff.targetAgent) {
+                continue
+            }
+            active.append(handoff)
+        }
+
+        return active
+    }
+
     /// Processes tool calls, handling both regular tools and handoff tools.
     ///
     /// When a tool call matches a handoff's `effectiveToolName`, the target agent
@@ -2070,6 +2092,7 @@ public struct Agent: AgentRuntime, Sendable {
         observer: (any AgentObserver)?,
         tracing: TracingHelper?,
         membraneAdapter: (any MembraneAgentAdapter)?,
+        context: AgentContext,
         startTime: ContinuousClock.Instant
     ) async throws -> FinalAssistantResponse? {
         let handoffMap = Dictionary(
@@ -2090,12 +2113,19 @@ public struct Agent: AgentRuntime, Sendable {
         for parsedCall in response.toolCalls {
             // Check if this is a handoff tool call
             if let handoffConfig = handoffMap[parsedCall.name] {
+                if let when = handoffConfig.when, await !when(context, handoffConfig.targetAgent) {
+                    throw AgentError.toolExecutionFailed(
+                        toolName: parsedCall.name,
+                        underlyingError: "Handoff is not enabled"
+                    )
+                }
+
                 let reason = parsedCall.arguments["reason"]?.stringValue ?? ""
                 let targetAgent = handoffConfig.targetAgent
 
                 let handoffStart = ContinuousClock.now
                 let spanId = await tracing?.traceToolCall(name: parsedCall.name, arguments: parsedCall.arguments)
-                await observer?.onHandoff(context: nil, fromAgent: self, toAgent: targetAgent)
+                await observer?.onHandoff(context: context, fromAgent: self, toAgent: targetAgent)
 
                 // Find the last user message to use as handoff input
                 let lastUserMessage = conversationHistory.last(where: {
@@ -2108,8 +2138,43 @@ public struct Agent: AgentRuntime, Sendable {
                     reason.isEmpty ? "Continue the conversation" : reason
                 }
 
+                let handoffData = HandoffInputData(
+                    sourceAgentName: name,
+                    targetAgentName: targetAgent.name,
+                    input: handoffInput,
+                    context: await context.snapshot,
+                    metadata: reason.isEmpty ? [:] : ["reason": .string(reason)]
+                )
+
+                if let onTransfer = handoffConfig.onTransfer {
+                    do {
+                        try await onTransfer(context, handoffData)
+                    } catch {
+                        Log.agents.warning("Handoff onTransfer callback failed for \(parsedCall.name): \(error)")
+                    }
+                }
+
+                let transformedData = handoffConfig.transform?(handoffData) ?? handoffData
+                let requestContext = transformedData.context.merging(transformedData.metadata) { _, new in new }
+                let handoffContext = await context.copy(additionalValues: requestContext)
+                if handoffConfig.nestHandoffHistory {
+                    await addNestedHandoffHistory(conversationHistory, to: handoffContext)
+                }
+
+                let handoffRequest = HandoffRequest(
+                    sourceAgentName: transformedData.sourceAgentName,
+                    targetAgentName: transformedData.targetAgentName,
+                    input: transformedData.input,
+                    reason: reason.isEmpty ? nil : reason,
+                    context: requestContext
+                )
+
                 let result = try await executeWithinRemainingTimeout(startTime: startTime) {
-                    try await targetAgent.run(handoffInput, session: nil, observer: observer)
+                    if let receiver = targetAgent as? any HandoffReceiver {
+                        try await receiver.handleHandoff(handoffRequest, context: handoffContext)
+                    } else {
+                        try await targetAgent.run(transformedData.input, session: nil, observer: observer)
+                    }
                 }
                 conversationHistory.append(.toolResult(
                     toolName: parsedCall.name,
@@ -2164,6 +2229,37 @@ public struct Agent: AgentRuntime, Sendable {
         }
 
         return nil
+    }
+
+    private func addNestedHandoffHistory(
+        _ conversationHistory: [ConversationMessage],
+        to context: AgentContext
+    ) async {
+        for message in conversationHistory {
+            switch message {
+            case let .system(content):
+                await context.addMessage(SwarmTranscriptCodec.encodeMessage(role: .system, content: content))
+            case let .user(content):
+                await context.addMessage(SwarmTranscriptCodec.encodeMessage(role: .user, content: content))
+            case let .assistant(content, toolCalls):
+                await context.addMessage(
+                    SwarmTranscriptCodec.encodeMessage(
+                        role: .assistant,
+                        content: content,
+                        toolCalls: toolCalls
+                    )
+                )
+            case let .toolResult(toolName, result, toolCallID):
+                await context.addMessage(
+                    SwarmTranscriptCodec.encodeMessage(
+                        role: .tool,
+                        content: result,
+                        toolName: toolName,
+                        toolCallID: toolCallID
+                    )
+                )
+            }
+        }
     }
 
     // MARK: - Prompt Building

--- a/Tests/SwarmTests/Agents/AgentHandoffRuntimeTests.swift
+++ b/Tests/SwarmTests/Agents/AgentHandoffRuntimeTests.swift
@@ -1,0 +1,169 @@
+import Foundation
+@testable import Swarm
+import Testing
+
+@Suite("Agent handoff runtime")
+struct AgentHandoffRuntimeTests {
+    @Test("Disabled handoffs are not advertised as tools")
+    func disabledHandoffsAreNotAdvertisedAsTools() async throws {
+        let provider = MockInferenceProvider()
+        await provider.setToolCallResponses([
+            InferenceResponse(content: "done", finishReason: .completed),
+        ])
+        let target = RecordingHandoffReceiver(name: "target-agent")
+        let handoff = HandoffConfiguration(
+            targetAgent: target,
+            toolNameOverride: "handoff_to_target",
+            when: { _, _ in false }
+        )
+        let regularTool = MockTool(name: "regular_tool", description: "A regular callable tool")
+        let agent = try Agent(
+            tools: [regularTool],
+            instructions: "Route only when enabled.",
+            configuration: AgentConfiguration(name: "source-agent", defaultTracingEnabled: false),
+            inferenceProvider: provider,
+            handoffs: [AnyHandoffConfiguration(handoff)]
+        )
+
+        _ = try await agent.run("do not route")
+
+        let toolCalls = await provider.toolCallMessageCalls
+        #expect(toolCalls.count == 1)
+        let toolNames = toolCalls[0].tools.map(\.name)
+        #expect(toolNames.contains("regular_tool"))
+        #expect(!toolNames.contains("handoff_to_target"))
+        #expect(await target.runInputs.isEmpty)
+        #expect(await target.handoffRequests.isEmpty)
+    }
+
+    @Test("Runtime handoff executes callbacks transform and nested history")
+    func runtimeHandoffExecutesCallbacksTransformAndNestedHistory() async throws {
+        let provider = MockInferenceProvider()
+        await provider.setToolCallResponses([
+            InferenceResponse(
+                content: nil,
+                toolCalls: [
+                    InferenceResponse.ParsedToolCall(
+                        id: "call_handoff",
+                        name: "handoff_to_target",
+                        arguments: ["reason": .string("needs specialist")]
+                    ),
+                ],
+                finishReason: .toolCall,
+                usage: nil
+            ),
+        ])
+
+        let target = RecordingHandoffReceiver(name: "target-agent")
+        let callbackRecorder = HandoffCallbackRecorder()
+        let handoff = HandoffConfiguration(
+            targetAgent: target,
+            toolNameOverride: "handoff_to_target",
+            onTransfer: { context, data in
+                await callbackRecorder.recordTransfer(data)
+                await context.set("transfer_seen", value: .string(data.input))
+            },
+            transform: { data in
+                HandoffInputData(
+                    sourceAgentName: data.sourceAgentName,
+                    targetAgentName: data.targetAgentName,
+                    input: "transformed: \(data.input)",
+                    context: data.context,
+                    metadata: data.metadata.merging(["transformed": .bool(true)]) { _, new in new }
+                )
+            },
+            when: { context, _ in
+                context.originalInput.contains("route")
+            },
+            nestHandoffHistory: true
+        )
+        let agent = try Agent(
+            tools: [],
+            instructions: "Route to target when needed.",
+            configuration: AgentConfiguration(name: "source-agent", defaultTracingEnabled: false),
+            inferenceProvider: provider,
+            handoffs: [AnyHandoffConfiguration(handoff)]
+        )
+
+        let result = try await agent.run("please route this")
+
+        #expect(result.output == "handled transformed: please route this")
+        #expect(await callbackRecorder.transferCount == 1)
+        #expect(await callbackRecorder.lastTransfer?.input == "please route this")
+
+        let requests = await target.handoffRequests
+        #expect(requests.count == 1)
+        let request = try #require(requests.first)
+        #expect(request.sourceAgentName == "source-agent")
+        #expect(request.targetAgentName == "target-agent")
+        #expect(request.input == "transformed: please route this")
+        #expect(request.reason == "needs specialist")
+        #expect(request.context["transformed"] == .bool(true))
+
+        let snapshots = await target.contextSnapshots
+        #expect(snapshots.count == 1)
+        let snapshot = try #require(snapshots.first)
+        #expect(snapshot["transfer_seen"] == .string("please route this"))
+
+        let nestedMessages = await target.contextMessages
+        #expect(nestedMessages.count == 1)
+        let messages = try #require(nestedMessages.first)
+        #expect(messages.contains { $0.content == "please route this" })
+    }
+}
+
+private actor RecordingHandoffReceiver: HandoffReceiver {
+    nonisolated let tools: [any AnyJSONTool] = []
+    nonisolated let instructions = "Record handoff requests"
+    nonisolated let configuration: AgentConfiguration
+    nonisolated let memory: (any Memory)? = nil
+    nonisolated let inferenceProvider: (any InferenceProvider)? = nil
+    nonisolated let tracer: (any Tracer)? = nil
+    nonisolated let inputGuardrails: [any InputGuardrail] = []
+    nonisolated let outputGuardrails: [any OutputGuardrail] = []
+    nonisolated let handoffs: [AnyHandoffConfiguration] = []
+
+    private(set) var runInputs: [String] = []
+    private(set) var handoffRequests: [HandoffRequest] = []
+    private(set) var contextSnapshots: [[String: SendableValue]] = []
+    private(set) var contextMessages: [[MemoryMessage]] = []
+
+    init(name: String) {
+        configuration = AgentConfiguration(name: name, defaultTracingEnabled: false)
+    }
+
+    func run(_ input: String, session _: (any Session)?, observer _: (any AgentObserver)?) async throws -> AgentResult {
+        runInputs.append(input)
+        return AgentResult(output: "handled \(input)")
+    }
+
+    nonisolated func stream(
+        _ input: String,
+        session _: (any Session)?,
+        observer _: (any AgentObserver)?
+    ) -> AsyncThrowingStream<AgentEvent, Error> {
+        StreamHelper.makeTrackedStream { continuation in
+            continuation.yield(.lifecycle(.completed(result: AgentResult(output: "handled \(input)"))))
+            continuation.finish()
+        }
+    }
+
+    func cancel() async {}
+
+    func handleHandoff(_ request: HandoffRequest, context: AgentContext) async throws -> AgentResult {
+        handoffRequests.append(request)
+        contextSnapshots.append(await context.snapshot)
+        contextMessages.append(await context.getMessages())
+        return AgentResult(output: "handled \(request.input)")
+    }
+}
+
+private actor HandoffCallbackRecorder {
+    private(set) var transferCount = 0
+    private(set) var lastTransfer: HandoffInputData?
+
+    func recordTransfer(_ data: HandoffInputData) {
+        transferCount += 1
+        lastTransfer = data
+    }
+}

--- a/Tests/SwarmTests/Agents/AgentHandoffRuntimeTests.swift
+++ b/Tests/SwarmTests/Agents/AgentHandoffRuntimeTests.swift
@@ -175,6 +175,77 @@ struct AgentHandoffRuntimeTests {
         #expect(messages.contains { $0.role == .user && $0.content == "target-only payload" })
     }
 
+    @Test("Nested handoff history preserves completed tool pairs for regular Agent targets")
+    func nestedHandoffHistoryPreservesCompletedToolPairsForRegularAgentTargets() async throws {
+        let sourceProvider = MockInferenceProvider()
+        await sourceProvider.setToolCallResponses([
+            InferenceResponse(
+                content: nil,
+                toolCalls: [
+                    InferenceResponse.ParsedToolCall(
+                        id: "call_lookup",
+                        name: "lookup_tool",
+                        arguments: [:]
+                    ),
+                ],
+                finishReason: .toolCall,
+                usage: nil
+            ),
+            InferenceResponse(
+                content: nil,
+                toolCalls: [
+                    InferenceResponse.ParsedToolCall(
+                        id: "call_handoff",
+                        name: "handoff_to_target",
+                        arguments: ["reason": .string("delegate")]
+                    ),
+                ],
+                finishReason: .toolCall,
+                usage: nil
+            ),
+        ])
+
+        let targetProvider = MockInferenceProvider(responses: ["target done"])
+        let target = try Agent(
+            tools: [],
+            instructions: "Use prior context.",
+            configuration: AgentConfiguration(name: "target-agent", defaultTracingEnabled: false),
+            memory: ConversationMemory(),
+            inferenceProvider: targetProvider
+        )
+        let handoff = HandoffConfiguration(
+            targetAgent: target,
+            toolNameOverride: "handoff_to_target",
+            nestHandoffHistory: true
+        )
+        let source = try Agent(
+            tools: [MockTool(name: "lookup_tool", result: .string("lookup result"))],
+            instructions: "Look up context, then route to target.",
+            configuration: AgentConfiguration(name: "source-agent", defaultTracingEnabled: false),
+            memory: ConversationMemory(),
+            inferenceProvider: sourceProvider,
+            handoffs: [AnyHandoffConfiguration(handoff)]
+        )
+
+        _ = try await source.run("please route this")
+
+        let targetCalls = await targetProvider.generateMessageCalls
+        let messages = try #require(targetCalls.first?.messages)
+        let assistantMessages = messages.filter { $0.role == .assistant }
+        let toolMessages = messages.filter { $0.role == .tool }
+
+        #expect(assistantMessages.contains {
+            $0.toolCalls.contains { $0.id == "call_lookup" && $0.name == "lookup_tool" }
+        })
+        #expect(toolMessages.contains {
+            $0.toolCallID == "call_lookup" && $0.name == "lookup_tool" && $0.content == "lookup result"
+        })
+        #expect(!assistantMessages.contains {
+            $0.toolCalls.contains { $0.id == "call_handoff" || $0.name == "handoff_to_target" }
+        })
+        #expect(!toolMessages.contains { $0.toolCallID == "call_handoff" || $0.name == "handoff_to_target" })
+    }
+
     @Test("Handoff tool call is recorded on parent result")
     func handoffToolCallIsRecordedOnParentResult() async throws {
         let provider = MockInferenceProvider()

--- a/Tests/SwarmTests/Agents/AgentHandoffRuntimeTests.swift
+++ b/Tests/SwarmTests/Agents/AgentHandoffRuntimeTests.swift
@@ -62,6 +62,7 @@ struct AgentHandoffRuntimeTests {
             onTransfer: { context, data in
                 await callbackRecorder.recordTransfer(data)
                 await context.set("transfer_seen", value: .string(data.input))
+                await context.set(.originalInput, value: .string("callback-updated-original-input"))
             },
             transform: { data in
                 HandoffInputData(
@@ -104,11 +105,74 @@ struct AgentHandoffRuntimeTests {
         #expect(snapshots.count == 1)
         let snapshot = try #require(snapshots.first)
         #expect(snapshot["transfer_seen"] == .string("please route this"))
+        #expect(snapshot[AgentContextKey.originalInput.rawValue] == .string("callback-updated-original-input"))
+        #expect(snapshot[AgentContextKey.executionPath.rawValue] == .array([.string("source-agent")]))
 
         let nestedMessages = await target.contextMessages
         #expect(nestedMessages.count == 1)
         let messages = try #require(nestedMessages.first)
         #expect(messages.contains { $0.content == "please route this" })
+
+        let paths = await target.executionPaths
+        #expect(paths.first == ["source-agent"])
+    }
+
+    @Test("Nested handoff history is passed to regular Agent targets")
+    func nestedHandoffHistoryIsPassedToRegularAgentTargets() async throws {
+        let sourceProvider = MockInferenceProvider()
+        await sourceProvider.setToolCallResponses([
+            InferenceResponse(
+                content: nil,
+                toolCalls: [
+                    InferenceResponse.ParsedToolCall(
+                        id: "call_handoff",
+                        name: "handoff_to_target",
+                        arguments: ["reason": .string("delegate")]
+                    ),
+                ],
+                finishReason: .toolCall,
+                usage: nil
+            ),
+        ])
+
+        let targetProvider = MockInferenceProvider(responses: ["target done"])
+        let target = try Agent(
+            tools: [],
+            instructions: "Use prior context.",
+            configuration: AgentConfiguration(name: "target-agent", defaultTracingEnabled: false),
+            memory: ConversationMemory(),
+            inferenceProvider: targetProvider
+        )
+        let handoff = HandoffConfiguration(
+            targetAgent: target,
+            toolNameOverride: "handoff_to_target",
+            transform: { data in
+                HandoffInputData(
+                    sourceAgentName: data.sourceAgentName,
+                    targetAgentName: data.targetAgentName,
+                    input: "target-only payload",
+                    context: data.context,
+                    metadata: data.metadata
+                )
+            },
+            nestHandoffHistory: true
+        )
+        let source = try Agent(
+            tools: [],
+            instructions: "Route to target.",
+            configuration: AgentConfiguration(name: "source-agent", defaultTracingEnabled: false),
+            memory: ConversationMemory(),
+            inferenceProvider: sourceProvider,
+            handoffs: [AnyHandoffConfiguration(handoff)]
+        )
+
+        let result = try await source.run("please route this")
+
+        #expect(result.output == "target done")
+        let targetCalls = await targetProvider.generateMessageCalls
+        let messages = try #require(targetCalls.first?.messages)
+        #expect(messages.contains { $0.role == .user && $0.content == "please route this" })
+        #expect(messages.contains { $0.role == .user && $0.content == "target-only payload" })
     }
 
     @Test("Handoff tool call is recorded on parent result")
@@ -170,6 +234,7 @@ private actor RecordingHandoffReceiver: HandoffReceiver {
     private(set) var handoffRequests: [HandoffRequest] = []
     private(set) var contextSnapshots: [[String: SendableValue]] = []
     private(set) var contextMessages: [[MemoryMessage]] = []
+    private(set) var executionPaths: [[String]] = []
 
     init(name: String) {
         configuration = AgentConfiguration(name: name, defaultTracingEnabled: false)
@@ -197,6 +262,7 @@ private actor RecordingHandoffReceiver: HandoffReceiver {
         handoffRequests.append(request)
         contextSnapshots.append(await context.snapshot)
         contextMessages.append(await context.getMessages())
+        executionPaths.append(await context.getExecutionPath())
         return AgentResult(output: "handled \(request.input)")
     }
 }

--- a/Tests/SwarmTests/Agents/AgentHandoffRuntimeTests.swift
+++ b/Tests/SwarmTests/Agents/AgentHandoffRuntimeTests.swift
@@ -110,6 +110,49 @@ struct AgentHandoffRuntimeTests {
         let messages = try #require(nestedMessages.first)
         #expect(messages.contains { $0.content == "please route this" })
     }
+
+    @Test("Handoff tool call is recorded on parent result")
+    func handoffToolCallIsRecordedOnParentResult() async throws {
+        let provider = MockInferenceProvider()
+        await provider.setToolCallResponses([
+            InferenceResponse(
+                content: nil,
+                toolCalls: [
+                    InferenceResponse.ParsedToolCall(
+                        id: "call_handoff",
+                        name: "handoff_to_target",
+                        arguments: ["reason": .string("delegate")]
+                    ),
+                ],
+                finishReason: .toolCall,
+                usage: nil
+            ),
+        ])
+        let target = RecordingHandoffReceiver(name: "target-agent")
+        let handoff = HandoffConfiguration(
+            targetAgent: target,
+            toolNameOverride: "handoff_to_target"
+        )
+        let agent = try Agent(
+            tools: [],
+            instructions: "Route to target.",
+            configuration: AgentConfiguration(name: "source-agent", defaultTracingEnabled: false),
+            inferenceProvider: provider,
+            handoffs: [AnyHandoffConfiguration(handoff)]
+        )
+
+        let result = try await agent.run("route this")
+
+        let handoffCall = try #require(result.toolCalls.first)
+        #expect(handoffCall.toolName == "handoff_to_target")
+        #expect(handoffCall.providerCallId == "call_handoff")
+        #expect(handoffCall.arguments["reason"] == .string("delegate"))
+
+        let handoffResult = try #require(result.toolResults.first)
+        #expect(handoffResult.callId == handoffCall.id)
+        #expect(handoffResult.isSuccess)
+        #expect(handoffResult.output == .string("handled route this"))
+    }
 }
 
 private actor RecordingHandoffReceiver: HandoffReceiver {

--- a/Tests/SwarmTests/Agents/AgentHandoffRuntimeTests.swift
+++ b/Tests/SwarmTests/Agents/AgentHandoffRuntimeTests.swift
@@ -288,6 +288,121 @@ struct AgentHandoffRuntimeTests {
         #expect(handoffResult.isSuccess)
         #expect(handoffResult.output == .string("handled route this"))
     }
+
+    @Test("Disabled handoff tool call is recoverable by default")
+    func disabledHandoffToolCallIsRecoverableByDefault() async throws {
+        let gate = HandoffPredicateGate(isEnabled: true)
+        let provider = GateDisablingToolCallProvider(gate: gate)
+        let target = RecordingHandoffReceiver(name: "target-agent")
+        let handoff = HandoffConfiguration(
+            targetAgent: target,
+            toolNameOverride: "handoff_to_target",
+            when: { _, _ in await gate.isEnabled }
+        )
+        let agent = try Agent(
+            tools: [],
+            instructions: "Route only when enabled.",
+            configuration: AgentConfiguration(name: "source-agent", defaultTracingEnabled: false),
+            inferenceProvider: provider,
+            handoffs: [AnyHandoffConfiguration(handoff)]
+        )
+
+        let result = try await agent.run("do not route")
+
+        #expect(result.output == "recovered")
+        #expect(await target.runInputs.isEmpty)
+        #expect(await target.handoffRequests.isEmpty)
+
+        let handoffCall = try #require(result.toolCalls.first)
+        #expect(handoffCall.toolName == "handoff_to_target")
+        #expect(handoffCall.providerCallId == "call_disabled_handoff")
+
+        let handoffResult = try #require(result.toolResults.first)
+        #expect(!handoffResult.isSuccess)
+        #expect(handoffResult.errorMessage == "Handoff is not enabled")
+    }
+}
+
+private actor HandoffPredicateGate {
+    private(set) var isEnabled: Bool
+
+    init(isEnabled: Bool) {
+        self.isEnabled = isEnabled
+    }
+
+    func disable() {
+        isEnabled = false
+    }
+}
+
+private actor GateDisablingToolCallProvider: InferenceProvider {
+    private let gate: HandoffPredicateGate
+
+    init(gate: HandoffPredicateGate) {
+        self.gate = gate
+    }
+
+    func generate(prompt _: String, options _: InferenceOptions) async throws -> String {
+        "recovered"
+    }
+
+    nonisolated func stream(prompt _: String, options _: InferenceOptions) -> AsyncThrowingStream<String, Error> {
+        StreamHelper.makeTrackedStream { continuation in
+            continuation.yield("recovered")
+            continuation.finish()
+        }
+    }
+
+    func generateWithToolCalls(
+        prompt _: String,
+        tools _: [ToolSchema],
+        options _: InferenceOptions
+    ) async throws -> InferenceResponse {
+        await gate.disable()
+        return disabledHandoffToolCallResponse()
+    }
+
+    func generate(messages _: [InferenceMessage], options _: InferenceOptions) async throws -> String {
+        "recovered"
+    }
+
+    nonisolated func stream(
+        messages _: [InferenceMessage],
+        options _: InferenceOptions
+    ) -> AsyncThrowingStream<String, Error> {
+        StreamHelper.makeTrackedStream { continuation in
+            continuation.yield("recovered")
+            continuation.finish()
+        }
+    }
+
+    func generateWithToolCalls(
+        messages _: [InferenceMessage],
+        tools _: [ToolSchema],
+        options _: InferenceOptions
+    ) async throws -> InferenceResponse {
+        await gate.disable()
+        return disabledHandoffToolCallResponse()
+    }
+
+    func countTokens(in text: String) async throws -> Int {
+        max(1, text.count)
+    }
+
+    private func disabledHandoffToolCallResponse() -> InferenceResponse {
+        InferenceResponse(
+            content: nil,
+            toolCalls: [
+                InferenceResponse.ParsedToolCall(
+                    id: "call_disabled_handoff",
+                    name: "handoff_to_target",
+                    arguments: ["reason": .string("stale route")]
+                ),
+            ],
+            finishReason: .toolCall,
+            usage: nil
+        )
+    }
 }
 
 private actor RecordingHandoffReceiver: HandoffReceiver {


### PR DESCRIPTION
## Summary
- execute configured handoff runtime options for SWARM-AUDIT-023: dynamic `when` filtering, `onTransfer`, transformed handoff input, context transfer, and nested history
- record handoff tool calls/results on the parent `AgentResult` for SWARM-AUDIT-024
- preserve callback-updated context, execution path, and nested history for regular `Agent` targets as part of the handoff runtime fix

## Verification
- `swift test --filter AgentHandoffRuntimeTests`
- `swift test --filter 'AgentHandoffRuntimeTests|HandoffBehaviorTests|AgentTests|AgentTranscriptContractTests|RunHooksTests'`
- `swift build --target Swarm`
- `git diff --check codex/fix-mcp-text-content-tests...HEAD`

Stacked on PR #94 / `codex/fix-mcp-text-content-tests`.