### PR TITLE
fix: raise swift-syntax floor to ≥601 (block 600.0.1 prebuilts)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ if includeDemo {
 }
 
 var packageDependencies: [Package.Dependency] = [
-    // swift-syntax range is intentionally widened to include 601/602 lines.
+    // Floor swift-syntax at 601 so SPM cannot resolve 600.x (especially 600.0.1).
     //
     // Background: Xcode 26 (Swift 6.2.x) ships implicit SwiftPM prebuilts for
     // swift-syntax via the swiftlang "MacroSupport" prebuilt server. The 600.0.1
@@ -27,11 +27,11 @@ var packageDependencies: [Package.Dependency] = [
     // "Unable to find module dependency: 'SwiftSyntax'" errors. That prebuilt
     // download cannot be disabled from a consumer project (SWIFT_USE_PREBUILT_MACROS=NO,
     // IDESwiftPackageEnablePrebuilts=NO, SWIFTPM_DISABLE_PREBUILTS=1 and
-    // -skipMacroValidation all fail to suppress it). Widening the range here lets
-    // SwiftPM resolve to 601+ on Swift 6.2 toolchains, which does not ship the
-    // broken prebuilt. Keep the upper bound below 603 for package-graph stability
-    // with the current Membrane/Hive integration pin set.
-    .package(url: "https://github.com/swiftlang/swift-syntax.git", "600.0.0"..<"603.0.0"),
+    // -skipMacroValidation all fail to suppress it). Floor ≥ 601 keeps resolution
+    // on toolchains/prebuilts that work with Swift 6.2 / Xcode 26.
+    // Only SwarmMacros (+ SwiftSyntaxMacrosTestSupport in tests) depends on
+    // swift-syntax. Upper bound stays <603 for package-graph stability.
+    .package(url: "https://github.com/swiftlang/swift-syntax.git", "601.0.0"..<"603.0.0"),
     .package(url: "https://github.com/apple/swift-log.git", from: "1.12.0"),
     .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.12.1"),
     .package(url: "https://github.com/open-telemetry/opentelemetry-swift-core.git", from: "2.4.1"),


### PR DESCRIPTION
## Summary

- Raise `swift-syntax` package lower bound from `600.0.0` to `601.0.0` (`"601.0.0"..<"603.0.0"`) so SPM cannot resolve broken **600.0.1** MacroSupport prebuilts on Xcode 26.
- Rewrite dependency comments for the post-Conduit story: only SwarmMacros uses swift-syntax; floor avoids `SDK does not match` / missing `SwiftSyntax`; upper bound remains `<603`.

## Context

Xcode 26 ships implicit SwiftPM MacroSupport prebuilts for swift-syntax. The **600.0.1** prebuilt fails to load on consumer machines (`SDK does not match` → `Unable to find module dependency: 'SwiftSyntax'`). Those downloads cannot be disabled from consumer projects. Local resolve already lands on **602.0.0**.

## Test plan

- [x] `swift package resolve` → swift-syntax **602.0.0**
- [x] `swift build`
- [x] `swift test --no-parallel --filter SwarmMacrosTests` (39 passed)
- [x] `swift test --no-parallel` (1708 passed, lean default)
- [x] `swift build --traits Integrations`
- [x] `swift test --no-parallel --traits Integrations` (1838 passed)

## Residual risk

A consumer app that forces swift-syntax 600.0.1 via another package can still hit the prebuilt failure; this package no longer allows that resolve path itself.