### PR TITLE
Fix web fetch and observability privacy audit issues

### DIFF
--- a/Sources/Swarm/Observability/ConsoleTracer.swift
+++ b/Sources/Swarm/Observability/ConsoleTracer.swift
@@ -100,7 +100,7 @@ public actor ConsoleTracer: Tracer {
         }
 
         // Add message
-        parts.append(event.message)
+        parts.append(TraceEventPublicLogSanitizer.message(for: event))
 
         // Add duration if present
         if let duration = event.duration {
@@ -123,7 +123,7 @@ public actor ConsoleTracer: Tracer {
 
         // Print metadata if not empty
         if !event.metadata.isEmpty {
-            printMetadata(event.metadata)
+            printMetadata(TraceEventPublicLogSanitizer.metadata(for: event))
         }
     }
 
@@ -214,19 +214,7 @@ public actor ConsoleTracer: Tracer {
         let prefix = colorized ? "\u{001B}[31m" : ""
         let reset = colorized ? "\u{001B}[0m" : ""
 
-        Log.tracing.error("\(prefix)  Error: \(error.type)\(reset)")
-        Log.tracing.error("\(prefix)  Message: \(error.message)\(reset)")
-
-        if let underlyingError = error.underlyingError {
-            Log.tracing.error("\(prefix)  Underlying: \(underlyingError)\(reset)")
-        }
-
-        if let stackTrace = error.stackTrace {
-            Log.tracing.error("\(prefix)  Stack Trace:\(reset)")
-            for frame in stackTrace {
-                Log.tracing.error("\(prefix)    \(frame)\(reset)")
-            }
-        }
+        Log.tracing.error("\(prefix)  Error: \(TraceEventPublicLogSanitizer.errorSummary(for: error))\(reset)")
     }
 
     /// Prints metadata with proper formatting.
@@ -316,7 +304,7 @@ package actor PrettyConsoleTracer: Tracer {
 
         // Print metadata if not empty
         if !event.metadata.isEmpty {
-            printMetadata(event.metadata)
+            printMetadata(TraceEventPublicLogSanitizer.metadata(for: event))
         }
 
         // Add blank line for visual separation
@@ -364,7 +352,7 @@ package actor PrettyConsoleTracer: Tracer {
         parts.append(kindIndicator)
 
         // Add message
-        parts.append(event.message)
+        parts.append(TraceEventPublicLogSanitizer.message(for: event))
 
         Log.tracing.info("\(parts.joined(separator: " "))")
     }
@@ -505,19 +493,7 @@ package actor PrettyConsoleTracer: Tracer {
         let reset = colorized ? "\u{001B}[0m" : ""
 
         Log.tracing.error("\(prefix)  ❌ Error Details:\(reset)")
-        Log.tracing.error("\(prefix)    🏷️  Type: \(error.type)\(reset)")
-        Log.tracing.error("\(prefix)    💬 Message: \(error.message)\(reset)")
-
-        if let underlyingError = error.underlyingError {
-            Log.tracing.error("\(prefix)    ⚡ Underlying: \(underlyingError)\(reset)")
-        }
-
-        if let stackTrace = error.stackTrace {
-            Log.tracing.error("\(prefix)    📚 Stack Trace:\(reset)")
-            for frame in stackTrace {
-                Log.tracing.error("\(prefix)      • \(frame)\(reset)")
-            }
-        }
+        Log.tracing.error("\(prefix)    🏷️  \(TraceEventPublicLogSanitizer.errorSummary(for: error))\(reset)")
     }
 
     /// Prints metadata with emoji formatting.

--- a/Sources/Swarm/Observability/OSLogTracer.swift
+++ b/Sources/Swarm/Observability/OSLogTracer.swift
@@ -87,7 +87,7 @@
             let message = formatLogMessage(event)
 
             // Emit the log message
-            logger.log(level: logType, "\(message, privacy: .public)")
+            logger.log(level: logType, "\(message, privacy: .private)")
 
             // Handle signpost intervals if enabled
             if emitSignposts {
@@ -162,7 +162,7 @@
             }
 
             // Add message
-            parts.append(event.message)
+            parts.append(TraceEventPublicLogSanitizer.message(for: event))
 
             // Add duration if present
             if let duration = event.duration {
@@ -172,7 +172,7 @@
 
             // Add error information if present
             if let error = event.error {
-                parts.append("error=\(error.type): \(error.message)")
+                parts.append("error=\(TraceEventPublicLogSanitizer.errorSummary(for: error))")
             }
 
             // Add trace/span IDs for debugging
@@ -223,7 +223,7 @@
             let state = signposter.beginInterval(name, id: signpostID(for: event.spanId))
             activeIntervals[event.spanId] = state
 
-            signposter.emitEvent("Start", id: signpostID(for: event.spanId), "\(description, privacy: .public)")
+            signposter.emitEvent("Start", id: signpostID(for: event.spanId), "\(description, privacy: .private)")
         }
 
         /// Ends a signpost interval for the given event.
@@ -241,11 +241,11 @@
                  .agentComplete,
                  .agentError:
                 name = "LegacyAgent Execution"
-                description = event.message
+                description = TraceEventPublicLogSanitizer.message(for: event)
             case .toolError,
                  .toolResult:
                 name = "Tool Execution"
-                description = event.message
+                description = TraceEventPublicLogSanitizer.message(for: event)
             default:
                 return
             }
@@ -254,7 +254,7 @@
 
             // Emit completion event
             let status = event.kind.rawValue
-            signposter.emitEvent("End", id: signpostID(for: event.spanId), "\(status): \(description, privacy: .public)")
+            signposter.emitEvent("End", id: signpostID(for: event.spanId), "\(status): \(description, privacy: .private)")
         }
 
         /// Creates a signpost ID from a UUID.

--- a/Sources/Swarm/Observability/SwiftLogTracer.swift
+++ b/Sources/Swarm/Observability/SwiftLogTracer.swift
@@ -94,7 +94,7 @@ public actor SwiftLogTracer: Tracer {
             parts.append("tool=\(toolName)")
         }
 
-        parts.append(event.message)
+        parts.append(TraceEventPublicLogSanitizer.message(for: event))
 
         if let duration = event.duration {
             parts.append("(\(String(format: "%.2f", duration * 1000))ms)")

--- a/Sources/Swarm/Observability/TraceEventPublicLogSanitizer.swift
+++ b/Sources/Swarm/Observability/TraceEventPublicLogSanitizer.swift
@@ -1,0 +1,81 @@
+// TraceEventPublicLogSanitizer.swift
+// Swarm Framework
+//
+// Redacts trace event payloads before they are written to public logs.
+
+import Foundation
+
+enum TraceEventPublicLogSanitizer {
+    private static let redacted = SendableValue.string("[redacted]")
+    private static let sensitiveMetadataTokens = [
+        "argument",
+        "args",
+        "content",
+        "decision",
+        "error",
+        "input",
+        "message",
+        "option",
+        "output",
+        "plan",
+        "prompt",
+        "reasoning",
+        "result",
+        "thought"
+    ]
+
+    static func message(for event: TraceEvent) -> String {
+        switch event.kind {
+        case .agentStart:
+            "Agent started"
+        case .agentComplete:
+            "Agent completed"
+        case .agentCancelled:
+            "Agent cancelled"
+        case .agentError:
+            "Agent error recorded"
+        case .toolCall:
+            "Tool call recorded"
+        case .toolResult:
+            "Tool result recorded"
+        case .toolError:
+            "Tool error recorded"
+        case .thought:
+            "Thought recorded"
+        case .decision:
+            "Decision recorded"
+        case .plan:
+            "Plan recorded"
+        case .memoryRead:
+            "Memory read recorded"
+        case .memoryWrite:
+            "Memory write recorded"
+        case .checkpoint:
+            "Checkpoint recorded"
+        case .metric:
+            "Metric recorded"
+        case .custom:
+            "Custom event recorded"
+        }
+    }
+
+    static func metadata(for event: TraceEvent) -> [String: SendableValue] {
+        event.metadata.mapValues { value in
+            value
+        }
+        .reduce(into: [:]) { sanitized, element in
+            let key = element.key
+            sanitized[key] = isSensitiveMetadataKey(key) ? redacted : element.value
+        }
+    }
+
+    static func errorSummary(for error: ErrorInfo?) -> String {
+        guard let error else { return "" }
+        return "\(error.type): [redacted]"
+    }
+
+    private static func isSensitiveMetadataKey(_ key: String) -> Bool {
+        let lowercased = key.lowercased()
+        return sensitiveMetadataTokens.contains { lowercased.contains($0) }
+    }
+}

--- a/Sources/Swarm/Tools/Web/WebSearchSupport.swift
+++ b/Sources/Swarm/Tools/Web/WebSearchSupport.swift
@@ -1294,7 +1294,7 @@ internal struct SafeWebFetcher: Sendable {
             request.setValue(conditionalLastModified, forHTTPHeaderField: "If-Modified-Since")
         }
 
-        let fetchDelegate = SafeWebFetchDelegate()
+        let fetchDelegate = SafeWebFetchDelegate(maxBodyBytes: configuration.maxBodyBytes)
         let session = URLSession(
             configuration: sessionConfiguration,
             delegate: fetchDelegate,
@@ -1390,7 +1390,12 @@ internal struct SafeWebFetcher: Sendable {
 }
 
 private final class SafeWebFetchDelegate: NSObject, URLSessionDataDelegate, URLSessionTaskDelegate, @unchecked Sendable {
+    private let maxBodyBytes: Int
     private let state = SafeWebFetchDelegateState()
+
+    init(maxBodyBytes: Int) {
+        self.maxBodyBytes = maxBodyBytes
+    }
 
     func fetch(_ request: URLRequest, using session: URLSession) async throws -> (Data, URLResponse) {
         let task = session.dataTask(with: request)
@@ -1423,10 +1428,15 @@ private final class SafeWebFetchDelegate: NSObject, URLSessionDataDelegate, URLS
 
     func urlSession(
         _: URLSession,
-        dataTask _: URLSessionDataTask,
+        dataTask: URLSessionDataTask,
         didReceive data: Data
     ) {
-        state.receive(data: data)
+        do {
+            try state.receive(data: data, maxBodyBytes: maxBodyBytes)
+        } catch {
+            state.finish(throwing: error)
+            dataTask.cancel()
+        }
     }
 
     func urlSession(
@@ -1467,7 +1477,7 @@ private final class SafeWebFetchDelegateState: @unchecked Sendable {
     private let lock = NSLock()
     private var continuation: CheckedContinuation<(Data, URLResponse), Error>?
     private var response: URLResponse?
-    private var data = Data()
+    private var accumulator = SafeWebBodyAccumulator()
     private var isFinished = false
 
     func start(_ continuation: CheckedContinuation<(Data, URLResponse), Error>) {
@@ -1482,9 +1492,9 @@ private final class SafeWebFetchDelegateState: @unchecked Sendable {
         }
     }
 
-    func receive(data newData: Data) {
-        lock.withLock {
-            data.append(newData)
+    func receive(data newData: Data, maxBodyBytes: Int) throws {
+        try lock.withLock {
+            try accumulator.append(newData, maxBodyBytes: maxBodyBytes)
         }
     }
 
@@ -1500,7 +1510,7 @@ private final class SafeWebFetchDelegateState: @unchecked Sendable {
                     )
                 )
             }
-            return .success((data, response))
+            return .success((accumulator.data, response))
         }
         resume(with: result)
     }
@@ -1535,6 +1545,21 @@ private final class SafeWebFetchDelegateState: @unchecked Sendable {
 
 private enum SafeWebFetchCompletion: Error {
     case alreadyFinished
+}
+
+internal struct SafeWebBodyAccumulator: Sendable {
+    private(set) var data = Data()
+
+    mutating func append(_ newData: Data, maxBodyBytes: Int) throws {
+        let nextCount = data.count + newData.count
+        guard nextCount <= maxBodyBytes else {
+            throw AgentError.toolExecutionFailed(
+                toolName: "websearch",
+                underlyingError: "Fetched body exceeded limit of \(maxBodyBytes) bytes"
+            )
+        }
+        data.append(newData)
+    }
 }
 
 private enum ResolvedHostAddress: Sendable {

--- a/Sources/Swarm/Tools/Web/WebSearchSupport.swift
+++ b/Sources/Swarm/Tools/Web/WebSearchSupport.swift
@@ -1265,6 +1265,15 @@ internal struct TavilySearchBackend: Sendable {
 
 internal struct SafeWebFetcher: Sendable {
     let configuration: WebSearchTool.Configuration
+    private let sessionConfiguration: URLSessionConfiguration
+
+    init(
+        configuration: WebSearchTool.Configuration,
+        sessionConfiguration: URLSessionConfiguration = .ephemeral
+    ) {
+        self.configuration = configuration
+        self.sessionConfiguration = sessionConfiguration
+    }
 
     func fetch(
         url: URL,
@@ -1285,15 +1294,17 @@ internal struct SafeWebFetcher: Sendable {
             request.setValue(conditionalLastModified, forHTTPHeaderField: "If-Modified-Since")
         }
 
-        let redirectDelegate = SafeWebFetchRedirectDelegate()
+        let fetchDelegate = SafeWebFetchDelegate()
         let session = URLSession(
-            configuration: .ephemeral,
-            delegate: redirectDelegate,
+            configuration: sessionConfiguration,
+            delegate: fetchDelegate,
             delegateQueue: nil
         )
         defer { session.finishTasksAndInvalidate() }
 
-        let (data, response) = try await session.data(for: request)
+        let data: Data
+        let response: URLResponse
+        (data, response) = try await fetchDelegate.fetch(request, using: session)
         guard let http = response as? HTTPURLResponse else {
             throw AgentError.toolExecutionFailed(toolName: "websearch", underlyingError: "Fetch returned a non-HTTP response")
         }
@@ -1378,20 +1389,152 @@ internal struct SafeWebFetcher: Sendable {
     }
 }
 
-private final class SafeWebFetchRedirectDelegate: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+private final class SafeWebFetchDelegate: NSObject, URLSessionDataDelegate, URLSessionTaskDelegate, @unchecked Sendable {
+    private let state = SafeWebFetchDelegateState()
+
+    func fetch(_ request: URLRequest, using session: URLSession) async throws -> (Data, URLResponse) {
+        let task = session.dataTask(with: request)
+        return try await withCheckedThrowingContinuation { continuation in
+            state.start(continuation)
+            task.resume()
+        }
+    }
+
+    func urlSession(
+        _: URLSession,
+        dataTask: URLSessionDataTask,
+        didReceive response: URLResponse,
+        completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
+    ) {
+        guard let url = response.url, SafeWebFetcher.isAllowedURL(url) else {
+            state.finish(
+                throwing: AgentError.invalidToolArguments(
+                    toolName: "websearch",
+                    reason: "Private-network hosts are blocked"
+                )
+            )
+            dataTask.cancel()
+            completionHandler(.cancel)
+            return
+        }
+        state.receive(response: response)
+        completionHandler(.allow)
+    }
+
+    func urlSession(
+        _: URLSession,
+        dataTask _: URLSessionDataTask,
+        didReceive data: Data
+    ) {
+        state.receive(data: data)
+    }
+
     func urlSession(
         _: URLSession,
         task _: URLSessionTask,
+        didCompleteWithError error: Error?
+    ) {
+        if let error {
+            state.finish(throwing: error)
+        } else {
+            state.finish()
+        }
+    }
+
+    func urlSession(
+        _: URLSession,
+        task: URLSessionTask,
         willPerformHTTPRedirection _: HTTPURLResponse,
         newRequest request: URLRequest,
         completionHandler: @escaping (URLRequest?) -> Void
     ) {
         guard let url = request.url, SafeWebFetcher.isAllowedURL(url) else {
+            state.finish(
+                throwing: AgentError.invalidToolArguments(
+                    toolName: "websearch",
+                    reason: "Private-network hosts are blocked"
+                )
+            )
+            task.cancel()
             completionHandler(nil)
             return
         }
         completionHandler(request)
     }
+}
+
+private final class SafeWebFetchDelegateState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<(Data, URLResponse), Error>?
+    private var response: URLResponse?
+    private var data = Data()
+    private var isFinished = false
+
+    func start(_ continuation: CheckedContinuation<(Data, URLResponse), Error>) {
+        lock.withLock {
+            self.continuation = continuation
+        }
+    }
+
+    func receive(response: URLResponse) {
+        lock.withLock {
+            self.response = response
+        }
+    }
+
+    func receive(data newData: Data) {
+        lock.withLock {
+            data.append(newData)
+        }
+    }
+
+    func finish() {
+        let result: Result<(Data, URLResponse), Error> = lock.withLock {
+            guard isFinished == false else { return .failure(SafeWebFetchCompletion.alreadyFinished) }
+            isFinished = true
+            guard let response else {
+                return .failure(
+                    AgentError.toolExecutionFailed(
+                        toolName: "websearch",
+                        underlyingError: "Fetch returned no response"
+                    )
+                )
+            }
+            return .success((data, response))
+        }
+        resume(with: result)
+    }
+
+    func finish(throwing error: Error) {
+        let result: Result<(Data, URLResponse), Error> = lock.withLock {
+            guard isFinished == false else { return .failure(SafeWebFetchCompletion.alreadyFinished) }
+            isFinished = true
+            return .failure(error)
+        }
+        resume(with: result)
+    }
+
+    private func resume(with result: Result<(Data, URLResponse), Error>) {
+        let continuation = lock.withLock {
+            let current = self.continuation
+            self.continuation = nil
+            return current
+        }
+        guard let continuation else { return }
+        switch result {
+        case let .success(value):
+            continuation.resume(returning: value)
+        case let .failure(error):
+            if (error as? SafeWebFetchCompletion) == .alreadyFinished {
+                return
+            }
+            continuation.resume(throwing: error)
+        }
+    }
+}
+
+private enum SafeWebFetchCompletion: Error {
+    case alreadyFinished
 }
 
 private enum ResolvedHostAddress: Sendable {

--- a/Sources/Swarm/Tools/Web/WebSearchSupport.swift
+++ b/Sources/Swarm/Tools/Web/WebSearchSupport.swift
@@ -1398,10 +1398,15 @@ private final class SafeWebFetchDelegate: NSObject, URLSessionDataDelegate, URLS
     }
 
     func fetch(_ request: URLRequest, using session: URLSession) async throws -> (Data, URLResponse) {
-        let task = session.dataTask(with: request)
-        return try await withCheckedThrowingContinuation { continuation in
-            state.start(continuation)
-            task.resume()
+        let task = SafeWebFetchTask(session.dataTask(with: request))
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                state.start(continuation)
+                task.resume()
+            }
+        } onCancel: {
+            task.cancel()
+            state.finish(throwing: CancellationError())
         }
     }
 
@@ -1473,16 +1478,41 @@ private final class SafeWebFetchDelegate: NSObject, URLSessionDataDelegate, URLS
     }
 }
 
+private final class SafeWebFetchTask: @unchecked Sendable {
+    private let task: URLSessionDataTask
+
+    init(_ task: URLSessionDataTask) {
+        self.task = task
+    }
+
+    func resume() {
+        task.resume()
+    }
+
+    func cancel() {
+        task.cancel()
+    }
+}
+
 private final class SafeWebFetchDelegateState: @unchecked Sendable {
     private let lock = NSLock()
     private var continuation: CheckedContinuation<(Data, URLResponse), Error>?
     private var response: URLResponse?
     private var accumulator = SafeWebBodyAccumulator()
     private var isFinished = false
+    private var finishedResult: Result<(Data, URLResponse), Error>?
 
     func start(_ continuation: CheckedContinuation<(Data, URLResponse), Error>) {
-        lock.withLock {
+        let result: Result<(Data, URLResponse), Error>? = lock.withLock {
+            if isFinished {
+                return finishedResult ?? .failure(CancellationError())
+            }
             self.continuation = continuation
+            return nil
+        }
+
+        if let result {
+            Self.resume(continuation, with: result)
         }
     }
 
@@ -1503,14 +1533,18 @@ private final class SafeWebFetchDelegateState: @unchecked Sendable {
             guard isFinished == false else { return .failure(SafeWebFetchCompletion.alreadyFinished) }
             isFinished = true
             guard let response else {
-                return .failure(
+                let result: Result<(Data, URLResponse), Error> = .failure(
                     AgentError.toolExecutionFailed(
                         toolName: "websearch",
                         underlyingError: "Fetch returned no response"
                     )
                 )
+                finishedResult = result
+                return result
             }
-            return .success((accumulator.data, response))
+            let result: Result<(Data, URLResponse), Error> = .success((accumulator.data, response))
+            finishedResult = result
+            return result
         }
         resume(with: result)
     }
@@ -1519,7 +1553,9 @@ private final class SafeWebFetchDelegateState: @unchecked Sendable {
         let result: Result<(Data, URLResponse), Error> = lock.withLock {
             guard isFinished == false else { return .failure(SafeWebFetchCompletion.alreadyFinished) }
             isFinished = true
-            return .failure(error)
+            let result: Result<(Data, URLResponse), Error> = .failure(error)
+            finishedResult = result
+            return result
         }
         resume(with: result)
     }
@@ -1531,6 +1567,13 @@ private final class SafeWebFetchDelegateState: @unchecked Sendable {
             return current
         }
         guard let continuation else { return }
+        Self.resume(continuation, with: result)
+    }
+
+    private static func resume(
+        _ continuation: CheckedContinuation<(Data, URLResponse), Error>,
+        with result: Result<(Data, URLResponse), Error>
+    ) {
         switch result {
         case let .success(value):
             continuation.resume(returning: value)

--- a/Sources/SwarmMacros/TraceableMacro.swift
+++ b/Sources/SwarmMacros/TraceableMacro.swift
@@ -51,16 +51,24 @@ public struct TraceableMacro: PeerMacro {
             ) async throws -> SendableValue {
                 let startTime = ContinuousClock.now
                 let traceId = UUID()
+                let spanId = UUID()
+                let argumentKeys = arguments.keys.sorted().map { SendableValue.string($0) }
 
                 // Emit start event
                 if let tracer = tracer {
-                    await tracer.record(TraceEvent(
-                        id: traceId,
-                        type: .toolCall,
-                        name: name,
-                        timestamp: Date(),
-                        duration: nil,
-                        metadata: ["arguments": .object(arguments)]
+                    await tracer.trace(TraceEvent(
+                        traceId: traceId,
+                        spanId: spanId,
+                        kind: .toolCall,
+                        level: .debug,
+                        message: "Tool call: \\(name)",
+                        metadata: [
+                            "tool_name": .string(name),
+                            "argument_count": .int(arguments.count),
+                            "argument_keys": .array(argumentKeys),
+                            "arguments_redacted": .bool(true)
+                        ],
+                        toolName: name
                     ))
                 }
 
@@ -70,16 +78,20 @@ public struct TraceableMacro: PeerMacro {
 
                     // Emit success event
                     if let tracer = tracer {
-                        await tracer.record(TraceEvent(
-                            id: traceId,
-                            type: .toolResult,
-                            name: name,
-                            timestamp: Date(),
-                            duration: duration,
+                        await tracer.trace(TraceEvent(
+                            traceId: traceId,
+                            spanId: spanId,
+                            duration: duration.timeInterval,
+                            kind: .toolResult,
+                            level: .debug,
+                            message: "Tool result: \\(name)",
                             metadata: [
-                                "result": result,
+                                "tool_name": .string(name),
+                                "result_length": .int(String(describing: result).count),
+                                "duration_ms": .double(duration.timeInterval * 1000),
                                 "success": .bool(true)
-                            ]
+                            ],
+                            toolName: name
                         ))
                     }
 
@@ -89,16 +101,20 @@ public struct TraceableMacro: PeerMacro {
 
                     // Emit error event
                     if let tracer = tracer {
-                        await tracer.record(TraceEvent(
-                            id: traceId,
-                            type: .error,
-                            name: name,
-                            timestamp: Date(),
-                            duration: duration,
+                        await tracer.trace(TraceEvent(
+                            traceId: traceId,
+                            spanId: spanId,
+                            duration: duration.timeInterval,
+                            kind: .toolError,
+                            level: .error,
+                            message: "Tool error: \\(name)",
                             metadata: [
-                                "error": .string(error.localizedDescription),
+                                "tool_name": .string(name),
+                                "error_type": .string(String(describing: type(of: error))),
+                                "duration_ms": .double(duration.timeInterval * 1000),
                                 "success": .bool(false)
-                            ]
+                            ],
+                            toolName: name
                         ))
                     }
 

--- a/Tests/SwarmMacrosTests/TraceableMacroTests.swift
+++ b/Tests/SwarmMacrosTests/TraceableMacroTests.swift
@@ -62,16 +62,26 @@ final class TraceableMacroTests: XCTestCase {
                 ) async throws -> SendableValue {
                     let startTime = ContinuousClock.now
                     let traceId = UUID()
+                    let spanId = UUID()
+                    let argumentKeys = arguments.keys.sorted().map {
+                        SendableValue.string($0)
+                    }
 
                     // Emit start event
                     if let tracer = tracer {
-                        await tracer.record(TraceEvent(
-                            id: traceId,
-                            type: .toolCall,
-                            name: name,
-                            timestamp: Date(),
-                            duration: nil,
-                            metadata: ["arguments": .object(arguments)]
+                        await tracer.trace(TraceEvent(
+                            traceId: traceId,
+                            spanId: spanId,
+                            kind: .toolCall,
+                            level: .debug,
+                            message: "Tool call: \\(name)",
+                            metadata: [
+                                "tool_name": .string(name),
+                                "argument_count": .int(arguments.count),
+                                "argument_keys": .array(argumentKeys),
+                                "arguments_redacted": .bool(true)
+                            ],
+                            toolName: name
                         ))
                     }
 
@@ -81,16 +91,20 @@ final class TraceableMacroTests: XCTestCase {
 
                         // Emit success event
                         if let tracer = tracer {
-                            await tracer.record(TraceEvent(
-                                id: traceId,
-                                type: .toolResult,
-                                name: name,
-                                timestamp: Date(),
-                                duration: duration,
+                            await tracer.trace(TraceEvent(
+                                traceId: traceId,
+                                spanId: spanId,
+                                duration: duration.timeInterval,
+                                kind: .toolResult,
+                                level: .debug,
+                                message: "Tool result: \\(name)",
                                 metadata: [
-                                    "result": result,
+                                    "tool_name": .string(name),
+                                    "result_length": .int(String(describing: result).count),
+                                    "duration_ms": .double(duration.timeInterval * 1000),
                                     "success": .bool(true)
-                                ]
+                                ],
+                                toolName: name
                             ))
                         }
 
@@ -100,16 +114,20 @@ final class TraceableMacroTests: XCTestCase {
 
                         // Emit error event
                         if let tracer = tracer {
-                            await tracer.record(TraceEvent(
-                                id: traceId,
-                                type: .error,
-                                name: name,
-                                timestamp: Date(),
-                                duration: duration,
+                            await tracer.trace(TraceEvent(
+                                traceId: traceId,
+                                spanId: spanId,
+                                duration: duration.timeInterval,
+                                kind: .toolError,
+                                level: .error,
+                                message: "Tool error: \\(name)",
                                 metadata: [
-                                    "error": .string(error.localizedDescription),
+                                    "tool_name": .string(name),
+                                    "error_type": .string(String(describing: type(of: error))),
+                                    "duration_ms": .double(duration.timeInterval * 1000),
                                     "success": .bool(false)
-                                ]
+                                ],
+                                toolName: name
                             ))
                         }
 

--- a/Tests/SwarmTests/Observability/ObservabilityPrivacyTests.swift
+++ b/Tests/SwarmTests/Observability/ObservabilityPrivacyTests.swift
@@ -1,0 +1,47 @@
+import Foundation
+@testable import Swarm
+import Testing
+
+@Suite("Observability Privacy Tests")
+struct ObservabilityPrivacyTests {
+    @Test("public trace log sanitizer removes sensitive content from messages metadata and errors")
+    func publicTraceLogSanitizerRedactsSensitiveContent() {
+        let traceId = UUID()
+        let spanId = UUID()
+        let secret = "sk-live-secret raw thought plan tool args"
+        let event = TraceEvent(
+            traceId: traceId,
+            spanId: spanId,
+            kind: .toolError,
+            level: .error,
+            message: "Tool failed with \(secret)",
+            metadata: [
+                "thought": .string(secret),
+                "plan": .string(secret),
+                "arguments": .dictionary(["api_key": .string(secret)]),
+                "error_message": .string(secret),
+                "safe_count": .int(2)
+            ],
+            agentName: "ResearchAgent",
+            toolName: "websearch",
+            error: ErrorInfo(
+                type: "FetchError",
+                message: secret,
+                stackTrace: ["frame with \(secret)"],
+                underlyingError: secret
+            )
+        )
+
+        let message = TraceEventPublicLogSanitizer.message(for: event)
+        let metadata = TraceEventPublicLogSanitizer.metadata(for: event)
+        let error = TraceEventPublicLogSanitizer.errorSummary(for: event.error)
+
+        #expect(message.contains(secret) == false)
+        #expect(metadata.description.contains(secret) == false)
+        #expect(error.contains(secret) == false)
+        #expect(metadata["safe_count"] == .int(2))
+        #expect(metadata["arguments"] == .string("[redacted]"))
+        #expect(metadata["thought"] == .string("[redacted]"))
+        #expect(error == "FetchError: [redacted]")
+    }
+}

--- a/Tests/SwarmTests/Tools/WebSearchSupportTests.swift
+++ b/Tests/SwarmTests/Tools/WebSearchSupportTests.swift
@@ -170,6 +170,43 @@ struct WebSearchSupportTests {
         #expect(RedirectWebFetchURLProtocol.didLoadBody == false)
     }
 
+    @Test("Safe web fetcher cancels URLSession task when caller cancels")
+    func fetcherCancelsURLSessionTaskWhenCallerCancels() async throws {
+        CancellableWebFetchURLProtocol.reset()
+        defer { CancellableWebFetchURLProtocol.reset() }
+
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("swarm-web-cancellation-tests", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root.deletingLastPathComponent()) }
+
+        let configuration = WebSearchTool.Configuration(
+            apiKey: nil,
+            persistFetchedArtifacts: false,
+            storeURL: root,
+            enabled: true
+        )
+        let sessionConfiguration = URLSessionConfiguration.ephemeral
+        sessionConfiguration.protocolClasses = [CancellableWebFetchURLProtocol.self]
+        let fetcher = SafeWebFetcher(configuration: configuration, sessionConfiguration: sessionConfiguration)
+        let url = try #require(URL(string: "https://example.com/slow"))
+
+        let fetchTask = Task {
+            try await fetcher.fetch(url: url, conditionalEtag: nil, conditionalLastModified: nil)
+        }
+        for _ in 0 ..< 100 where !CancellableWebFetchURLProtocol.didStartLoading {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(CancellableWebFetchURLProtocol.didStartLoading)
+        fetchTask.cancel()
+
+        await #expect(throws: CancellationError.self) {
+            _ = try await fetchTask.value
+        }
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(CancellableWebFetchURLProtocol.didStopLoading)
+    }
+
     @Test("Safe web fetch body accumulator rejects overflow chunks before appending")
     func bodyAccumulatorRejectsOverflowBeforeAppend() throws {
         var accumulator = SafeWebBodyAccumulator()
@@ -331,5 +368,73 @@ private final class BodyLoadState: @unchecked Sendable {
 
     func reset() {
         lock.withLock { bodyLoaded = false }
+    }
+}
+
+private final class CancellableWebFetchURLProtocol: URLProtocol {
+    private static let state = CancellationState()
+
+    static var didStopLoading: Bool {
+        state.didStopLoading
+    }
+
+    static var didStartLoading: Bool {
+        state.didStartLoading
+    }
+
+    static func reset() {
+        state.reset()
+    }
+
+    override class func canInit(with _: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        Self.state.markStarted()
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "text/plain"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+    }
+
+    override func stopLoading() {
+        Self.state.markStopped()
+    }
+}
+
+private final class CancellationState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var started = false
+    private var stopped = false
+
+    var didStartLoading: Bool {
+        lock.withLock { started }
+    }
+
+    var didStopLoading: Bool {
+        lock.withLock { stopped }
+    }
+
+    func markStarted() {
+        lock.withLock { started = true }
+    }
+
+    func markStopped() {
+        lock.withLock { stopped = true }
+    }
+
+    func reset() {
+        lock.withLock {
+            started = false
+            stopped = false
+        }
     }
 }

--- a/Tests/SwarmTests/Tools/WebSearchSupportTests.swift
+++ b/Tests/SwarmTests/Tools/WebSearchSupportTests.swift
@@ -138,6 +138,38 @@ struct WebSearchSupportTests {
         }
     }
 
+    @Test("Safe web fetcher rejects private redirects before accepting body bytes")
+    func fetcherRejectsPrivateRedirectBeforeBodyRead() async throws {
+        RedirectWebFetchURLProtocol.reset()
+        defer { RedirectWebFetchURLProtocol.reset() }
+
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("swarm-web-final-url-tests", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root.deletingLastPathComponent()) }
+
+        let configuration = WebSearchTool.Configuration(
+            apiKey: nil,
+            persistFetchedArtifacts: false,
+            storeURL: root,
+            enabled: true
+        )
+        let sessionConfiguration = URLSessionConfiguration.ephemeral
+        sessionConfiguration.protocolClasses = [RedirectWebFetchURLProtocol.self]
+        let fetcher = SafeWebFetcher(configuration: configuration, sessionConfiguration: sessionConfiguration)
+        let publicURL = try #require(URL(string: "https://example.com/redirected"))
+
+        await #expect(throws: AgentError.self) {
+            _ = try await fetcher.fetch(
+                url: publicURL,
+                conditionalEtag: nil,
+                conditionalLastModified: nil
+            )
+        }
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(RedirectWebFetchURLProtocol.didLoadBody == false)
+    }
+
     @Test("Merged hits prefer close cached results")
     func mergeHitsPrefersUsefulCachedHits() {
         let cached = WebSearchHit(
@@ -226,5 +258,66 @@ struct WebSearchSupportTests {
         let matches = try await store.searchSections(query: "updated instructions", topK: 10)
         #expect(matches.count == 1)
         #expect(matches.first?.section.text.contains("Updated instructions") == true)
+    }
+}
+
+private final class RedirectWebFetchURLProtocol: URLProtocol {
+    private static let state = BodyLoadState()
+
+    static var didLoadBody: Bool {
+        state.didLoadBody
+    }
+
+    static func reset() {
+        state.reset()
+    }
+
+    override class func canInit(with _: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard request.url?.host != "127.0.0.1" else {
+            Self.state.markBodyLoaded()
+            client?.urlProtocol(self, didLoad: Data("private body".utf8))
+            client?.urlProtocolDidFinishLoading(self)
+            return
+        }
+
+        guard let redirectURL = URL(string: "http://127.0.0.1/private") else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+            return
+        }
+        let redirectRequest = URLRequest(url: redirectURL)
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: 302,
+            httpVersion: nil,
+            headerFields: ["Location": redirectURL.absoluteString]
+        )!
+        client?.urlProtocol(self, wasRedirectedTo: redirectRequest, redirectResponse: response)
+    }
+
+    override func stopLoading() {}
+}
+
+private final class BodyLoadState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var bodyLoaded = false
+
+    var didLoadBody: Bool {
+        lock.withLock { bodyLoaded }
+    }
+
+    func markBodyLoaded() {
+        lock.withLock { bodyLoaded = true }
+    }
+
+    func reset() {
+        lock.withLock { bodyLoaded = false }
     }
 }

--- a/Tests/SwarmTests/Tools/WebSearchSupportTests.swift
+++ b/Tests/SwarmTests/Tools/WebSearchSupportTests.swift
@@ -170,6 +170,18 @@ struct WebSearchSupportTests {
         #expect(RedirectWebFetchURLProtocol.didLoadBody == false)
     }
 
+    @Test("Safe web fetch body accumulator rejects overflow chunks before appending")
+    func bodyAccumulatorRejectsOverflowBeforeAppend() throws {
+        var accumulator = SafeWebBodyAccumulator()
+        try accumulator.append(Data(repeating: 0x41, count: 5), maxBodyBytes: 5)
+
+        #expect(accumulator.data.count == 5)
+        #expect(throws: AgentError.self) {
+            try accumulator.append(Data([0x42]), maxBodyBytes: 5)
+        }
+        #expect(accumulator.data == Data(repeating: 0x41, count: 5))
+    }
+
     @Test("Merged hits prefer close cached results")
     func mergeHitsPrefersUsefulCachedHits() {
         let cached = WebSearchHit(

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,32 @@
+# Web Security / Observability Audit Fixes
+
+## Plan
+
+- [x] Baseline the existing dirty web fetch changes and preserve unrelated edits.
+- [x] SWARM-AUDIT-030: add focused redirect/final URL and DNS destination tests, then validate every redirect/final destination before body acceptance.
+- [ ] SWARM-AUDIT-031: add a focused oversized-body streaming test, then enforce `maxBodyBytes` while bytes arrive instead of after full buffering.
+- [ ] SWARM-AUDIT-032: add focused observability tests for thought/plan/tool/error metadata redaction, then make SwiftLog/OSLog output privacy-safe by default.
+- [ ] SWARM-AUDIT-038: inspect branch task/audit notes and web/security/observability code for any remaining concrete issue; if stale, document evidence and add proof where useful.
+- [ ] Run focused tests after each fix, then run a broader relevant test slice before pushing.
+- [ ] Commit one code-changing issue per commit, push `codex/audit-web-security-20260517`, and open a PR against `codex/fix-mcp-text-content-tests` if the cluster is complete.
+
+## Assumptions To Verify
+
+- Existing edits in `WebSearchSupport.swift` and `WebSearchSupportTests.swift` are user-owned or prior-agent work and should be preserved unless they conflict with the requested fixes.
+- The safe fetch implementation is the only web fetch path in scope for SWARM-AUDIT-030 and SWARM-AUDIT-031.
+- The observability leak is limited to tracers/log sinks rather than trace event in-memory data contracts; tests should distinguish redacted exported text from structured internal event data.
+- SWARM-AUDIT-038 may already be stale; evidence must come from current branch notes/code/tests, not from assumption.
+
+## Progress
+
+- [x] Planning complete.
+- [x] SWARM-AUDIT-030 complete.
+- [ ] SWARM-AUDIT-031 complete.
+- [ ] SWARM-AUDIT-032 complete.
+- [ ] SWARM-AUDIT-038 complete.
+- [ ] Final verification complete.
+- [ ] Pushed and PR created.
+
+## Review
+
+- SWARM-AUDIT-030: `swift test --filter WebSearchSupportTests` passes after adding DNS/redirect coverage and delegate-driven redirect/final response validation.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -6,8 +6,8 @@
 - [x] SWARM-AUDIT-030: add focused redirect/final URL and DNS destination tests, then validate every redirect/final destination before body acceptance.
 - [x] SWARM-AUDIT-031: add a focused oversized-body streaming test, then enforce `maxBodyBytes` while bytes arrive instead of after full buffering.
 - [x] SWARM-AUDIT-032: add focused observability tests for thought/plan/tool/error metadata redaction, then make SwiftLog/OSLog output privacy-safe by default.
-- [ ] SWARM-AUDIT-038: inspect branch task/audit notes and web/security/observability code for any remaining concrete issue; if stale, document evidence and add proof where useful.
-- [ ] Run focused tests after each fix, then run a broader relevant test slice before pushing.
+- [x] SWARM-AUDIT-038: inspect branch task/audit notes and web/security/observability code for any remaining concrete issue; if stale, document evidence and add proof where useful.
+- [x] Run focused tests after each fix, then run a broader relevant test slice before pushing.
 - [ ] Commit one code-changing issue per commit, push `codex/audit-web-security-20260517`, and open a PR against `codex/fix-mcp-text-content-tests` if the cluster is complete.
 
 ## Assumptions To Verify
@@ -23,8 +23,8 @@
 - [x] SWARM-AUDIT-030 complete.
 - [x] SWARM-AUDIT-031 complete.
 - [x] SWARM-AUDIT-032 complete.
-- [ ] SWARM-AUDIT-038 complete.
-- [ ] Final verification complete.
+- [x] SWARM-AUDIT-038 complete.
+- [x] Final verification complete.
 - [ ] Pushed and PR created.
 
 ## Review
@@ -32,3 +32,5 @@
 - SWARM-AUDIT-030: `swift test --filter WebSearchSupportTests` passes after adding DNS/redirect coverage and delegate-driven redirect/final response validation.
 - SWARM-AUDIT-031: `swift test --filter WebSearchSupportTests/bodyAccumulatorRejectsOverflowBeforeAppend` first failed because `SafeWebBodyAccumulator` was missing; after adding streaming accumulation, `swift test --filter WebSearchSupportTests` passes.
 - SWARM-AUDIT-032: `swift test --filter ObservabilityPrivacyTests` first failed because no public-log sanitizer existed; after adding the sanitizer and wiring SwiftLog, OSLog, ConsoleTracer, and PrettyConsoleTracer through it, `swift test --filter Observability` passes.
+- SWARM-AUDIT-038: branch notes did not list a separate remaining item, but code inspection found `@Traceable` still generated raw argument, result, and error metadata. `swift test --filter TraceableMacroTests/testTraceableMacroExpansion` failed with the raw expansion, then passed after updating the macro to emit counts, argument keys, lengths, duration, and error type only. `swift test --filter TraceableMacroTests` passes.
+- Final verification before push: `swift test --filter WebSearchSupportTests`, `swift test --filter Observability`, and `swift test --filter TraceableMacroTests` all pass.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -8,7 +8,7 @@
 - [x] SWARM-AUDIT-032: add focused observability tests for thought/plan/tool/error metadata redaction, then make SwiftLog/OSLog output privacy-safe by default.
 - [x] SWARM-AUDIT-038: inspect branch task/audit notes and web/security/observability code for any remaining concrete issue; if stale, document evidence and add proof where useful.
 - [x] Run focused tests after each fix, then run a broader relevant test slice before pushing.
-- [ ] Commit one code-changing issue per commit, push `codex/audit-web-security-20260517`, and open a PR against `codex/fix-mcp-text-content-tests` if the cluster is complete.
+- [x] Commit one code-changing issue per commit, push `codex/audit-web-security-20260517`, and open a PR against `codex/fix-mcp-text-content-tests` if the cluster is complete.
 
 ## Assumptions To Verify
 
@@ -25,7 +25,7 @@
 - [x] SWARM-AUDIT-032 complete.
 - [x] SWARM-AUDIT-038 complete.
 - [x] Final verification complete.
-- [ ] Pushed and PR created.
+- [x] Pushed and PR created.
 
 ## Review
 
@@ -34,3 +34,4 @@
 - SWARM-AUDIT-032: `swift test --filter ObservabilityPrivacyTests` first failed because no public-log sanitizer existed; after adding the sanitizer and wiring SwiftLog, OSLog, ConsoleTracer, and PrettyConsoleTracer through it, `swift test --filter Observability` passes.
 - SWARM-AUDIT-038: branch notes did not list a separate remaining item, but code inspection found `@Traceable` still generated raw argument, result, and error metadata. `swift test --filter TraceableMacroTests/testTraceableMacroExpansion` failed with the raw expansion, then passed after updating the macro to emit counts, argument keys, lengths, duration, and error type only. `swift test --filter TraceableMacroTests` passes.
 - Final verification before push: `swift test --filter WebSearchSupportTests`, `swift test --filter Observability`, and `swift test --filter TraceableMacroTests` all pass.
+- Pushed `codex/audit-web-security-20260517` and updated PR https://github.com/christopherkarani/Swarm/pull/103 against `codex/fix-mcp-text-content-tests`.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -5,7 +5,7 @@
 - [x] Baseline the existing dirty web fetch changes and preserve unrelated edits.
 - [x] SWARM-AUDIT-030: add focused redirect/final URL and DNS destination tests, then validate every redirect/final destination before body acceptance.
 - [x] SWARM-AUDIT-031: add a focused oversized-body streaming test, then enforce `maxBodyBytes` while bytes arrive instead of after full buffering.
-- [ ] SWARM-AUDIT-032: add focused observability tests for thought/plan/tool/error metadata redaction, then make SwiftLog/OSLog output privacy-safe by default.
+- [x] SWARM-AUDIT-032: add focused observability tests for thought/plan/tool/error metadata redaction, then make SwiftLog/OSLog output privacy-safe by default.
 - [ ] SWARM-AUDIT-038: inspect branch task/audit notes and web/security/observability code for any remaining concrete issue; if stale, document evidence and add proof where useful.
 - [ ] Run focused tests after each fix, then run a broader relevant test slice before pushing.
 - [ ] Commit one code-changing issue per commit, push `codex/audit-web-security-20260517`, and open a PR against `codex/fix-mcp-text-content-tests` if the cluster is complete.
@@ -22,7 +22,7 @@
 - [x] Planning complete.
 - [x] SWARM-AUDIT-030 complete.
 - [x] SWARM-AUDIT-031 complete.
-- [ ] SWARM-AUDIT-032 complete.
+- [x] SWARM-AUDIT-032 complete.
 - [ ] SWARM-AUDIT-038 complete.
 - [ ] Final verification complete.
 - [ ] Pushed and PR created.
@@ -31,3 +31,4 @@
 
 - SWARM-AUDIT-030: `swift test --filter WebSearchSupportTests` passes after adding DNS/redirect coverage and delegate-driven redirect/final response validation.
 - SWARM-AUDIT-031: `swift test --filter WebSearchSupportTests/bodyAccumulatorRejectsOverflowBeforeAppend` first failed because `SafeWebBodyAccumulator` was missing; after adding streaming accumulation, `swift test --filter WebSearchSupportTests` passes.
+- SWARM-AUDIT-032: `swift test --filter ObservabilityPrivacyTests` first failed because no public-log sanitizer existed; after adding the sanitizer and wiring SwiftLog, OSLog, ConsoleTracer, and PrettyConsoleTracer through it, `swift test --filter Observability` passes.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -4,7 +4,7 @@
 
 - [x] Baseline the existing dirty web fetch changes and preserve unrelated edits.
 - [x] SWARM-AUDIT-030: add focused redirect/final URL and DNS destination tests, then validate every redirect/final destination before body acceptance.
-- [ ] SWARM-AUDIT-031: add a focused oversized-body streaming test, then enforce `maxBodyBytes` while bytes arrive instead of after full buffering.
+- [x] SWARM-AUDIT-031: add a focused oversized-body streaming test, then enforce `maxBodyBytes` while bytes arrive instead of after full buffering.
 - [ ] SWARM-AUDIT-032: add focused observability tests for thought/plan/tool/error metadata redaction, then make SwiftLog/OSLog output privacy-safe by default.
 - [ ] SWARM-AUDIT-038: inspect branch task/audit notes and web/security/observability code for any remaining concrete issue; if stale, document evidence and add proof where useful.
 - [ ] Run focused tests after each fix, then run a broader relevant test slice before pushing.
@@ -21,7 +21,7 @@
 
 - [x] Planning complete.
 - [x] SWARM-AUDIT-030 complete.
-- [ ] SWARM-AUDIT-031 complete.
+- [x] SWARM-AUDIT-031 complete.
 - [ ] SWARM-AUDIT-032 complete.
 - [ ] SWARM-AUDIT-038 complete.
 - [ ] Final verification complete.
@@ -30,3 +30,4 @@
 ## Review
 
 - SWARM-AUDIT-030: `swift test --filter WebSearchSupportTests` passes after adding DNS/redirect coverage and delegate-driven redirect/final response validation.
+- SWARM-AUDIT-031: `swift test --filter WebSearchSupportTests/bodyAccumulatorRejectsOverflowBeforeAppend` first failed because `SafeWebBodyAccumulator` was missing; after adding streaming accumulation, `swift test --filter WebSearchSupportTests` passes.


### PR DESCRIPTION
## Summary
- validate safe web fetch redirects/final destinations and DNS-resolved hosts before accepting private-network responses
- enforce web fetch body limits during streamed accumulation instead of only after full buffering
- redact public trace log messages, metadata, and error summaries across SwiftLog, OSLog, ConsoleTracer, and PrettyConsoleTracer
- fix the remaining SWARM-AUDIT-038 observability issue: @Traceable macro expansion no longer emits raw arguments, results, or error text

## Audit IDs
- SWARM-AUDIT-030
- SWARM-AUDIT-031
- SWARM-AUDIT-032
- SWARM-AUDIT-038

## Verification
- swift test --filter WebSearchSupportTests
- swift test --filter Observability
- swift test --filter TraceableMacroTests
