### PR TITLE
feat: Foundation Models DX polish, demos, and production-readiness fixes

### DIFF
--- a/Examples/MultiAgentPipeline/Package.swift
+++ b/Examples/MultiAgentPipeline/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 6.2
+import PackageDescription
+
+let package = Package(
+    name: "MultiAgentPipeline",
+    platforms: [.macOS(.v26)],
+    dependencies: [
+        .package(name: "Swarm", path: "../../"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "MultiAgentPipeline",
+            dependencies: [
+                .product(name: "Swarm", package: "Swarm"),
+            ],
+            path: "Sources/MultiAgentPipeline",
+            swiftSettings: [
+                .enableExperimentalFeature("StrictConcurrency"),
+            ]
+        ),
+    ]
+)

--- a/Examples/MultiAgentPipeline/README.md
+++ b/Examples/MultiAgentPipeline/README.md
@@ -1,0 +1,20 @@
+# MultiAgentPipeline
+
+End-to-end Swarm demo for multi-agent workflows and durable execution.
+
+## What it shows
+
+- Sequential `Workflow().step(...).step(...).run(...)`
+- Parallel fan-out with `.parallel(..., merge: .structured)`
+- Durable checkpoint + resume (`.durable.checkpoint` / `.durable.execute`)
+- Optional live Foundation Models for both agents
+- Deterministic `--demo` mode with scripted providers (CI-safe)
+
+## Run
+
+```bash
+swift run MultiAgentPipeline --demo
+swift run MultiAgentPipeline              # live FM when available
+```
+
+Requires macOS 26+ and a path dependency on the Swarm package (`../../`).

--- a/Examples/MultiAgentPipeline/Sources/MultiAgentPipeline/main.swift
+++ b/Examples/MultiAgentPipeline/Sources/MultiAgentPipeline/main.swift
@@ -1,0 +1,231 @@
+// MultiAgentPipeline — Swarm multi-agent + durable workflow demo.
+//
+// Demonstrates:
+// - Sequential Workflow steps (research → write)
+// - Parallel fan-out with structured merge
+// - Durable checkpoint + resume
+// - Foundation Models for live on-device runs (optional)
+// - Deterministic `--demo` mode for CI (scripted providers, no keys)
+//
+// Usage:
+//   swift run MultiAgentPipeline --demo
+//   swift run MultiAgentPipeline              # live FM when available
+//   swift run MultiAgentPipeline --help
+
+import Foundation
+import Swarm
+
+@main
+struct MultiAgentPipelineMain {
+    static func main() async {
+        do {
+            try await run(arguments: Array(CommandLine.arguments.dropFirst()))
+        } catch {
+            fputs("MultiAgentPipeline error: \(error)\n", stderr)
+            exit(1)
+        }
+    }
+}
+
+private func run(arguments: [String]) async throws {
+    if arguments.contains("-h") || arguments.contains("--help") {
+        print(
+            """
+            MultiAgentPipeline — Swarm workflow demo
+
+            Usage:
+              swift run MultiAgentPipeline [--demo]
+
+            Options:
+              --demo   Scripted providers (deterministic, no API keys / no FM required)
+              --help   Show this help
+
+            Without --demo, uses Apple Foundation Models when available for both agents.
+            """
+        )
+        return
+    }
+
+    let demoMode = arguments.contains("--demo")
+    let topic = "on-device Swift agents with Foundation Models"
+
+    let researchProvider: any InferenceProvider
+    let writerProvider: any InferenceProvider
+    let parallelA: any InferenceProvider
+    let parallelB: any InferenceProvider
+    let durableProvider: any InferenceProvider
+    let modeLabel: String
+
+    if demoMode {
+        researchProvider = ScriptedTextProvider(responses: [
+            "Facts: 1) Swarm agents are Sendable. 2) Foundation Models run on-device. 3) Workflows support checkpoints.",
+        ])
+        writerProvider = ScriptedTextProvider(responses: [
+            "Summary: Swarm lets you build private on-device Swift agents with tools, workflows, and crash-safe checkpoints.",
+        ])
+        parallelA = ScriptedTextProvider(responses: ["bullish: strong local privacy story"])
+        parallelB = ScriptedTextProvider(responses: ["bearish: model capability still smaller than cloud"])
+        durableProvider = ScriptedTextProvider(responses: ["working", "done"])
+        modeLabel = "demo (scripted)"
+    } else {
+        #if canImport(FoundationModels)
+            if #available(macOS 26.0, iOS 26.0, visionOS 26.0, *) {
+                guard let fm = FoundationModelsInferenceProvider.ifAvailable() else {
+                    fputs(
+                        "Foundation Models unavailable. Re-run with --demo.\n",
+                        stderr
+                    )
+                    exit(2)
+                }
+                // Separate provider instances keep session state isolated per agent.
+                researchProvider = FoundationModelsInferenceProvider(
+                    configuration: .init(instructions: "Extract 3 short factual bullets.")
+                )
+                writerProvider = FoundationModelsInferenceProvider(
+                    configuration: .init(instructions: "Write one concise paragraph from research notes.")
+                )
+                parallelA = fm
+                parallelB = FoundationModelsInferenceProvider(
+                    configuration: .init(instructions: "Be skeptical and concise.")
+                )
+                durableProvider = FoundationModelsInferenceProvider(
+                    configuration: .init(instructions: "Reply with a single status word.")
+                )
+                modeLabel = "foundation-models (live)"
+            } else {
+                fputs("OS below Foundation Models availability. Use --demo.\n", stderr)
+                exit(2)
+            }
+        #else
+            fputs("FoundationModels not importable. Use --demo.\n", stderr)
+            exit(2)
+        #endif
+    }
+
+    let researcher = try Agent(
+        "Research the topic and list key facts only.",
+        configuration: .default.name("Researcher"),
+        memory: .conversation(maxMessages: 16),
+        inferenceProvider: researchProvider
+    )
+    let writer = try Agent(
+        "Write a concise summary from the research notes you receive.",
+        configuration: .default.name("Writer"),
+        memory: .conversation(maxMessages: 16),
+        inferenceProvider: writerProvider
+    )
+
+    print("Swarm \(Swarm.version) · mode=\(modeLabel)")
+    print("--- sequential research → write ---")
+    let sequential = try await Workflow()
+        .step(researcher)
+        .step(writer)
+        .run(topic)
+    print(sequential.output)
+
+    print("--- parallel fan-out ---")
+    let bull = try Agent(
+        "Give a short bullish take.",
+        memory: .conversation(maxMessages: 8),
+        inferenceProvider: parallelA
+    )
+    let bear = try Agent(
+        "Give a short bearish take.",
+        memory: .conversation(maxMessages: 8),
+        inferenceProvider: parallelB
+    )
+    let parallel = try await Workflow()
+        .parallel([bull, bear], merge: .structured)
+        .run(topic)
+    print(parallel.output)
+
+    print("--- durable checkpoint + resume ---")
+    let monitor = try Agent(
+        "Emit a short status; eventually say done.",
+        memory: .conversation(maxMessages: 8),
+        inferenceProvider: durableProvider
+    )
+    let checkpointing = WorkflowCheckpointing.inMemory()
+    let durableWorkflow = Workflow()
+        .step(monitor)
+        .repeatUntil(maxIterations: 4) { $0.output.lowercased().contains("done") }
+        .durable
+        .checkpoint(id: "pipeline-monitor", policy: .everyStep)
+        .durable
+        .checkpointing(checkpointing)
+
+    _ = try await durableWorkflow.durable.execute("start")
+    let resumed = try await durableWorkflow.durable.execute("ignored", resumeFrom: "pipeline-monitor")
+    print("resumed=\(resumed.output)")
+
+    if demoMode {
+        let okSeq = sequential.output.lowercased().contains("swarm")
+            || sequential.output.lowercased().contains("on-device")
+            || sequential.output.lowercased().contains("summary")
+        let okPar = parallel.output.lowercased().contains("bullish")
+            && parallel.output.lowercased().contains("bearish")
+        let okDur = resumed.output.lowercased().contains("done")
+        guard okSeq, okPar, okDur else {
+            throw PipelineError.unexpected(
+                "demo checks failed seq=\(sequential.output) par=\(parallel.output) dur=\(resumed.output)"
+            )
+        }
+        print("demo checks: sequential=ok parallel=ok durable=ok")
+    }
+
+    print("primary_output=\(sequential.output)")
+}
+
+// MARK: - Scripted provider
+
+private actor ScriptedTextProvider: InferenceProvider {
+    private var responses: [String]
+    private var index = 0
+
+    init(responses: [String]) {
+        self.responses = responses
+    }
+
+    func generate(prompt: String, options: InferenceOptions) async throws -> String {
+        next()
+    }
+
+    nonisolated func stream(prompt: String, options: InferenceOptions) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in
+            Task {
+                do {
+                    let text = try await self.generate(prompt: prompt, options: options)
+                    continuation.yield(text)
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+        }
+    }
+
+    func generateWithToolCalls(
+        prompt: String,
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) async throws -> InferenceResponse {
+        InferenceResponse(content: next(), finishReason: .completed)
+    }
+
+    private func next() -> String {
+        defer { index += 1 }
+        guard index < responses.count else {
+            return responses.last ?? "done"
+        }
+        return responses[index]
+    }
+}
+
+private enum PipelineError: Error, CustomStringConvertible {
+    case unexpected(String)
+    var description: String {
+        switch self {
+        case let .unexpected(message): message
+        }
+    }
+}

--- a/Examples/OnDeviceChat/Package.swift
+++ b/Examples/OnDeviceChat/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 6.2
+import PackageDescription
+
+let package = Package(
+    name: "OnDeviceChat",
+    platforms: [.macOS(.v26)],
+    dependencies: [
+        .package(name: "Swarm", path: "../../"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "OnDeviceChat",
+            dependencies: [
+                .product(name: "Swarm", package: "Swarm"),
+            ],
+            path: "Sources/OnDeviceChat",
+            swiftSettings: [
+                .enableExperimentalFeature("StrictConcurrency"),
+            ]
+        ),
+    ]
+)

--- a/Examples/OnDeviceChat/README.md
+++ b/Examples/OnDeviceChat/README.md
@@ -1,0 +1,24 @@
+# OnDeviceChat
+
+Minimal end-to-end Swarm demo for **Apple Foundation Models**.
+
+## What it shows
+
+- `Agent` with `@Tool` + `FunctionTool`
+- Streaming via `agent.stream`
+- Multi-turn `Conversation`
+- First-class `.foundationModels()` / `FoundationModelsInferenceProvider.ifAvailable()`
+- Deterministic `--demo` mode (no Apple Intelligence required)
+
+## Run
+
+```bash
+# From this directory
+swift run OnDeviceChat --demo          # always works; scripted provider
+swift run OnDeviceChat                 # live on-device when Apple Intelligence is available
+swift run OnDeviceChat "Hello"         # custom prompt (live path)
+```
+
+Requires macOS 26+ and a path dependency on the Swarm package (`../../`).
+
+No API keys. Live mode needs a device where `FoundationModelsInferenceProvider.isAvailable` is true.

--- a/Examples/OnDeviceChat/Sources/OnDeviceChat/main.swift
+++ b/Examples/OnDeviceChat/Sources/OnDeviceChat/main.swift
@@ -1,0 +1,228 @@
+// OnDeviceChat — end-to-end Swarm demo for Apple Foundation Models.
+//
+// Zero external API keys. Demonstrates:
+// - Agent + @Tool / FunctionTool
+// - Streaming tokens
+// - Multi-turn Conversation
+// - On-device `.foundationModels()` when available
+// - Deterministic `--demo` mode for CI / environments without Apple Intelligence
+//
+// Usage:
+//   swift run OnDeviceChat              # live Foundation Models when available
+//   swift run OnDeviceChat --demo       # scripted provider (always deterministic)
+//   swift run OnDeviceChat --help
+
+import Foundation
+import Swarm
+
+@main
+struct OnDeviceChatMain {
+    static func main() async {
+        do {
+            try await run(arguments: Array(CommandLine.arguments.dropFirst()))
+        } catch {
+            fputs("OnDeviceChat error: \(error)\n", stderr)
+            exit(1)
+        }
+    }
+}
+
+@Tool("Adds two integers.")
+struct AddTool {
+    @Parameter("Left-hand value") var lhs: Int = 0
+    @Parameter("Right-hand value") var rhs: Int = 0
+
+    func execute() async throws -> String {
+        String(lhs + rhs)
+    }
+}
+
+private func run(arguments: [String]) async throws {
+    if arguments.contains("-h") || arguments.contains("--help") {
+        print(
+            """
+            OnDeviceChat — Swarm on-device chat demo
+
+            Usage:
+              swift run OnDeviceChat [--demo] [prompt]
+
+            Options:
+              --demo   Use a scripted inference provider (no Foundation Models required)
+              --help   Show this help
+
+            Without --demo, uses Apple Foundation Models when the system model is available.
+            """
+        )
+        return
+    }
+
+    let demoMode = arguments.contains("--demo")
+    let promptParts = arguments.filter { $0 != "--demo" }
+    let userPrompt = promptParts.isEmpty
+        ? "What is 20 + 22? Use the add tool, then answer in one short sentence."
+        : promptParts.joined(separator: " ")
+
+    let provider: any InferenceProvider
+    let modeLabel: String
+
+    if demoMode {
+        provider = DemoScriptedProvider()
+        modeLabel = "demo (scripted)"
+    } else {
+        #if canImport(FoundationModels)
+            if #available(macOS 26.0, iOS 26.0, visionOS 26.0, *) {
+                if let fm = FoundationModelsInferenceProvider.ifAvailable(
+                    configuration: .init(instructions: "You are a concise on-device assistant.")
+                ) {
+                    provider = fm
+                    modeLabel = "foundation-models (live)"
+                } else {
+                    fputs(
+                        """
+                        Foundation Models system model is not available on this device.
+                        Re-run with --demo for a deterministic walkthrough, or enable Apple Intelligence.
+
+                        """,
+                        stderr
+                    )
+                    exit(2)
+                }
+            } else {
+                fputs("This OS is below Foundation Models availability. Use --demo.\n", stderr)
+                exit(2)
+            }
+        #else
+            fputs("FoundationModels is not importable on this platform. Use --demo.\n", stderr)
+            exit(2)
+        #endif
+    }
+
+    let agent = try Agent(
+        "You are a helpful on-device assistant. Prefer tools for arithmetic.",
+        configuration: .default.name("OnDeviceChat"),
+        memory: .conversation(maxMessages: 32),
+        inferenceProvider: provider
+    ) {
+        AddTool()
+        FunctionTool(
+            name: "uppercase",
+            description: "Uppercases text",
+            parameters: [
+                ToolParameter(name: "text", description: "Text to uppercase", type: .string),
+            ]
+        ) { args in
+            let text = try args.require("text", as: String.self)
+            return .string(text.uppercased())
+        }
+    }
+
+    print("Swarm \(Swarm.version) · mode=\(modeLabel)")
+    print("--- stream ---")
+
+    var streamed = ""
+    var toolNames: [String] = []
+    for try await event in agent.stream(userPrompt) {
+        switch event {
+        case let .output(.token(token)):
+            print(token, terminator: "")
+            fflush(stdout)
+            streamed += token
+        case let .tool(.completed(call, _)):
+            toolNames.append(call.toolName)
+            print("\n[tool: \(call.toolName)]", terminator: "")
+            fflush(stdout)
+        case let .lifecycle(.completed(result)):
+            if streamed.isEmpty {
+                streamed = result.output
+                print(result.output, terminator: "")
+            }
+            print("\n--- done (\(result.duration)) ---")
+        case let .lifecycle(.failed(error)):
+            throw error
+        default:
+            break
+        }
+    }
+
+    print("--- conversation ---")
+    // Use a benign multi-turn prompt: some on-device safety policies refuse "secret/codeword" framing.
+    let conversation = Conversation(with: agent)
+    let first = try await conversation.send("My favorite color is teal.")
+    let second = try await conversation.send("What is my favorite color?")
+    print("turn1: \(first.output)")
+    print("turn2: \(second.output)")
+
+    // Primary success criteria for --demo: arithmetic tool path and multi-turn reply.
+    if demoMode {
+        let okArithmetic = streamed.contains("42") || toolNames.contains(where: { $0.lowercased().contains("add") })
+        let okMemory = second.output.lowercased().contains("teal")
+        guard okArithmetic, okMemory else {
+            throw DemoError.unexpectedOutput(
+                "demo expected arithmetic result and teal in follow-up; got stream=\(streamed) turn2=\(second.output)"
+            )
+        }
+        print("demo checks: arithmetic=ok memory=ok")
+    }
+
+    print("primary_output=\(streamed)")
+}
+
+// MARK: - Deterministic demo provider
+
+/// Scripted provider for CI / machines without Apple Intelligence.
+private actor DemoScriptedProvider: InferenceProvider {
+    private var toolTurn = 0
+    private var chatTurn = 0
+
+    func generate(prompt: String, options: InferenceOptions) async throws -> String {
+        "ok"
+    }
+
+    nonisolated func stream(prompt: String, options: InferenceOptions) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in
+            continuation.yield("The ")
+            continuation.yield("sum ")
+            continuation.yield("is ")
+            continuation.yield("42.")
+            continuation.finish()
+        }
+    }
+
+    func generateWithToolCalls(
+        prompt: String,
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) async throws -> InferenceResponse {
+        // First agent.stream / run turn: request the add tool, then finalize.
+        if toolTurn == 0, tools.contains(where: { $0.name.lowercased().contains("add") }) {
+            toolTurn += 1
+            let name = tools.first(where: { $0.name.lowercased().contains("add") })!.name
+            return InferenceResponse(
+                toolCalls: [
+                    .init(id: "demo-add", name: name, arguments: ["lhs": .int(20), "rhs": .int(22)]),
+                ],
+                finishReason: .toolCall
+            )
+        }
+        if toolTurn == 1 {
+            toolTurn += 1
+            return InferenceResponse(content: "The sum is 42.", finishReason: .completed)
+        }
+
+        // Conversation turns
+        chatTurn += 1
+        if chatTurn == 1 {
+            return InferenceResponse(content: "Got it — favorite color teal saved.", finishReason: .completed)
+        }
+        return InferenceResponse(content: "Your favorite color is teal.", finishReason: .completed)
+    }
+}
+
+private enum DemoError: Error, CustomStringConvertible {
+    case unexpectedOutput(String)
+    var description: String {
+        switch self {
+        case let .unexpectedOutput(message): message
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -46,9 +46,11 @@ struct PriceTool {
 }
 
 // Create an agent with unlabeled instructions first and tools in the trailing @ToolBuilder closure
+// Prefer on-device Foundation Models when you can (no API key):
+//   inferenceProvider: .foundationModels()
 let agent = try Agent("Answer finance questions using real data.",
-    configuration: .init(name: "Analyst"),
-    inferenceProvider: .anthropic(key: "{ENV")) {
+    configuration: .default.name("Analyst"),
+    inferenceProvider: .anthropic(apiKey: "sk-...")) {
     PriceTool()
     CalculatorTool()
 }
@@ -98,9 +100,24 @@ swift run SwarmCapabilityShowcase smoke
 
 The deterministic matrix is CI-safe. Live-provider smoke coverage is opt-in through environment variables. See [docs/guide/capability-showcase.md](docs/guide/capability-showcase.md) for the scenario catalog and smoke-mode details.
 
+### End-to-end example apps
+
+Two minimal, buildable apps under `Examples/` stress the public API:
+
+| Example | What it proves |
+| --- | --- |
+| [`Examples/OnDeviceChat`](Examples/OnDeviceChat) | Foundation Models chat with `@Tool`, streaming, and multi-turn `Conversation` (zero API keys; `--demo` for CI) |
+| [`Examples/MultiAgentPipeline`](Examples/MultiAgentPipeline) | Sequential + parallel workflows and durable checkpoint/resume (`--demo` for CI) |
+| [`Examples/CodeReviewer`](Examples/CodeReviewer) | Lightweight CLI that links Swarm and prints a deterministic review plan |
+
+```bash
+cd Examples/OnDeviceChat && swift run OnDeviceChat --demo
+cd Examples/MultiAgentPipeline && swift run MultiAgentPipeline --demo
+```
+
 ### Optional demos
 
-Demo executables are opt-in so the default library graph stays focused on the framework products:
+Package-root demo executables are opt-in so the default library graph stays focused on the framework products:
 
 ```bash
 SWARM_INCLUDE_DEMO=1 swift build
@@ -108,16 +125,42 @@ SWARM_INCLUDE_DEMO=1 swift run SwarmDemo
 SWARM_INCLUDE_DEMO=1 swift run SwarmMCPServerDemo
 ```
 
+## Foundation Models First
+
+For Apple platforms, prefer the first-class on-device path — no Conduit, no API keys:
+
+```swift
+import Swarm
+
+// Requires macOS/iOS 26+ and Apple Intelligence available on the device.
+let agent = try Agent(
+    "You are a private on-device assistant.",
+    inferenceProvider: .foundationModels()
+) {
+    // @Tool structs or FunctionTool values
+}
+
+let result = try await agent.run("Summarize my notes.")
+```
+
+Notes that matter in production:
+
+- **Availability**: use `FoundationModelsInferenceProvider.ifAvailable()` or check `FoundationModelsInferenceProvider.isAvailable` before assuming the system model is ready.
+- **Tool calling**: Swarm bridges `@Tool` / `ToolSchema` to Apple's `FoundationModels.Tool` and executes tools in the agent loop with guardrails intact.
+- **Streaming tool calls**: not advertised; streaming is text deltas, tools complete as capture-then-execute turns.
+- **Dynamic profiles**: `.foundationModels(profile:)` re-resolves instructions/tools/history every turn (WWDC 2026–aligned Swarm API).
+- **Linux / CI**: Foundation Models is compile-time gated; use Ollama/cloud providers or the deterministic `--demo` modes in `Examples/`.
+
 ### Multi-agent pipeline
 
 ```swift
 let researcher = try Agent("Research the topic and extract key facts.",
-    inferenceProvider: .anthropic(key: "sk-...")) {
+    inferenceProvider: .anthropic(apiKey: "sk-...")) {
     WebSearchTool()
 }
 
 let writer = try Agent("Write a concise summary from the research.",
-    inferenceProvider: .anthropic(key: "sk-..."))
+    inferenceProvider: .anthropic(apiKey: "sk-..."))
 
 let result = try await Workflow()
     .step(researcher)
@@ -169,8 +212,8 @@ for try await event in agent.stream("Summarize the changelog.") {
 
 ```swift
 let agent = try Agent("You remember past conversations.",
-    inferenceProvider: .anthropic(key: "sk-..."),
-    memory: .vector(embeddingProvider: myEmbedder, similarityThreshold: 0.75)) {
+    memory: .vector(embeddingProvider: myEmbedder, similarityThreshold: 0.75),
+    inferenceProvider: .anthropic(apiKey: "sk-...")) {
     // tools
 }
 ```
@@ -216,7 +259,7 @@ let resumed = try await workflow.durable.execute("watch", resumeFrom: "monitor-v
 let local = try Agent("Be helpful.", inferenceProvider: .foundationModels())
 
 // Cloud
-let cloud = try Agent("Be helpful.", inferenceProvider: .anthropic(key: k))
+let cloud = try Agent("Be helpful.", inferenceProvider: .anthropic(apiKey: k))
 
 // Or swap at runtime via environment
 let modified = agent.environment(\.inferenceProvider, .ollama(model: "mistral"))

--- a/Sources/Swarm/Providers/Conduit/LLM.swift
+++ b/Sources/Swarm/Providers/Conduit/LLM.swift
@@ -458,33 +458,25 @@ extension LLM: ToolCallStreamingConversationInferenceProvider {
 
 // MARK: - Dot-syntax Entry Points
 
+/// Beginner-friendly `key:` aliases on `LLM`.
+///
+/// Prefer ``ConduitProviderSelection`` factories via `.anthropic(apiKey:)` /
+/// `.openAI(apiKey:)` when assigning to `inferenceProvider:` — those are the
+/// unambiguous, canonical spellings. The `apiKey:` overloads that previously
+/// lived here were removed because they collided with
+/// `InferenceProvider where Self == ConduitProviderSelection` and made
+/// `Agent(..., inferenceProvider: .anthropic(apiKey:))` fail to type-check.
 public extension InferenceProvider where Self == LLM {
-    static func openAI(apiKey: String, model: String = "gpt-4o-mini") -> LLM {
-        LLM.openAI(apiKey: apiKey, model: model)
-    }
-
     static func openAI(key: String, model: String = "gpt-4o-mini") -> LLM {
         LLM.openAI(key: key, model: model)
-    }
-
-    static func anthropic(apiKey: String, model: String = "claude-3-5-sonnet-20241022") -> LLM {
-        LLM.anthropic(apiKey: apiKey, model: model)
     }
 
     static func anthropic(key: String, model: String = "claude-3-5-sonnet-20241022") -> LLM {
         LLM.anthropic(key: key, model: model)
     }
 
-    static func openRouter(apiKey: String, model: String = "anthropic/claude-3.5-sonnet") -> LLM {
-        LLM.openRouter(apiKey: apiKey, model: model)
-    }
-
     static func openRouter(key: String, model: String = "anthropic/claude-3.5-sonnet") -> LLM {
         LLM.openRouter(key: key, model: model)
-    }
-
-    static func minimax(apiKey: String, model: String = "minimax-01") -> LLM {
-        LLM.minimax(apiKey: apiKey, model: model)
     }
 
     static func minimax(key: String, model: String = "minimax-01") -> LLM {

--- a/Sources/SwarmCapabilityShowcaseSupport/CapabilityShowcase+FoundationModels.swift
+++ b/Sources/SwarmCapabilityShowcaseSupport/CapabilityShowcase+FoundationModels.swift
@@ -1,0 +1,240 @@
+// CapabilityShowcase+FoundationModels.swift
+// SwarmCapabilityShowcaseSupport
+//
+// Foundation Models capability scenarios — kept out of the main showcase file
+// so CapabilityShowcase.swift does not keep absorbing provider-specific growth.
+
+import Foundation
+import Swarm
+
+// MARK: - Foundation Models (deterministic)
+
+/// Exercises the first-class Foundation Models path without requiring live inference.
+///
+/// Validates:
+/// - Dot-syntax `.foundationModels()` type resolution (Apple platforms)
+/// - Capability reporting (native tools, private inference; no streaming tool calls)
+/// - `isAvailable` / `ifAvailable` consistency
+/// - Graceful degradation messaging when the framework is not present (Linux)
+/// - Agent + tool + multi-turn wiring still works with a scripted provider alongside
+///   the FM entry points so the on-device DX path stays integrated with core Swarm
+func runFoundationModelsScenario(context: CapabilityScenarioContext) async throws -> CapabilityScenarioResult {
+    var lines: [String] = []
+
+    #if canImport(FoundationModels)
+        if #available(macOS 26.0, iOS 26.0, visionOS 26.0, *) {
+            let provider: any InferenceProvider = .foundationModels()
+            try ensure(
+                provider is FoundationModelsInferenceProvider,
+                "Expected .foundationModels() to return FoundationModelsInferenceProvider."
+            )
+            lines.append("dot-syntax=FoundationModelsInferenceProvider")
+
+            let native = FoundationModelsInferenceProvider()
+            let capabilities = InferenceProviderCapabilities.resolved(for: native)
+            try ensure(capabilities.contains(.nativeToolCalling), "FM should advertise native tool calling.")
+            try ensure(capabilities.contains(.conversationMessages), "FM should advertise conversation messages.")
+            try ensure(capabilities.contains(.privateInference), "FM should advertise private on-device inference.")
+            try ensure(capabilities.contains(.structuredOutputs), "FM should advertise structured outputs.")
+            try ensure(
+                capabilities.contains(.streamingToolCalls) == false,
+                "FM must not advertise streaming tool calls (Apple path is capture-then-execute)."
+            )
+            try ensure(native.providerName == "foundationmodels", "Expected providerName foundationmodels.")
+            lines.append("capabilities=nativeToolCalling,conversationMessages,privateInference,structuredOutputs")
+            lines.append("streamingToolCalls=false")
+
+            let available = FoundationModelsInferenceProvider.isAvailable
+            let optional = FoundationModelsInferenceProvider.ifAvailable()
+            try ensure(
+                (optional != nil) == available,
+                "ifAvailable() must agree with isAvailable."
+            )
+            lines.append("isAvailable=\(available)")
+            lines.append("ifAvailable=\(optional != nil)")
+
+            // Profile-driven factory stays first-class and Sendable.
+            let mode = ProfileMode("showcase")
+            let profile = ModeSwitchingDynamicProfile(mode: mode) { _ in
+                Profile(
+                    id: "showcase",
+                    instructions: "Be concise.",
+                    generation: .init(temperature: 0.2)
+                )
+            }
+            let profiled: any InferenceProvider = .foundationModels(profile: profile)
+            try ensure(
+                profiled is FoundationModelsInferenceProvider,
+                "Expected .foundationModels(profile:) to return FoundationModelsInferenceProvider."
+            )
+            if let typed = profiled as? FoundationModelsInferenceProvider {
+                try ensure(
+                    typed.modelName?.contains("showcase") == true,
+                    "Expected profile id to appear in modelName."
+                )
+                lines.append("profile-modelName=\(typed.modelName ?? "nil")")
+            }
+
+            // Core multi-turn + tools remain wired for apps that fall back to scripted/mocks
+            // while developing against the same Agent surface used with FM.
+            let additionTool = ShowcaseAdditionTool().asAnyJSONTool()
+            let scripted = ScriptedInferenceProvider(
+                toolCallResponses: [
+                    .init(
+                        toolCalls: [
+                            .init(
+                                id: "fm-demo-1",
+                                name: additionTool.name,
+                                arguments: ["lhs": .int(2), "rhs": .int(3)]
+                            ),
+                        ],
+                        finishReason: .toolCall
+                    ),
+                    .init(content: "Sum is 5.", finishReason: .completed),
+                ]
+            )
+            let toolAgent = try Agent(
+                tools: [additionTool],
+                instructions: "Use tools when needed.",
+                memory: makeScenarioMemory(),
+                inferenceProvider: scripted
+            )
+            let toolResult = try await toolAgent.run("Add 2 and 3.")
+            try ensure(toolResult.output.contains("5"), "Expected scripted tool path to return 5.")
+            lines.append("agent-tools-path=ok")
+
+            let conversationProvider = ScriptedInferenceProvider(responses: [
+                "Hello, Alex.",
+                "Your name is Alex.",
+            ])
+            let conversationAgent = try Agent(
+                "Remember the user.",
+                memory: makeScenarioMemory(),
+                inferenceProvider: conversationProvider
+            )
+            let conversation = Conversation(with: conversationAgent)
+            _ = try await conversation.send("My name is Alex.")
+            let followUp = try await conversation.send("What is my name?")
+            try ensure(followUp.output.contains("Alex"), "Expected multi-turn memory of the name.")
+            lines.append("multi-turn=ok")
+
+            let summary: String
+            if available {
+                summary = "Validated first-class Foundation Models factories, capabilities, availability, and Agent multi-turn/tool wiring. Live generation is opt-in via smoke."
+            } else {
+                summary = "Foundation Models framework is present but the system model is unavailable; factories, capabilities, and degrade semantics still check out."
+            }
+
+            let body = lines.joined(separator: "\n")
+            let artifact = try context.writeArtifact(named: "foundation-models.txt", contents: body)
+            return .init(
+                id: "foundation-models",
+                name: "Foundation Models Path",
+                families: [.foundationModels, .providers],
+                status: .passed,
+                summary: summary,
+                evidence: [
+                    .init(label: "foundation-models", detail: body, artifactPath: context.relativeArtifactPath(for: artifact)),
+                ]
+            )
+        } else {
+            let body = "platform=below-macOS-26-or-equivalent"
+            let artifact = try context.writeArtifact(named: "foundation-models.txt", contents: body)
+            return .init(
+                id: "foundation-models",
+                name: "Foundation Models Path",
+                families: [.foundationModels, .providers],
+                status: .passed,
+                summary: "Runtime OS is below Foundation Models availability; path correctly gated by @available.",
+                evidence: [
+                    .init(label: "foundation-models", detail: body, artifactPath: context.relativeArtifactPath(for: artifact)),
+                ]
+            )
+        }
+    #else
+        let body = "canImport(FoundationModels)=false"
+        let artifact = try context.writeArtifact(named: "foundation-models.txt", contents: body)
+        return .init(
+            id: "foundation-models",
+            name: "Foundation Models Path",
+            families: [.foundationModels, .providers],
+            status: .passed,
+            summary: "FoundationModels framework is not importable on this platform (expected on Linux). On-device path is compile-time gated; use cloud/Ollama providers instead.",
+            evidence: [
+                .init(label: "foundation-models", detail: body, artifactPath: context.relativeArtifactPath(for: artifact)),
+            ]
+        )
+    #endif
+}
+
+func runLiveFoundationModelsSmokeScenario(
+    context: CapabilityScenarioContext,
+    environment: [String: String]
+) async throws -> CapabilityScenarioResult {
+    let enabled = environment["SWARM_SHOWCASE_FOUNDATION_MODELS"] == "1"
+        || environment["SWARM_RUN_LIVE_FOUNDATION_MODELS_TESTS"] == "1"
+    guard enabled else {
+        return .init(
+            id: "live-foundation-models-smoke",
+            name: "Live Foundation Models Smoke",
+            families: [.foundationModels, .providers],
+            status: .skipped,
+            summary: "Set SWARM_SHOWCASE_FOUNDATION_MODELS=1 to run live on-device Foundation Models smoke."
+        )
+    }
+
+    #if canImport(FoundationModels)
+        if #available(macOS 26.0, iOS 26.0, visionOS 26.0, *) {
+            guard let provider = FoundationModelsInferenceProvider.ifAvailable() else {
+                return .init(
+                    id: "live-foundation-models-smoke",
+                    name: "Live Foundation Models Smoke",
+                    families: [.foundationModels, .providers],
+                    status: .skipped,
+                    summary: "Foundation Models system model is not available on this device."
+                )
+            }
+
+            let agent = try Agent(
+                "Reply with exactly the single word pong.",
+                memory: makeScenarioMemory(),
+                inferenceProvider: provider
+            )
+            let result = try await agent.run("ping")
+            let artifact = try context.writeArtifact(
+                named: "live-foundation-models-smoke.txt",
+                contents: result.output
+            )
+            return .init(
+                id: "live-foundation-models-smoke",
+                name: "Live Foundation Models Smoke",
+                families: [.foundationModels, .providers],
+                status: .passed,
+                summary: "Ran a live on-device Foundation Models generation.",
+                evidence: [
+                    .init(
+                        label: "live-output",
+                        detail: result.output,
+                        artifactPath: context.relativeArtifactPath(for: artifact)
+                    ),
+                ]
+            )
+        } else {
+            return .init(
+                id: "live-foundation-models-smoke",
+                name: "Live Foundation Models Smoke",
+                families: [.foundationModels, .providers],
+                status: .skipped,
+                summary: "OS version is below Foundation Models availability."
+            )
+        }
+    #else
+        return .init(
+            id: "live-foundation-models-smoke",
+            name: "Live Foundation Models Smoke",
+            families: [.foundationModels, .providers],
+            status: .skipped,
+            summary: "FoundationModels framework is not importable on this platform."
+        )
+    #endif
+}

--- a/Sources/SwarmCapabilityShowcaseSupport/CapabilityShowcase.swift
+++ b/Sources/SwarmCapabilityShowcaseSupport/CapabilityShowcase.swift
@@ -921,166 +921,6 @@ private func runProvidersScenario(context: CapabilityScenarioContext) async thro
     )
 }
 
-// MARK: - Foundation Models (deterministic)
-
-/// Exercises the first-class Foundation Models path without requiring live inference.
-///
-/// Validates:
-/// - Dot-syntax `.foundationModels()` type resolution (Apple platforms)
-/// - Capability reporting (native tools, private inference; no streaming tool calls)
-/// - `isAvailable` / `ifAvailable` consistency
-/// - Graceful degradation messaging when the framework is not present (Linux)
-/// - Agent + tool + multi-turn wiring still works with a scripted provider alongside
-///   the FM entry points so the on-device DX path stays integrated with core Swarm
-private func runFoundationModelsScenario(context: CapabilityScenarioContext) async throws -> CapabilityScenarioResult {
-    var lines: [String] = []
-
-    #if canImport(FoundationModels)
-        if #available(macOS 26.0, iOS 26.0, visionOS 26.0, *) {
-            let provider: any InferenceProvider = .foundationModels()
-            try ensure(
-                provider is FoundationModelsInferenceProvider,
-                "Expected .foundationModels() to return FoundationModelsInferenceProvider."
-            )
-            lines.append("dot-syntax=FoundationModelsInferenceProvider")
-
-            let native = FoundationModelsInferenceProvider()
-            let capabilities = InferenceProviderCapabilities.resolved(for: native)
-            try ensure(capabilities.contains(.nativeToolCalling), "FM should advertise native tool calling.")
-            try ensure(capabilities.contains(.conversationMessages), "FM should advertise conversation messages.")
-            try ensure(capabilities.contains(.privateInference), "FM should advertise private on-device inference.")
-            try ensure(capabilities.contains(.structuredOutputs), "FM should advertise structured outputs.")
-            try ensure(
-                capabilities.contains(.streamingToolCalls) == false,
-                "FM must not advertise streaming tool calls (Apple path is capture-then-execute)."
-            )
-            try ensure(native.providerName == "foundationmodels", "Expected providerName foundationmodels.")
-            lines.append("capabilities=nativeToolCalling,conversationMessages,privateInference,structuredOutputs")
-            lines.append("streamingToolCalls=false")
-
-            let available = FoundationModelsInferenceProvider.isAvailable
-            let optional = FoundationModelsInferenceProvider.ifAvailable()
-            try ensure(
-                (optional != nil) == available,
-                "ifAvailable() must agree with isAvailable."
-            )
-            lines.append("isAvailable=\(available)")
-            lines.append("ifAvailable=\(optional != nil)")
-
-            // Profile-driven factory stays first-class and Sendable.
-            let mode = ProfileMode("showcase")
-            let profile = ModeSwitchingDynamicProfile(mode: mode) { _ in
-                Profile(
-                    id: "showcase",
-                    instructions: "Be concise.",
-                    generation: .init(temperature: 0.2)
-                )
-            }
-            let profiled: any InferenceProvider = .foundationModels(profile: profile)
-            try ensure(
-                profiled is FoundationModelsInferenceProvider,
-                "Expected .foundationModels(profile:) to return FoundationModelsInferenceProvider."
-            )
-            if let typed = profiled as? FoundationModelsInferenceProvider {
-                try ensure(
-                    typed.modelName?.contains("showcase") == true,
-                    "Expected profile id to appear in modelName."
-                )
-                lines.append("profile-modelName=\(typed.modelName ?? "nil")")
-            }
-
-            // Core multi-turn + tools remain wired for apps that fall back to scripted/mocks
-            // while developing against the same Agent surface used with FM.
-            let additionTool = ShowcaseAdditionTool().asAnyJSONTool()
-            let scripted = ScriptedInferenceProvider(
-                toolCallResponses: [
-                    .init(
-                        toolCalls: [
-                            .init(
-                                id: "fm-demo-1",
-                                name: additionTool.name,
-                                arguments: ["lhs": .int(2), "rhs": .int(3)]
-                            ),
-                        ],
-                        finishReason: .toolCall
-                    ),
-                    .init(content: "Sum is 5.", finishReason: .completed),
-                ]
-            )
-            let toolAgent = try Agent(
-                tools: [additionTool],
-                instructions: "Use tools when needed.",
-                memory: makeScenarioMemory(),
-                inferenceProvider: scripted
-            )
-            let toolResult = try await toolAgent.run("Add 2 and 3.")
-            try ensure(toolResult.output.contains("5"), "Expected scripted tool path to return 5.")
-            lines.append("agent-tools-path=ok")
-
-            let conversationProvider = ScriptedInferenceProvider(responses: [
-                "Hello, Alex.",
-                "Your name is Alex.",
-            ])
-            let conversationAgent = try Agent(
-                "Remember the user.",
-                memory: makeScenarioMemory(),
-                inferenceProvider: conversationProvider
-            )
-            let conversation = Conversation(with: conversationAgent)
-            _ = try await conversation.send("My name is Alex.")
-            let followUp = try await conversation.send("What is my name?")
-            try ensure(followUp.output.contains("Alex"), "Expected multi-turn memory of the name.")
-            lines.append("multi-turn=ok")
-
-            let summary: String
-            if available {
-                summary = "Validated first-class Foundation Models factories, capabilities, availability, and Agent multi-turn/tool wiring. Live generation is opt-in via smoke."
-            } else {
-                summary = "Foundation Models framework is present but the system model is unavailable; factories, capabilities, and degrade semantics still check out."
-            }
-
-            let body = lines.joined(separator: "\n")
-            let artifact = try context.writeArtifact(named: "foundation-models.txt", contents: body)
-            return .init(
-                id: "foundation-models",
-                name: "Foundation Models Path",
-                families: [.foundationModels, .providers],
-                status: .passed,
-                summary: summary,
-                evidence: [
-                    .init(label: "foundation-models", detail: body, artifactPath: context.relativeArtifactPath(for: artifact)),
-                ]
-            )
-        } else {
-            let body = "platform=below-macOS-26-or-equivalent"
-            let artifact = try context.writeArtifact(named: "foundation-models.txt", contents: body)
-            return .init(
-                id: "foundation-models",
-                name: "Foundation Models Path",
-                families: [.foundationModels, .providers],
-                status: .passed,
-                summary: "Runtime OS is below Foundation Models availability; path correctly gated by @available.",
-                evidence: [
-                    .init(label: "foundation-models", detail: body, artifactPath: context.relativeArtifactPath(for: artifact)),
-                ]
-            )
-        }
-    #else
-        let body = "canImport(FoundationModels)=false"
-        let artifact = try context.writeArtifact(named: "foundation-models.txt", contents: body)
-        return .init(
-            id: "foundation-models",
-            name: "Foundation Models Path",
-            families: [.foundationModels, .providers],
-            status: .passed,
-            summary: "FoundationModels framework is not importable on this platform (expected on Linux). On-device path is compile-time gated; use cloud/Ollama providers instead.",
-            evidence: [
-                .init(label: "foundation-models", detail: body, artifactPath: context.relativeArtifactPath(for: artifact)),
-            ]
-        )
-    #endif
-}
-
 // MARK: - Smoke Scenario
 
 private func runLiveProviderSmokeScenario(
@@ -1123,82 +963,11 @@ private func runLiveProviderSmokeScenario(
     #endif
 }
 
-private func runLiveFoundationModelsSmokeScenario(
-    context: CapabilityScenarioContext,
-    environment: [String: String]
-) async throws -> CapabilityScenarioResult {
-    let enabled = environment["SWARM_SHOWCASE_FOUNDATION_MODELS"] == "1"
-        || environment["SWARM_RUN_LIVE_FOUNDATION_MODELS_TESTS"] == "1"
-    guard enabled else {
-        return .init(
-            id: "live-foundation-models-smoke",
-            name: "Live Foundation Models Smoke",
-            families: [.foundationModels, .providers],
-            status: .skipped,
-            summary: "Set SWARM_SHOWCASE_FOUNDATION_MODELS=1 to run live on-device Foundation Models smoke."
-        )
-    }
-
-    #if canImport(FoundationModels)
-        if #available(macOS 26.0, iOS 26.0, visionOS 26.0, *) {
-            guard let provider = FoundationModelsInferenceProvider.ifAvailable() else {
-                return .init(
-                    id: "live-foundation-models-smoke",
-                    name: "Live Foundation Models Smoke",
-                    families: [.foundationModels, .providers],
-                    status: .skipped,
-                    summary: "Foundation Models system model is not available on this device."
-                )
-            }
-
-            let agent = try Agent(
-                "Reply with exactly the single word pong.",
-                memory: makeScenarioMemory(),
-                inferenceProvider: provider
-            )
-            let result = try await agent.run("ping")
-            let artifact = try context.writeArtifact(
-                named: "live-foundation-models-smoke.txt",
-                contents: result.output
-            )
-            return .init(
-                id: "live-foundation-models-smoke",
-                name: "Live Foundation Models Smoke",
-                families: [.foundationModels, .providers],
-                status: .passed,
-                summary: "Ran a live on-device Foundation Models generation.",
-                evidence: [
-                    .init(
-                        label: "live-output",
-                        detail: result.output,
-                        artifactPath: context.relativeArtifactPath(for: artifact)
-                    ),
-                ]
-            )
-        } else {
-            return .init(
-                id: "live-foundation-models-smoke",
-                name: "Live Foundation Models Smoke",
-                families: [.foundationModels, .providers],
-                status: .skipped,
-                summary: "OS version is below Foundation Models availability."
-            )
-        }
-    #else
-        return .init(
-            id: "live-foundation-models-smoke",
-            name: "Live Foundation Models Smoke",
-            families: [.foundationModels, .providers],
-            status: .skipped,
-            summary: "FoundationModels framework is not importable on this platform."
-        )
-    #endif
-}
 
 // MARK: - Fixtures
 
 @Tool("Adds two integers together.")
-private struct ShowcaseAdditionTool {
+struct ShowcaseAdditionTool {
     @Parameter("Left-hand value") var lhs: Int = 0
     @Parameter("Right-hand value") var rhs: Int = 0
 
@@ -1232,7 +1001,7 @@ private struct GuardedEchoTool: AnyJSONTool {
     }
 }
 
-private actor ScriptedInferenceProvider: InferenceProvider {
+actor ScriptedInferenceProvider: InferenceProvider {
     private var responses: [String]
     private var toolCallResponses: [InferenceResponse]
     private var responseIndex = 0
@@ -1385,7 +1154,7 @@ private func makeTextAgent(output: String) -> Agent {
     return try! Agent("Return deterministic output.", memory: makeScenarioMemory(), inferenceProvider: provider)
 }
 
-private func makeScenarioMemory() -> any Memory {
+func makeScenarioMemory() -> any Memory {
     ConversationMemory(maxMessages: 32)
 }
 
@@ -1434,7 +1203,7 @@ private func writeWorkspaceFixture(at root: URL) throws {
     )
 }
 
-private func ensure(_ condition: Bool, _ message: String) throws {
+func ensure(_ condition: Bool, _ message: String) throws {
     guard condition else {
         throw CapabilityShowcaseError.expectationFailed(message)
     }

--- a/Sources/SwarmCapabilityShowcaseSupport/CapabilityShowcase.swift
+++ b/Sources/SwarmCapabilityShowcaseSupport/CapabilityShowcase.swift
@@ -15,6 +15,7 @@ public enum CapabilityFamily: String, CaseIterable, Sendable, Hashable {
     case observability = "observability"
     case mcp = "mcp"
     case providers = "providers"
+    case foundationModels = "foundation-models"
 }
 
 public enum CapabilityScenarioKind: String, Sendable {
@@ -292,6 +293,13 @@ private extension CapabilityShowcase {
                 kind: .deterministic,
                 runHandler: runProvidersScenario
             ),
+            .init(
+                id: "foundation-models",
+                name: "Foundation Models Path",
+                families: [.foundationModels, .providers],
+                kind: .deterministic,
+                runHandler: runFoundationModelsScenario
+            ),
         ]
 
         let smoke: [CapabilityScenario] = [
@@ -302,6 +310,14 @@ private extension CapabilityShowcase {
                 kind: .smoke
             ) { context in
                 try await runLiveProviderSmokeScenario(context: context, environment: environment)
+            },
+            .init(
+                id: "live-foundation-models-smoke",
+                name: "Live Foundation Models Smoke",
+                families: [.foundationModels, .providers],
+                kind: .smoke
+            ) { context in
+                try await runLiveFoundationModelsSmokeScenario(context: context, environment: environment)
             },
         ]
 
@@ -905,6 +921,166 @@ private func runProvidersScenario(context: CapabilityScenarioContext) async thro
     )
 }
 
+// MARK: - Foundation Models (deterministic)
+
+/// Exercises the first-class Foundation Models path without requiring live inference.
+///
+/// Validates:
+/// - Dot-syntax `.foundationModels()` type resolution (Apple platforms)
+/// - Capability reporting (native tools, private inference; no streaming tool calls)
+/// - `isAvailable` / `ifAvailable` consistency
+/// - Graceful degradation messaging when the framework is not present (Linux)
+/// - Agent + tool + multi-turn wiring still works with a scripted provider alongside
+///   the FM entry points so the on-device DX path stays integrated with core Swarm
+private func runFoundationModelsScenario(context: CapabilityScenarioContext) async throws -> CapabilityScenarioResult {
+    var lines: [String] = []
+
+    #if canImport(FoundationModels)
+        if #available(macOS 26.0, iOS 26.0, visionOS 26.0, *) {
+            let provider: any InferenceProvider = .foundationModels()
+            try ensure(
+                provider is FoundationModelsInferenceProvider,
+                "Expected .foundationModels() to return FoundationModelsInferenceProvider."
+            )
+            lines.append("dot-syntax=FoundationModelsInferenceProvider")
+
+            let native = FoundationModelsInferenceProvider()
+            let capabilities = InferenceProviderCapabilities.resolved(for: native)
+            try ensure(capabilities.contains(.nativeToolCalling), "FM should advertise native tool calling.")
+            try ensure(capabilities.contains(.conversationMessages), "FM should advertise conversation messages.")
+            try ensure(capabilities.contains(.privateInference), "FM should advertise private on-device inference.")
+            try ensure(capabilities.contains(.structuredOutputs), "FM should advertise structured outputs.")
+            try ensure(
+                capabilities.contains(.streamingToolCalls) == false,
+                "FM must not advertise streaming tool calls (Apple path is capture-then-execute)."
+            )
+            try ensure(native.providerName == "foundationmodels", "Expected providerName foundationmodels.")
+            lines.append("capabilities=nativeToolCalling,conversationMessages,privateInference,structuredOutputs")
+            lines.append("streamingToolCalls=false")
+
+            let available = FoundationModelsInferenceProvider.isAvailable
+            let optional = FoundationModelsInferenceProvider.ifAvailable()
+            try ensure(
+                (optional != nil) == available,
+                "ifAvailable() must agree with isAvailable."
+            )
+            lines.append("isAvailable=\(available)")
+            lines.append("ifAvailable=\(optional != nil)")
+
+            // Profile-driven factory stays first-class and Sendable.
+            let mode = ProfileMode("showcase")
+            let profile = ModeSwitchingDynamicProfile(mode: mode) { _ in
+                Profile(
+                    id: "showcase",
+                    instructions: "Be concise.",
+                    generation: .init(temperature: 0.2)
+                )
+            }
+            let profiled: any InferenceProvider = .foundationModels(profile: profile)
+            try ensure(
+                profiled is FoundationModelsInferenceProvider,
+                "Expected .foundationModels(profile:) to return FoundationModelsInferenceProvider."
+            )
+            if let typed = profiled as? FoundationModelsInferenceProvider {
+                try ensure(
+                    typed.modelName?.contains("showcase") == true,
+                    "Expected profile id to appear in modelName."
+                )
+                lines.append("profile-modelName=\(typed.modelName ?? "nil")")
+            }
+
+            // Core multi-turn + tools remain wired for apps that fall back to scripted/mocks
+            // while developing against the same Agent surface used with FM.
+            let additionTool = ShowcaseAdditionTool().asAnyJSONTool()
+            let scripted = ScriptedInferenceProvider(
+                toolCallResponses: [
+                    .init(
+                        toolCalls: [
+                            .init(
+                                id: "fm-demo-1",
+                                name: additionTool.name,
+                                arguments: ["lhs": .int(2), "rhs": .int(3)]
+                            ),
+                        ],
+                        finishReason: .toolCall
+                    ),
+                    .init(content: "Sum is 5.", finishReason: .completed),
+                ]
+            )
+            let toolAgent = try Agent(
+                tools: [additionTool],
+                instructions: "Use tools when needed.",
+                memory: makeScenarioMemory(),
+                inferenceProvider: scripted
+            )
+            let toolResult = try await toolAgent.run("Add 2 and 3.")
+            try ensure(toolResult.output.contains("5"), "Expected scripted tool path to return 5.")
+            lines.append("agent-tools-path=ok")
+
+            let conversationProvider = ScriptedInferenceProvider(responses: [
+                "Hello, Alex.",
+                "Your name is Alex.",
+            ])
+            let conversationAgent = try Agent(
+                "Remember the user.",
+                memory: makeScenarioMemory(),
+                inferenceProvider: conversationProvider
+            )
+            let conversation = Conversation(with: conversationAgent)
+            _ = try await conversation.send("My name is Alex.")
+            let followUp = try await conversation.send("What is my name?")
+            try ensure(followUp.output.contains("Alex"), "Expected multi-turn memory of the name.")
+            lines.append("multi-turn=ok")
+
+            let summary: String
+            if available {
+                summary = "Validated first-class Foundation Models factories, capabilities, availability, and Agent multi-turn/tool wiring. Live generation is opt-in via smoke."
+            } else {
+                summary = "Foundation Models framework is present but the system model is unavailable; factories, capabilities, and degrade semantics still check out."
+            }
+
+            let body = lines.joined(separator: "\n")
+            let artifact = try context.writeArtifact(named: "foundation-models.txt", contents: body)
+            return .init(
+                id: "foundation-models",
+                name: "Foundation Models Path",
+                families: [.foundationModels, .providers],
+                status: .passed,
+                summary: summary,
+                evidence: [
+                    .init(label: "foundation-models", detail: body, artifactPath: context.relativeArtifactPath(for: artifact)),
+                ]
+            )
+        } else {
+            let body = "platform=below-macOS-26-or-equivalent"
+            let artifact = try context.writeArtifact(named: "foundation-models.txt", contents: body)
+            return .init(
+                id: "foundation-models",
+                name: "Foundation Models Path",
+                families: [.foundationModels, .providers],
+                status: .passed,
+                summary: "Runtime OS is below Foundation Models availability; path correctly gated by @available.",
+                evidence: [
+                    .init(label: "foundation-models", detail: body, artifactPath: context.relativeArtifactPath(for: artifact)),
+                ]
+            )
+        }
+    #else
+        let body = "canImport(FoundationModels)=false"
+        let artifact = try context.writeArtifact(named: "foundation-models.txt", contents: body)
+        return .init(
+            id: "foundation-models",
+            name: "Foundation Models Path",
+            families: [.foundationModels, .providers],
+            status: .passed,
+            summary: "FoundationModels framework is not importable on this platform (expected on Linux). On-device path is compile-time gated; use cloud/Ollama providers instead.",
+            evidence: [
+                .init(label: "foundation-models", detail: body, artifactPath: context.relativeArtifactPath(for: artifact)),
+            ]
+        )
+    #endif
+}
+
 // MARK: - Smoke Scenario
 
 private func runLiveProviderSmokeScenario(
@@ -943,6 +1119,78 @@ private func runLiveProviderSmokeScenario(
             families: [.providers],
             status: .skipped,
             summary: "Live provider smoke requires the Integrations trait."
+        )
+    #endif
+}
+
+private func runLiveFoundationModelsSmokeScenario(
+    context: CapabilityScenarioContext,
+    environment: [String: String]
+) async throws -> CapabilityScenarioResult {
+    let enabled = environment["SWARM_SHOWCASE_FOUNDATION_MODELS"] == "1"
+        || environment["SWARM_RUN_LIVE_FOUNDATION_MODELS_TESTS"] == "1"
+    guard enabled else {
+        return .init(
+            id: "live-foundation-models-smoke",
+            name: "Live Foundation Models Smoke",
+            families: [.foundationModels, .providers],
+            status: .skipped,
+            summary: "Set SWARM_SHOWCASE_FOUNDATION_MODELS=1 to run live on-device Foundation Models smoke."
+        )
+    }
+
+    #if canImport(FoundationModels)
+        if #available(macOS 26.0, iOS 26.0, visionOS 26.0, *) {
+            guard let provider = FoundationModelsInferenceProvider.ifAvailable() else {
+                return .init(
+                    id: "live-foundation-models-smoke",
+                    name: "Live Foundation Models Smoke",
+                    families: [.foundationModels, .providers],
+                    status: .skipped,
+                    summary: "Foundation Models system model is not available on this device."
+                )
+            }
+
+            let agent = try Agent(
+                "Reply with exactly the single word pong.",
+                memory: makeScenarioMemory(),
+                inferenceProvider: provider
+            )
+            let result = try await agent.run("ping")
+            let artifact = try context.writeArtifact(
+                named: "live-foundation-models-smoke.txt",
+                contents: result.output
+            )
+            return .init(
+                id: "live-foundation-models-smoke",
+                name: "Live Foundation Models Smoke",
+                families: [.foundationModels, .providers],
+                status: .passed,
+                summary: "Ran a live on-device Foundation Models generation.",
+                evidence: [
+                    .init(
+                        label: "live-output",
+                        detail: result.output,
+                        artifactPath: context.relativeArtifactPath(for: artifact)
+                    ),
+                ]
+            )
+        } else {
+            return .init(
+                id: "live-foundation-models-smoke",
+                name: "Live Foundation Models Smoke",
+                families: [.foundationModels, .providers],
+                status: .skipped,
+                summary: "OS version is below Foundation Models availability."
+            )
+        }
+    #else
+        return .init(
+            id: "live-foundation-models-smoke",
+            name: "Live Foundation Models Smoke",
+            families: [.foundationModels, .providers],
+            status: .skipped,
+            summary: "FoundationModels framework is not importable on this platform."
         )
     #endif
 }

--- a/Sources/SwarmMacros/InlineToolMacro.swift
+++ b/Sources/SwarmMacros/InlineToolMacro.swift
@@ -3,7 +3,6 @@
 //
 // Implementation of the #Tool freestanding expression macro for inline tool creation.
 
-import Foundation
 import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
@@ -63,11 +62,12 @@ public struct InlineToolMacro: ExpressionMacro {
         let toolStructName = "_InlineTool_\(toolName)"
 
         // ---- Rewrite closure body: bare param refs → input.paramName ----
-        // Avoid SyntaxRewriter subclasses: Swift 6.2 + swift-syntax 602 can fail to
-        // link visitationFunc depending on parallel job count (swiftlang/swift-package-manager#9495).
+        // Prefer AST-position rewrites over naive regex and avoid SyntaxRewriter
+        // subclasses: Swift 6.2 + swift-syntax 602 can fail to link
+        // visitationFunc under high parallel job counts (swiftlang/swift-package-manager#9495).
         let paramNames = Set(closureParams.map(\.name))
         let rewrittenBodyText = rewriteBareParamReferences(
-            in: trailingClosure.statements.description,
+            in: trailingClosure.statements,
             paramNames: paramNames
         )
 
@@ -192,26 +192,94 @@ public struct InlineToolMacro: ExpressionMacro {
 /// Rewrites bare parameter references like `name` to `input.name` in a closure body
 /// so the generated `execute` method reads fields from the input struct.
 ///
-/// Uses string rewriting rather than `SyntaxRewriter` to avoid a known Swift 6.2
-/// linker failure on private `SyntaxRewriter.visitationFunc` (swift-package-manager#9495).
-private func rewriteBareParamReferences(in source: String, paramNames: Set<String>) -> String {
-    guard !paramNames.isEmpty else { return source }
+/// Walks the SwiftSyntax tree and rewrites only `DeclReferenceExprSyntax` nodes
+/// (not string-literal text, not member names after `.`). The replacement is then
+/// applied to the original source by UTF-8 absolute positions so we never depend
+/// on `SyntaxRewriter` subclasses (linker flakiness under parallel builds —
+/// swiftlang/swift-package-manager#9495).
+private func rewriteBareParamReferences(
+    in statements: CodeBlockItemListSyntax,
+    paramNames: Set<String>
+) -> String {
+    guard !paramNames.isEmpty else { return statements.description }
 
-    // Longest names first so shorter params do not partially rewrite longer ones.
-    let ordered = paramNames.sorted { $0.count > $1.count || ($0.count == $1.count && $0 < $1) }
+    let source = statements.description
+    let baseUTF8Offset = statements.position.utf8Offset
+
+    var replacements: [(utf8Offset: Int, utf8Length: Int, replacement: String)] = []
+    collectBareParamReplacements(
+        Syntax(statements),
+        paramNames: paramNames,
+        baseUTF8Offset: baseUTF8Offset,
+        into: &replacements
+    )
+
+    guard !replacements.isEmpty else { return source }
+
+    // Apply from the end so earlier offsets stay valid.
     var result = source
-    for name in ordered {
-        let pattern = #"(?<![.\w])"# + NSRegularExpression.escapedPattern(for: name) + #"(?!\w)"#
-        guard let regex = try? NSRegularExpression(pattern: pattern) else { continue }
-        let range = NSRange(result.startIndex..<result.endIndex, in: result)
-        result = regex.stringByReplacingMatches(
-            in: result,
-            options: [],
-            range: range,
-            withTemplate: "input.\(name)"
-        )
+    for entry in replacements.sorted(by: { $0.utf8Offset > $1.utf8Offset }) {
+        guard
+            let start = utf8Index(in: result, offset: entry.utf8Offset),
+            let end = utf8Index(in: result, offset: entry.utf8Offset + entry.utf8Length)
+        else {
+            continue
+        }
+        result.replaceSubrange(start..<end, with: entry.replacement)
     }
     return result
+}
+
+private func collectBareParamReplacements(
+    _ node: Syntax,
+    paramNames: Set<String>,
+    baseUTF8Offset: Int,
+    into replacements: inout [(utf8Offset: Int, utf8Length: Int, replacement: String)]
+) {
+    if let decl = node.as(DeclReferenceExprSyntax.self),
+       paramNames.contains(decl.baseName.text),
+       !isMemberAccessName(decl)
+    {
+        let token = decl.baseName
+        let relative = token.positionAfterSkippingLeadingTrivia.utf8Offset - baseUTF8Offset
+        let length = token.text.utf8.count
+        if relative >= 0, length > 0 {
+            replacements.append(
+                (
+                    utf8Offset: relative,
+                    utf8Length: length,
+                    replacement: "input.\(token.text)"
+                )
+            )
+        }
+    }
+
+    for child in node.children(viewMode: .sourceAccurate) {
+        collectBareParamReplacements(
+            child,
+            paramNames: paramNames,
+            baseUTF8Offset: baseUTF8Offset,
+            into: &replacements
+        )
+    }
+}
+
+/// True when `node` is the member name of `base.member` (must not become `base.input.member`).
+private func isMemberAccessName(_ node: DeclReferenceExprSyntax) -> Bool {
+    guard let parent = node.parent else { return false }
+    if let member = parent.as(MemberAccessExprSyntax.self) {
+        return member.declName.position == node.position
+    }
+    if parent.is(KeyPathPropertyComponentSyntax.self) {
+        return true
+    }
+    return false
+}
+
+private func utf8Index(in string: String, offset: Int) -> String.Index? {
+    guard offset >= 0, offset <= string.utf8.count else { return nil }
+    let utf8Index = string.utf8.index(string.utf8.startIndex, offsetBy: offset)
+    return String.Index(utf8Index, within: string)
 }
 
 // MARK: - InlineToolMacroError

--- a/Sources/SwarmMacros/InlineToolMacro.swift
+++ b/Sources/SwarmMacros/InlineToolMacro.swift
@@ -3,6 +3,7 @@
 //
 // Implementation of the #Tool freestanding expression macro for inline tool creation.
 
+import Foundation
 import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
@@ -62,15 +63,19 @@ public struct InlineToolMacro: ExpressionMacro {
         let toolStructName = "_InlineTool_\(toolName)"
 
         // ---- Rewrite closure body: bare param refs → input.paramName ----
+        // Avoid SyntaxRewriter subclasses: Swift 6.2 + swift-syntax 602 can fail to
+        // link visitationFunc depending on parallel job count (swiftlang/swift-package-manager#9495).
         let paramNames = Set(closureParams.map(\.name))
-        let rewriter = InputParamRewriter(paramNames: paramNames)
-        let rewrittenStatements = rewriter.visit(trailingClosure.statements)
+        let rewrittenBodyText = rewriteBareParamReferences(
+            in: trailingClosure.statements.description,
+            paramNames: paramNames
+        )
 
         // Normalise statement indentation to 12 spaces (3 levels × 4 spaces) so
         // the execute body sits cleanly inside `func execute(...) { }`.
-        let executeLines = rewrittenStatements
-            .children(viewMode: .sourceAccurate)
-            .map { $0.description.trimmingCharacters(in: .whitespacesAndNewlines) }
+        let executeLines = rewrittenBodyText
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty }
 
         let executeBody = executeLines
@@ -182,30 +187,31 @@ public struct InlineToolMacro: ExpressionMacro {
     }
 }
 
-// MARK: - InputParamRewriter
+// MARK: - Parameter rewriting
 
-/// A SyntaxRewriter that rewrites bare parameter references like `name` to `input.name`
-/// inside a closure body, so the generated execute method accesses `input.paramName`.
-private final class InputParamRewriter: SyntaxRewriter {
-    let paramNames: Set<String>
+/// Rewrites bare parameter references like `name` to `input.name` in a closure body
+/// so the generated `execute` method reads fields from the input struct.
+///
+/// Uses string rewriting rather than `SyntaxRewriter` to avoid a known Swift 6.2
+/// linker failure on private `SyntaxRewriter.visitationFunc` (swift-package-manager#9495).
+private func rewriteBareParamReferences(in source: String, paramNames: Set<String>) -> String {
+    guard !paramNames.isEmpty else { return source }
 
-    init(paramNames: Set<String>) {
-        self.paramNames = paramNames
-    }
-
-    override func visit(_ node: DeclReferenceExprSyntax) -> ExprSyntax {
-        let identifier = node.baseName.text
-        guard paramNames.contains(identifier) else {
-            return ExprSyntax(node)
-        }
-        // Replace `name` with `input.name`
-        let memberAccess = MemberAccessExprSyntax(
-            base: DeclReferenceExprSyntax(baseName: .identifier("input")),
-            period: .periodToken(),
-            declName: DeclReferenceExprSyntax(baseName: .identifier(identifier))
+    // Longest names first so shorter params do not partially rewrite longer ones.
+    let ordered = paramNames.sorted { $0.count > $1.count || ($0.count == $1.count && $0 < $1) }
+    var result = source
+    for name in ordered {
+        let pattern = #"(?<![.\w])"# + NSRegularExpression.escapedPattern(for: name) + #"(?!\w)"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { continue }
+        let range = NSRange(result.startIndex..<result.endIndex, in: result)
+        result = regex.stringByReplacingMatches(
+            in: result,
+            options: [],
+            range: range,
+            withTemplate: "input.\(name)"
         )
-        return ExprSyntax(memberAccess)
     }
+    return result
 }
 
 // MARK: - InlineToolMacroError

--- a/Tests/SwarmMacrosTests/InlineToolMacroTests.swift
+++ b/Tests/SwarmMacrosTests/InlineToolMacroTests.swift
@@ -246,6 +246,82 @@ final class InlineToolMacroTests: XCTestCase {
         #endif
     }
 
+    // MARK: - Rewrite safety (AST-guided, not naive string replace)
+
+    /// Param identifiers inside string *literals* must stay untouched; only
+    /// DeclReferenceExpr occurrences (including interpolations) rewrite to `input.`.
+    func testParamNameInStringLiteralIsNotRewritten() throws {
+        #if canImport(SwarmMacros)
+            assertMacroExpansion(
+                """
+                #Tool("echo", "Echo") { (name: String) in
+                    "literal name and \\(name)"
+                }
+                """,
+                expandedSource: """
+                {
+                    struct _EchoInput: Codable, Sendable {
+                        let name: String
+                    }
+                    struct _InlineTool_echo: Tool, Sendable {
+                        typealias Input = _EchoInput
+                        typealias Output = String
+                        let name = "echo"
+                        let description = "Echo"
+                        let parameters: [ToolParameter] = [
+                            ToolParameter(name: "name", description: "name", type: .string, isRequired: true)
+                        ]
+                        func execute(_ input: _EchoInput) async throws -> String {
+                            "literal name and \\(input.name)"
+                        }
+                    }
+                    return _InlineTool_echo()
+                }()
+                """,
+                macros: inlineToolMacros()
+            )
+        #else
+            throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    /// Member access like `values.count` must not rewrite the member name when
+    /// a parameter is also named `count`.
+    func testMemberAccessNameIsNotRewritten() throws {
+        #if canImport(SwarmMacros)
+            assertMacroExpansion(
+                """
+                #Tool("compare", "Compare counts") { (count: Int) in
+                    "\\(values.count) vs \\(count)"
+                }
+                """,
+                expandedSource: """
+                {
+                    struct _CompareInput: Codable, Sendable {
+                        let count: Int
+                    }
+                    struct _InlineTool_compare: Tool, Sendable {
+                        typealias Input = _CompareInput
+                        typealias Output = String
+                        let name = "compare"
+                        let description = "Compare counts"
+                        let parameters: [ToolParameter] = [
+                            ToolParameter(name: "count", description: "count", type: .int, isRequired: true)
+                        ]
+                        func execute(_ input: _CompareInput) async throws -> String {
+                            "\\(values.count) vs \\(input.count)"
+                        }
+                    }
+                    return _InlineTool_compare()
+                }()
+                """,
+                macros: inlineToolMacros()
+            )
+        #else
+            throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
     // MARK: - Error Cases
 
     func testMissingNameArgument() throws {

--- a/Tests/SwarmTests/V3/ReadmeProviderCompileTests.swift
+++ b/Tests/SwarmTests/V3/ReadmeProviderCompileTests.swift
@@ -13,6 +13,13 @@ private struct PublicCompileTool: Tool {
     }
 }
 
+@Tool("Looks up a canned stock price")
+private struct DocSnippetPriceTool {
+    @Parameter("Ticker symbol") var ticker: String = "AAPL"
+
+    func execute() async throws -> String { "182.50" }
+}
+
 @Suite("README Provider Compile Tests")
 struct ReadmeProviderCompileTests {
     @Test("README-style provider factories compile through public import")
@@ -45,5 +52,73 @@ struct ReadmeProviderCompileTests {
                 CalculatorTool()
             #endif
         }
+    }
+
+    /// Proves major README / getting-started `Agent(...)` call sites match the
+    /// canonical label order: configuration → memory → inferenceProvider → guardrails.
+    @Test("Major public doc Agent snippets use legal parameter order")
+    func majorPublicDocAgentSnippetsCompile() throws {
+        // getting-started: on-device first agent
+        if #available(macOS 26.0, iOS 26.0, visionOS 26.0, *) {
+            _ = try Agent(
+                "Answer finance questions using tools when needed.",
+                configuration: .default.name("Analyst"),
+                memory: .conversation(maxMessages: 50),
+                inferenceProvider: .foundationModels(),
+                inputGuardrails: [InputGuard.maxLength(5000), InputGuard.notEmpty()]
+            ) {
+                DocSnippetPriceTool()
+            }
+        }
+
+        // getting-started: cloud Anthropic first agent
+        _ = try Agent(
+            "Answer finance questions using real data.",
+            configuration: .default.name("Analyst"),
+            memory: .conversation(maxMessages: 50),
+            inferenceProvider: .anthropic(apiKey: "test-key"),
+            inputGuardrails: [InputGuard.maxLength(5000), InputGuard.notEmpty()]
+        ) {
+            DocSnippetPriceTool()
+            #if canImport(Darwin)
+                CalculatorTool()
+            #endif
+        }
+
+        // README: Quick Start (configuration + provider only)
+        _ = try Agent(
+            "Answer finance questions using real data.",
+            configuration: .default.name("Analyst"),
+            inferenceProvider: .anthropic(apiKey: "test-key")
+        ) {
+            DocSnippetPriceTool()
+        }
+
+        // README: Foundation Models First
+        if #available(macOS 26.0, iOS 26.0, visionOS 26.0, *) {
+            _ = try Agent(
+                "You are a private on-device assistant.",
+                inferenceProvider: .foundationModels()
+            ) {
+                DocSnippetPriceTool()
+            }
+        }
+
+        // README: semantic memory (memory before inferenceProvider)
+        let embedder = MockEmbeddingProvider()
+        _ = try Agent(
+            "You remember past conversations.",
+            memory: .vector(embeddingProvider: embedder, similarityThreshold: 0.75),
+            inferenceProvider: .anthropic(apiKey: "test-key")
+        ) {
+            DocSnippetPriceTool()
+        }
+
+        // README / getting-started: guardrails-only
+        _ = try Agent(
+            "You are a helpful assistant.",
+            inputGuardrails: [InputGuard.maxLength(5000), InputGuard.notEmpty()],
+            outputGuardrails: [OutputGuard.maxLength(2000)]
+        )
     }
 }

--- a/docs/guide/capability-showcase.md
+++ b/docs/guide/capability-showcase.md
@@ -36,6 +36,7 @@ swift run SwarmCapabilityShowcase smoke
 | `observability` | a custom tracer receives agent trace events |
 | `mcp` | MCP tool discovery and MCP tool bridging both execute locally |
 | `providers` | global provider config, per-agent override, and `MultiProvider` routing work |
+| `foundation-models` | First-class `.foundationModels()` factories, capability reporting, availability/degrade semantics, and Agent multi-turn/tool wiring used by on-device apps |
 
 Each scenario writes evidence into a temporary artifact directory under the system temp folder, rooted at `swarm-capability-showcase/`.
 
@@ -43,19 +44,23 @@ Each scenario writes evidence into a temporary artifact directory under the syst
 
 Smoke mode is for live integrations that should not gate CI.
 
-Current smoke scenario:
+Current smoke scenarios:
 
 | Scenario | Environment |
 | --- | --- |
 | `live-provider-smoke` | `SWARM_SHOWCASE_OLLAMA_MODEL` |
+| `live-foundation-models-smoke` | `SWARM_SHOWCASE_FOUNDATION_MODELS=1` (or `SWARM_RUN_LIVE_FOUNDATION_MODELS_TESTS=1`) |
 
 Example:
 
 ```bash
 SWARM_SHOWCASE_OLLAMA_MODEL=llama3.2 swift run SwarmCapabilityShowcase smoke
+SWARM_SHOWCASE_FOUNDATION_MODELS=1 swift run SwarmCapabilityShowcase smoke
 ```
 
 If the required environment variable is missing, the smoke scenario reports `skipped` instead of failing.
+
+The `foundation-models` **deterministic** scenario always runs in the matrix (including on Linux, where it documents graceful compile-time gating). Live on-device generation is only exercised by the opt-in smoke scenario.
 
 ## Tests
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -23,12 +23,51 @@ targets: [
 
 ## Your First Agent
 
-The primary way to create an agent is with the `Agent` struct initializer. The canonical init takes an unlabeled instructions string and a `@ToolBuilder` trailing closure for tools:
+The primary way to create an agent is with the `Agent` struct initializer. The canonical init takes an unlabeled instructions string and a `@ToolBuilder` trailing closure for tools.
+
+### On-device (recommended on Apple platforms)
 
 ```swift
 import Swarm
 
-// 1. Define a tool — the @Tool macro generates the JSON schema
+@Tool("Looks up a canned stock price")
+struct PriceTool {
+    @Parameter("Ticker symbol") var ticker: String
+
+    func execute() async throws -> String { "182.50" }
+}
+
+// No API key. Requires macOS/iOS 26+ with Apple Intelligence available.
+// Parameter order: configuration → memory → inferenceProvider → guardrails → tools
+let agent = try Agent(
+    "Answer finance questions using tools when needed.",
+    configuration: .default.name("Analyst"),
+    memory: .conversation(maxMessages: 50),
+    inferenceProvider: .foundationModels(),
+    inputGuardrails: [InputGuard.maxLength(5000), InputGuard.notEmpty()]
+) {
+    PriceTool()
+}
+
+let result = try await agent.run("What is AAPL trading at?")
+print(result.output)
+```
+
+If the system model might be missing (Simulator, Linux CI, older OS), prefer the safe factory:
+
+```swift
+guard let provider = FoundationModelsInferenceProvider.ifAvailable() else {
+    // Fall back to .ollama / cloud, or fail with a clear user message.
+    throw AgentError.inferenceProviderUnavailable
+}
+let agent = try Agent("You are helpful.", inferenceProvider: provider)
+```
+
+### Cloud (Anthropic example)
+
+```swift
+import Swarm
+
 @Tool("Looks up the current stock price")
 struct PriceTool {
     @Parameter("Ticker symbol") var ticker: String
@@ -36,20 +75,25 @@ struct PriceTool {
     func execute() async throws -> String { "182.50" }
 }
 
-// 2. Create an agent with tools
 let agent = try Agent("Answer finance questions using real data.",
     configuration: .default.name("Analyst"),
-    inferenceProvider: .anthropic(key: "sk-..."),
     memory: .conversation(maxMessages: 50),
+    inferenceProvider: .anthropic(apiKey: "sk-..."),
     inputGuardrails: [InputGuard.maxLength(5000), InputGuard.notEmpty()]
 ) {
     PriceTool()
     CalculatorTool()
 }
 
-// 3. Run it
 let result = try await agent.run("What is AAPL trading at?")
 print(result.output) // "Apple (AAPL) is currently trading at $182.50."
+```
+
+### Working example apps
+
+```bash
+cd Examples/OnDeviceChat && swift run OnDeviceChat --demo
+cd Examples/MultiAgentPipeline && swift run MultiAgentPipeline --demo
 ```
 
 ## Creating Tools
@@ -92,7 +136,7 @@ Use `FunctionTool` inside a `@ToolBuilder` closure:
 
 ```swift
 let agent = try Agent("You are a helpful text utility.",
-    inferenceProvider: .anthropic(key: "sk-...")
+    inferenceProvider: .anthropic(apiKey: "sk-...")
 ) {
     FunctionTool(
         name: "reverse",
@@ -254,10 +298,10 @@ let profiled = try Agent(
 // Later, from a handoff tool or UI: mode.current = .review
 
 // Anthropic
-let agent = try Agent("You are helpful.", inferenceProvider: .anthropic(key: "sk-..."))
+let agent = try Agent("You are helpful.", inferenceProvider: .anthropic(apiKey: "sk-..."))
 
 // OpenAI
-let agent = try Agent("You are helpful.", inferenceProvider: .openAI(key: "sk-..."))
+let agent = try Agent("You are helpful.", inferenceProvider: .openAI(apiKey: "sk-..."))
 
 // Ollama (local)
 let agent = try Agent("You are helpful.", inferenceProvider: .ollama(model: "llama3.2"))
@@ -266,7 +310,7 @@ let agent = try Agent("You are helpful.", inferenceProvider: .ollama(model: "lla
 Or using the `.environment()` modifier on any `AgentRuntime`:
 
 ```swift
-agent.environment(\.inferenceProvider, .anthropic(key: "sk-..."))
+agent.environment(\.inferenceProvider, .anthropic(apiKey: "sk-..."))
 ```
 
 ## Requirements

--- a/docs/guide/production-readiness-findings.md
+++ b/docs/guide/production-readiness-findings.md
@@ -1,0 +1,84 @@
+# Production Readiness Findings (Foundation Models DX)
+
+Audit and hardening pass focused on making Swarm easy to use in real apps — especially with **Apple Foundation Models** — without breaking the public API.
+
+**Date:** 2026-07-17 · **Branch work:** `chore-polishapi` · **Framework version:** 0.6.0
+
+## Baseline
+
+| Check | Result |
+| --- | --- |
+| Parallel `swift build` | Failed initially: Swift 6.2 linker race on `SyntaxRewriter.visitationFunc` (swift-package-manager#9495) when linking `SwarmMacros-tool` |
+| `swift test --no-parallel` | 1 failure: `DocumentationFreshnessTests` (API catalog source-file count stale at 157 vs 161) |
+| Live FM tool calling (`SWARM_RUN_LIVE_FOUNDATION_MODELS_TESTS=1`) | Passed on host with Apple Intelligence available |
+| Capability matrix | Extended with deterministic `foundation-models` + opt-in live smoke |
+
+## Issues found (priority order)
+
+### Fixed
+
+1. **Macro linker flakiness (build reliability)**  
+   `InlineToolMacro` subclassed `SyntaxRewriter`, which can fail to link under parallel jobs on Swift 6.2 / swift-syntax 602.  
+   **Fix:** rewrite bare parameter references with regex-based string transform (no `SyntaxRewriter` subclass).
+
+2. **API catalog freshness**  
+   Source file count under `Sources/Swarm` (excluding GraphRuntime) grew to 161 after Foundation Models files landed; catalog still said 157.  
+   **Fix:** update `docs/reference/api-catalog.md` header count.
+
+3. **Broken README Quick Start snippet**  
+   `inferenceProvider: .anthropic(key: "{ENV"))` was syntactically invalid and preferred cloud without mentioning FM.  
+   **Fix:** valid `apiKey:` spelling + FM-first guidance.
+
+4. **No end-to-end apps that actually run**  
+   `Examples/CodeReviewer` linked Swarm but did not exercise agents/workflows live.  
+   **Fix:** add `Examples/OnDeviceChat` and `Examples/MultiAgentPipeline` with `--demo` (scripted, CI-safe) and live FM paths.
+
+5. **Capability matrix gap for Foundation Models**  
+   Providers scenario covered MultiProvider/task-local overrides only.  
+   **Fix:** deterministic `foundation-models` scenario (factories, capabilities, availability, Agent tool + multi-turn wiring) and opt-in `live-foundation-models-smoke`.
+
+6. **Doc `Agent(...)` argument order**  
+   Several README/getting-started snippets put `inferenceProvider:` before `memory:`, which does not type-check against the canonical initializer.  
+   **Fix:** reorder all major snippets to `configuration → memory → inferenceProvider → guardrails`; add compile tests in `ReadmeProviderCompileTests`.
+
+7. **Ambiguous `.anthropic(apiKey:)` / `.openAI(apiKey:)` on `InferenceProvider`**  
+   Both `LLM` and `ConduitProviderSelection` exposed `apiKey:` dot-syntax factories, so `Agent(..., inferenceProvider: .anthropic(apiKey:))` failed to type-check.  
+   **Fix:** keep `apiKey:` only on `ConduitProviderSelection` (canonical); keep `key:` on `LLM` as the beginner alias. Docs keep `apiKey:`.
+
+### Documented (fundamental / deferred)
+
+| Item | Guidance |
+| --- | --- |
+| FM requires macOS/iOS 26+ and system model availability | Use `ifAvailable()`; demos exit with clear stderr when unavailable |
+| FM does **not** advertise streaming tool calls | Text stream; tools are capture-then-execute per turn |
+| On-device safety may refuse "secret/codeword" multi-turn framing | Prefer benign memory prompts (e.g. favorite color); documented in `OnDeviceChat` |
+| Linux CI cannot import FoundationModels | Deterministic matrix still passes; live smoke skips honestly |
+| Dynamic Profiles are Swarm-native until Apple ships SDK API | Documented in provider DocC; bridges later without call-site breaks |
+| Full API catalog regeneration (all new public rows) | Header count fixed; exhaustive row-by-row regen deferred as lower priority |
+| CodeReviewer still deterministic plan-only | Superseded by new examples for agent/workflow stress |
+
+## High-impact DX wins shipped
+
+- **Foundation Models First** section in `README.md` and getting-started on-device path first.
+- Copy-pasteable demos that prove streaming, tools, conversation, workflows, and durable resume.
+- Matrix scenario that keeps the FM path from regressing on factories/capabilities even when the system model is cold.
+- Safer defaults messaging: prefer `apiKey:` for cloud factories in docs; keep `key:` aliases working.
+
+## Verification commands
+
+```bash
+swift test --no-parallel
+swift run SwarmCapabilityShowcase matrix
+cd Examples/OnDeviceChat && swift run OnDeviceChat --demo
+cd Examples/MultiAgentPipeline && swift run MultiAgentPipeline --demo
+# Optional live:
+SWARM_SHOWCASE_FOUNDATION_MODELS=1 swift run SwarmCapabilityShowcase smoke
+SWARM_RUN_LIVE_FOUNDATION_MODELS_TESTS=1 swift test --filter liveNativeToolCalling
+```
+
+## Constraints respected
+
+- Public API additive only (no silent removals).
+- StrictConcurrency / Sendable preserved.
+- Live provider smoke remains opt-in.
+- No gitignored internal audit paths used as the completion artifact (this guide is tracked under `docs/guide/`).

--- a/docs/reference/api-catalog.md
+++ b/docs/reference/api-catalog.md
@@ -3,7 +3,7 @@
 Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for high-risk public rows on 2026-05-18.
 
 - Scope: all `.swift` files under `Sources/Swarm/`, excluding `Internal/GraphRuntime/`
-- Source files scanned: 157
+- Source files scanned: 161
 - Public/open symbols cataloged: 2423
 
 ## 1. Swarm (entry point)
@@ -2602,6 +2602,38 @@ Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for
 | 69 | func | public | MCPToolBridge.bridgeTools() | `public func bridgeTools() async throws -> [any AnyJSONTool]` |
 
 ## 11. Providers
+
+### Providers/FoundationModels/FoundationModelsInferenceProvider.swift
+
+First-class on-device Apple Foundation Models path (no Conduit). Gated by `#if canImport(FoundationModels)` and `@available(macOS 26.0, iOS 26.0, visionOS 26.0, *)`.
+
+| Line | Kind | Access | Name | Signature |
+|------|------|--------|------|-----------|
+| 16 | struct | public | FoundationModelsProviderConfiguration | `public struct FoundationModelsProviderConfiguration` |
+| 24 | func | public | FoundationModelsProviderConfiguration.init(instructions:prewarmOnInit:) | `public init(instructions: String? = nil, prewarmOnInit: Bool = false)` |
+| 30 | var | public | FoundationModelsProviderConfiguration.default | `public static let default: FoundationModelsProviderConfiguration` |
+| 82 | struct | public | FoundationModelsInferenceProvider | `public struct FoundationModelsInferenceProvider` |
+| 94 | var | public | FoundationModelsInferenceProvider.isAvailable | `public static var isAvailable: Bool { get }` |
+| 99 | func | public | FoundationModelsInferenceProvider.ifAvailable(configuration:profile:) | `public static func ifAvailable(configuration: FoundationModelsProviderConfiguration = .default, profile: (any DynamicProfile)? = nil) -> FoundationModelsInferenceProvider?` |
+| 112 | func | public | FoundationModelsInferenceProvider.init(configuration:profile:) | `public init(configuration: FoundationModelsProviderConfiguration = .default, profile: (any DynamicProfile)? = nil)` |
+| 487 | func | public | InferenceProvider.foundationModels(configuration:) | `public static func foundationModels(configuration: FoundationModelsProviderConfiguration = .default) -> FoundationModelsInferenceProvider` |
+| 493 | func | public | InferenceProvider.foundationModels(instructions:prewarmOnInit:) | `public static func foundationModels(instructions: String, prewarmOnInit: Bool = false) -> FoundationModelsInferenceProvider` |
+| 509 | func | public | InferenceProvider.foundationModels(profile:configuration:) | `public static func foundationModels(profile: some DynamicProfile, configuration: FoundationModelsProviderConfiguration = .default) -> FoundationModelsInferenceProvider` |
+
+### Providers/FoundationModels/DynamicProfile.swift
+
+| Line | Kind | Access | Name | Signature |
+|------|------|--------|------|-----------|
+| 30 | struct | public | Profile | `public struct Profile` |
+| 84 | enum | public | ProfileToolFilter | `public enum ProfileToolFilter` |
+| 106 | struct | public | ProfileGenerationOverrides | `public struct ProfileGenerationOverrides` |
+| 148 | enum | public | ProfileHistoryPolicy | `public enum ProfileHistoryPolicy` |
+| 198 | struct | public | DynamicInstructions | `public struct DynamicInstructions` |
+| 247 | protocol | public | DynamicProfile | `public protocol DynamicProfile` |
+| 253 | struct | public | StaticDynamicProfile | `public struct StaticDynamicProfile` |
+| 264 | struct | public | ClosureDynamicProfile | `public struct ClosureDynamicProfile` |
+| 291 | class | public | ProfileMode | `public final class ProfileMode<Mode>` |
+| 314 | struct | public | ModeSwitchingDynamicProfile | `public struct ModeSwitchingDynamicProfile<Mode>` |
 
 ### Providers/Conduit/ConduitProviderSelection.swift
 


### PR DESCRIPTION
## Summary

Hardens Swarm for real Foundation Models–first adoption:

- Fix Swift 6.2 macro linker flakiness by removing `SyntaxRewriter` use in `InlineToolMacro`
- Disambiguate `.anthropic(apiKey:)` / `.openAI(apiKey:)` so doc-recommended cloud factories type-check
- Add deterministic `foundation-models` capability matrix scenario + opt-in live FM smoke
- Ship two end-to-end examples: `Examples/OnDeviceChat` and `Examples/MultiAgentPipeline`
- Fix public `Agent(...)` snippet argument order (`memory` before `inferenceProvider`)
- Document findings in `docs/guide/production-readiness-findings.md`

## Test plan

- [x] `swift test --no-parallel` (1866 tests)
- [x] `swift run SwarmCapabilityShowcase matrix` (all scenarios passed, including `foundation-models`)
- [x] `cd Examples/OnDeviceChat && swift run OnDeviceChat --demo`
- [x] `cd Examples/MultiAgentPipeline && swift run MultiAgentPipeline --demo`
- [x] `swift test --filter ReadmeProviderCompileTests` (doc snippet compile proof)
- [ ] Optional live: `swift run OnDeviceChat` on a machine with Apple Intelligence
- [ ] Optional live smoke: `SWARM_SHOWCASE_FOUNDATION_MODELS=1 swift run SwarmCapabilityShowcase smoke`