### PR TITLE
Fix Membrane Wax pointer storage audit issues

### DIFF
--- a/Sources/Swarm/Integration/Membrane/MembraneAgentAdapter.swift
+++ b/Sources/Swarm/Integration/Membrane/MembraneAgentAdapter.swift
@@ -107,7 +107,6 @@ public actor DefaultMembraneAgentAdapter: MembraneAgentAdapter {
     public init(configuration: MembraneFeatureConfiguration = .default) {
         self.configuration = configuration
 
-        jitLoader = JITToolLoader(jitMinToolCount: configuration.jitMinToolCount)
         let store = InMemoryPointerStore()
         pointerStore = store
         pointerResolver = PointerResolver(
@@ -136,15 +135,11 @@ public actor DefaultMembraneAgentAdapter: MembraneAgentAdapter {
 
         let manifests = sortedSchemas.map { ToolManifest(name: $0.name, description: $0.description) }
 
-        // For small-context providers (strict4k), force allowList even with few tools.
-        // Default JIT threshold is 12; for strict4k we drop to 4 to save prompt tokens.
+        // For small-context providers (strict4k), enter JIT with fewer tools to save prompt tokens.
         let effectiveMinTools = profile.preset == .strict4k ? min(4, configuration.jitMinToolCount) : configuration.jitMinToolCount
+        let jitLoader = JITToolLoader(jitMinToolCount: effectiveMinTools)
         var nextPlan: ToolPlan
-        if manifests.count >= effectiveMinTools {
-            nextPlan = jitLoader.plan(tools: manifests, existingPlan: toolPlan)
-        } else {
-            nextPlan = jitLoader.plan(tools: manifests, existingPlan: toolPlan)
-        }
+        nextPlan = jitLoader.plan(tools: manifests, existingPlan: toolPlan)
 
         switch nextPlan {
         case .allowAll:
@@ -321,7 +316,6 @@ public actor DefaultMembraneAgentAdapter: MembraneAgentAdapter {
     private var pointerIDs: [String] = []
     private var usageCounts: [String: Int] = [:]
 
-    private let jitLoader: JITToolLoader
     private let pointerStore: InMemoryPointerStore
     private let pointerResolver: PointerResolver
     private var toolPlan: ToolPlan

--- a/Sources/Swarm/Integration/Membrane/WaxMembraneStorage.swift
+++ b/Sources/Swarm/Integration/Membrane/WaxMembraneStorage.swift
@@ -3,6 +3,15 @@ import Foundation
 import MembraneCore
 import Wax
 
+protocol WaxPointerIndex: Sendable {
+    func save(_ text: String, metadata: [String: String]) async throws
+    func flush() async throws
+    func search(_ query: String, options: Wax.Memory.SearchOptions) async throws -> Wax.Memory.Results
+    func close() async throws
+}
+
+extension Wax.Memory: WaxPointerIndex {}
+
 actor WaxMembraneStorage: PointerStore, ContextRecallStore {
     private enum MetadataKey {
         static let kind = "membrane.kind"
@@ -37,11 +46,16 @@ actor WaxMembraneStorage: PointerStore, ContextRecallStore {
     }
 
     private let url: URL
-    private var memory: Wax.Memory?
+    private let memoryFactory: @Sendable (URL) async throws -> any WaxPointerIndex
+    private var memory: (any WaxPointerIndex)?
     private var cachedPayloads: [String: Data] = [:]
 
-    init(url: URL = defaultStoreURL) {
+    init(
+        url: URL = defaultStoreURL,
+        memoryFactory: @escaping @Sendable (URL) async throws -> any WaxPointerIndex = { try await Wax.Memory(at: $0) }
+    ) {
         self.url = url
+        self.memoryFactory = memoryFactory
     }
 
     func store(payload: Data, dataType: MemoryPointer.DataType, summary: String) async throws -> MemoryPointer {
@@ -59,19 +73,24 @@ actor WaxMembraneStorage: PointerStore, ContextRecallStore {
         )
 
         let memory = try await ensureMemory()
-        try await memory.save(
-            storedDocument,
-            metadata: [
-                MetadataKey.kind: MetadataKey.pointerPayloadKind,
-                MetadataKey.pointerID: pointerID,
-                MetadataKey.pointerSHA256: sha256,
-                MetadataKey.pointerDataType: dataType.rawValue,
-                MetadataKey.payloadEncoding: "frame",
-                MetadataKey.payloadFrameID: String(payloadFrameID),
-                MetadataKey.summary: summary,
-            ]
-        )
-        try await memory.flush()
+        do {
+            try await memory.save(
+                storedDocument,
+                metadata: [
+                    MetadataKey.kind: MetadataKey.pointerPayloadKind,
+                    MetadataKey.pointerID: pointerID,
+                    MetadataKey.pointerSHA256: sha256,
+                    MetadataKey.pointerDataType: dataType.rawValue,
+                    MetadataKey.payloadEncoding: "frame",
+                    MetadataKey.payloadFrameID: String(payloadFrameID),
+                    MetadataKey.summary: summary,
+                ]
+            )
+            try await memory.flush()
+        } catch {
+            try? await deletePersistedFrame(frameID: payloadFrameID)
+            throw error
+        }
 
         cachedPayloads[pointerID] = payload
         return MemoryPointer(
@@ -134,11 +153,11 @@ actor WaxMembraneStorage: PointerStore, ContextRecallStore {
         }
     }
 
-    private func ensureMemory() async throws -> Wax.Memory {
+    private func ensureMemory() async throws -> any WaxPointerIndex {
         if let memory {
             return memory
         }
-        let resolved = try await Wax.Memory(at: url)
+        let resolved = try await memoryFactory(url)
         memory = resolved
         return resolved
     }
@@ -156,6 +175,20 @@ actor WaxMembraneStorage: PointerStore, ContextRecallStore {
         return try await Wax.FrameStore.create(at: url)
     }
 
+    private func withFrameStore<Result>(
+        _ body: (Wax.FrameStore) async throws -> Result
+    ) async throws -> Result {
+        let frameStore = try await openFrameStore()
+        do {
+            let result = try await body(frameStore)
+            await frameStore.close()
+            return result
+        } catch {
+            await frameStore.close()
+            throw error
+        }
+    }
+
     private func persistPayloadFrame(
         _ payload: Data,
         pointerID: String,
@@ -163,37 +196,44 @@ actor WaxMembraneStorage: PointerStore, ContextRecallStore {
         dataType: MemoryPointer.DataType
     ) async throws -> UInt64 {
         try await closeMemoryIfOpen()
-        let frameStore = try await openFrameStore()
-        let frameID = try await frameStore.put(
-            payload,
-            kind: MetadataKey.pointerPayloadFrameKind,
-            metadata: [
-                MetadataKey.kind: MetadataKey.pointerPayloadFrameKind,
-                MetadataKey.pointerID: pointerID,
-                MetadataKey.pointerSHA256: sha256,
-                MetadataKey.pointerDataType: dataType.rawValue,
-                MetadataKey.payloadEncoding: "raw",
-            ]
-        )
-        await frameStore.close()
-        return frameID
+        return try await withFrameStore { frameStore in
+            try await frameStore.put(
+                payload,
+                kind: MetadataKey.pointerPayloadFrameKind,
+                metadata: [
+                    MetadataKey.kind: MetadataKey.pointerPayloadFrameKind,
+                    MetadataKey.pointerID: pointerID,
+                    MetadataKey.pointerSHA256: sha256,
+                    MetadataKey.pointerDataType: dataType.rawValue,
+                    MetadataKey.payloadEncoding: "raw",
+                ]
+            )
+        }
     }
 
     private func persistedPayloadFrame(pointerID: String) async throws -> Data? {
         try await closeMemoryIfOpen()
-        let frameStore = try await openFrameStore()
-        let frames = await frameStore.frames()
-        guard let frame = frames.reversed().first(where: {
-            $0.status == .active &&
-                $0.metadata[MetadataKey.pointerID] == pointerID &&
-                $0.metadata[MetadataKey.kind] == MetadataKey.pointerPayloadFrameKind
-        }) else {
-            await frameStore.close()
-            return nil
+        return try await withFrameStore { frameStore in
+            let frames = await frameStore.frames()
+            guard let frame = frames.reversed().first(where: {
+                $0.status == .active &&
+                    $0.metadata[MetadataKey.pointerID] == pointerID &&
+                    $0.metadata[MetadataKey.kind] == MetadataKey.pointerPayloadFrameKind
+            }) else {
+                return nil
+            }
+            return try await frameStore.content(frameID: frame.id)
         }
-        let payload = try await frameStore.content(frameID: frame.id)
-        await frameStore.close()
-        return payload
+    }
+
+    private func deletePersistedFrame(frameID: UInt64) async throws {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return
+        }
+        try await closeMemoryIfOpen()
+        try await withFrameStore { frameStore in
+            try await frameStore.delete(frameID: frameID)
+        }
     }
 
     private func deletePersistedFrames(pointerID: String) async throws {
@@ -201,12 +241,12 @@ actor WaxMembraneStorage: PointerStore, ContextRecallStore {
             return
         }
         try await closeMemoryIfOpen()
-        let frameStore = try await Wax.FrameStore.open(at: url)
-        let frames = await frameStore.frames()
-        for frame in frames where frame.status == .active && frame.metadata[MetadataKey.pointerID] == pointerID {
-            try await frameStore.delete(frameID: frame.id)
+        try await withFrameStore { frameStore in
+            let frames = await frameStore.frames()
+            for frame in frames where frame.status == .active && frame.metadata[MetadataKey.pointerID] == pointerID {
+                try await frameStore.delete(frameID: frame.id)
+            }
         }
-        await frameStore.close()
     }
 
     private static func pointerID(for payload: Data) -> String {

--- a/Sources/Swarm/Integration/Membrane/WaxMembraneStorage.swift
+++ b/Sources/Swarm/Integration/Membrane/WaxMembraneStorage.swift
@@ -111,6 +111,7 @@ actor WaxMembraneStorage: PointerStore, ContextRecallStore {
 
     func delete(pointerID: String) async {
         cachedPayloads[pointerID] = nil
+        try? await deletePersistedFrames(pointerID: pointerID)
     }
 
     func recall(query: String, limit: Int) async throws -> [ContextRecallCandidate] {
@@ -193,6 +194,19 @@ actor WaxMembraneStorage: PointerStore, ContextRecallStore {
         let payload = try await frameStore.content(frameID: frame.id)
         await frameStore.close()
         return payload
+    }
+
+    private func deletePersistedFrames(pointerID: String) async throws {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return
+        }
+        try await closeMemoryIfOpen()
+        let frameStore = try await Wax.FrameStore.open(at: url)
+        let frames = await frameStore.frames()
+        for frame in frames where frame.status == .active && frame.metadata[MetadataKey.pointerID] == pointerID {
+            try await frameStore.delete(frameID: frame.id)
+        }
+        await frameStore.close()
     }
 
     private static func pointerID(for payload: Data) -> String {

--- a/Sources/Swarm/Integration/Membrane/WaxMembraneStorage.swift
+++ b/Sources/Swarm/Integration/Membrane/WaxMembraneStorage.swift
@@ -10,8 +10,10 @@ actor WaxMembraneStorage: PointerStore, ContextRecallStore {
         static let pointerSHA256 = "membrane.pointer.sha256"
         static let pointerDataType = "membrane.pointer.dataType"
         static let payloadEncoding = "membrane.pointer.payloadEncoding"
+        static let payloadFrameID = "membrane.pointer.payloadFrameID"
         static let summary = "membrane.pointer.summary"
         static let pointerPayloadKind = "pointerPayload"
+        static let pointerPayloadFrameKind = "membrane.pointer.payloadFrame"
     }
 
     private enum StorageFormat {
@@ -44,14 +46,16 @@ actor WaxMembraneStorage: PointerStore, ContextRecallStore {
 
     func store(payload: Data, dataType: MemoryPointer.DataType, summary: String) async throws -> MemoryPointer {
         let pointerID = Self.pointerID(for: payload)
-        let encodedPayload = payload.base64EncodedString()
         let sha256 = Self.sha256Hex(payload)
-        let searchableText = Self.searchablePayloadText(payload: payload, summary: summary)
+        let payloadFrameID = try await persistPayloadFrame(
+            payload,
+            pointerID: pointerID,
+            sha256: sha256,
+            dataType: dataType
+        )
         let storedDocument = Self.storedPointerDocument(
             pointerID: pointerID,
-            summary: summary,
-            searchableText: searchableText,
-            encodedPayload: encodedPayload
+            summary: summary
         )
 
         let memory = try await ensureMemory()
@@ -62,7 +66,8 @@ actor WaxMembraneStorage: PointerStore, ContextRecallStore {
                 MetadataKey.pointerID: pointerID,
                 MetadataKey.pointerSHA256: sha256,
                 MetadataKey.pointerDataType: dataType.rawValue,
-                MetadataKey.payloadEncoding: "base64",
+                MetadataKey.payloadEncoding: "frame",
+                MetadataKey.payloadFrameID: String(payloadFrameID),
                 MetadataKey.summary: summary,
             ]
         )
@@ -80,6 +85,11 @@ actor WaxMembraneStorage: PointerStore, ContextRecallStore {
     func resolve(pointerID: String) async throws -> Data {
         if let cached = cachedPayloads[pointerID] {
             return cached
+        }
+
+        if let payload = try await persistedPayloadFrame(pointerID: pointerID) {
+            cachedPayloads[pointerID] = payload
+            return payload
         }
 
         let memory = try await ensureMemory()
@@ -132,6 +142,59 @@ actor WaxMembraneStorage: PointerStore, ContextRecallStore {
         return resolved
     }
 
+    private func closeMemoryIfOpen() async throws {
+        guard let existing = memory else { return }
+        try await existing.close()
+        memory = nil
+    }
+
+    private func openFrameStore() async throws -> Wax.FrameStore {
+        if FileManager.default.fileExists(atPath: url.path) {
+            return try await Wax.FrameStore.open(at: url)
+        }
+        return try await Wax.FrameStore.create(at: url)
+    }
+
+    private func persistPayloadFrame(
+        _ payload: Data,
+        pointerID: String,
+        sha256: String,
+        dataType: MemoryPointer.DataType
+    ) async throws -> UInt64 {
+        try await closeMemoryIfOpen()
+        let frameStore = try await openFrameStore()
+        let frameID = try await frameStore.put(
+            payload,
+            kind: MetadataKey.pointerPayloadFrameKind,
+            metadata: [
+                MetadataKey.kind: MetadataKey.pointerPayloadFrameKind,
+                MetadataKey.pointerID: pointerID,
+                MetadataKey.pointerSHA256: sha256,
+                MetadataKey.pointerDataType: dataType.rawValue,
+                MetadataKey.payloadEncoding: "raw",
+            ]
+        )
+        await frameStore.close()
+        return frameID
+    }
+
+    private func persistedPayloadFrame(pointerID: String) async throws -> Data? {
+        try await closeMemoryIfOpen()
+        let frameStore = try await openFrameStore()
+        let frames = await frameStore.frames()
+        guard let frame = frames.reversed().first(where: {
+            $0.status == .active &&
+                $0.metadata[MetadataKey.pointerID] == pointerID &&
+                $0.metadata[MetadataKey.kind] == MetadataKey.pointerPayloadFrameKind
+        }) else {
+            await frameStore.close()
+            return nil
+        }
+        let payload = try await frameStore.content(frameID: frame.id)
+        await frameStore.close()
+        return payload
+    }
+
     private static func pointerID(for payload: Data) -> String {
         let hash = sha256Hex(payload)
         return "ptr_\(hash.prefix(16))"
@@ -141,25 +204,13 @@ actor WaxMembraneStorage: PointerStore, ContextRecallStore {
         SHA256.hash(data: payload).map { String(format: "%02x", $0) }.joined()
     }
 
-    private static func searchablePayloadText(payload: Data, summary: String) -> String {
-        guard let decoded = String(data: payload, encoding: .utf8)?
-            .trimmingCharacters(in: .whitespacesAndNewlines),
-            decoded.isEmpty == false else {
-            return summary
-        }
-        return decoded
-    }
-
     private static func storedPointerDocument(
         pointerID: String,
-        summary: String,
-        searchableText: String,
-        encodedPayload: String
+        summary: String
     ) -> String {
         """
         pointer_id: \(pointerID)
         summary: \(summary)
-        \(searchableText)\(StorageFormat.payloadMarker)\(encodedPayload)
         """
     }
 

--- a/Tests/SwarmTests/MembraneIntegrationTests.swift
+++ b/Tests/SwarmTests/MembraneIntegrationTests.swift
@@ -328,6 +328,28 @@ struct MembraneIntegrationTests {
         #expect(summaryMatches.allSatisfy { !$0.content.contains("__payload_base64__") })
         #expect(summaryMatches.allSatisfy { !$0.content.contains(Data(secret.utf8).base64EncodedString()) })
     }
+
+    @Test("Wax membrane pointer delete removes persisted payload")
+    func waxMembranePointerDeleteRemovesPersistedPayload() async throws {
+        let url = temporaryWaxStoreURL()
+        let storage = WaxMembraneStorage(url: url)
+        let payload = Data("SWARM-AUDIT-041-persisted-delete".utf8)
+        let pointer = try await storage.store(
+            payload: payload,
+            dataType: .document,
+            summary: "Delete me"
+        )
+        #expect(try await storage.resolve(pointerID: pointer.id) == payload)
+
+        await storage.delete(pointerID: pointer.id)
+
+        await #expect(throws: MembraneError.self) {
+            _ = try await storage.resolve(pointerID: pointer.id)
+        }
+
+        let matches = try await storage.recall(query: "Delete me", limit: 5)
+        #expect(matches.allSatisfy { $0.provenance.metadata["membrane.pointer.id"] != pointer.id })
+    }
 }
 
 private func defaultAdapterToolSchemas() -> [ToolSchema] {

--- a/Tests/SwarmTests/MembraneIntegrationTests.swift
+++ b/Tests/SwarmTests/MembraneIntegrationTests.swift
@@ -309,6 +309,36 @@ struct MembraneIntegrationTests {
         #expect(names.contains("gamma"))
     }
 
+    @Test("strict4k planning enters JIT at the lowered four-tool threshold")
+    func strict4kPlanningUsesLoweredJITThreshold() async throws {
+        let adapter = DefaultMembraneAgentAdapter(
+            configuration: MembraneFeatureConfiguration(jitMinToolCount: 12, defaultJITLoadCount: 2)
+        )
+        let toolSchemas = [
+            ToolSchema(name: "alpha", description: "alpha", parameters: []),
+            ToolSchema(name: "beta", description: "beta", parameters: []),
+            ToolSchema(name: "gamma", description: "gamma", parameters: []),
+            ToolSchema(name: "delta", description: "delta", parameters: []),
+        ]
+
+        let planned = try await adapter.plan(
+            prompt: "hello",
+            toolSchemas: toolSchemas,
+            profile: .strict4k
+        )
+
+        let names = Set(planned.toolSchemas.map(\.name))
+        #expect(planned.mode == "jit")
+        #expect(names.contains("alpha"))
+        #expect(names.contains("beta"))
+        #expect(names.contains("gamma") == false)
+        #expect(names.contains("delta") == false)
+        #expect(names.contains(MembraneInternalToolName.loadToolSchema))
+        #expect(names.contains(MembraneInternalToolName.addTools))
+        #expect(names.contains(MembraneInternalToolName.removeTools))
+        #expect(names.contains(MembraneInternalToolName.resolvePointer))
+    }
+
     @Test("Wax membrane pointer recall does not index private payload bytes")
     func waxMembranePointerRecallDoesNotIndexPrivatePayloadBytes() async throws {
         let storage = WaxMembraneStorage(url: temporaryWaxStoreURL())

--- a/Tests/SwarmTests/MembraneIntegrationTests.swift
+++ b/Tests/SwarmTests/MembraneIntegrationTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MembraneCore
 @testable import Swarm
 import Testing
 
@@ -307,6 +308,26 @@ struct MembraneIntegrationTests {
         #expect(names.contains("beta"))
         #expect(names.contains("gamma"))
     }
+
+    @Test("Wax membrane pointer recall does not index private payload bytes")
+    func waxMembranePointerRecallDoesNotIndexPrivatePayloadBytes() async throws {
+        let storage = WaxMembraneStorage(url: temporaryWaxStoreURL())
+        let secret = "SWARM-AUDIT-040-private-payload-\(UUID().uuidString)"
+        _ = try await storage.store(
+            payload: Data(secret.utf8),
+            dataType: .document,
+            summary: "Public pointer summary only"
+        )
+
+        let secretMatches = try await storage.recall(query: secret, limit: 5)
+        #expect(secretMatches.allSatisfy { !$0.content.contains(secret) })
+
+        let summaryMatches = try await storage.recall(query: "Public pointer summary", limit: 5)
+        #expect(summaryMatches.contains { $0.content.contains("Public pointer summary") })
+        #expect(summaryMatches.allSatisfy { !$0.content.contains(secret) })
+        #expect(summaryMatches.allSatisfy { !$0.content.contains("__payload_base64__") })
+        #expect(summaryMatches.allSatisfy { !$0.content.contains(Data(secret.utf8).base64EncodedString()) })
+    }
 }
 
 private func defaultAdapterToolSchemas() -> [ToolSchema] {
@@ -369,6 +390,13 @@ private func makeTestTools(count: Int) -> [any AnyJSONTool] {
     (0 ..< count).map { index in
         MembraneTestTool(name: String(format: "tool_%02d", count - index))
     }
+}
+
+private func temporaryWaxStoreURL() -> URL {
+    let root = FileManager.default.temporaryDirectory
+        .appendingPathComponent("SwarmMembraneIntegrationTests", isDirectory: true)
+    try? FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    return root.appendingPathComponent("\(UUID().uuidString).mv2s")
 }
 
 private struct MembraneTestTool: AnyJSONTool, Sendable {

--- a/Tests/SwarmTests/MembraneIntegrationTests.swift
+++ b/Tests/SwarmTests/MembraneIntegrationTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import MembraneCore
 @testable import Swarm
 import Testing
+import Wax
 
 @Suite("Membrane Integration")
 struct MembraneIntegrationTests {
@@ -380,6 +381,30 @@ struct MembraneIntegrationTests {
         let matches = try await storage.recall(query: "Delete me", limit: 5)
         #expect(matches.allSatisfy { $0.provenance.metadata["membrane.pointer.id"] != pointer.id })
     }
+
+    @Test("Wax membrane pointer store rolls back payload frame when indexing fails")
+    func waxMembranePointerStoreRollsBackPayloadFrameWhenIndexingFails() async throws {
+        let url = temporaryWaxStoreURL()
+        let failingIndex = FailingWaxPointerIndex()
+        let storage = WaxMembraneStorage(url: url) { _ in failingIndex }
+
+        await #expect(throws: FailingWaxPointerIndex.Failure.self) {
+            _ = try await storage.store(
+                payload: Data("SWARM-AUDIT-042-rollback-payload".utf8),
+                dataType: .document,
+                summary: "Must roll back"
+            )
+        }
+
+        let frameStore = try await Wax.FrameStore.open(at: url)
+        let activePayloadFrames = await frameStore.frames().filter {
+            $0.status == .active &&
+                $0.metadata["membrane.kind"] == "membrane.pointer.payloadFrame"
+        }
+        await frameStore.close()
+
+        #expect(activePayloadFrames.isEmpty)
+    }
 }
 
 private func defaultAdapterToolSchemas() -> [ToolSchema] {
@@ -481,6 +506,22 @@ private struct StructuredPayloadTool: AnyJSONTool, Sendable {
             "items": .array((0 ..< 20).map { .string("item-\($0)") })
         ])
     }
+}
+
+private actor FailingWaxPointerIndex: WaxPointerIndex {
+    struct Failure: Error {}
+
+    func save(_: String, metadata _: [String: String]) async throws {
+        throw Failure()
+    }
+
+    func flush() async throws {}
+
+    func search(_ query: String, options _: Wax.Memory.SearchOptions) async throws -> Wax.Memory.Results {
+        Wax.Memory.Results(query: query, items: [], totalTokens: 0)
+    }
+
+    func close() async throws {}
 }
 
 private actor PointerResolvingInferenceProvider: InferenceProvider, ConversationInferenceProvider {


### PR DESCRIPTION
## Summary
- Store Wax-backed Membrane pointer payload bytes in non-text Wax frames so recall/search text stays summary-only and does not expose payload markers or base64.
- Delete persisted Wax frames for Membrane pointers, not just the actor cache.
- Honor the lowered strict4k JIT threshold by constructing the JIT loader with the effective threshold.

## Tests
- swift test --filter 'MembraneIntegrationTests.waxMembranePointerRecallDoesNotIndexPrivatePayloadBytes'
- swift test --filter 'MembraneIntegrationTests.waxMembranePointerDeleteRemovesPersistedPayload'
- swift test --filter 'MembraneIntegrationTests.strict4kPlanningUsesLoweredJITThreshold'
- swift test --filter MembraneIntegrationTests
- swift build --target Swarm
- git diff --check