### PR TITLE
Fix docs, release, example, and Linux audit issues

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,7 @@ name: Deploy Docs
 on:
   push:
     branches: [main]
+  pull_request:
   workflow_dispatch:
 
 permissions:
@@ -32,6 +33,7 @@ jobs:
           path: docs/.vitepress/dist
 
   deploy:
+    if: github.event_name != 'pull_request'
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,5 +1,5 @@
 # Swarm CI Workflow
-# Builds and tests on macOS and Linux
+# Builds and tests on macOS; verifies the Linux core build lane on Ubuntu
 
 name: Swift CI
 
@@ -59,12 +59,12 @@ jobs:
         run: swift run SwarmCapabilityShowcase matrix
 
       - name: Test CodeReviewer example
-        run: swift test
+        run: SWARM_CORE_ONLY=1 swift test
         working-directory: Examples/CodeReviewer
 
-  # Linux Build & Test (core features, no SwiftData)
+  # Linux core build lane
   build-linux:
-    name: Build & Test (Linux)
+    name: Build (Linux Core)
     runs-on: ubuntu-latest
 
     steps:
@@ -88,14 +88,8 @@ jobs:
           restore-keys: |
             linux-swift-
 
-      - name: Resolve dependencies
-        run: swift package resolve
-
-      - name: Build
-        run: swift build
-
-      - name: Run tests
-        run: SWARM_HIVE_RUNTIME=1 SWARM_INCLUDE_HIVE=1 swift test --no-parallel
+      - name: Run Linux core lane
+        run: scripts/ci/verify-linux-core.sh
 
   # Code Quality (macOS only - SwiftLint/SwiftFormat)
   code-quality:

--- a/Examples/CodeReviewer/Package.swift
+++ b/Examples/CodeReviewer/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "CodeReviewer",
     platforms: [.macOS(.v26)],
     dependencies: [
-        .package(path: "../../")
+        .package(name: "Swarm", path: "../../")
     ],
     targets: [
         .executableTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,7 @@ import PackageDescription
 import CompilerPluginSupport
 import Foundation
 let includeDemo = ProcessInfo.processInfo.environment["SWARM_INCLUDE_DEMO"] == "1"
+let coreOnly = ProcessInfo.processInfo.environment["SWARM_CORE_ONLY"] == "1"
 
 var packageProducts: [Product] = [
     .library(name: "Swarm", targets: ["Swarm"]),
@@ -34,40 +35,66 @@ var packageDependencies: [Package.Dependency] = [
     .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.11.0"),
     .package(url: "https://github.com/open-telemetry/opentelemetry-swift-core.git", from: "2.3.0"),
     .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.13.2"),
-    // Production graph must resolve to the published tag set that is known to build together.
-    .package(url: "https://github.com/christopherkarani/Wax.git", exact: "0.1.20"),
-    .package(
-        url: "https://github.com/christopherkarani/Conduit",
-        exact: "0.3.14",
-        traits: [
-            .trait(name: "OpenAI"),
-            .trait(name: "OpenRouter"),
-            .trait(name: "Anthropic"),
-            .trait(name: "MLX"),
-        ]
-    ),
-    .package(url: "https://github.com/christopherkarani/ContextCore.git", exact: "1.0.0"),
-    .package(url: "https://github.com/christopherkarani/Membrane", exact: "0.1.3"),
-    .package(url: "https://github.com/christopherkarani/Hive", exact: "0.2.0"),
 ]
+
+let integrationTrait = "Integrations"
+if !coreOnly {
+    packageDependencies += [
+        // Production graph must resolve to the published tag set that is known to build together.
+        .package(url: "https://github.com/christopherkarani/Wax.git", exact: "0.1.20"),
+        .package(
+            url: "https://github.com/christopherkarani/Conduit",
+            exact: "0.3.14",
+            traits: [
+                .trait(name: "OpenAI"),
+                .trait(name: "OpenRouter"),
+                .trait(name: "Anthropic"),
+                .trait(name: "MLX"),
+            ]
+        ),
+        .package(url: "https://github.com/christopherkarani/ContextCore.git", exact: "1.0.0"),
+        .package(url: "https://github.com/christopherkarani/Membrane", exact: "0.1.3"),
+        .package(url: "https://github.com/christopherkarani/Hive", exact: "0.2.0"),
+    ]
+}
 
 var swarmDependencies: [Target.Dependency] = [
     "SwarmMacros",
     .product(name: "Logging", package: "swift-log"),
     .product(name: "SwiftSoup", package: "SwiftSoup"),
-    .product(name: "Wax", package: "Wax"),
-    .product(name: "Conduit", package: "Conduit"),
-    .product(name: "ConduitAdvanced", package: "Conduit"),
-    .product(name: "ContextCore", package: "ContextCore"),
-    .product(name: "HiveCore", package: "Hive"),
-    .product(name: "Membrane", package: "Membrane"),
-    .product(name: "MembraneCore", package: "Membrane"),
-    .product(name: "MembraneHive", package: "Membrane")
 ]
 
 var swarmSwiftSettings: [SwiftSetting] = [
     .enableExperimentalFeature("StrictConcurrency"),
     .define("SWARM_HIVE", .when(traits: ["hive"])),
+]
+
+if !coreOnly {
+    swarmDependencies += [
+        .product(name: "Wax", package: "Wax", condition: .when(traits: [integrationTrait])),
+        .product(name: "Conduit", package: "Conduit", condition: .when(traits: [integrationTrait])),
+        .product(name: "ConduitAdvanced", package: "Conduit", condition: .when(traits: [integrationTrait])),
+        .product(name: "ContextCore", package: "ContextCore", condition: .when(traits: [integrationTrait])),
+        .product(name: "HiveCore", package: "Hive", condition: .when(traits: [integrationTrait])),
+        .product(name: "Membrane", package: "Membrane", condition: .when(traits: [integrationTrait])),
+        .product(name: "MembraneCore", package: "Membrane", condition: .when(traits: [integrationTrait])),
+        .product(name: "MembraneHive", package: "Membrane", condition: .when(traits: [integrationTrait])),
+    ]
+    swarmSwiftSettings.append(.define("SWARM_INTEGRATIONS", .when(traits: [integrationTrait])))
+}
+
+let swarmCoreOnlyExcludes = [
+    "Integration/Wax",
+    "Integration/Membrane/SessionMembraneAgentAdapter.swift",
+    "Integration/Membrane/WaxMembraneStorage.swift",
+    "Internal/GraphRuntime",
+    "Memory/ContextCoreMemory.swift",
+    "Memory/DefaultAgentMemory.swift",
+    "Providers/Conduit",
+    "Tools/Web",
+    "Workflow/WorkflowCheckpointCodec.swift",
+    "Workflow/WorkflowCheckpointStore.swift",
+    "Workflow/WorkflowDurableEngine.swift",
 ]
 
 var packageTargets: [Target] = [
@@ -89,6 +116,7 @@ var packageTargets: [Target] = [
     .target(
         name: "Swarm",
         dependencies: swarmDependencies,
+        exclude: coreOnly ? swarmCoreOnlyExcludes : [],
         swiftSettings: swarmSwiftSettings
     ),
     .target(
@@ -137,27 +165,23 @@ var packageTargets: [Target] = [
     .testTarget(
         name: "SwarmTests",
         dependencies: {
-            let dependencies: [Target.Dependency] = [
+            var dependencies: [Target.Dependency] = [
                 "Swarm",
                 "SwarmMCP",
-                .product(name: "Conduit", package: "Conduit"),
-                .product(name: "ConduitAdvanced", package: "Conduit"),
-                .product(name: "Membrane", package: "Membrane"),
-                .product(name: "MembraneCore", package: "Membrane"),
             ]
+            if !coreOnly {
+                dependencies += [
+                    .product(name: "Conduit", package: "Conduit"),
+                    .product(name: "ConduitAdvanced", package: "Conduit"),
+                    .product(name: "Membrane", package: "Membrane"),
+                    .product(name: "MembraneCore", package: "Membrane"),
+                ]
+            }
             return dependencies
         }(),
         resources: [
             .copy("Guardrails/INTEGRATION_TEST_SUMMARY.md"),
             .copy("Guardrails/QUICK_REFERENCE.md")
-        ],
-        swiftSettings: swarmSwiftSettings
-    ),
-    .testTarget(
-        name: "HiveSwarmTests",
-        dependencies: [
-            "Swarm",
-            .product(name: "HiveCore", package: "Hive")
         ],
         swiftSettings: swarmSwiftSettings
     ),
@@ -191,6 +215,19 @@ var packageTargets: [Target] = [
         swiftSettings: swarmSwiftSettings
     )
 ]
+
+if !coreOnly {
+    packageTargets.append(
+        .testTarget(
+            name: "HiveSwarmTests",
+            dependencies: [
+                "Swarm",
+                .product(name: "HiveCore", package: "Hive")
+            ],
+            swiftSettings: swarmSwiftSettings
+        )
+    )
+}
 
 if includeDemo {
     packageTargets.append(
@@ -226,6 +263,11 @@ let package = Package(
     ],
     products: packageProducts,
     traits: [
+        .default(enabledTraits: [integrationTrait]),
+        .trait(
+            name: integrationTrait,
+            description: "Enable provider, memory, graph runtime, Wax, Membrane, ContextCore, Conduit, and Hive integrations."
+        ),
         .trait(
             name: "hive",
             description: "Enable Hive-backed workflow and runtime integration features."

--- a/README.md
+++ b/README.md
@@ -345,7 +345,15 @@ for message in await conversation.messages {
 | tvOS     | 26.0+   |
 | Linux    | Ubuntu 22.04+ with Swift 6.2 |
 
-Foundation Models require iOS 26 / macOS 26. Cloud providers work on any Swift 6.2 platform including Linux.
+Foundation Models require iOS 26 / macOS 26. Linux CI verifies the core
+`Swarm` and `SwarmMCP` build lane with:
+
+```bash
+scripts/ci/verify-linux-core.sh
+```
+
+Provider availability on Linux depends on the selected provider package and its
+published dependency graph.
 
 ## Documentation
 

--- a/Sources/Swarm/Agents/Agent.swift
+++ b/Sources/Swarm/Agents/Agent.swift
@@ -1141,6 +1141,7 @@ public struct Agent: AgentRuntime, Sendable {
     }
 
     static func makeDefaultMemory() throws -> any Memory {
+        #if SWARM_INTEGRATIONS
         if SwarmRuntimeEnvironment.isRunningTests {
             let root = FileManager.default.temporaryDirectory
                 .appendingPathComponent("SwarmDefaultMemoryTests", isDirectory: true)
@@ -1151,10 +1152,14 @@ public struct Agent: AgentRuntime, Sendable {
             ))
         }
         return try DefaultAgentMemory()
+        #else
+        return SlidingWindowMemory()
+        #endif
     }
 
     private func resolvedToolRegistry() async throws -> ToolRegistry {
         let baseTools = await toolRegistry.allTools
+        #if SWARM_INTEGRATIONS
         guard !baseTools.contains(where: { $0.name == "websearch" }) else {
             return try ToolRegistry(tools: baseTools)
         }
@@ -1170,6 +1175,9 @@ public struct Agent: AgentRuntime, Sendable {
         var tools = baseTools
         tools.append(WebSearchTool(configuration: ambientWeb))
         return try ToolRegistry(tools: tools)
+        #else
+        return try ToolRegistry(tools: baseTools)
+        #endif
     }
 
     private func resolvedInferenceOptions(
@@ -1361,11 +1369,13 @@ public struct Agent: AgentRuntime, Sendable {
                         query = input
                     }
                     var windowedContext = ""
+                    #if SWARM_INTEGRATIONS
                     if let defaultMem = activeMemory as? DefaultAgentMemory {
                         windowedContext = await defaultMem.context(for: query, tokenLimit: historyBudget)
                     } else if let ccMemory = activeMemory as? ContextCoreMemory {
                         windowedContext = await ccMemory.context(for: query, tokenLimit: historyBudget)
                     }
+                    #endif
                     if !windowedContext.isEmpty {
                         let livePrompt = buildPrompt(from: conversationHistory)
                         rawPrompt = """

--- a/Sources/Swarm/Core/SendableValue.swift
+++ b/Sources/Swarm/Core/SendableValue.swift
@@ -371,6 +371,10 @@ public extension SendableValue {
         (try? fromJSONObject(value)) ?? .null
     }
 
+    package func toJSONObject() -> Any {
+        _convertToJSONObject()
+    }
+
     // MARK: Private
 
     /// Converts a JSON object to SendableValue.

--- a/Sources/Swarm/Integration/Membrane/MembraneAgentAdapter.swift
+++ b/Sources/Swarm/Integration/Membrane/MembraneAgentAdapter.swift
@@ -1,6 +1,8 @@
 import Foundation
+#if SWARM_INTEGRATIONS
 import Membrane
 import MembraneHive
+#endif
 
 public struct MembraneFeatureConfiguration: Sendable, Equatable {
     public static let `default` = MembraneFeatureConfiguration()
@@ -103,6 +105,7 @@ public protocol MembraneAgentAdapter: Sendable {
     func snapshotCheckpointData() async throws -> Data?
 }
 
+#if SWARM_INTEGRATIONS
 public actor DefaultMembraneAgentAdapter: MembraneAgentAdapter {
     public init(configuration: MembraneFeatureConfiguration = .default) {
         self.configuration = configuration
@@ -403,3 +406,37 @@ public actor DefaultMembraneAgentAdapter: MembraneAgentAdapter {
         let usageCounts: [String: Int]
     }
 }
+#else
+public actor DefaultMembraneAgentAdapter: MembraneAgentAdapter {
+    public init(configuration _: MembraneFeatureConfiguration = .default) {}
+
+    public func plan(
+        prompt: String,
+        toolSchemas: [ToolSchema],
+        profile _: ContextProfile
+    ) async throws -> MembranePlannedBoundary {
+        MembranePlannedBoundary(prompt: prompt, toolSchemas: toolSchemas, mode: "disabled")
+    }
+
+    public func transformToolResult(
+        toolName _: String,
+        output: String,
+        profile _: ContextProfile = .balanced
+    ) async throws -> MembraneToolResultBoundary {
+        MembraneToolResultBoundary(textForConversation: output)
+    }
+
+    public func handleInternalToolCall(
+        name _: String,
+        arguments _: [String: SendableValue]
+    ) async throws -> String? {
+        nil
+    }
+
+    public func restore(checkpointData _: Data?) async throws {}
+
+    public func snapshotCheckpointData() async throws -> Data? {
+        nil
+    }
+}
+#endif

--- a/Sources/Swarm/Internal/GraphRuntime/ToolRegistryAdapter.swift
+++ b/Sources/Swarm/Internal/GraphRuntime/ToolRegistryAdapter.swift
@@ -227,28 +227,3 @@ extension ToolRegistryAdapter {
         }
     }
 }
-
-extension SendableValue {
-    func toJSONObject() -> Any {
-        switch self {
-        case .null:
-            return NSNull()
-        case let .bool(value):
-            return value
-        case let .int(value):
-            return value
-        case let .double(value):
-            return value
-        case let .string(value):
-            return value
-        case let .array(values):
-            return values.map { $0.toJSONObject() }
-        case let .dictionary(values):
-            var result: [String: Any] = [:]
-            for (key, value) in values {
-                result[key] = value.toJSONObject()
-            }
-            return result
-        }
-    }
-}

--- a/Sources/Swarm/Memory/CompositeMemory.swift
+++ b/Sources/Swarm/Memory/CompositeMemory.swift
@@ -25,7 +25,11 @@ actor CompositeMemory: Memory, MemoryPromptDescriptor, MemorySessionLifecycle, M
         self.memoryPromptGuidance = memoryPromptGuidance
         self.memoryPriority = memoryPriority
         self.tokenEstimator = tokenEstimator
+        #if SWARM_INTEGRATIONS
         self.trackedSessionMemory = trackedSessionMemory ?? memories.first { $0 is DefaultAgentMemory }
+        #else
+        self.trackedSessionMemory = trackedSessionMemory
+        #endif
         self.allowsAutomaticSessionSeeding = memories.contains(where: Self.allowsSessionSeeding)
     }
 

--- a/Sources/Swarm/Providers/DefaultInferenceProviderFactory.swift
+++ b/Sources/Swarm/Providers/DefaultInferenceProviderFactory.swift
@@ -10,10 +10,12 @@ import Foundation
 
 enum DefaultInferenceProviderFactory {
     static func makeFoundationModelsProviderIfAvailable() -> (any InferenceProvider)? {
+        #if SWARM_INTEGRATIONS
         #if canImport(FoundationModels)
         if #available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *) {
             return ConduitProviderSelection.foundationModelsIfAvailable()?.makeProvider()
         }
+        #endif
         #endif
         return nil
     }

--- a/Sources/Swarm/Tools/WebSearchTool.swift
+++ b/Sources/Swarm/Tools/WebSearchTool.swift
@@ -273,20 +273,34 @@ public struct WebSearchTool: AnyJSONTool, Sendable {
     }
 
     public func execute(arguments: [String: SendableValue]) async throws -> SendableValue {
+        #if SWARM_INTEGRATIONS
         let request = try parseRequest(arguments: arguments)
         let envelope = try await WebToolRuntime.shared.execute(
             request: request,
             configuration: resolvedConfiguration
         )
         return .string(formatLegacy(envelope))
+        #else
+        throw AgentError.toolExecutionFailed(
+            toolName: name,
+            underlyingError: "Web search requires the Integrations trait."
+        )
+        #endif
     }
 
     public func execute() async throws -> String {
+        #if SWARM_INTEGRATIONS
         let envelope = try await WebToolRuntime.shared.execute(
             request: legacyRequest(),
             configuration: resolvedConfiguration
         )
         return formatLegacy(envelope)
+        #else
+        throw AgentError.toolExecutionFailed(
+            toolName: name,
+            underlyingError: "Web search requires the Integrations trait."
+        )
+        #endif
     }
 
     private var resolvedConfiguration: Configuration {
@@ -296,6 +310,7 @@ public struct WebSearchTool: AnyJSONTool, Sendable {
         return Configuration(apiKey: legacyAPIKey)
     }
 
+    #if SWARM_INTEGRATIONS
     private func parseRequest(arguments: [String: SendableValue]) throws -> WebToolRequest {
         let rawMode = arguments["mode"]?.stringValue ?? mode
         let parsedMode = Mode(rawValue: rawMode.lowercased()) ?? .search
@@ -369,6 +384,7 @@ public struct WebSearchTool: AnyJSONTool, Sendable {
 
         return lines.joined(separator: "\n")
     }
+    #endif
 }
 
 private func nonEmpty(_ value: String) -> String? {

--- a/Sources/Swarm/Workflow/Workflow+Durable.swift
+++ b/Sources/Swarm/Workflow/Workflow+Durable.swift
@@ -55,6 +55,7 @@ public extension Workflow {
 
 extension Workflow {
     func executeDurable(_ input: String, resumeFrom checkpointID: String?) async throws -> AgentResult {
+        #if SWARM_INTEGRATIONS
         guard let checkpoint = advancedConfiguration.checkpoint else {
             if checkpointID != nil {
                 throw WorkflowError.invalidWorkflow(
@@ -88,5 +89,15 @@ extension Workflow {
         return try await executeWithTimeout {
             try await engine.run(startInput: input)
         }
+        #else
+        if checkpointID != nil || advancedConfiguration.checkpoint != nil || advancedConfiguration.checkpointing != nil {
+            throw WorkflowError.invalidWorkflow(
+                reason: "Durable workflow execution requires the Integrations trait."
+            )
+        }
+        return try await executeWithTimeout {
+            try await executeDirect(input: input)
+        }
+        #endif
     }
 }

--- a/Sources/Swarm/Workflow/WorkflowCheckpointing.swift
+++ b/Sources/Swarm/Workflow/WorkflowCheckpointing.swift
@@ -2,19 +2,31 @@ import Foundation
 
 /// Checkpoint persistence configuration for advanced workflows.
 public struct WorkflowCheckpointing: Sendable {
+    #if SWARM_INTEGRATIONS
     let backend: any WorkflowDurableCheckpointStore
 
     init(backend: some WorkflowDurableCheckpointStore) {
         self.backend = backend
     }
+    #else
+    init() {}
+    #endif
 
     /// In-memory checkpoint persistence.
     public static func inMemory() -> WorkflowCheckpointing {
+        #if SWARM_INTEGRATIONS
         WorkflowCheckpointing(backend: WorkflowInMemoryCheckpointStore())
+        #else
+        WorkflowCheckpointing()
+        #endif
     }
 
     /// File-system checkpoint persistence rooted at `directory`.
     public static func fileSystem(directory: URL) -> WorkflowCheckpointing {
+        #if SWARM_INTEGRATIONS
         WorkflowCheckpointing(backend: WorkflowFileCheckpointStore(directory: directory))
+        #else
+        WorkflowCheckpointing()
+        #endif
     }
 }

--- a/Tests/SwarmTests/DocumentationFreshnessTests.swift
+++ b/Tests/SwarmTests/DocumentationFreshnessTests.swift
@@ -128,6 +128,62 @@ struct DocumentationFreshnessTests {
         }
     }
 
+    @Test("docs workflow builds pull requests without deploying Pages")
+    func docsWorkflowBuildsPullRequestsWithoutDeployingPages() throws {
+        let workflow = try readRepoFile(".github/workflows/docs.yml")
+
+        #expect(workflow.contains("pull_request:"))
+        #expect(workflow.contains("if: github.event_name != 'pull_request'"))
+        #expect(workflow.contains("npm run docs:build"))
+    }
+
+    @Test("release checklist includes docs and example pre-tag gates")
+    func releaseChecklistIncludesDocsAndExamplePreTagGates() throws {
+        let checklist = try readRepoFile("docs/release/release-checklist.md")
+
+        #expect(checklist.contains("npm ci"))
+        #expect(checklist.contains("npm run docs:build"))
+        #expect(checklist.contains("SWARM_CORE_ONLY=1 swift test --package-path Examples/CodeReviewer"))
+        #expect(checklist.contains("scripts/ci/verify-remote-release.sh"))
+    }
+
+    @Test("remote release verifier runs the standalone CodeReviewer example")
+    func remoteReleaseVerifierRunsCodeReviewerExample() throws {
+        let script = try readRepoFile("scripts/ci/verify-remote-release.sh")
+
+        #expect(script.contains("SWARM_CORE_ONLY=1"))
+        #expect(script.contains("swift test --package-path Examples/CodeReviewer"))
+        #expect(script.contains("EXAMPLE_LOG="))
+        #expect(script.contains("CodeReviewer test log"))
+    }
+
+    @Test("Linux workflow runs the shared core-lane verifier")
+    func linuxWorkflowRunsSharedCoreLaneVerifier() throws {
+        let workflow = try readRepoFile(".github/workflows/swift.yml")
+        let script = try readRepoFile("scripts/ci/verify-linux-core.sh")
+
+        #expect(workflow.contains("Build (Linux Core)"))
+        #expect(workflow.contains("scripts/ci/verify-linux-core.sh"))
+        #expect(workflow.contains("SWARM_CORE_ONLY=1 swift test"))
+        #expect(script.contains("SWARM_CORE_ONLY=1"))
+        #expect(script.contains("--disable-default-traits --target Swarm"))
+        #expect(script.contains("--disable-default-traits --target SwarmMCP"))
+    }
+
+    @Test("public Linux docs point at the core verifier instead of overclaiming provider parity")
+    func publicLinuxDocsPointAtCoreVerifier() throws {
+        let checkedFiles = [
+            "README.md",
+            "docs/guide/getting-started.md",
+        ]
+
+        for file in checkedFiles {
+            let text = try readRepoFile(file)
+            #expect(text.contains("scripts/ci/verify-linux-core.sh"), "\(file) should point at the Linux core verifier")
+            #expect(text.contains("Provider availability on Linux depends"), "\(file) should qualify provider support")
+        }
+    }
+
     private func readRepoFile(_ relativePath: String) throws -> String {
         try String(contentsOf: repoRoot.appendingPathComponent(relativePath), encoding: .utf8)
     }

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -253,7 +253,10 @@ agent.environment(\.inferenceProvider, .anthropic(key: "sk-..."))
 | Linux | Ubuntu 22.04+ with Swift 6.2 |
 
 ::: tip
-Foundation Models require iOS 26 / macOS 26. Cloud providers (Anthropic, OpenAI, Ollama) work on any Swift 6.2 platform including Linux.
+Foundation Models require iOS 26 / macOS 26. Linux CI verifies the core
+`Swarm` and `SwarmMCP` build lane with `scripts/ci/verify-linux-core.sh`.
+Provider availability on Linux depends on the selected provider package and its
+published dependency graph.
 :::
 
 ## Next Steps

--- a/docs/reference/api-catalog.md
+++ b/docs/reference/api-catalog.md
@@ -3,7 +3,7 @@
 Generated from `Sources/Swarm/` on 2026-04-30.
 
 - Scope: all `.swift` files under `Sources/Swarm/`, excluding `Internal/GraphRuntime/`
-- Source files scanned: 154
+- Source files scanned: 155
 - Public/open symbols cataloged: 2423
 
 ## 1. Swarm (entry point)

--- a/docs/release/release-checklist.md
+++ b/docs/release/release-checklist.md
@@ -8,10 +8,14 @@ Publish a `Swarm` GitHub tag that downstream users can resolve and build without
 
 1. Update release notes and changelog content.
 2. Verify `Package.swift` uses the intended published dependency graph for remote consumers.
-3. Run remote-only verification:
+3. Run local documentation and example verification:
+   - `npm ci`
+   - `npm run docs:build`
+   - `SWARM_CORE_ONLY=1 swift test --package-path Examples/CodeReviewer`
+4. Run remote-only verification:
    - `scripts/ci/verify-remote-release.sh`
-4. Confirm no compiler warnings or errors appear in the release build logs.
-5. Smoke-test consumption from a clean external package after tagging.
+5. Confirm no compiler warnings or errors appear in the release build logs.
+6. Smoke-test consumption from a clean external package after tagging.
 
 ## User-Owned Steps
 
@@ -24,6 +28,8 @@ Publish a `Swarm` GitHub tag that downstream users can resolve and build without
 - Working tree is intentional and reviewed.
 - `swift build` passes.
 - `swift test` passes.
+- `npm run docs:build` passes after a clean `npm ci`.
+- `SWARM_CORE_ONLY=1 swift test --package-path Examples/CodeReviewer` passes.
 - `scripts/ci/verify-remote-release.sh` passes.
 - README/examples still match the public package interface.
 - If `Swarm` depends on newer published internal tags, those upstream tags already exist.

--- a/scripts/ci/verify-linux-core.sh
+++ b/scripts/ci/verify-linux-core.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+JOBS="${SWIFT_BUILD_JOBS:-1}"
+
+echo "linux-core: build Swarm with default traits disabled"
+SWARM_CORE_ONLY=1 CONDUIT_SKIP_MLX_DEPS=1 swift build -j "$JOBS" --disable-default-traits --target Swarm
+
+echo "linux-core: build SwarmMCP with default traits disabled"
+SWARM_CORE_ONLY=1 CONDUIT_SKIP_MLX_DEPS=1 swift build -j "$JOBS" --disable-default-traits --target SwarmMCP

--- a/scripts/ci/verify-remote-release.sh
+++ b/scripts/ci/verify-remote-release.sh
@@ -6,12 +6,14 @@ cd "$ROOT_DIR"
 
 BUILD_LOG="${BUILD_LOG:-/tmp/swarm-release-build.log}"
 TEST_LOG="${TEST_LOG:-/tmp/swarm-release-test.log}"
+EXAMPLE_LOG="${EXAMPLE_LOG:-/tmp/swarm-release-codereviewer-test.log}"
 
 echo "release-check: remote-only resolve/build/test for Swarm"
 
 AISTACK_USE_LOCAL_DEPS=0 CONDUIT_SKIP_MLX_DEPS=1 swift package resolve
 AISTACK_USE_LOCAL_DEPS=0 CONDUIT_SKIP_MLX_DEPS=1 swift build 2>&1 | tee "$BUILD_LOG"
 AISTACK_USE_LOCAL_DEPS=0 CONDUIT_SKIP_MLX_DEPS=1 swift test 2>&1 | tee "$TEST_LOG"
+SWARM_CORE_ONLY=1 AISTACK_USE_LOCAL_DEPS=0 CONDUIT_SKIP_MLX_DEPS=1 swift test --package-path Examples/CodeReviewer 2>&1 | tee "$EXAMPLE_LOG"
 
 if rg -n '\bwarning:|\berror:' "$BUILD_LOG" >/dev/null; then
   echo "release-check: compiler diagnostics found in build log" >&2
@@ -22,6 +24,12 @@ fi
 if rg -n '\bwarning:' "$TEST_LOG" >/dev/null; then
   echo "release-check: compiler warnings found in test log" >&2
   rg -n '\bwarning:' "$TEST_LOG" >&2 || true
+  exit 1
+fi
+
+if rg -n '\bwarning:' "$EXAMPLE_LOG" >/dev/null; then
+  echo "release-check: compiler warnings found in CodeReviewer test log" >&2
+  rg -n '\bwarning:' "$EXAMPLE_LOG" >&2 || true
   exit 1
 fi
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,35 @@
+# Audit Docs/Release/Linux Plan
+
+Branch: `codex/audit-docs-release-linux-20260517`
+Base: `origin/codex/fix-mcp-text-content-tests`
+Scope: docs/release/example/Linux cluster only: `SWARM-AUDIT-048`, `049`, `050`, `054`, `057`, `058`.
+
+## Assumptions To Research First
+
+- [x] Confirm each audit ID maps to docs, release, example, or Linux/core-lane files.
+- [x] Confirm existing CI/docs/example commands and avoid expanding beyond the owned cluster.
+- [x] Confirm the practical local proof commands before editing.
+
+## Implementation Checklist
+
+- [x] `SWARM-AUDIT-048`: docs workflow builds on PRs and only deploys Pages outside PRs.
+- [x] `SWARM-AUDIT-049`: remote release verification script exists, is executable, and is covered by docs freshness tests.
+- [x] `SWARM-AUDIT-050`: CodeReviewer has a real executable entrypoint and standalone tests; CI/release gates run it in the core lane.
+- [x] `SWARM-AUDIT-054`: release verifier fails on warning diagnostics from build/test/example logs.
+- [x] `SWARM-AUDIT-057`: `SWARM_CORE_ONLY=1` removes integration dependencies and gates source references for core-only builds.
+- [x] `SWARM-AUDIT-058`: Linux CI now runs the shared core verifier for `Swarm` and `SwarmMCP`.
+
+## Verification Plan
+
+- [x] Run targeted docs/release/example/Linux commands as practical.
+- [ ] Run `git diff --check`.
+- [ ] Push branch and open PR against `codex/fix-mcp-text-content-tests` with `gh --repo christopherkarani/Swarm`.
+
+## Review Results
+
+- `swift test --filter DocumentationFreshnessTests` passed.
+- `npm ci` passed; npm reported four moderate audit findings in VitePress transitive dependencies.
+- `npm run docs:build` passed.
+- `SWARM_CORE_ONLY=1 swift test --package-path Examples/CodeReviewer` passed.
+- `CONDUIT_SKIP_MLX_DEPS=1 swift build --target Swarm` passed.
+- `scripts/ci/verify-linux-core.sh` passed for `Swarm` and `SwarmMCP`.


### PR DESCRIPTION
## Summary
- add a core-only package lane that avoids optional integration dependency resolution
- make Linux CI run the shared core verifier for Swarm and SwarmMCP
- build docs on PRs without deploying Pages
- wire release gates for docs, CodeReviewer, and warning-free logs
- keep CodeReviewer runnable as a core-lane standalone example

## Verification
- swift test --filter DocumentationFreshnessTests
- npm ci
- npm run docs:build
- SWARM_CORE_ONLY=1 swift test --package-path Examples/CodeReviewer
- CONDUIT_SKIP_MLX_DEPS=1 swift build --target Swarm
- scripts/ci/verify-linux-core.sh
- git diff --check

Note: npm ci reports 4 moderate npm audit findings in VitePress transitive dependencies; docs build still passes.