### PR TITLE
fix: harden workflow timeout race

### DIFF
--- a/Sources/Swarm/Workflow/Workflow.swift
+++ b/Sources/Swarm/Workflow/Workflow.swift
@@ -530,12 +530,13 @@ public struct Workflow: Sendable {
     ) async throws -> AgentResult {
         if let timeoutDuration {
             let coordinator = WorkflowTimedOperationCoordinator<AgentResult>()
+            let priority = Task.currentPriority
             return try await withTaskCancellationHandler(
                 operation: {
                     try await withCheckedThrowingContinuation { continuation in
                         coordinator.install(continuation: continuation)
 
-                        let operationTask = Task {
+                        let operationTask = Task.detached(priority: priority) {
                             do {
                                 coordinator.finish(returning: try await operation())
                             } catch {
@@ -544,7 +545,7 @@ public struct Workflow: Sendable {
                         }
                         coordinator.setOperationTask(operationTask)
 
-                        let timeoutTask = Task {
+                        let timeoutTask = Task.detached(priority: priority) {
                             do {
                                 try await Task.sleep(for: timeoutDuration)
                                 operationTask.cancel()


### PR DESCRIPTION
## Summary
- switch workflow timeout helper tasks to detached tasks while preserving caller priority
- decouple timeout completion from blocked workflow work so non-cooperative steps cannot hold the caller open
- keep the change surgical to the workflow timeout path only

## Problem
The framework regression suite exposed an intermittent failure in `Workflow timeout returns without waiting for non-cooperative work`. Under wider suite contention, the workflow timeout path could return later than the API contract allows even though the timeout duration had already expired.

## Fix
`Workflow.executeWithTimeout` now launches both the wrapped operation and the timeout watchdog with `Task.detached(priority: Task.currentPriority)`. That keeps timeout completion independent from the blocked workflow's execution context while still preserving the caller's priority.

## Verification
- `swift test --filter FrameworkDXRegressionTests/workflowTimeoutReturnsWithoutWaitingForNonCooperativeWork` repeated 5 times
- `swift test`
- `swift build`

## Notes
- Left unrelated local changes in `.gitignore`, `.omo/`, and `.orca/` untouched.
