### PR TITLE
Fix tools guardrails and workspace audit issues

### DIFF
--- a/Sources/Swarm/Guardrails/GuardrailRunner.swift
+++ b/Sources/Swarm/Guardrails/GuardrailRunner.swift
@@ -13,6 +13,7 @@ import Foundation
 /// `GuardrailRunnerConfiguration` controls how the runner executes guardrails:
 /// - Sequential vs parallel execution
 /// - Stop-on-first-tripwire vs run-all behavior
+/// - Per-guardrail timeout enforcement
 ///
 /// Use the static factory properties for common configurations:
 /// ```swift
@@ -49,6 +50,12 @@ public struct GuardrailRunnerConfiguration: Sendable, Equatable {
     /// - `false`: Continue all guardrails, throw at end if any tripwired
     public let stopOnFirstTripwire: Bool
 
+    /// Maximum duration allowed for each guardrail validation.
+    ///
+    /// A `nil` value disables timeout enforcement. The default keeps guardrails
+    /// from stalling agent execution indefinitely.
+    public let timeout: Duration?
+
     // MARK: - Initialization
 
     /// Creates a guardrail runner configuration.
@@ -60,15 +67,21 @@ public struct GuardrailRunnerConfiguration: Sendable, Equatable {
     ///   - stopOnFirstTripwire: Whether to stop on first tripwire. Default: true
     ///     - `true`: Stop immediately when any guardrail triggers (faster, less information)
     ///     - `false`: Run all guardrails even after tripwires (slower, more diagnostic info)
+    ///   - timeout: Per-guardrail timeout. Default: 30 seconds. Pass `nil` to disable.
     ///
     /// ## Performance Notes
     ///
     /// - Parallel execution is faster but results may arrive out of order
     /// - Stop-on-first is recommended for production (fail-fast)
     /// - Run-all is useful for testing and diagnostics
-    public init(runInParallel: Bool = false, stopOnFirstTripwire: Bool = true) {
+    public init(
+        runInParallel: Bool = false,
+        stopOnFirstTripwire: Bool = true,
+        timeout: Duration? = .seconds(30)
+    ) {
         self.runInParallel = runInParallel
         self.stopOnFirstTripwire = stopOnFirstTripwire
+        self.timeout = timeout
     }
 }
 
@@ -120,6 +133,15 @@ public struct GuardrailExecutionResult: Sendable, Equatable {
     public init(guardrailName: String, result: GuardrailResult) {
         self.guardrailName = guardrailName
         self.result = result
+    }
+}
+
+private struct GuardrailTimeoutError: Error, LocalizedError, Sendable {
+    let guardrailName: String
+    let timeout: Duration
+
+    var errorDescription: String? {
+        "Guardrail '\(guardrailName)' timed out after \(timeout)."
     }
 }
 
@@ -197,6 +219,31 @@ public actor GuardrailRunner {
             guardrailType: guardrailType,
             result: result
         )
+    }
+
+    private func validateWithTimeout<Result: Sendable>(
+        guardrailName: String,
+        operation: @escaping @Sendable () async throws -> Result
+    ) async throws -> Result {
+        guard let timeout = configuration.timeout else {
+            return try await operation()
+        }
+
+        return try await withThrowingTaskGroup(of: Result.self) { group in
+            group.addTask {
+                try await operation()
+            }
+            group.addTask {
+                try await Task.sleep(for: timeout)
+                throw GuardrailTimeoutError(guardrailName: guardrailName, timeout: timeout)
+            }
+
+            guard let result = try await group.next() else {
+                throw GuardrailTimeoutError(guardrailName: guardrailName, timeout: timeout)
+            }
+            group.cancelAll()
+            return result
+        }
     }
 
     // MARK: - Input Guardrails
@@ -326,7 +373,9 @@ extension GuardrailRunner {
             try Task.checkCancellation()
 
             do {
-                let result = try await guardrail.validate(input, context: context)
+                let result = try await validateWithTimeout(guardrailName: guardrail.name) {
+                    try await guardrail.validate(input, context: context)
+                }
                 let executionResult = GuardrailExecutionResult(
                     guardrailName: guardrail.name,
                     result: result
@@ -384,7 +433,9 @@ extension GuardrailRunner {
             try Task.checkCancellation()
 
             do {
-                let result = try await guardrail.validate(output, agent: agent, context: context)
+                let result = try await validateWithTimeout(guardrailName: guardrail.name) {
+                    try await guardrail.validate(output, agent: agent, context: context)
+                }
                 let executionResult = GuardrailExecutionResult(
                     guardrailName: guardrail.name,
                     result: result
@@ -442,7 +493,9 @@ extension GuardrailRunner {
             try Task.checkCancellation()
 
             do {
-                let result = try await guardrail.validate(data)
+                let result = try await validateWithTimeout(guardrailName: guardrail.name) {
+                    try await guardrail.validate(data)
+                }
                 let executionResult = GuardrailExecutionResult(
                     guardrailName: guardrail.name,
                     result: result
@@ -501,7 +554,9 @@ extension GuardrailRunner {
             try Task.checkCancellation()
 
             do {
-                let result = try await guardrail.validate(data, output: output)
+                let result = try await validateWithTimeout(guardrailName: guardrail.name) {
+                    try await guardrail.validate(data, output: output)
+                }
                 let executionResult = GuardrailExecutionResult(
                     guardrailName: guardrail.name,
                     result: result
@@ -568,7 +623,9 @@ extension GuardrailRunner {
             for (index, guardrail) in guardrails.enumerated() {
                 group.addTask {
                     do {
-                        let result = try await guardrail.validate(input, context: context)
+                        let result = try await self.validateWithTimeout(guardrailName: guardrail.name) {
+                            try await guardrail.validate(input, context: context)
+                        }
                         return (index, GuardrailExecutionResult(
                             guardrailName: guardrail.name,
                             result: result
@@ -646,7 +703,9 @@ extension GuardrailRunner {
             for (index, guardrail) in guardrails.enumerated() {
                 group.addTask {
                     do {
-                        let result = try await guardrail.validate(output, agent: agent, context: context)
+                        let result = try await self.validateWithTimeout(guardrailName: guardrail.name) {
+                            try await guardrail.validate(output, agent: agent, context: context)
+                        }
                         return (index, GuardrailExecutionResult(
                             guardrailName: guardrail.name,
                             result: result
@@ -724,7 +783,9 @@ extension GuardrailRunner {
             for (index, guardrail) in guardrails.enumerated() {
                 group.addTask {
                     do {
-                        let result = try await guardrail.validate(data)
+                        let result = try await self.validateWithTimeout(guardrailName: guardrail.name) {
+                            try await guardrail.validate(data)
+                        }
                         return (index, GuardrailExecutionResult(
                             guardrailName: guardrail.name,
                             result: result
@@ -803,7 +864,9 @@ extension GuardrailRunner {
             for (index, guardrail) in guardrails.enumerated() {
                 group.addTask {
                     do {
-                        let result = try await guardrail.validate(data, output: output)
+                        let result = try await self.validateWithTimeout(guardrailName: guardrail.name) {
+                            try await guardrail.validate(data, output: output)
+                        }
                         return (index, GuardrailExecutionResult(
                             guardrailName: guardrail.name,
                             result: result

--- a/Sources/Swarm/Guardrails/GuardrailRunner.swift
+++ b/Sources/Swarm/Guardrails/GuardrailRunner.swift
@@ -560,19 +560,19 @@ extension GuardrailRunner {
     ) async throws -> [GuardrailExecutionResult] {
         try Task.checkCancellation()
 
-        return try await withThrowingTaskGroup(of: GuardrailExecutionResult.self) { group in
-            var results: [GuardrailExecutionResult] = []
-            results.reserveCapacity(guardrails.count)
+        return try await withThrowingTaskGroup(of: (Int, GuardrailExecutionResult).self) { group in
+            var indexedResults: [(Int, GuardrailExecutionResult)] = []
+            indexedResults.reserveCapacity(guardrails.count)
 
             // Add all guardrails to the task group
-            for guardrail in guardrails {
+            for (index, guardrail) in guardrails.enumerated() {
                 group.addTask {
                     do {
                         let result = try await guardrail.validate(input, context: context)
-                        return GuardrailExecutionResult(
+                        return (index, GuardrailExecutionResult(
                             guardrailName: guardrail.name,
                             result: result
-                        )
+                        ))
                     } catch let error as GuardrailError {
                         throw error
                     } catch {
@@ -585,7 +585,7 @@ extension GuardrailRunner {
             }
 
             // Collect results
-            for try await executionResult in group {
+            for try await (index, executionResult) in group {
                 if executionResult.result.tripwireTriggered, configuration.stopOnFirstTripwire {
                     await emitGuardrailEvent(
                         guardrailName: executionResult.guardrailName,
@@ -601,17 +601,22 @@ extension GuardrailRunner {
                         outputInfo: executionResult.result.outputInfo
                     )
                 }
-                results.append(executionResult)
+                indexedResults.append((index, executionResult))
             }
+
+            indexedResults.sort { $0.0 < $1.0 }
+            let results = indexedResults.map(\.1)
 
             // Check if any tripwires were triggered (when not stopping on first)
             if let tripwiredResult = results.first(where: { $0.result.tripwireTriggered }) {
-                await emitGuardrailEvent(
-                    guardrailName: tripwiredResult.guardrailName,
-                    guardrailType: .input,
-                    result: tripwiredResult.result,
-                    context: context
-                )
+                for result in results where result.result.tripwireTriggered {
+                    await emitGuardrailEvent(
+                        guardrailName: result.guardrailName,
+                        guardrailType: .input,
+                        result: result.result,
+                        context: context
+                    )
+                }
                 throw GuardrailError.inputTripwireTriggered(
                     guardrailName: tripwiredResult.guardrailName,
                     message: tripwiredResult.result.message,
@@ -633,19 +638,19 @@ extension GuardrailRunner {
 
         let agentName = agent.configuration.name
 
-        return try await withThrowingTaskGroup(of: GuardrailExecutionResult.self) { group in
-            var results: [GuardrailExecutionResult] = []
-            results.reserveCapacity(guardrails.count)
+        return try await withThrowingTaskGroup(of: (Int, GuardrailExecutionResult).self) { group in
+            var indexedResults: [(Int, GuardrailExecutionResult)] = []
+            indexedResults.reserveCapacity(guardrails.count)
 
             // Add all guardrails to the task group
-            for guardrail in guardrails {
+            for (index, guardrail) in guardrails.enumerated() {
                 group.addTask {
                     do {
                         let result = try await guardrail.validate(output, agent: agent, context: context)
-                        return GuardrailExecutionResult(
+                        return (index, GuardrailExecutionResult(
                             guardrailName: guardrail.name,
                             result: result
-                        )
+                        ))
                     } catch let error as GuardrailError {
                         throw error
                     } catch {
@@ -658,7 +663,7 @@ extension GuardrailRunner {
             }
 
             // Collect results
-            for try await executionResult in group {
+            for try await (index, executionResult) in group {
                 if executionResult.result.tripwireTriggered, configuration.stopOnFirstTripwire {
                     await emitGuardrailEvent(
                         guardrailName: executionResult.guardrailName,
@@ -675,17 +680,22 @@ extension GuardrailRunner {
                         outputInfo: executionResult.result.outputInfo
                     )
                 }
-                results.append(executionResult)
+                indexedResults.append((index, executionResult))
             }
+
+            indexedResults.sort { $0.0 < $1.0 }
+            let results = indexedResults.map(\.1)
 
             // Check if any tripwires were triggered (when not stopping on first)
             if let tripwiredResult = results.first(where: { $0.result.tripwireTriggered }) {
-                await emitGuardrailEvent(
-                    guardrailName: tripwiredResult.guardrailName,
-                    guardrailType: .output,
-                    result: tripwiredResult.result,
-                    context: context
-                )
+                for result in results where result.result.tripwireTriggered {
+                    await emitGuardrailEvent(
+                        guardrailName: result.guardrailName,
+                        guardrailType: .output,
+                        result: result.result,
+                        context: context
+                    )
+                }
                 throw GuardrailError.outputTripwireTriggered(
                     guardrailName: tripwiredResult.guardrailName,
                     agentName: agentName,
@@ -706,19 +716,19 @@ extension GuardrailRunner {
 
         let toolName = data.tool.name
 
-        return try await withThrowingTaskGroup(of: GuardrailExecutionResult.self) { group in
-            var results: [GuardrailExecutionResult] = []
-            results.reserveCapacity(guardrails.count)
+        return try await withThrowingTaskGroup(of: (Int, GuardrailExecutionResult).self) { group in
+            var indexedResults: [(Int, GuardrailExecutionResult)] = []
+            indexedResults.reserveCapacity(guardrails.count)
 
             // Add all guardrails to the task group
-            for guardrail in guardrails {
+            for (index, guardrail) in guardrails.enumerated() {
                 group.addTask {
                     do {
                         let result = try await guardrail.validate(data)
-                        return GuardrailExecutionResult(
+                        return (index, GuardrailExecutionResult(
                             guardrailName: guardrail.name,
                             result: result
-                        )
+                        ))
                     } catch let error as GuardrailError {
                         throw error
                     } catch {
@@ -731,7 +741,7 @@ extension GuardrailRunner {
             }
 
             // Collect results
-            for try await executionResult in group {
+            for try await (index, executionResult) in group {
                 if executionResult.result.tripwireTriggered, configuration.stopOnFirstTripwire {
                     await emitGuardrailEvent(
                         guardrailName: executionResult.guardrailName,
@@ -748,17 +758,22 @@ extension GuardrailRunner {
                         outputInfo: executionResult.result.outputInfo
                     )
                 }
-                results.append(executionResult)
+                indexedResults.append((index, executionResult))
             }
+
+            indexedResults.sort { $0.0 < $1.0 }
+            let results = indexedResults.map(\.1)
 
             // Check if any tripwires were triggered (when not stopping on first)
             if let tripwiredResult = results.first(where: { $0.result.tripwireTriggered }) {
-                await emitGuardrailEvent(
-                    guardrailName: tripwiredResult.guardrailName,
-                    guardrailType: .toolInput,
-                    result: tripwiredResult.result,
-                    context: data.context
-                )
+                for result in results where result.result.tripwireTriggered {
+                    await emitGuardrailEvent(
+                        guardrailName: result.guardrailName,
+                        guardrailType: .toolInput,
+                        result: result.result,
+                        context: data.context
+                    )
+                }
                 throw GuardrailError.toolInputTripwireTriggered(
                     guardrailName: tripwiredResult.guardrailName,
                     toolName: toolName,
@@ -780,19 +795,19 @@ extension GuardrailRunner {
 
         let toolName = data.tool.name
 
-        return try await withThrowingTaskGroup(of: GuardrailExecutionResult.self) { group in
-            var results: [GuardrailExecutionResult] = []
-            results.reserveCapacity(guardrails.count)
+        return try await withThrowingTaskGroup(of: (Int, GuardrailExecutionResult).self) { group in
+            var indexedResults: [(Int, GuardrailExecutionResult)] = []
+            indexedResults.reserveCapacity(guardrails.count)
 
             // Add all guardrails to the task group
-            for guardrail in guardrails {
+            for (index, guardrail) in guardrails.enumerated() {
                 group.addTask {
                     do {
                         let result = try await guardrail.validate(data, output: output)
-                        return GuardrailExecutionResult(
+                        return (index, GuardrailExecutionResult(
                             guardrailName: guardrail.name,
                             result: result
-                        )
+                        ))
                     } catch let error as GuardrailError {
                         throw error
                     } catch {
@@ -805,7 +820,7 @@ extension GuardrailRunner {
             }
 
             // Collect results
-            for try await executionResult in group {
+            for try await (index, executionResult) in group {
                 if executionResult.result.tripwireTriggered, configuration.stopOnFirstTripwire {
                     await emitGuardrailEvent(
                         guardrailName: executionResult.guardrailName,
@@ -822,17 +837,22 @@ extension GuardrailRunner {
                         outputInfo: executionResult.result.outputInfo
                     )
                 }
-                results.append(executionResult)
+                indexedResults.append((index, executionResult))
             }
+
+            indexedResults.sort { $0.0 < $1.0 }
+            let results = indexedResults.map(\.1)
 
             // Check if any tripwires were triggered (when not stopping on first)
             if let tripwiredResult = results.first(where: { $0.result.tripwireTriggered }) {
-                await emitGuardrailEvent(
-                    guardrailName: tripwiredResult.guardrailName,
-                    guardrailType: .toolOutput,
-                    result: tripwiredResult.result,
-                    context: data.context
-                )
+                for result in results where result.result.tripwireTriggered {
+                    await emitGuardrailEvent(
+                        guardrailName: result.guardrailName,
+                        guardrailType: .toolOutput,
+                        result: result.result,
+                        context: data.context
+                    )
+                }
                 throw GuardrailError.toolOutputTripwireTriggered(
                     guardrailName: tripwiredResult.guardrailName,
                     toolName: toolName,

--- a/Sources/Swarm/Guardrails/GuardrailRunner.swift
+++ b/Sources/Swarm/Guardrails/GuardrailRunner.swift
@@ -136,6 +136,55 @@ public struct GuardrailExecutionResult: Sendable, Equatable {
     }
 }
 
+private final class GuardrailTimeoutRace<Result: Sendable>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var completed = false
+    private var operationTask: Task<Void, Never>?
+    private var timeoutTask: Task<Void, Never>?
+
+    func setOperationTask(_ task: Task<Void, Never>) {
+        lock.lock()
+        let shouldCancel = completed
+        if !completed {
+            operationTask = task
+        }
+        lock.unlock()
+
+        if shouldCancel {
+            task.cancel()
+        }
+    }
+
+    func setTimeoutTask(_ task: Task<Void, Never>) {
+        lock.lock()
+        let shouldCancel = completed
+        if !completed {
+            timeoutTask = task
+        }
+        lock.unlock()
+
+        if shouldCancel {
+            task.cancel()
+        }
+    }
+
+    func complete(_ resume: () -> Void) {
+        lock.lock()
+        guard !completed else {
+            lock.unlock()
+            return
+        }
+        completed = true
+        let operationTask = operationTask
+        let timeoutTask = timeoutTask
+        lock.unlock()
+
+        operationTask?.cancel()
+        timeoutTask?.cancel()
+        resume()
+    }
+}
+
 private struct GuardrailTimeoutError: Error, LocalizedError, Sendable {
     let guardrailName: String
     let timeout: Duration
@@ -229,20 +278,33 @@ public actor GuardrailRunner {
             return try await operation()
         }
 
-        return try await withThrowingTaskGroup(of: Result.self) { group in
-            group.addTask {
-                try await operation()
+        let race = GuardrailTimeoutRace<Result>()
+        return try await withCheckedThrowingContinuation { continuation in
+            let operationTask = Task {
+                do {
+                    let result = try await operation()
+                    race.complete {
+                        continuation.resume(returning: result)
+                    }
+                } catch {
+                    race.complete {
+                        continuation.resume(throwing: error)
+                    }
+                }
             }
-            group.addTask {
-                try await Task.sleep(for: timeout)
-                throw GuardrailTimeoutError(guardrailName: guardrailName, timeout: timeout)
-            }
+            race.setOperationTask(operationTask)
 
-            guard let result = try await group.next() else {
-                throw GuardrailTimeoutError(guardrailName: guardrailName, timeout: timeout)
+            let timeoutTask = Task {
+                do {
+                    try await Task.sleep(for: timeout)
+                } catch {
+                    return
+                }
+                race.complete {
+                    continuation.resume(throwing: GuardrailTimeoutError(guardrailName: guardrailName, timeout: timeout))
+                }
             }
-            group.cancelAll()
-            return result
+            race.setTimeoutTask(timeoutTask)
         }
     }
 

--- a/Sources/Swarm/Resilience/RetryPolicy.swift
+++ b/Sources/Swarm/Resilience/RetryPolicy.swift
@@ -220,6 +220,10 @@ public struct RetryPolicy: Sendable {
             do {
                 return try await operation()
             } catch {
+                if error is CancellationError || Task.isCancelled {
+                    throw error
+                }
+
                 lastError = error
 
                 // Check if we should retry
@@ -261,7 +265,11 @@ public struct RetryPolicy: Sendable {
             return 0
         }
 
-        return min(UInt64(nanoseconds), Self.maxBackoffNanoseconds)
+        if nanoseconds >= Double(Self.maxBackoffNanoseconds) {
+            return Self.maxBackoffNanoseconds
+        }
+
+        return UInt64(nanoseconds)
     }
 }
 

--- a/Sources/Swarm/Tools/ParallelToolExecutor.swift
+++ b/Sources/Swarm/Tools/ParallelToolExecutor.swift
@@ -308,9 +308,9 @@ public actor ParallelToolExecutor {
     ) async throws -> [ToolExecutionResult] {
         guard !calls.isEmpty else { return [] }
 
-        // Validate all tools exist first
+        // Validate all tools exist and are enabled before any execution starts.
         for call in calls {
-            guard await registry.tool(named: call.toolName) != nil else {
+            guard let tool = await registry.tool(named: call.toolName), tool.isEnabled else {
                 throw AgentError.toolNotFound(name: call.toolName)
             }
         }

--- a/Sources/Swarm/Tools/Tool.swift
+++ b/Sources/Swarm/Tools/Tool.swift
@@ -509,6 +509,13 @@ private enum ToolArgumentProcessor {
         path: String,
         depth: Int = 0
     ) throws {
+        guard depth < maxDepth else {
+            throw AgentError.invalidToolArguments(
+                toolName: toolName,
+                reason: "Maximum nesting depth (\(maxDepth)) exceeded at path: \(path)"
+            )
+        }
+
         switch expected {
         case .any:
             return
@@ -584,6 +591,13 @@ private enum ToolArgumentProcessor {
         path: String,
         depth: Int = 0
     ) throws -> SendableValue {
+        guard depth < maxDepth else {
+            throw AgentError.invalidToolArguments(
+                toolName: toolName,
+                reason: "Maximum nesting depth (\(maxDepth)) exceeded at path: \(path)"
+            )
+        }
+
         switch expected {
         case .any:
             return value

--- a/Sources/Swarm/Tools/ToolBridging.swift
+++ b/Sources/Swarm/Tools/ToolBridging.swift
@@ -18,6 +18,7 @@ public struct AnyJSONToolAdapter<T: Tool>: AnyJSONTool, Sendable {
     public var parameters: [ToolParameter] { tool.parameters }
     public var inputGuardrails: [any ToolInputGuardrail] { tool.inputGuardrails }
     public var outputGuardrails: [any ToolOutputGuardrail] { tool.outputGuardrails }
+    public var executionSemantics: ToolExecutionSemantics { tool.executionSemantics }
 
     public init(_ tool: T) {
         self.tool = tool
@@ -55,4 +56,3 @@ public extension Tool {
         AnyJSONToolAdapter(self)
     }
 }
-

--- a/Sources/Swarm/Tools/ZoniSearchTool.swift
+++ b/Sources/Swarm/Tools/ZoniSearchTool.swift
@@ -5,8 +5,22 @@
 
 import Foundation
 
-// Note: Requires Zoni framework dependency
-// import Zoni 
+// Note: Apps can inject a Zoni-backed search closure when the Zoni package is
+// linked by the host app.
+
+public struct ZoniSearchDocument: Sendable, Equatable {
+    public let id: String
+    public let title: String
+    public let content: String
+    public let collection: String?
+
+    public init(id: String, title: String, content: String, collection: String? = nil) {
+        self.id = id
+        self.title = title
+        self.content = content
+        self.collection = collection
+    }
+}
 
 /// A tool that uses the Zoni RAG framework to search through indexed documents.
 ///
@@ -30,37 +44,96 @@ public struct ZoniSearchTool {
     
     @Parameter("Optional category or collection to limit the search to", default: nil)
     var collection: String?
-    
-    /// The Zoni RAG pipeline used for retrieval.
-    /// In a real app, this would be initialized with an embedding provider and vector store.
-    // private let pipeline: RAGPipeline
-    
+
+    private let search: @Sendable (String, String?) async throws -> String
+
     public init() {
-        // Initialize @Parameter properties with defaults
+        self.init(documents: [])
+    }
+
+    public init(documents: [ZoniSearchDocument]) {
+        self.init { query, collection in
+            Self.searchDocuments(documents, query: query, collection: collection)
+        }
+    }
+
+    public init(search: @escaping @Sendable (String, String?) async throws -> String) {
         self.query = ""
         self.collection = nil
-        
-        // Initialize your Zoni pipeline here or pass it in
-        // self.pipeline = pipeline
+        self.search = search
     }
     
     public func execute() async throws -> String {
-        // Example integration:
-        /*
-        let response = try await pipeline.query(query)
-        
-        let sources = response.sources
-            .map { "- \($0.metadata["filename"] ?? "Unknown source")" }
-            .joined(separator: "\n")
-            
-        return """
-        Answer: \(response.answer)
-        
-        Sources:
-        \(sources)
-        """
-        */
-        
-        throw Error.pipelineNotConfigured
+        try await search(query, collection)
+    }
+
+    private static func searchDocuments(
+        _ documents: [ZoniSearchDocument],
+        query: String,
+        collection: String?
+    ) -> String {
+        let tokens = tokenize(query)
+        guard !tokens.isEmpty else {
+            return "No query provided."
+        }
+
+        let collectionFilter = collection?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let matches = documents.compactMap { document -> (document: ZoniSearchDocument, score: Int)? in
+            if let collectionFilter, !collectionFilter.isEmpty {
+                guard document.collection?.lowercased() == collectionFilter else {
+                    return nil
+                }
+            }
+
+            let haystack = "\(document.title) \(document.content)".lowercased()
+            let score = tokens.reduce(into: 0) { total, token in
+                if haystack.contains(token) {
+                    total += document.title.lowercased().contains(token) ? 2 : 1
+                }
+            }
+            return score > 0 ? (document, score) : nil
+        }
+        .sorted { lhs, rhs in
+            if lhs.score == rhs.score {
+                lhs.document.title < rhs.document.title
+            } else {
+                lhs.score > rhs.score
+            }
+        }
+        .prefix(5)
+
+        guard !matches.isEmpty else {
+            return "No matching documents found."
+        }
+
+        let rendered = matches.map { match in
+            let snippet = makeSnippet(from: match.document.content, tokens: tokens)
+            return "- \(match.document.title): \(snippet)"
+        }
+        .joined(separator: "\n")
+
+        return "Search results:\n\(rendered)"
+    }
+
+    private static func tokenize(_ query: String) -> [String] {
+        query.lowercased()
+            .split { !$0.isLetter && !$0.isNumber }
+            .map(String.init)
+            .filter { $0.count > 1 }
+    }
+
+    private static func makeSnippet(from content: String, tokens: [String]) -> String {
+        let sentences = content
+            .split(whereSeparator: { ".?!".contains($0) })
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+
+        if let sentence = sentences.first(where: { sentence in
+            let lowercased = sentence.lowercased()
+            return tokens.contains { lowercased.contains($0) }
+        }) {
+            return sentence
+        }
+
+        return String(content.prefix(240))
     }
 }

--- a/Sources/Swarm/Workspace/AgentWorkspace.swift
+++ b/Sources/Swarm/Workspace/AgentWorkspace.swift
@@ -76,13 +76,21 @@ public struct AgentWorkspace: Sendable {
             do {
                 let spec = try parseAgentSpec(at: specURL)
                 for skillID in spec.skills {
-                    let skillURL = skillsDirectory.appendingPathComponent(skillID, isDirectory: true).appendingPathComponent("SKILL.md")
+                    let skillURL: URL
                     do {
+                        let safeSkillID = try validatedPathComponent(
+                            skillID,
+                            field: "skills",
+                            path: relativePath(for: specURL)
+                        )
+                        skillURL = skillsDirectory
+                            .appendingPathComponent(safeSkillID, isDirectory: true)
+                            .appendingPathComponent("SKILL.md")
                         _ = try parseSkill(at: skillURL)
                     } catch {
                         issues.append(
                             WorkspaceValidationIssue(
-                                path: relativePath(for: skillURL),
+                                path: relativePath(for: specURL),
                                 message: error.localizedDescription
                             )
                         )
@@ -151,13 +159,19 @@ extension AgentWorkspace {
     }
 
     func loadAgentSpec(id: String) throws -> WorkspaceAgentSpec {
+        let id = try validatedPathComponent(id, field: "id", path: relativePath(for: agentsDirectory))
         let specURL = agentsDirectory.appendingPathComponent("\(id).md")
         return try parseAgentSpec(at: specURL)
     }
 
     func loadSkills(named names: [String]) throws -> [WorkspaceSkill] {
         try names.map { name in
-            try parseSkill(at: skillsDirectory.appendingPathComponent(name, isDirectory: true).appendingPathComponent("SKILL.md"))
+            let name = try validatedPathComponent(name, field: "name", path: relativePath(for: skillsDirectory))
+            return try parseSkill(
+                at: skillsDirectory
+                    .appendingPathComponent(name, isDirectory: true)
+                    .appendingPathComponent("SKILL.md")
+            )
         }
     }
 
@@ -309,6 +323,15 @@ extension AgentWorkspace {
         }
 
         let id = try document.requiredString("id", path: relativePath(for: url))
+        _ = try validatedPathComponent(id, field: "id", path: relativePath(for: url))
+        let expectedID = url.deletingPathExtension().lastPathComponent
+        guard id == expectedID else {
+            throw AgentWorkspaceError.invalidField(
+                path: relativePath(for: url),
+                field: "id",
+                reason: "must match file name '\(expectedID)'"
+            )
+        }
         let title = try document.requiredString("title", path: relativePath(for: url))
         _ = try document.requiredInt("revision", path: relativePath(for: url))
         _ = try document.requiredString("updated_at", path: relativePath(for: url))
@@ -346,6 +369,7 @@ extension AgentWorkspace {
         }
 
         let name = try document.requiredString("name", path: relativePath(for: url))
+        _ = try validatedPathComponent(name, field: "name", path: relativePath(for: url))
         let description = try document.requiredString("description", path: relativePath(for: url))
         let directoryName = url.deletingLastPathComponent().lastPathComponent
         guard name == directoryName else {
@@ -454,6 +478,24 @@ extension AgentWorkspace {
             return suffix.isEmpty ? "." : String(suffix.drop(while: { $0 == "/" }))
         }
         return url.path
+    }
+
+    private func validatedPathComponent(_ value: String, field: String, path: String) throws -> String {
+        guard value.trimmingCharacters(in: .whitespacesAndNewlines) == value,
+              !value.isEmpty,
+              value != ".",
+              value != "..",
+              !value.contains("/"),
+              !value.contains("\\")
+        else {
+            throw AgentWorkspaceError.invalidField(
+                path: path,
+                field: field,
+                reason: "must be a single path component"
+            )
+        }
+
+        return value
     }
 
     private func remap(error: AgentWorkspaceError, to path: String) -> AgentWorkspaceError {

--- a/Tests/SwarmTests/Guardrails/GuardrailIntegrationTests.swift
+++ b/Tests/SwarmTests/Guardrails/GuardrailIntegrationTests.swift
@@ -720,6 +720,48 @@ extension GuardrailIntegrationTests {
         #expect(latestStart < earliestEnd, "Expected parallel guardrail execution; intervals did not overlap.")
     }
 
+    @Test("Parallel run-all input guardrails return results in input order")
+    func parallelRunAllInputGuardrailsReturnResultsInInputOrder() async throws {
+        let slow = InputGuard("slow_first") { _, _ in
+            try? await Task.sleep(for: .milliseconds(40))
+            return .passed(message: "slow passed")
+        }
+        let fast = InputGuard("fast_second") { _, _ in
+            .passed(message: "fast passed")
+        }
+        let runner = GuardrailRunner(
+            configuration: GuardrailRunnerConfiguration(runInParallel: true, stopOnFirstTripwire: false)
+        )
+
+        let results = try await runner.runInputGuardrails([slow, fast], input: "safe", context: nil)
+
+        #expect(results.map(\.guardrailName) == ["slow_first", "fast_second"])
+    }
+
+    @Test("Parallel run-all input guardrails emit all tripwire observer events")
+    func parallelRunAllInputGuardrailsEmitAllTripwireObserverEvents() async throws {
+        let observer = RecordingGuardrailObserver()
+        let slow = InputGuard("slow_blocker") { _, _ in
+            try? await Task.sleep(for: .milliseconds(40))
+            return .tripwire(message: "slow blocked")
+        }
+        let fast = InputGuard("fast_blocker") { _, _ in
+            .tripwire(message: "fast blocked")
+        }
+        let runner = GuardrailRunner(
+            configuration: GuardrailRunnerConfiguration(runInParallel: true, stopOnFirstTripwire: false),
+            observer: observer
+        )
+
+        await #expect(throws: GuardrailError.self) {
+            _ = try await runner.runInputGuardrails([slow, fast], input: "blocked", context: nil)
+        }
+
+        let events = await observer.events
+        #expect(Set(events.map(\.name)) == ["slow_blocker", "fast_blocker"])
+        #expect(events.count == 2)
+    }
+
     @Test("Parallel input guardrail tripwire emits observer event")
     func parallelInputGuardrailTripwireEmitsObserverEvent() async throws {
         let observer = RecordingGuardrailObserver()

--- a/Tests/SwarmTests/Guardrails/GuardrailIntegrationTests.swift
+++ b/Tests/SwarmTests/Guardrails/GuardrailIntegrationTests.swift
@@ -762,6 +762,36 @@ extension GuardrailIntegrationTests {
         #expect(events.count == 2)
     }
 
+    @Test("Input guardrails honor configured timeout")
+    func inputGuardrailsHonorConfiguredTimeout() async throws {
+        let slow = InputGuard("slow_timeout") { _, _ in
+            try await Task.sleep(for: .milliseconds(200))
+            return .passed(message: "too late")
+        }
+        let runner = GuardrailRunner(
+            configuration: GuardrailRunnerConfiguration(timeout: .milliseconds(10))
+        )
+
+        await #expect(throws: GuardrailError.self) {
+            _ = try await runner.runInputGuardrails([slow], input: "safe", context: nil)
+        }
+    }
+
+    @Test("Parallel input guardrails honor configured timeout")
+    func parallelInputGuardrailsHonorConfiguredTimeout() async throws {
+        let slow = InputGuard("parallel_slow_timeout") { _, _ in
+            try await Task.sleep(for: .milliseconds(200))
+            return .passed(message: "too late")
+        }
+        let runner = GuardrailRunner(
+            configuration: GuardrailRunnerConfiguration(runInParallel: true, timeout: .milliseconds(10))
+        )
+
+        await #expect(throws: GuardrailError.self) {
+            _ = try await runner.runInputGuardrails([slow], input: "safe", context: nil)
+        }
+    }
+
     @Test("Parallel input guardrail tripwire emits observer event")
     func parallelInputGuardrailTripwireEmitsObserverEvent() async throws {
         let observer = RecordingGuardrailObserver()

--- a/Tests/SwarmTests/Guardrails/GuardrailIntegrationTests.swift
+++ b/Tests/SwarmTests/Guardrails/GuardrailIntegrationTests.swift
@@ -7,6 +7,11 @@
 import Foundation
 @testable import Swarm
 import Testing
+#if canImport(Darwin)
+    import Darwin
+#elseif canImport(Glibc)
+    import Glibc
+#endif
 
 // MARK: - MockGuardrailAgent
 
@@ -775,6 +780,24 @@ extension GuardrailIntegrationTests {
         await #expect(throws: GuardrailError.self) {
             _ = try await runner.runInputGuardrails([slow], input: "safe", context: nil)
         }
+    }
+
+    @Test("Input guardrail timeout returns before noncooperative operation finishes")
+    func inputGuardrailTimeoutReturnsBeforeNoncooperativeOperationFinishes() async throws {
+        let blocking = InputGuard("blocking_timeout") { _, _ in
+            usleep(1_000_000)
+            return .passed(message: "too late")
+        }
+        let runner = GuardrailRunner(
+            configuration: GuardrailRunnerConfiguration(timeout: .milliseconds(20))
+        )
+        let start = ContinuousClock.now
+
+        await #expect(throws: GuardrailError.self) {
+            _ = try await runner.runInputGuardrails([blocking], input: "safe", context: nil)
+        }
+
+        #expect(start.duration(to: ContinuousClock.now) < .milliseconds(500))
     }
 
     @Test("Parallel input guardrails honor configured timeout")

--- a/Tests/SwarmTests/Resilience/ResilienceTests+Retry.swift
+++ b/Tests/SwarmTests/Resilience/ResilienceTests+Retry.swift
@@ -269,6 +269,87 @@ struct RetryPolicyTests {
         #expect(callbacks[1].0 == 2)
     }
 
+    @Test("Cancellation is propagated without retry")
+    func cancellationIsPropagatedWithoutRetry() async throws {
+        let counter = TestCounter()
+        let retryRecorder = TestRecorder<Int>()
+        let policy = RetryPolicy(
+            maxAttempts: 3,
+            backoff: .immediate,
+            onRetry: { attempt, _ in
+                await retryRecorder.append(attempt)
+            }
+        )
+
+        do {
+            _ = try await policy.execute {
+                _ = await counter.increment()
+                throw CancellationError()
+            }
+            Issue.record("Expected CancellationError")
+        } catch is CancellationError {
+            // Expected.
+        } catch {
+            Issue.record("Expected CancellationError, got \(error)")
+        }
+
+        #expect(await counter.get() == 1)
+        #expect(await retryRecorder.getAll().isEmpty)
+    }
+
+    @Test("Huge finite retry delays clamp instead of trapping")
+    func hugeFiniteRetryDelaysClampInsteadOfTrapping() async throws {
+        let counter = TestCounter()
+        let policy = RetryPolicy(
+            maxAttempts: 1,
+            backoff: .exponential(base: 1.0e20, multiplier: 2.0, maxDelay: 1.0e20)
+        )
+
+        let task = Task<String, Error> {
+            try await policy.execute {
+                _ = await counter.increment()
+                throw TestError.transient
+            }
+        }
+
+        while await counter.get() == 0 {
+            try await Task.sleep(for: .milliseconds(1))
+        }
+        try await Task.sleep(for: .milliseconds(5))
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            Issue.record("Expected CancellationError")
+        } catch is CancellationError {
+            // Expected after the oversized delay is clamped and sleep is cancelled.
+        } catch {
+            Issue.record("Expected CancellationError, got \(error)")
+        }
+
+        #expect(await counter.get() == 1)
+    }
+
+    @Test("Small finite retry delay still retries")
+    func smallFiniteRetryDelayStillRetries() async throws {
+        let counter = TestCounter()
+        let policy = RetryPolicy(
+            maxAttempts: 1,
+            backoff: .immediate
+        )
+
+        let result = try await policy.execute {
+            let attempt = await counter.increment()
+            if attempt == 1 {
+                throw TestError.transient
+            }
+            return "recovered"
+        }
+
+        #expect(result == "recovered")
+        #expect(await counter.get() == 2)
+    }
+
     // MARK: - Static Convenience Tests
 
     @Test("Static noRetry policy fails immediately")

--- a/Tests/SwarmTests/Tools/ParallelToolExecutorTests.swift
+++ b/Tests/SwarmTests/Tools/ParallelToolExecutorTests.swift
@@ -151,6 +151,35 @@ struct ParallelToolExecutorTests {
         #expect(executionCount == 0)
     }
 
+    @Test("Fail-fast strategy rejects disabled tools before execution")
+    func failFastRejectsDisabledToolBeforeExecution() async throws {
+        let counter = ToolExecutionCounter()
+        let enabledTool = CountingTool(name: "enabled_tool", counter: counter)
+        let disabledTool = DisabledTestTool(name: "disabled_tool")
+
+        let registry = try await createRegistry(tools: [enabledTool, disabledTool])
+        let executor = ParallelToolExecutor()
+        let agent = createMockAgent()
+
+        let calls = [
+            ToolCall(toolName: "enabled_tool", arguments: [:]),
+            ToolCall(toolName: "disabled_tool", arguments: [:])
+        ]
+
+        await #expect(throws: AgentError.self) {
+            _ = try await executor.executeInParallel(
+                calls,
+                using: registry,
+                agent: agent,
+                context: nil,
+                errorStrategy: .failFast
+            )
+        }
+
+        let executionCount = await counter.snapshot()
+        #expect(executionCount == 0)
+    }
+
     @Test("Error strategy .failFast throws on first error")
     func errorStrategyFailFast() async throws {
         let successTool1 = MockDelayTool(name: "success1", delay: .zero, resultValue: .string("ok1"))

--- a/Tests/SwarmTests/Tools/ToolParameterTests.swift
+++ b/Tests/SwarmTests/Tools/ToolParameterTests.swift
@@ -393,6 +393,20 @@ struct ToolProtocolExtensionTests {
         #expect(schema.parameters[0].name == "param1")
     }
 
+    @Test("Typed tool adapter preserves execution semantics")
+    func typedToolAdapterPreservesExecutionSemantics() {
+        let adapter = SemanticTypedTool().asAnyJSONTool()
+        let expected = ToolExecutionSemantics(
+            sideEffectLevel: .readOnly,
+            retryPolicy: .safe,
+            approvalRequirement: .never,
+            resultDurability: .artifactBacked
+        )
+
+        #expect(adapter.executionSemantics == expected)
+        #expect(adapter.schema.executionSemantics == expected)
+    }
+
     // MARK: - validateArguments
 
     @Test("validateArguments succeeds with all required parameters")
@@ -500,6 +514,28 @@ struct ToolProtocolExtensionTests {
         }
 
         #expect(caughtError)
+    }
+
+    @Test("validateArguments rejects deeply nested arrays")
+    func validateArgumentsRejectsDeeplyNestedArrays() {
+        var type = ToolParameter.ParameterType.string
+        var value = SendableValue.string("leaf")
+
+        for _ in 0 ..< 60 {
+            type = .array(elementType: type)
+            value = .array([value])
+        }
+
+        let tool = MockTool(
+            name: "deep_tool",
+            parameters: [
+                ToolParameter(name: "payload", description: "Nested payload", type: type)
+            ]
+        )
+
+        #expect(throws: AgentError.self) {
+            try tool.validateArguments(["payload": value])
+        }
     }
 
     // MARK: - requiredString
@@ -650,5 +686,26 @@ struct ToolProtocolExtensionTests {
         let value = tool.optionalString("units", from: arguments, default: "celsius")
 
         #expect(value == "fahrenheit")
+    }
+}
+
+private struct SemanticTypedTool: Tool {
+    struct Input: Codable, Sendable {}
+    struct Output: Codable, Sendable {
+        let ok: Bool
+    }
+
+    let name = "semantic_typed_tool"
+    let description = "Typed tool with explicit semantics"
+    let parameters: [ToolParameter] = []
+    let executionSemantics = ToolExecutionSemantics(
+        sideEffectLevel: .readOnly,
+        retryPolicy: .safe,
+        approvalRequirement: .never,
+        resultDurability: .artifactBacked
+    )
+
+    func execute(_: Input) async throws -> Output {
+        Output(ok: true)
     }
 }

--- a/Tests/SwarmTests/Tools/ToolSchemaIntegrationTests.swift
+++ b/Tests/SwarmTests/Tools/ToolSchemaIntegrationTests.swift
@@ -32,6 +32,21 @@ struct ToolSchemaIntegrationTests {
         #expect(schemas[0].parameters.first?.name == "text")
     }
 
+    @Test("ToolRegistry batch registration is atomic")
+    func registryBatchRegistrationIsAtomic() async throws {
+        let registry = ToolRegistry()
+        try await registry.register(MockTool(name: "existing"))
+
+        let newTool = MockTool(name: "new")
+        let duplicate = MockTool(name: "existing")
+
+        await #expect(throws: ToolRegistryError.self) {
+            try await registry.register([newTool, duplicate])
+        }
+        #expect(await registry.tool(named: "new") == nil)
+        #expect(await registry.tool(named: "existing") != nil)
+    }
+
     @Test("Agents accept typed Tool arrays")
     func agentsAcceptTypedTools() throws {
         let tool = SchemaEchoTool()

--- a/Tests/SwarmTests/Tools/ZoniSearchToolTests.swift
+++ b/Tests/SwarmTests/Tools/ZoniSearchToolTests.swift
@@ -4,12 +4,39 @@ import Testing
 
 @Suite("ZoniSearchTool")
 struct ZoniSearchToolTests {
-    @Test("Unconfigured execution throws deterministic error")
-    func unconfiguredExecutionThrows() async throws {
-        let tool = ZoniSearchTool()
+    @Test("Default execution returns empty search result")
+    func defaultExecutionReturnsEmptySearchResult() async throws {
+        var tool = ZoniSearchTool()
+        tool.query = "refund window"
 
-        await #expect(throws: ZoniSearchTool.Error.self) {
-            _ = try await tool.execute()
-        }
+        let result = try await tool.execute()
+
+        #expect(result.contains("No matching documents found"))
+    }
+
+    @Test("In-memory documents provide usable search results")
+    func inMemoryDocumentsProvideUsableSearchResults() async throws {
+        var tool = ZoniSearchTool(documents: [
+            ZoniSearchDocument(
+                id: "refunds",
+                title: "Refund Policy",
+                content: "Customers have 30 days to request a refund.",
+                collection: "support"
+            ),
+            ZoniSearchDocument(
+                id: "shipping",
+                title: "Shipping Policy",
+                content: "Ground shipping takes five days.",
+                collection: "support"
+            )
+        ])
+        tool.query = "refund"
+        tool.collection = "support"
+
+        let result = try await tool.execute()
+
+        #expect(result.contains("Refund Policy"))
+        #expect(result.contains("30 days"))
+        #expect(!result.contains("Shipping Policy"))
     }
 }

--- a/Tests/SwarmTests/Workspace/AgentWorkspaceTests.swift
+++ b/Tests/SwarmTests/Workspace/AgentWorkspaceTests.swift
@@ -334,6 +334,94 @@ struct AgentWorkspaceTests {
         #expect(Set(agent.tools.map(\.name)) == ["refund_lookup", "ticket_create"])
     }
 
+    @Test("Workspace validation rejects agent spec id mismatch")
+    func workspaceValidationRejectsAgentSpecIDMismatch() async throws {
+        let workspaceRoot = try makeWorkspaceRoot()
+        defer { try? FileManager.default.removeItem(at: workspaceRoot) }
+        try writeFile(
+            at: workspaceRoot.appendingPathComponent(".swarm/agents/support.md"),
+            contents: """
+            ---
+            schema_version: 1
+            id: billing
+            title: Billing
+            skills: []
+            revision: 1
+            updated_at: 2026-05-17T00:00:00Z
+            ---
+            You are the billing agent.
+            """
+        )
+
+        let workspace = try AgentWorkspace(
+            bundleRoot: workspaceRoot,
+            writableRoot: workspaceRoot.appendingPathComponent("Writable", isDirectory: true),
+            indexCacheRoot: workspaceRoot.appendingPathComponent("Cache", isDirectory: true)
+        )
+
+        let report = try await workspace.validate()
+        #expect(report.isValid == false)
+        #expect(report.issues.contains {
+            $0.path == ".swarm/agents/support.md" && $0.message.contains("id")
+        })
+    }
+
+    @Test("Workspace rejects path traversal agent spec identifiers")
+    func workspaceRejectsPathTraversalAgentSpecIdentifiers() throws {
+        let workspaceRoot = try makeWorkspaceRoot()
+        defer { try? FileManager.default.removeItem(at: workspaceRoot) }
+        try writeFile(
+            at: workspaceRoot.appendingPathComponent(".swarm/outside.md"),
+            contents: """
+            ---
+            schema_version: 1
+            id: outside
+            title: Outside
+            skills: []
+            revision: 1
+            updated_at: 2026-05-17T00:00:00Z
+            ---
+            This spec must not be loadable through path traversal.
+            """
+        )
+
+        let workspace = try AgentWorkspace(
+            bundleRoot: workspaceRoot,
+            writableRoot: workspaceRoot.appendingPathComponent("Writable", isDirectory: true),
+            indexCacheRoot: workspaceRoot.appendingPathComponent("Cache", isDirectory: true)
+        )
+
+        #expect(throws: AgentWorkspaceError.self) {
+            _ = try workspace.loadAgentSpec(id: "../outside")
+        }
+    }
+
+    @Test("Workspace rejects path traversal skill names")
+    func workspaceRejectsPathTraversalSkillNames() throws {
+        let workspaceRoot = try makeWorkspaceRoot()
+        defer { try? FileManager.default.removeItem(at: workspaceRoot) }
+        try writeFile(
+            at: workspaceRoot.appendingPathComponent(".swarm/outside/SKILL.md"),
+            contents: """
+            ---
+            name: outside
+            description: Outside
+            ---
+            This skill must not be loadable through path traversal.
+            """
+        )
+
+        let workspace = try AgentWorkspace(
+            bundleRoot: workspaceRoot,
+            writableRoot: workspaceRoot.appendingPathComponent("Writable", isDirectory: true),
+            indexCacheRoot: workspaceRoot.appendingPathComponent("Cache", isDirectory: true)
+        )
+
+        #expect(throws: AgentWorkspaceError.self) {
+            _ = try workspace.loadSkills(named: ["../outside"])
+        }
+    }
+
     @Test("Workspace validation reports malformed SKILL.md")
     func workspaceValidationReportsMalformedSkill() async throws {
         let workspaceRoot = try makeWorkspaceRoot()


### PR DESCRIPTION
## Summary
- preserve typed tool execution semantics and enforce nested argument depth limits
- reject disabled fail-fast tools, cover atomic tool batch registration, and make ZoniSearchTool executable by default/injection
- align parallel guardrail results/events, enforce guardrail timeouts, and harden retry cancellation/delay clamping
- validate workspace agent IDs and skill names as safe path components

## Audit IDs
- SWARM-AUDIT-025, 026, 029, 033, 034, 035, 037

## Verification
- swift test --filter 'ParallelToolExecutorTests/failFastRejectsDisabledToolBeforeExecution|ToolProtocolExtensionTests/typedToolAdapterPreservesExecutionSemantics|ToolProtocolExtensionTests/validateArgumentsRejectsDeeplyNestedArrays|GuardrailIntegrationTests/parallelRunAllInputGuardrailsReturnResultsInInputOrder|GuardrailIntegrationTests/parallelRunAllInputGuardrailsEmitAllTripwireObserverEvents|GuardrailIntegrationTests/inputGuardrailsHonorConfiguredTimeout|GuardrailIntegrationTests/parallelInputGuardrailsHonorConfiguredTimeout|RetryPolicyTests/cancellationIsPropagatedWithoutRetry|RetryPolicyTests/hugeFiniteRetryDelaysClampInsteadOfTrapping|RetryPolicyTests/smallFiniteRetryDelayStillRetries|AgentWorkspaceTests/workspaceValidationRejectsAgentSpecIDMismatch|AgentWorkspaceTests/workspaceRejectsPathTraversalAgentSpecIdentifiers|AgentWorkspaceTests/workspaceRejectsPathTraversalSkillNames|ToolSchemaIntegrationTests/registryBatchRegistrationIsAtomic|ZoniSearchToolTests'\n- swift build --target Swarm\n- git diff --check