### PR TITLE
feat: vendor HiveCore, Membrane, and ContextCore in-tree

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,14 @@ Swarm/
 │   │   ├── Macros/                # Public macro declarations
 │   │   ├── Integration/           # Membrane and Wax integrations
 │   │   └── Internal/GraphRuntime/ # Compiled DAG runtime (internal)
+│   ├── HiveCore/                  # In-tree durable graph (Integrations only)
+│   ├── MembraneCore/              # In-tree Membrane core (Integrations only)
+│   ├── Membrane/                  # In-tree Membrane session (Integrations only)
+│   ├── MembraneContextCore/       # In-tree Membrane↔ContextCore (Integrations)
+│   ├── ContextCoreTypes/          # In-tree ContextCore types (Integrations)
+│   ├── ContextCoreShaders/        # In-tree Metal shaders (Integrations)
+│   ├── ContextCoreEngine/         # In-tree ContextCore engine (Integrations)
+│   ├── ContextCore/               # In-tree ContextCore façade (Integrations)
 │   ├── SwarmMacros/               # Compiler plugin (@Tool, @Parameter,
 │   │                              #   @Traceable, #Prompt, builders)
 │   ├── SwarmMembrane/             # Membrane workflow integration product
@@ -94,7 +102,15 @@ swift test --filter SwarmTests.WorkflowTests   # Run a single suite
 
 Default consumers get lean Swarm (core + Foundation Models). Enable the
 `Integrations` trait for durable Hive workflows, ContextCore+Wax default
-memory, Membrane adapters, and web helpers:
+memory, Membrane adapters, and web helpers.
+
+HiveCore, Membrane (`MembraneCore` / `Membrane` / `MembraneContextCore`), and
+ContextCore (`ContextCoreTypes` / `ContextCoreShaders` / `ContextCoreEngine` /
+`ContextCore`) are **native in-tree** `Sources/` targets — internal modules
+only (no separate library products). They are linked into Swarm only when
+Integrations is on. Wax remains a remote package + trait-gated product;
+MetalANNS stays remote for the ContextCore chain. Lean resolve must not pull
+package identities `hive`, `membrane`, or `contextcore`.
 
 ```bash
 swift build --traits Integrations

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,9 +108,12 @@ HiveCore, Membrane (`MembraneCore` / `Membrane` / `MembraneContextCore`), and
 ContextCore (`ContextCoreTypes` / `ContextCoreShaders` / `ContextCoreEngine` /
 `ContextCore`) are **native in-tree** `Sources/` targets — internal modules
 only (no separate library products). They are linked into Swarm only when
-Integrations is on. Wax remains a remote package + trait-gated product;
-MetalANNS stays remote for the ContextCore chain. Lean resolve must not pull
-package identities `hive`, `membrane`, or `contextcore`.
+Integrations is on. ContextCore / full Membrane session stack are Apple-only
+(Metal/CoreML); Linux Integrations still links Hive + MembraneCore + web.
+Wax remains a remote package + trait-gated product; MetalANNS stays remote for
+the ContextCore chain. Lean resolve must not pull package identities `hive`,
+`membrane`, or `contextcore`, but still resolves Wax/MetalANNS/crypto/mutex/
+collections unless `SWARM_CORE_ONLY=1`.
 
 ```bash
 swift build --traits Integrations

--- a/Package.swift
+++ b/Package.swift
@@ -39,18 +39,22 @@ var packageDependencies: [Package.Dependency] = [
 ]
 
 // Integrations trait: opt-in graph/memory/web/Hive paths (off by default).
-// Roadmap: Hive, Membrane, and ContextCore become in-tree Sources/ targets
-// (local folders linked only when Integrations is on). Wax stays remote for now.
-// Remotes below are temporary until that vendor lands.
+// HiveCore, Membrane*, and ContextCore* are native in-tree Sources/ targets,
+// linked only when Integrations is enabled. Wax stays remote + trait-gated.
+// MetalANNS stays remote (ContextCore → MetalANNS → GRDB).
 let integrationTrait = "Integrations"
 if !coreOnly {
     packageDependencies += [
-        // Temporary remotes until Hive/Membrane/ContextCore are vendored under Sources/.
-        // Wax remains an external package + trait-gated product dependency.
+        // External packages used by Integrations-linked in-tree targets / products.
+        // HiveCore → swift-crypto, swift-mutex
+        // MembraneCore → OrderedCollections (swift-collections)
+        // ContextCore* → MetalANNS
+        // Swarm → Wax (trait-gated product)
         .package(url: "https://github.com/christopherkarani/Wax.git", exact: "0.1.23"),
-        .package(url: "https://github.com/christopherkarani/ContextCore.git", exact: "1.0.0"),
-        .package(url: "https://github.com/christopherkarani/Membrane", exact: "0.1.4"),
-        .package(url: "https://github.com/christopherkarani/Hive", exact: "0.2.1"),
+        .package(url: "https://github.com/christopherkarani/MetalANNS.git", from: "0.1.3"),
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "3.7.0"),
+        .package(url: "https://github.com/swhitty/swift-mutex.git", from: "0.0.6"),
+        .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),
     ]
 }
 
@@ -67,11 +71,14 @@ var swarmSwiftSettings: [SwiftSetting] = [
 
 if !coreOnly {
     swarmDependencies += [
+        // In-tree Integrations modules (linked only when trait is on).
+        .target(name: "HiveCore", condition: .when(traits: [integrationTrait])),
+        .target(name: "Membrane", condition: .when(traits: [integrationTrait])),
+        .target(name: "MembraneCore", condition: .when(traits: [integrationTrait])),
+        .target(name: "MembraneContextCore", condition: .when(traits: [integrationTrait])),
+        .target(name: "ContextCore", condition: .when(traits: [integrationTrait])),
+        // Wax remains an external package + trait-gated product dependency.
         .product(name: "Wax", package: "Wax", condition: .when(traits: [integrationTrait])),
-        .product(name: "ContextCore", package: "ContextCore", condition: .when(traits: [integrationTrait])),
-        .product(name: "HiveCore", package: "Hive", condition: .when(traits: [integrationTrait])),
-        .product(name: "Membrane", package: "Membrane", condition: .when(traits: [integrationTrait])),
-        .product(name: "MembraneCore", package: "Membrane", condition: .when(traits: [integrationTrait])),
     ]
     swarmSwiftSettings.append(.define("SWARM_INTEGRATIONS", .when(traits: [integrationTrait])))
 }
@@ -163,8 +170,8 @@ var packageTargets: [Target] = [
             ]
             if !coreOnly {
                 dependencies += [
-                    .product(name: "Membrane", package: "Membrane", condition: .when(traits: [integrationTrait])),
-                    .product(name: "MembraneCore", package: "Membrane", condition: .when(traits: [integrationTrait])),
+                    .target(name: "Membrane", condition: .when(traits: [integrationTrait])),
+                    .target(name: "MembraneCore", condition: .when(traits: [integrationTrait])),
                 ]
             }
             return dependencies
@@ -203,16 +210,102 @@ var packageTargets: [Target] = [
 ]
 
 if !coreOnly {
-    packageTargets.append(
+    // MARK: - In-tree Integrations modules (internal targets only — no library products)
+    // HiveCore, Membrane*, ContextCore* live under Sources/ and are linked into Swarm
+    // only when the Integrations trait is enabled.
+
+    packageTargets += [
+        // HiveCore — durable graph / checkpoint runtime
+        .target(
+            name: "HiveCore",
+            dependencies: [
+                .product(name: "Crypto", package: "swift-crypto"),
+                .product(name: "Mutex", package: "swift-mutex"),
+            ],
+            path: "Sources/HiveCore",
+            exclude: ["README.md"]
+        ),
+
+        // Membrane stack
+        .target(
+            name: "MembraneCore",
+            dependencies: [
+                .product(name: "OrderedCollections", package: "swift-collections"),
+            ],
+            path: "Sources/MembraneCore",
+            swiftSettings: [.swiftLanguageMode(.v6)]
+        ),
+        .target(
+            name: "MembraneContextCore",
+            dependencies: [
+                "MembraneCore",
+                "ContextCore",
+            ],
+            path: "Sources/MembraneContextCore",
+            swiftSettings: [.swiftLanguageMode(.v6)]
+        ),
+        .target(
+            name: "Membrane",
+            dependencies: [
+                "MembraneCore",
+                "MembraneContextCore",
+            ],
+            path: "Sources/Membrane",
+            swiftSettings: [.swiftLanguageMode(.v6)]
+        ),
+
+        // ContextCore stack (MetalANNS remains remote)
+        .target(
+            name: "ContextCoreTypes",
+            path: "Sources/ContextCoreTypes"
+        ),
+        .target(
+            name: "ContextCoreShaders",
+            path: "Sources/ContextCoreShaders",
+            resources: [.process("Shaders")],
+            linkerSettings: [
+                .linkedFramework("Metal", .when(platforms: [.macOS, .iOS, .tvOS, .visionOS])),
+            ]
+        ),
+        .target(
+            name: "ContextCoreEngine",
+            dependencies: [
+                "ContextCoreShaders",
+                "ContextCoreTypes",
+                .product(name: "MetalANNS", package: "MetalANNS"),
+            ],
+            path: "Sources/ContextCoreEngine",
+            linkerSettings: [
+                .linkedFramework("Metal", .when(platforms: [.macOS, .iOS, .tvOS, .visionOS])),
+                .linkedFramework("CoreML", .when(platforms: [.macOS, .iOS, .tvOS, .visionOS])),
+                .linkedFramework("Accelerate", .when(platforms: [.macOS, .iOS, .tvOS, .visionOS])),
+            ]
+        ),
+        .target(
+            name: "ContextCore",
+            dependencies: [
+                "ContextCoreEngine",
+                "ContextCoreTypes",
+                .product(name: "MetalANNS", package: "MetalANNS"),
+            ],
+            path: "Sources/ContextCore",
+            resources: [.process("Resources")],
+            linkerSettings: [
+                .linkedFramework("Metal", .when(platforms: [.macOS, .iOS, .tvOS, .visionOS])),
+                .linkedFramework("CoreML", .when(platforms: [.macOS, .iOS, .tvOS, .visionOS])),
+                .linkedFramework("Accelerate", .when(platforms: [.macOS, .iOS, .tvOS, .visionOS])),
+            ]
+        ),
+
         .testTarget(
             name: "HiveSwarmTests",
             dependencies: [
                 "Swarm",
-                .product(name: "HiveCore", package: "Hive", condition: .when(traits: [integrationTrait])),
+                .target(name: "HiveCore", condition: .when(traits: [integrationTrait])),
             ],
             swiftSettings: swarmSwiftSettings
-        )
-    )
+        ),
+    ]
 }
 
 if includeDemo {
@@ -255,8 +348,9 @@ let package = Package(
             name: integrationTrait,
             description: """
             Enable SWARM_INTEGRATIONS: durable Hive workflows, ContextCore+Wax default memory, \
-            Membrane adapters, and web helpers. Off by default. Hive/Membrane/ContextCore are \
-            planned as in-tree Sources/ targets; Wax remains an external package for now.
+            Membrane adapters, and web helpers. Off by default. HiveCore, Membrane, and \
+            ContextCore are native in-tree Sources/ targets (internal; not separate products). \
+            Wax remains an external package for now.
             """
         ),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -42,16 +42,24 @@ var packageDependencies: [Package.Dependency] = [
 // HiveCore, Membrane*, and ContextCore* are native in-tree Sources/ targets,
 // linked only when Integrations is enabled. Wax stays remote + trait-gated.
 // MetalANNS stays remote (ContextCore → MetalANNS → GRDB).
+//
+// ContextCore / Membrane (full stack) require Apple frameworks (Metal, CoreML,
+// Accelerate). They are trait-linked only on Apple platforms so Linux
+// Integrations can still build Hive + MembraneCore + web helpers without
+// compiling the GPU memory stack.
 let integrationTrait = "Integrations"
+let appleIntegrationPlatforms: [Platform] = [.macOS, .iOS, .tvOS, .visionOS]
 if !coreOnly {
     packageDependencies += [
-        // External packages used by Integrations-linked in-tree targets / products.
+        // Declared for non-coreOnly resolves (lean + Integrations). Trait controls
+        // *link* of Wax / in-tree modules; resolve still downloads these packages
+        // (and MetalANNS → GRDB) unless SWARM_CORE_ONLY=1.
         // HiveCore → swift-crypto, swift-mutex
         // MembraneCore → OrderedCollections (swift-collections)
-        // ContextCore* → MetalANNS
+        // ContextCore* → MetalANNS (Apple platforms only at link/compile)
         // Swarm → Wax (trait-gated product)
         .package(url: "https://github.com/christopherkarani/Wax.git", exact: "0.1.23"),
-        .package(url: "https://github.com/christopherkarani/MetalANNS.git", from: "0.1.3"),
+        .package(url: "https://github.com/christopherkarani/MetalANNS.git", exact: "0.1.3"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "3.7.0"),
         .package(url: "https://github.com/swhitty/swift-mutex.git", from: "0.0.6"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),
@@ -71,12 +79,22 @@ var swarmSwiftSettings: [SwiftSetting] = [
 
 if !coreOnly {
     swarmDependencies += [
-        // In-tree Integrations modules (linked only when trait is on).
+        // Portable Integrations modules (all platforms when trait is on).
         .target(name: "HiveCore", condition: .when(traits: [integrationTrait])),
-        .target(name: "Membrane", condition: .when(traits: [integrationTrait])),
         .target(name: "MembraneCore", condition: .when(traits: [integrationTrait])),
-        .target(name: "MembraneContextCore", condition: .when(traits: [integrationTrait])),
-        .target(name: "ContextCore", condition: .when(traits: [integrationTrait])),
+        // Apple-only memory / Membrane session stack (Metal / CoreML / MetalANNS).
+        .target(
+            name: "Membrane",
+            condition: .when(platforms: appleIntegrationPlatforms, traits: [integrationTrait])
+        ),
+        .target(
+            name: "MembraneContextCore",
+            condition: .when(platforms: appleIntegrationPlatforms, traits: [integrationTrait])
+        ),
+        .target(
+            name: "ContextCore",
+            condition: .when(platforms: appleIntegrationPlatforms, traits: [integrationTrait])
+        ),
         // Wax remains an external package + trait-gated product dependency.
         .product(name: "Wax", package: "Wax", condition: .when(traits: [integrationTrait])),
     ]
@@ -170,8 +188,11 @@ var packageTargets: [Target] = [
             ]
             if !coreOnly {
                 dependencies += [
-                    .target(name: "Membrane", condition: .when(traits: [integrationTrait])),
                     .target(name: "MembraneCore", condition: .when(traits: [integrationTrait])),
+                    .target(
+                        name: "Membrane",
+                        condition: .when(platforms: appleIntegrationPlatforms, traits: [integrationTrait])
+                    ),
                 ]
             }
             return dependencies
@@ -214,6 +235,11 @@ if !coreOnly {
     // HiveCore, Membrane*, ContextCore* live under Sources/ and are linked into Swarm
     // only when the Integrations trait is enabled.
 
+    let integrationsTargetSwiftSettings: [SwiftSetting] = [
+        .enableExperimentalFeature("StrictConcurrency"),
+        .swiftLanguageMode(.v6),
+    ]
+
     packageTargets += [
         // HiveCore — durable graph / checkpoint runtime
         .target(
@@ -223,7 +249,8 @@ if !coreOnly {
                 .product(name: "Mutex", package: "swift-mutex"),
             ],
             path: "Sources/HiveCore",
-            exclude: ["README.md"]
+            exclude: ["README.md"],
+            swiftSettings: integrationsTargetSwiftSettings
         ),
 
         // Membrane stack
@@ -233,7 +260,7 @@ if !coreOnly {
                 .product(name: "OrderedCollections", package: "swift-collections"),
             ],
             path: "Sources/MembraneCore",
-            swiftSettings: [.swiftLanguageMode(.v6)]
+            swiftSettings: integrationsTargetSwiftSettings
         ),
         .target(
             name: "MembraneContextCore",
@@ -242,7 +269,7 @@ if !coreOnly {
                 "ContextCore",
             ],
             path: "Sources/MembraneContextCore",
-            swiftSettings: [.swiftLanguageMode(.v6)]
+            swiftSettings: integrationsTargetSwiftSettings
         ),
         .target(
             name: "Membrane",
@@ -251,20 +278,22 @@ if !coreOnly {
                 "MembraneContextCore",
             ],
             path: "Sources/Membrane",
-            swiftSettings: [.swiftLanguageMode(.v6)]
+            swiftSettings: integrationsTargetSwiftSettings
         ),
 
-        // ContextCore stack (MetalANNS remains remote)
+        // ContextCore stack (MetalANNS remains remote; Apple-linked via Swarm deps)
         .target(
             name: "ContextCoreTypes",
-            path: "Sources/ContextCoreTypes"
+            path: "Sources/ContextCoreTypes",
+            swiftSettings: integrationsTargetSwiftSettings
         ),
         .target(
             name: "ContextCoreShaders",
             path: "Sources/ContextCoreShaders",
             resources: [.process("Shaders")],
+            swiftSettings: integrationsTargetSwiftSettings,
             linkerSettings: [
-                .linkedFramework("Metal", .when(platforms: [.macOS, .iOS, .tvOS, .visionOS])),
+                .linkedFramework("Metal", .when(platforms: appleIntegrationPlatforms)),
             ]
         ),
         .target(
@@ -272,13 +301,18 @@ if !coreOnly {
             dependencies: [
                 "ContextCoreShaders",
                 "ContextCoreTypes",
-                .product(name: "MetalANNS", package: "MetalANNS"),
+                .product(
+                    name: "MetalANNS",
+                    package: "MetalANNS",
+                    condition: .when(platforms: appleIntegrationPlatforms)
+                ),
             ],
             path: "Sources/ContextCoreEngine",
+            swiftSettings: integrationsTargetSwiftSettings,
             linkerSettings: [
-                .linkedFramework("Metal", .when(platforms: [.macOS, .iOS, .tvOS, .visionOS])),
-                .linkedFramework("CoreML", .when(platforms: [.macOS, .iOS, .tvOS, .visionOS])),
-                .linkedFramework("Accelerate", .when(platforms: [.macOS, .iOS, .tvOS, .visionOS])),
+                .linkedFramework("Metal", .when(platforms: appleIntegrationPlatforms)),
+                .linkedFramework("CoreML", .when(platforms: appleIntegrationPlatforms)),
+                .linkedFramework("Accelerate", .when(platforms: appleIntegrationPlatforms)),
             ]
         ),
         .target(
@@ -286,14 +320,19 @@ if !coreOnly {
             dependencies: [
                 "ContextCoreEngine",
                 "ContextCoreTypes",
-                .product(name: "MetalANNS", package: "MetalANNS"),
+                .product(
+                    name: "MetalANNS",
+                    package: "MetalANNS",
+                    condition: .when(platforms: appleIntegrationPlatforms)
+                ),
             ],
             path: "Sources/ContextCore",
             resources: [.process("Resources")],
+            swiftSettings: integrationsTargetSwiftSettings,
             linkerSettings: [
-                .linkedFramework("Metal", .when(platforms: [.macOS, .iOS, .tvOS, .visionOS])),
-                .linkedFramework("CoreML", .when(platforms: [.macOS, .iOS, .tvOS, .visionOS])),
-                .linkedFramework("Accelerate", .when(platforms: [.macOS, .iOS, .tvOS, .visionOS])),
+                .linkedFramework("Metal", .when(platforms: appleIntegrationPlatforms)),
+                .linkedFramework("CoreML", .when(platforms: appleIntegrationPlatforms)),
+                .linkedFramework("Accelerate", .when(platforms: appleIntegrationPlatforms)),
             ]
         ),
 
@@ -350,6 +389,8 @@ let package = Package(
             Enable SWARM_INTEGRATIONS: durable Hive workflows, ContextCore+Wax default memory, \
             Membrane adapters, and web helpers. Off by default. HiveCore, Membrane, and \
             ContextCore are native in-tree Sources/ targets (internal; not separate products). \
+            ContextCore / full Membrane session stack require Apple platforms (Metal/CoreML); \
+            Linux Integrations still gets Hive + MembraneCore + web helpers. \
             Wax remains an external package for now.
             """
         ),

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Two agents, one pipeline, compiled to a DAG with crash recovery and Swift concur
 
 Default **link** is **lean**: core Swarm + on-device Foundation Models. Graph/memory/web/Hive paths are trait-gated (off by default) and are not linked into Swarm unless you enable Integrations.
 
-HiveCore, Membrane, and ContextCore are **native in-tree** `Sources/` targets (internal modules — not separate library products). Enabling Integrations **links** those modules plus Wax (still remote) and SwiftSoup; omitting the trait does not link them into Swarm. Lean resolve does not pull Hive/Membrane/ContextCore packages.
+HiveCore, Membrane, and ContextCore are **native in-tree** `Sources/` targets (internal modules — not separate library products). Enabling Integrations **links** those modules plus Wax (still remote) and SwiftSoup; omitting the trait does not link them into Swarm. Lean resolve does not pull Hive/Membrane/ContextCore **package identities**, but still resolves Wax, MetalANNS (→ GRDB), swift-crypto, swift-mutex, and swift-collections unless `SWARM_CORE_ONLY=1`. ContextCore / full Membrane session stack require Apple platforms (Metal/CoreML); Linux Integrations still builds Hive + MembraneCore + web helpers. DefaultAgentMemory uses a CoreML embedding model that is **not** bundled — without `minilm-l6-v2.mlpackage`, ContextCore falls back to deterministic pseudo-embeddings.
 
 ```swift
 // Lean default link (recommended for most apps)

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Two agents, one pipeline, compiled to a DAG with crash recovery and Swift concur
 
 ## Install
 
-Default **link** is **lean**: core Swarm + on-device Foundation Models. Graph/memory/web/Hive **products** are trait-gated (off by default) and are not linked into Swarm unless you enable Integrations.
+Default **link** is **lean**: core Swarm + on-device Foundation Models. Graph/memory/web/Hive paths are trait-gated (off by default) and are not linked into Swarm unless you enable Integrations.
 
-SwiftPM may still **resolve** temporary remote packages (Hive/Membrane/ContextCore/Wax, and SwiftSoup for web HTML parsing) listed in `Package.swift` until those libraries are vendored as in-tree targets. Enabling Integrations **links** them (including SwiftSoup); omitting the trait does not link them into Swarm.
+HiveCore, Membrane, and ContextCore are **native in-tree** `Sources/` targets (internal modules — not separate library products). Enabling Integrations **links** those modules plus Wax (still remote) and SwiftSoup; omitting the trait does not link them into Swarm. Lean resolve does not pull Hive/Membrane/ContextCore packages.
 
 ```swift
 // Lean default link (recommended for most apps)

--- a/Sources/ContextCore/AgentContext.swift
+++ b/Sources/ContextCore/AgentContext.swift
@@ -1,0 +1,719 @@
+import Foundation
+import OSLog
+import os.lock
+import ContextCoreEngine
+
+extension Logger {
+    static let contextCore = Logger(subsystem: "com.contextcore", category: "AgentContext")
+    static let consolidation = Logger(subsystem: "com.contextcore", category: "Consolidation")
+    static let scoring = Logger(subsystem: "com.contextcore", category: "Scoring")
+}
+
+/// High-level actor API coordinating retrieval, scoring, packing, compression, and persistence.
+public actor AgentContext {
+    /// Immutable runtime configuration for this context instance.
+    public let configuration: ContextConfiguration
+
+    private var sessionStore = SessionStore()
+
+    private let episodicStore: EpisodicStore
+    private let semanticStore: SemanticStore
+    private let proceduralStore: ProceduralStore
+
+    private let scoringEngine: ScoringEngine
+    private let attentionEngine: AttentionEngine
+    private let compressionEngine: CompressionEngine
+    private let consolidationEngine: ConsolidationEngine
+    private let progressiveCompressor: ProgressiveCompressor
+
+    private let windowPacker: WindowPacker
+    private let chunkOrderer: ChunkOrderer
+
+    private let embeddingProvider: any EmbeddingProvider
+    private let tokenCounter: any TokenCounter
+
+    private let consolidationScheduler: ConsolidationScheduler
+
+    private nonisolated let statsLock = OSAllocatedUnfairLock(initialState: ContextStats())
+
+    /// Latest nonisolated runtime stats snapshot.
+    public nonisolated var stats: ContextStats {
+        statsLock.withLock { $0 }
+    }
+
+    /// Creates an ``AgentContext`` and initializes all processing subsystems.
+    ///
+    /// - Parameter configuration: Runtime configuration. Defaults to ``ContextConfiguration/default``.
+    /// - Throws: `ContextCoreError.metalDeviceUnavailable` when no compatible Metal device exists.
+    public init(configuration: ContextConfiguration = .default) throws {
+        self.configuration = configuration
+
+        let provider = CachingEmbeddingProvider(
+            base: configuration.embeddingProvider,
+            cache: EmbeddingCache(capacity: 512)
+        )
+        self.embeddingProvider = provider
+        self.tokenCounter = configuration.tokenCounter
+
+        self.episodicStore = EpisodicStore()
+        self.semanticStore = SemanticStore()
+        self.proceduralStore = ProceduralStore()
+
+        self.scoringEngine = try ScoringEngine()
+        self.attentionEngine = try AttentionEngine()
+        self.compressionEngine = try CompressionEngine(
+            embeddingProvider: provider,
+            tokenCounter: configuration.tokenCounter,
+            compressionDelegate: configuration.compressionDelegate
+        )
+        self.consolidationEngine = try ConsolidationEngine(
+            embeddingProvider: provider
+        )
+
+        self.progressiveCompressor = ProgressiveCompressor(
+            compressionEngine: self.compressionEngine,
+            tokenCounter: configuration.tokenCounter
+        )
+        self.windowPacker = WindowPacker(
+            compressionEngine: self.compressionEngine,
+            tokenCounter: configuration.tokenCounter,
+            minimumChunkSize: 50,
+            recentTurnsGuaranteed: configuration.recentTurnsGuaranteed
+        )
+        self.chunkOrderer = ChunkOrderer()
+
+        self.consolidationScheduler = ConsolidationScheduler(
+            engine: self.consolidationEngine,
+            countThreshold: configuration.consolidationThreshold,
+            insertionThreshold: 50,
+            similarityThreshold: configuration.similarityMergeThreshold
+        )
+
+        statsLock.withLock { snapshot in
+            snapshot.proceduralCount = 0
+        }
+
+        Task.detached(priority: .background) {
+            _ = try? await provider.embed("warmup")
+        }
+    }
+
+    /// Restores an ``AgentContext`` from a checkpoint file.
+    ///
+    /// - Parameter url: Checkpoint file URL.
+    /// - Returns: A restored context with persisted stores and session metadata.
+    /// - Throws: `ContextCoreError.checkpointCorrupt` when data cannot be decoded or schema is unsupported.
+    public static func load(from url: URL) async throws -> AgentContext {
+        let data: Data
+        do {
+            data = try Data(contentsOf: url)
+        } catch {
+            throw error
+        }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        let checkpoint: ContextCheckpoint
+        do {
+            checkpoint = try decoder.decode(ContextCheckpoint.self, from: data)
+        } catch {
+            Logger.contextCore.error("Error in load(from:): \(error.localizedDescription, privacy: .public)")
+            throw ContextCoreError.checkpointCorrupt
+        }
+
+        guard checkpoint.version == 1 else {
+            Logger.contextCore.error("Error in load(from:): unsupported checkpoint version \(checkpoint.version, privacy: .public)")
+            throw ContextCoreError.checkpointCorrupt
+        }
+
+        let config = checkpoint.configuration.apply(to: .default)
+        let context = try AgentContext(configuration: config)
+        try await context.restore(from: checkpoint)
+        return context
+    }
+
+    /// Begins a new session and optionally sets the session system prompt.
+    ///
+    /// - Parameters:
+    ///   - id: Session identifier. Defaults to a new UUID.
+    ///   - systemPrompt: Optional system prompt pinned into subsequent windows.
+    /// - Throws: Propagates errors from implicit session-end consolidation when a session is already active.
+    public func beginSession(id: UUID = UUID(), systemPrompt: String? = nil) async throws {
+        if sessionStore.isSessionActive {
+            try await endSession()
+        }
+
+        sessionStore.begin(id: id, systemPrompt: systemPrompt)
+        let totalSessions = sessionStore.totalSessions
+        mutateStats { snapshot in
+            snapshot.totalSessions = totalSessions
+        }
+
+        Logger.contextCore.info("Session started: \(id.uuidString, privacy: .public)")
+    }
+
+    /// Ends the active session and runs a consolidation pass.
+    ///
+    /// - Throws: `ContextCoreError.sessionNotStarted` when no session is active.
+    public func endSession() async throws {
+        guard let sessionID = sessionStore.currentSessionID else {
+            throw ContextCoreError.sessionNotStarted
+        }
+
+        Logger.consolidation.info("Consolidation started: session=\(sessionID.uuidString, privacy: .public)")
+
+        let result = try await consolidationEngine.consolidate(
+            session: sessionID,
+            episodicStore: episodicStore,
+            semanticStore: semanticStore,
+            threshold: configuration.similarityMergeThreshold
+        )
+
+        sessionStore.end()
+        await refreshCountStats(lastConsolidationLatencyMs: result.durationMs)
+
+        Logger.consolidation.info(
+            "Consolidation complete: promoted=\(result.factsPromoted, privacy: .public) evicted=\(result.chunksEvicted, privacy: .public) durationMs=\(result.durationMs, privacy: .public)"
+        )
+        Logger.contextCore.info("Session ended: \(sessionID.uuidString, privacy: .public)")
+    }
+
+    /// Appends a turn into episodic memory and recent-turn buffers.
+    ///
+    /// - Parameter turn: Turn to append.
+    /// - Throws: `ContextCoreError.sessionNotStarted` if no session is active.
+    public func append(turn: Turn) async throws {
+        guard let sessionID = sessionStore.currentSessionID else {
+            throw ContextCoreError.sessionNotStarted
+        }
+
+        var enriched = turn
+        if enriched.embedding == nil {
+            enriched.embedding = try await embedText(turn.content)
+        }
+
+        if enriched.tokenCount <= 0 {
+            enriched.tokenCount = tokenCounter.count(turn.content)
+        }
+
+        try await episodicStore.insert(turn: enriched)
+
+        let maxRecentBuffer = max(configuration.recentTurnsGuaranteed * 2, configuration.recentTurnsGuaranteed)
+        sessionStore.appendRecent(enriched, maxBufferSize: maxRecentBuffer)
+
+        let episodicCount = await episodicStore.count
+        await consolidationScheduler.notifyInsertion(
+            episodicCount: episodicCount,
+            session: sessionID,
+            episodicStore: episodicStore,
+            semanticStore: semanticStore
+        )
+
+        mutateStats { snapshot in
+            snapshot.episodicCount = episodicCount
+        }
+    }
+
+    /// Builds an optimal context window for the current task.
+    ///
+    /// Scores all memory against the task embedding, packs results into the effective token budget,
+    /// and orders chunks for attention-aware model consumption. Episodic and semantic scoring run in
+    /// parallel with `async let`.
+    ///
+    /// - Parameters:
+    ///   - currentTask: Natural language task query used for memory relevance scoring.
+    ///   - maxTokens: Optional override for ``ContextConfiguration/maxTokens``.
+    /// - Returns: A packed ``ContextWindow`` ready for ``ContextWindow/formatted(style:)``.
+    /// - Throws: `ContextCoreError.sessionNotStarted` when no session is active.
+    /// - Throws: `ContextCoreError.tokenBudgetTooSmall` when guaranteed context exceeds effective budget.
+    ///
+    /// ## Example
+    ///
+    /// ```swift
+    /// let window = try await context.buildWindow(
+    ///     currentTask: "Help debug a Swift concurrency issue",
+    ///     maxTokens: 4096
+    /// )
+    /// let prompt = window.formatted(style: .chatML)
+    /// ```
+    ///
+    /// - Complexity: O(n log n) over retrieved candidates plus GPU scoring dispatch.
+    public func buildWindow(
+        currentTask: String,
+        maxTokens: Int? = nil
+    ) async throws -> ContextWindow {
+        guard let sessionID = sessionStore.currentSessionID else {
+            throw ContextCoreError.sessionNotStarted
+        }
+
+        let start = Date()
+
+        let rawBudget = maxTokens ?? configuration.maxTokens
+        let effectiveBudget = Int((Float(rawBudget) * (1.0 - configuration.tokenBudgetSafetyMargin)).rounded(.down))
+        guard effectiveBudget > 0 else {
+            throw ContextCoreError.tokenBudgetTooSmall
+        }
+
+        let guaranteedTokens = guaranteedTokenUsage()
+        guard guaranteedTokens <= effectiveBudget else {
+            throw ContextCoreError.tokenBudgetTooSmall
+        }
+
+        let taskEmbedding = try await embedText(currentTask)
+
+        let allEpisodic = await episodicStore.allChunks()
+        let allSemantic = await semanticStore.allChunks()
+
+        async let episodicScoring = scoreMemory(
+            taskEmbedding: taskEmbedding,
+            chunks: allEpisodic,
+            halfLifeDays: configuration.episodicHalfLifeDays
+        )
+
+        async let semanticScoring = scoreMemory(
+            taskEmbedding: taskEmbedding,
+            chunks: allSemantic,
+            halfLifeDays: configuration.semanticHalfLifeDays
+        )
+
+        let scoredEpisodic = try await episodicScoring
+        let scoredSemantic = try await semanticScoring
+
+        let proceduralTools = await proceduralStore.retrieve(taskType: currentTask)
+        let scoredProcedural = makeProceduralCandidates(
+            tools: proceduralTools,
+            taskEmbedding: taskEmbedding,
+            sessionID: sessionID
+        )
+
+        var merged: [(chunk: MemoryChunk, score: Float)] = []
+        merged.append(contentsOf: scoredEpisodic.prefix(configuration.episodicMemoryK))
+        merged.append(contentsOf: scoredSemantic.prefix(configuration.semanticMemoryK))
+        merged.append(contentsOf: scoredProcedural)
+
+        let reranked = try await applyAttentionRerank(
+            query: taskEmbedding,
+            scoredMemory: merged
+        )
+
+        let recentTurns = sessionStore.guaranteedRecentTurns(count: configuration.recentTurnsGuaranteed)
+
+        let packed = try await windowPacker.pack(
+            systemPrompt: sessionStore.systemPrompt,
+            recentTurns: recentTurns,
+            scoredMemory: reranked,
+            budget: effectiveBudget
+        )
+
+        let ordered = chunkOrderer.order(packed.chunks, strategy: .typeGrouped)
+        let finalWindow = ContextWindow(chunks: ordered, budget: effectiveBudget)
+
+        let elapsedMs = Date().timeIntervalSince(start) * 1000
+        let averageScore: Float
+        if finalWindow.chunks.isEmpty {
+            averageScore = 0
+        } else {
+            averageScore = finalWindow.chunks.reduce(Float.zero) { $0 + $1.score } / Float(finalWindow.chunks.count)
+        }
+
+        let compressionRatio: Float
+        if finalWindow.chunks.isEmpty {
+            compressionRatio = 0
+        } else {
+            compressionRatio = Float(finalWindow.compressedChunks) / Float(finalWindow.chunks.count)
+        }
+
+        mutateStats { snapshot in
+            snapshot.lastBuildWindowLatencyMs = elapsedMs
+            snapshot.averageRelevanceScore = averageScore
+            snapshot.compressionRatio = compressionRatio
+        }
+
+        Logger.scoring.debug(
+            "Window built: tokens=\(finalWindow.totalTokens, privacy: .public) chunks=\(finalWindow.chunks.count, privacy: .public) latencyMs=\(elapsedMs, privacy: .public)"
+        )
+
+        return finalWindow
+    }
+
+    /// Stores a semantic fact for long-term retrieval.
+    ///
+    /// - Parameter fact: Fact text to embed and upsert.
+    /// - Throws: Embedding or semantic-store failures.
+    public func remember(_ fact: String) async throws {
+        let embedding = try await embedText(fact)
+        try await semanticStore.upsert(fact: fact, embedding: embedding)
+
+        let semanticCount = await semanticStore.count
+        mutateStats { snapshot in
+            snapshot.semanticCount = semanticCount
+        }
+    }
+
+    /// Soft-forgets a chunk by reducing its retention score.
+    ///
+    /// - Parameter id: Chunk identifier to demote.
+    /// - Throws: `ContextCoreError.chunkNotFound` when the chunk does not exist.
+    public func forget(id: UUID) async throws {
+        var found = false
+
+        do {
+            try await episodicStore.updateRetentionScore(id: id, delta: -1.0)
+            found = true
+        } catch let error as ContextCoreError {
+            if case .chunkNotFound = error {
+                // Ignore and try semantic.
+            } else {
+                throw error
+            }
+        }
+
+        do {
+            try await semanticStore.updateRetentionScore(id: id, delta: -1.0)
+            found = true
+        } catch let error as ContextCoreError {
+            if case .chunkNotFound = error {
+                // Ignore.
+            } else {
+                throw error
+            }
+        }
+
+        if !found {
+            throw ContextCoreError.chunkNotFound(id: id)
+        }
+    }
+
+    /// Recalls top semantic and episodic chunks for a query.
+    ///
+    /// - Parameters:
+    ///   - query: Natural language query.
+    ///   - k: Maximum number of chunks to return.
+    /// - Returns: Top chunks sorted by similarity and recency tie-breaker.
+    /// - Throws: Embedding and retrieval errors.
+    public func recall(query: String, k: Int = 5) async throws -> [MemoryChunk] {
+        let resolvedK = max(0, k)
+        guard resolvedK > 0 else {
+            return []
+        }
+
+        let embedding = try await embedText(query)
+
+        async let episodicResults = episodicStore.retrieve(query: embedding, k: resolvedK)
+        async let semanticResults = semanticStore.retrieve(query: embedding, k: resolvedK)
+
+        let combined = try await episodicResults + semanticResults
+        let deduped = deduplicate(chunks: combined)
+
+        let scored = deduped.compactMap { chunk -> (MemoryChunk, Float)? in
+            guard chunk.retentionScore > 0.01 else {
+                return nil
+            }
+            let score = Self.cosineSimilarity(embedding, chunk.embedding)
+            return (chunk, score)
+        }
+
+        return scored
+            .sorted { lhs, rhs in
+                if lhs.1 == rhs.1 {
+                    return lhs.0.createdAt > rhs.0.createdAt
+                }
+                return lhs.1 > rhs.1
+            }
+            .prefix(resolvedK)
+            .map(\.0)
+    }
+
+    /// Runs an explicit consolidation pass for the active session.
+    ///
+    /// - Throws: `ContextCoreError.sessionNotStarted` when no session is active.
+    public func consolidate() async throws {
+        guard let sessionID = sessionStore.currentSessionID else {
+            throw ContextCoreError.sessionNotStarted
+        }
+
+        Logger.consolidation.info("Consolidation started: session=\(sessionID.uuidString, privacy: .public)")
+
+        let result = try await consolidationEngine.consolidate(
+            session: sessionID,
+            episodicStore: episodicStore,
+            semanticStore: semanticStore,
+            threshold: configuration.similarityMergeThreshold
+        )
+
+        await refreshCountStats(lastConsolidationLatencyMs: result.durationMs)
+
+        Logger.consolidation.info(
+            "Consolidation complete: promoted=\(result.factsPromoted, privacy: .public) evicted=\(result.chunksEvicted, privacy: .public) durationMs=\(result.durationMs, privacy: .public)"
+        )
+    }
+
+    /// Persists full runtime state to a checkpoint file.
+    ///
+    /// Writes atomically through a temporary file and move operation.
+    ///
+    /// - Parameter url: Destination checkpoint URL.
+    /// - Throws: `ContextCoreError.checkpointCorrupt` when encoding or file I/O fails.
+    public func checkpoint(to url: URL) async throws {
+        let checkpoint = ContextCheckpoint(
+            episodicChunks: await episodicStore.allChunks(),
+            semanticChunks: await semanticStore.allChunks(),
+            proceduralPatterns: await proceduralStore.allPatterns(),
+            lastSessionID: sessionStore.currentSessionID,
+            systemPrompt: sessionStore.systemPrompt,
+            recentTurns: sessionStore.recentTurns,
+            totalSessions: sessionStore.totalSessions,
+            configuration: .init(configuration: configuration)
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+
+        let data: Data
+        do {
+            data = try encoder.encode(checkpoint)
+        } catch {
+            Logger.contextCore.error("Error in checkpoint(to:): \(error.localizedDescription, privacy: .public)")
+            throw ContextCoreError.checkpointCorrupt
+        }
+
+        let parent = url.deletingLastPathComponent()
+        let fileManager = FileManager.default
+
+        do {
+            try fileManager.createDirectory(at: parent, withIntermediateDirectories: true)
+
+            let tempURL = parent.appendingPathComponent(".\(url.lastPathComponent).tmp-\(UUID().uuidString)")
+            try data.write(to: tempURL, options: .atomic)
+
+            if fileManager.fileExists(atPath: url.path) {
+                try fileManager.removeItem(at: url)
+            }
+            try fileManager.moveItem(at: tempURL, to: url)
+            Logger.contextCore.info("Checkpoint saved to \(url.path, privacy: .public)")
+        } catch {
+            Logger.contextCore.error("Error in checkpoint(to:): \(error.localizedDescription, privacy: .public)")
+            throw ContextCoreError.checkpointCorrupt
+        }
+    }
+
+    private func restore(from checkpoint: ContextCheckpoint) async throws {
+        for chunk in checkpoint.episodicChunks {
+            try await episodicStore.insert(chunk: chunk)
+        }
+
+        for chunk in checkpoint.semanticChunks {
+            try await semanticStore.insert(chunk: chunk)
+        }
+
+        for (taskType, tools) in checkpoint.proceduralPatterns {
+            await proceduralStore.record(taskType: taskType, tools: tools)
+        }
+
+        sessionStore = SessionStore(
+            currentSessionID: checkpoint.lastSessionID,
+            systemPrompt: checkpoint.systemPrompt,
+            recentTurns: checkpoint.recentTurns,
+            totalSessions: checkpoint.totalSessions
+        )
+
+        await refreshCountStats()
+        let proceduralCount = await proceduralStore.count
+        mutateStats { snapshot in
+            snapshot.totalSessions = checkpoint.totalSessions
+            snapshot.proceduralCount = proceduralCount
+        }
+    }
+
+    private func scoreMemory(
+        taskEmbedding: [Float],
+        chunks: [MemoryChunk],
+        halfLifeDays: Double
+    ) async throws -> [(chunk: MemoryChunk, score: Float)] {
+        guard !chunks.isEmpty else {
+            return []
+        }
+
+        let timestamps = chunks.map(\.createdAt)
+        let halfLife = max(halfLifeDays * 86_400, 1)
+
+        let recencyWeights = try await scoringEngine.computeRecencyWeights(
+            timestamps: timestamps,
+            halfLife: halfLife
+        )
+
+        let baseScores = try await scoringEngine.scoreChunksUnsorted(
+            query: taskEmbedding,
+            chunks: chunks,
+            recencyWeights: recencyWeights,
+            relevanceWeight: configuration.relevanceWeight,
+            recencyWeight: max(0, 1.0 - configuration.relevanceWeight)
+        )
+
+        return baseScores
+            .map { item in
+                let weightedScore = item.score * max(item.chunk.retentionScore, 0)
+                return (chunk: item.chunk, score: weightedScore)
+            }
+            .filter { $0.score > 0.0001 }
+            .sorted {
+                if $0.score == $1.score {
+                    return $0.chunk.createdAt > $1.chunk.createdAt
+                }
+                return $0.score > $1.score
+            }
+    }
+
+    private func makeProceduralCandidates(
+        tools: [ToolCall],
+        taskEmbedding: [Float],
+        sessionID: UUID
+    ) -> [(chunk: MemoryChunk, score: Float)] {
+        guard !tools.isEmpty else {
+            return []
+        }
+
+        return tools.enumerated().map { index, tool in
+            let content = "Tool \(tool.name): input=\(tool.input) output=\(tool.output)"
+            let chunk = MemoryChunk(
+                content: content,
+                embedding: taskEmbedding,
+                type: .procedural,
+                createdAt: .now,
+                lastAccessedAt: .now,
+                accessCount: 1,
+                retentionScore: 1.0,
+                sourceSessionID: sessionID,
+                metadata: ["durationMs": String(format: "%.2f", tool.durationMs)]
+            )
+
+            let decay = Float(index) * 0.01
+            let score = max(0.25, 0.75 - decay)
+            return (chunk: chunk, score: score)
+        }
+    }
+
+    private func applyAttentionRerank(
+        query: [Float],
+        scoredMemory: [(chunk: MemoryChunk, score: Float)]
+    ) async throws -> [(chunk: MemoryChunk, score: Float)] {
+        guard scoredMemory.count > 1 else {
+            return scoredMemory
+        }
+
+        let chunks = scoredMemory.map(\.chunk)
+        let attentionScores = try await attentionEngine.scoreWindowForEviction(
+            taskQuery: query,
+            windowChunks: chunks,
+            relevanceWeight: configuration.relevanceWeight,
+            centralityWeight: configuration.centralityWeight
+        )
+
+        let evictionByID = Dictionary(uniqueKeysWithValues: attentionScores.map { ($0.chunk.id, $0.evictionScore) })
+        let values = attentionScores.map(\.evictionScore)
+        let minValue = values.min() ?? 0
+        let maxValue = values.max() ?? 0
+        let range = max(maxValue - minValue, 0.000_001)
+
+        let reranked = scoredMemory.map { item -> (chunk: MemoryChunk, score: Float) in
+            let eviction = evictionByID[item.chunk.id] ?? minValue
+            let normalized = (eviction - minValue) / range
+            let keepScore = 1.0 - normalized
+            let blended = (item.score * 0.85) + (keepScore * 0.15)
+            return (chunk: item.chunk, score: blended)
+        }
+
+        return reranked.sorted {
+            if $0.score == $1.score {
+                return $0.chunk.createdAt > $1.chunk.createdAt
+            }
+            return $0.score > $1.score
+        }
+    }
+
+    private func embedText(_ text: String) async throws -> [Float] {
+        do {
+            return try await embeddingProvider.embed(text)
+        } catch let error as ContextCoreError {
+            throw error
+        } catch {
+            Logger.contextCore.error("Error in embedText(_:): \(error.localizedDescription, privacy: .public)")
+            throw ContextCoreError.embeddingFailed(error.localizedDescription)
+        }
+    }
+
+    private func guaranteedTokenUsage() -> Int {
+        var total = 0
+
+        if let systemPrompt = sessionStore.systemPrompt {
+            total += tokenCounter.count(systemPrompt)
+        }
+
+        for turn in sessionStore.guaranteedRecentTurns(count: configuration.recentTurnsGuaranteed) {
+            total += max(0, turn.tokenCount > 0 ? turn.tokenCount : tokenCounter.count(turn.content))
+        }
+
+        return total
+    }
+
+    private func deduplicate(chunks: [MemoryChunk]) -> [MemoryChunk] {
+        var seen = Set<UUID>()
+        var deduped: [MemoryChunk] = []
+        deduped.reserveCapacity(chunks.count)
+
+        for chunk in chunks where !seen.contains(chunk.id) {
+            seen.insert(chunk.id)
+            deduped.append(chunk)
+        }
+
+        return deduped
+    }
+
+    private func mutateStats(_ mutation: @Sendable (inout ContextStats) -> Void) {
+        statsLock.withLock { snapshot in
+            mutation(&snapshot)
+        }
+    }
+
+    private func refreshCountStats(lastConsolidationLatencyMs: Double? = nil) async {
+        let episodicCount = await episodicStore.count
+        let semanticCount = await semanticStore.count
+        let proceduralCount = await proceduralStore.count
+        let totalSessions = sessionStore.totalSessions
+
+        mutateStats { snapshot in
+            snapshot.episodicCount = episodicCount
+            snapshot.semanticCount = semanticCount
+            snapshot.proceduralCount = proceduralCount
+            snapshot.totalSessions = totalSessions
+            if let lastConsolidationLatencyMs {
+                snapshot.lastConsolidationLatencyMs = lastConsolidationLatencyMs
+            }
+        }
+    }
+
+    private static func cosineSimilarity(_ lhs: [Float], _ rhs: [Float]) -> Float {
+        guard lhs.count == rhs.count, !lhs.isEmpty else {
+            return 0
+        }
+
+        var dot: Float = 0
+        var lhsNorm: Float = 0
+        var rhsNorm: Float = 0
+
+        for index in lhs.indices {
+            dot += lhs[index] * rhs[index]
+            lhsNorm += lhs[index] * lhs[index]
+            rhsNorm += rhs[index] * rhs[index]
+        }
+
+        let denominator = lhsNorm.squareRoot() * rhsNorm.squareRoot()
+        guard denominator > 0 else {
+            return 0
+        }
+
+        return dot / denominator
+    }
+}

--- a/Sources/ContextCore/ChunkOrderer.swift
+++ b/Sources/ContextCore/ChunkOrderer.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+/// Ordering policies for arranging context chunks.
+public enum OrderingStrategy: Sendable {
+    /// Group by source type and place guaranteed recent turns last.
+    case typeGrouped
+    /// Order by ascending relevance score.
+    case relevanceAscending
+    /// Order by timestamp ascending.
+    case chronological
+}
+
+/// Orders chunks after packing to optimize downstream model attention.
+public struct ChunkOrderer: Sendable {
+    /// Creates a chunk orderer.
+    public init() {}
+
+    /// Orders chunks using a selected strategy.
+    ///
+    /// - Parameters:
+    ///   - chunks: Packed chunks to arrange.
+    ///   - strategy: Ordering strategy to apply.
+    /// - Returns: Reordered chunks.
+    public func order(
+        _ chunks: [ContextChunk],
+        strategy: OrderingStrategy = .typeGrouped
+    ) -> [ContextChunk] {
+        guard chunks.count > 1 else {
+            return chunks
+        }
+
+        let systemPrompt = chunks.first { $0.isSystemPrompt }
+        let remainingChunks: [ContextChunk]
+        if let systemPrompt {
+            remainingChunks = chunks.filter { $0.id != systemPrompt.id }
+        } else {
+            remainingChunks = chunks
+        }
+
+        let orderedRemaining: [ContextChunk]
+        switch strategy {
+        case .typeGrouped:
+            let semantic = remainingChunks
+                .filter { $0.source == .semantic && !$0.isGuaranteedRecent }
+                .sorted(by: chronologicalSort)
+            let episodic = remainingChunks
+                .filter { $0.source == .episodic && !$0.isGuaranteedRecent }
+                .sorted(by: chronologicalSort)
+            let procedural = remainingChunks
+                .filter { $0.source == .procedural && !$0.isGuaranteedRecent }
+                .sorted(by: chronologicalSort)
+            let recentTurns = remainingChunks
+                .filter(\ .isGuaranteedRecent)
+                .sorted(by: chronologicalSort)
+
+            let groupedIDs = Set((semantic + episodic + procedural + recentTurns).map(\ .id))
+            let fallback = remainingChunks
+                .filter { !groupedIDs.contains($0.id) }
+                .sorted(by: chronologicalSort)
+
+            orderedRemaining = semantic + episodic + procedural + fallback + recentTurns
+
+        case .relevanceAscending:
+            orderedRemaining = remainingChunks.sorted(by: relevanceAscendingSort)
+
+        case .chronological:
+            orderedRemaining = remainingChunks.sorted(by: chronologicalSort)
+        }
+
+        if let systemPrompt {
+            return [systemPrompt] + orderedRemaining
+        }
+        return orderedRemaining
+    }
+
+    private func chronologicalSort(_ lhs: ContextChunk, _ rhs: ContextChunk) -> Bool {
+        if lhs.timestamp == rhs.timestamp {
+            return lhs.id.uuidString < rhs.id.uuidString
+        }
+        return lhs.timestamp < rhs.timestamp
+    }
+
+    private func relevanceAscendingSort(_ lhs: ContextChunk, _ rhs: ContextChunk) -> Bool {
+        if lhs.score == rhs.score {
+            return chronologicalSort(lhs, rhs)
+        }
+        return lhs.score < rhs.score
+    }
+}

--- a/Sources/ContextCore/CompressionDelegate.swift
+++ b/Sources/ContextCore/CompressionDelegate.swift
@@ -1,0 +1,4 @@
+import ContextCoreTypes
+
+/// Public alias for `ContextCoreTypes.CompressionDelegate`.
+public typealias CompressionDelegate = ContextCoreTypes.CompressionDelegate

--- a/Sources/ContextCore/ContextConfiguration.swift
+++ b/Sources/ContextCore/ContextConfiguration.swift
@@ -1,0 +1,109 @@
+/// Runtime tuning parameters for ``AgentContext``.
+public struct ContextConfiguration: Sendable {
+    /// Maximum token budget before safety margin is applied.
+    public var maxTokens: Int
+    /// Reserved fraction of budget to absorb token-count drift.
+    public var tokenBudgetSafetyMargin: Float
+    /// Number of episodic candidates retained per build.
+    public var episodicMemoryK: Int
+    /// Number of semantic candidates retained per build.
+    public var semanticMemoryK: Int
+    /// Number of latest turns guaranteed in every window.
+    public var recentTurnsGuaranteed: Int
+    /// Half-life for episodic recency decay in days.
+    public var episodicHalfLifeDays: Double
+    /// Half-life for semantic recency decay in days.
+    public var semanticHalfLifeDays: Double
+    /// Episodic-count threshold that triggers auto-consolidation.
+    public var consolidationThreshold: Int
+    /// Similarity threshold used for duplicate merge detection.
+    public var similarityMergeThreshold: Float
+    /// Weight assigned to semantic similarity scoring.
+    public var relevanceWeight: Float
+    /// Weight assigned to attention centrality scoring.
+    public var centralityWeight: Float
+    /// ANN search breadth parameter.
+    public var efSearch: Int
+    /// Embedding backend used for query and chunk vectors.
+    public var embeddingProvider: any EmbeddingProvider
+    /// Token counter used for packing decisions.
+    public var tokenCounter: any TokenCounter
+    /// Optional delegate for abstractive compression and fact extraction.
+    public var compressionDelegate: (any CompressionDelegate)?
+
+    /// Creates a fully specified configuration.
+    ///
+    /// - Parameters:
+    ///   - maxTokens: Maximum token budget before margin.
+    ///   - tokenBudgetSafetyMargin: Reserved budget fraction.
+    ///   - episodicMemoryK: Episodic retrieval count.
+    ///   - semanticMemoryK: Semantic retrieval count.
+    ///   - recentTurnsGuaranteed: Number of guaranteed recent turns.
+    ///   - episodicHalfLifeDays: Episodic half-life in days.
+    ///   - semanticHalfLifeDays: Semantic half-life in days.
+    ///   - consolidationThreshold: Auto-consolidation threshold.
+    ///   - similarityMergeThreshold: Duplicate merge threshold.
+    ///   - relevanceWeight: Similarity weight.
+    ///   - centralityWeight: Centrality weight.
+    ///   - efSearch: ANN search breadth.
+    ///   - embeddingProvider: Embedding backend.
+    ///   - tokenCounter: Token counter backend.
+    ///   - compressionDelegate: Optional compression delegate.
+    public init(
+        maxTokens: Int,
+        tokenBudgetSafetyMargin: Float,
+        episodicMemoryK: Int,
+        semanticMemoryK: Int,
+        recentTurnsGuaranteed: Int,
+        episodicHalfLifeDays: Double,
+        semanticHalfLifeDays: Double,
+        consolidationThreshold: Int,
+        similarityMergeThreshold: Float,
+        relevanceWeight: Float,
+        centralityWeight: Float,
+        efSearch: Int,
+        embeddingProvider: any EmbeddingProvider,
+        tokenCounter: any TokenCounter,
+        compressionDelegate: (any CompressionDelegate)? = nil
+    ) {
+        self.maxTokens = maxTokens
+        self.tokenBudgetSafetyMargin = tokenBudgetSafetyMargin
+        self.episodicMemoryK = episodicMemoryK
+        self.semanticMemoryK = semanticMemoryK
+        self.recentTurnsGuaranteed = recentTurnsGuaranteed
+        self.episodicHalfLifeDays = episodicHalfLifeDays
+        self.semanticHalfLifeDays = semanticHalfLifeDays
+        self.consolidationThreshold = consolidationThreshold
+        self.similarityMergeThreshold = similarityMergeThreshold
+        self.relevanceWeight = relevanceWeight
+        self.centralityWeight = centralityWeight
+        self.efSearch = efSearch
+        self.embeddingProvider = embeddingProvider
+        self.tokenCounter = tokenCounter
+        self.compressionDelegate = compressionDelegate
+    }
+
+    /// Production-oriented default configuration.
+    public static var `default`: ContextConfiguration {
+        ContextConfiguration(
+            maxTokens: 4096,
+            tokenBudgetSafetyMargin: 0.10,
+            episodicMemoryK: 8,
+            semanticMemoryK: 4,
+            recentTurnsGuaranteed: 3,
+            episodicHalfLifeDays: 7,
+            semanticHalfLifeDays: 90,
+            consolidationThreshold: 200,
+            similarityMergeThreshold: 0.92,
+            relevanceWeight: 0.7,
+            centralityWeight: 0.4,
+            efSearch: 64,
+            embeddingProvider: CachingEmbeddingProvider(
+                base: CoreMLEmbeddingProvider(),
+                cache: EmbeddingCache(capacity: 512)
+            ),
+            tokenCounter: ApproximateTokenCounter(),
+            compressionDelegate: nil
+        )
+    }
+}

--- a/Sources/ContextCore/ContextCore.docc/ArchitectureOverview.md
+++ b/Sources/ContextCore/ContextCore.docc/ArchitectureOverview.md
@@ -1,0 +1,44 @@
+# Architecture Overview
+
+ContextCore manages four complementary memory layers and builds a task-specific working context window for each model call.
+
+## Four Memory Types
+
+- Working memory: The final ``ContextWindow`` injected into the model prompt.
+- Episodic memory: Turn-level conversation history stored in vector space for fast similarity retrieval.
+- Semantic memory: Consolidated high-value facts promoted from episodic memory for longer retention.
+- Procedural memory: Tool usage patterns and execution traces keyed by task type.
+
+## Scoring and Packing Pipeline
+
+1. Embed the current task query.
+2. Retrieve episodic and semantic candidates.
+3. Compute relevance and recency scores on GPU via ``ScoringEngine``.
+4. Apply attention-based reranking via ``AttentionEngine``.
+5. Pack candidates under budget with ``WindowPacker``.
+6. Optionally compress low-priority chunks via ``ProgressiveCompressor``.
+7. Order chunks for model attention using ``ChunkOrderer``.
+
+## Consolidation Flow
+
+Consolidation periodically scans episodic memory for near-duplicate chunks, promotes durable facts into semantic memory, and evicts low-retention episodic chunks. This keeps long sessions stable without unbounded growth.
+
+## Full Stack
+
+```text
+┌─────────────────────────────────────┐
+│         Your App / Bebop            │  ← domain logic, UI, business rules
+├─────────────────────────────────────┤
+│           ContextCore               │  ← this framework
+│  AgentContext · WindowPacker        │
+│  ConsolidationEngine · Scoring      │
+│  Metal kernels (5 shaders)          │
+├─────────────────────────────────────┤
+│            MetalANNS                │  ← vector index dependency
+│  Fixed out-degree graph · NN-Descent│
+│  Metal kernels (5 shaders)          │
+├─────────────────────────────────────┤
+│         Apple Frameworks            │
+│  Metal · CoreML · Accelerate · ANE  │
+└─────────────────────────────────────┘
+```

--- a/Sources/ContextCore/ContextCore.docc/ContextCore.md
+++ b/Sources/ContextCore/ContextCore.docc/ContextCore.md
@@ -1,0 +1,48 @@
+# ``ContextCore``
+
+GPU-accelerated context management for on-device AI agents.
+
+## Overview
+
+ContextCore sits between an agent reasoning loop and the model context window.
+It scores, ranks, compresses, and curates candidate memory in real time before each model call.
+
+## Topics
+
+### Essentials
+
+- <doc:GettingStarted>
+- ``AgentContext``
+- ``ContextWindow``
+
+### Memory Types
+
+- <doc:ArchitectureOverview>
+- ``MemoryChunk``
+- ``MemoryType``
+
+### Configuration
+
+- <doc:TuningGuide>
+- ``ContextConfiguration``
+
+### Integration
+
+- <doc:IntegratingWithAppleFoundationModels>
+- <doc:IntegratingWithWax>
+
+### Data Model
+
+- ``Turn``
+- ``TurnRole``
+- ``ToolCall``
+
+### Protocols
+
+- ``EmbeddingProvider``
+- ``TokenCounter``
+- ``CompressionDelegate``
+
+### Errors
+
+- ``ContextCoreError``

--- a/Sources/ContextCore/ContextCore.docc/GettingStarted.md
+++ b/Sources/ContextCore/ContextCore.docc/GettingStarted.md
@@ -1,0 +1,81 @@
+# Getting Started
+
+Integrate ContextCore into an agent loop in under five minutes.
+
+## 1. Access ContextCore via Swarm Integrations
+
+ContextCore ships as an **in-tree** internal module under Swarm
+(`Sources/ContextCore`). Enable the Swarm `Integrations` trait; do not add a
+separate ContextCore package dependency.
+
+```swift
+// Consumer Package.swift
+.package(
+    url: "https://github.com/christopherkarani/Swarm.git",
+    from: "0.6.0",
+    traits: ["Integrations"]
+)
+
+// Target dependencies
+"Swarm"
+```
+
+Within Swarm sources, `import ContextCore` works when Integrations is on.
+External apps typically use Swarm's memory APIs (`DefaultAgentMemory`) rather
+than depending on the internal ContextCore target directly.
+
+## 2. Create an ``AgentContext``
+
+Use the default configuration first, then tune for your workload.
+
+```swift
+import ContextCore
+
+let context = try AgentContext()
+```
+
+## 3. Begin a Session
+
+Start each user interaction session explicitly.
+
+```swift
+try await context.beginSession(systemPrompt: "You are a helpful coding assistant.")
+```
+
+## 4. Append Turns in Your Loop
+
+Append every user and assistant turn so episodic memory stays current.
+
+```swift
+try await context.append(turn: Turn(role: .user, content: userMessage))
+try await context.append(turn: Turn(role: .assistant, content: assistantMessage))
+```
+
+## 5. Build the Context Window Before Model Calls
+
+Call `buildWindow` with the current task and token budget.
+
+```swift
+let window = try await context.buildWindow(
+    currentTask: userMessage,
+    maxTokens: 4096
+)
+```
+
+## 6. Format and Send to the Model
+
+Choose a formatter compatible with your model prompt format.
+
+```swift
+let prompt = window.formatted(style: .chatML)
+// send `prompt` to your model runtime
+```
+
+## 7. End Session and Checkpoint
+
+End sessions when complete, and checkpoint for persistence.
+
+```swift
+try await context.endSession()
+try await context.checkpoint(to: URL(fileURLWithPath: "./context-checkpoint.json"))
+```

--- a/Sources/ContextCore/ContextCore.docc/IntegratingWithAppleFoundationModels.md
+++ b/Sources/ContextCore/ContextCore.docc/IntegratingWithAppleFoundationModels.md
@@ -1,0 +1,46 @@
+# Integrating With Apple Foundation Models
+
+You can inject any embedding backend by conforming to ``EmbeddingProvider``.
+
+```swift
+import ContextCore
+import FoundationModels
+
+struct AppleFoundationEmbeddingProvider: EmbeddingProvider {
+    let dimension = 384
+
+    func embed(_ text: String) async throws -> [Float] {
+        // Replace with the current FoundationModels embedding API.
+        // Keep output normalized and stable in `dimension`.
+        fatalError("Implement with your FoundationModels SDK version")
+    }
+
+    func embedBatch(_ texts: [String]) async throws -> [[Float]] {
+        var vectors: [[Float]] = []
+        vectors.reserveCapacity(texts.count)
+        for text in texts {
+            vectors.append(try await embed(text))
+        }
+        return vectors
+    }
+}
+
+struct FoundationModelsTokenCounter: TokenCounter {
+    func count(_ text: String) -> Int {
+        // Replace with exact tokenizer counting for your model.
+        text.split(whereSeparator: { !$0.isLetter && !$0.isNumber }).count
+    }
+}
+
+var config = ContextConfiguration.default
+config.embeddingProvider = AppleFoundationEmbeddingProvider()
+config.tokenCounter = FoundationModelsTokenCounter()
+
+let context = try AgentContext(configuration: config)
+```
+
+## Notes
+
+- Ensure your embedding dimension matches stored chunk vectors.
+- Prefer exact tokenizer integration when available; then `tokenBudgetSafetyMargin` can be reduced.
+- Keep provider behavior deterministic for reproducible benchmarks and tests.

--- a/Sources/ContextCore/ContextCore.docc/IntegratingWithWax.md
+++ b/Sources/ContextCore/ContextCore.docc/IntegratingWithWax.md
@@ -1,0 +1,42 @@
+# Integrating With Wax
+
+Use Wax as durable long-term memory and ContextCore as the real-time context curation layer.
+
+## Integration Pattern
+
+1. Keep durable memories in Wax's long-term store.
+2. On each loop, fetch candidate facts from Wax and inject into ContextCore via ``AgentContext/remember(_:)``.
+3. Append live turns to ``AgentContext``.
+4. Build the final context window with ``AgentContext/buildWindow(currentTask:maxTokens:)``.
+5. Send the formatted window to the model runtime.
+
+## Bridging Example
+
+```swift
+import ContextCore
+
+func runLoopStep(
+    waxFacts: [String],
+    userMessage: String,
+    context: AgentContext
+) async throws -> String {
+    for fact in waxFacts {
+        try await context.remember(fact)
+    }
+
+    try await context.append(turn: Turn(role: .user, content: userMessage))
+
+    let window = try await context.buildWindow(
+        currentTask: userMessage,
+        maxTokens: 4096
+    )
+
+    return window.formatted(style: .chatML)
+}
+```
+
+## Operational Guidance
+
+- Keep Wax as the source of truth for durable memory.
+- Use ContextCore for per-call relevance ranking, compression, and ordering.
+- Periodically checkpoint ContextCore with ``AgentContext/checkpoint(to:)`` for fast restart.

--- a/Sources/ContextCore/ContextCore.docc/TuningGuide.md
+++ b/Sources/ContextCore/ContextCore.docc/TuningGuide.md
@@ -1,0 +1,40 @@
+# Tuning Guide
+
+Tune ``ContextConfiguration`` to balance latency, retrieval quality, and memory behavior for your workload.
+
+## Parameter Reference
+
+| Parameter | Default | Effect | Tune when... |
+|---|---:|---|---|
+| `maxTokens` | `4096` | Hard token budget | Your model has larger/smaller context |
+| `tokenBudgetSafetyMargin` | `0.10` | Headroom fraction | You have exact tokenizer (set to 0) |
+| `episodicMemoryK` | `8` | Chunks from episodic per call | Sessions are short (decrease) or long (increase) |
+| `semanticMemoryK` | `4` | Chunks from semantic per call | Few facts (decrease) or knowledge-heavy (increase) |
+| `recentTurnsGuaranteed` | `3` | Recent turns always included | Fast back-and-forth (increase) or long turns (decrease) |
+| `episodicHalfLifeDays` | `7` | Episodic recency decay | Short-lived tasks (decrease) or long projects (increase) |
+| `semanticHalfLifeDays` | `90` | Semantic recency decay | Facts change often (decrease) or are stable (increase) |
+| `consolidationThreshold` | `200` | Auto-consolidation trigger | Memory-constrained (decrease) or large sessions (increase) |
+| `similarityMergeThreshold` | `0.92` | Duplicate detection bar | False merges (increase) or missed duplicates (decrease) |
+| `relevanceWeight` | `0.7` | Similarity vs recency blend | Task-focused (increase) or time-sensitive (decrease) |
+| `centralityWeight` | `0.4` | Centrality vs relevance for eviction | Prefer topically connected (increase) or task-relevant (decrease) |
+| `efSearch` | `64` | ANN search breadth | Recall is low (increase) or latency is high (decrease) |
+| `embeddingProvider` | `CoreMLEmbeddingProvider + cache` | Query/chunk embedding source | Swap for custom model/provider |
+| `tokenCounter` | `ApproximateTokenCounter` | Token estimation for packing | Inject exact model tokenizer |
+| `compressionDelegate` | `nil` | Optional abstractive compression | You want higher-quality summaries |
+
+## Practical Profiles
+
+- Low latency: decrease `episodicMemoryK`/`semanticMemoryK`, increase `tokenBudgetSafetyMargin`, keep `efSearch` moderate.
+- High recall: increase `episodicMemoryK`, `semanticMemoryK`, and `efSearch`; expect higher p95/p99 latency.
+- Long-running projects: increase half-life values and consolidation threshold to preserve durable context.
+
+## Starting Point
+
+```swift
+var config = ContextConfiguration.default
+config.maxTokens = 4096
+config.episodicMemoryK = 8
+config.semanticMemoryK = 4
+config.relevanceWeight = 0.7
+let context = try AgentContext(configuration: config)
+```

--- a/Sources/ContextCore/ContextCore.swift
+++ b/Sources/ContextCore/ContextCore.swift
@@ -1,0 +1,23 @@
+import ContextCoreEngine
+
+/// Public alias for the engine embedding cache.
+public typealias EmbeddingCache = ContextCoreEngine.EmbeddingCache
+/// Public alias for CPU reference implementations.
+public typealias CPUReference = ContextCoreEngine.CPUReference
+/// Public alias for GPU relevance scoring engine.
+public typealias ScoringEngine = ContextCoreEngine.ScoringEngine
+/// Public alias for GPU attention scoring engine.
+public typealias AttentionEngine = ContextCoreEngine.AttentionEngine
+/// Public alias for compression engine.
+public typealias CompressionEngine = ContextCoreEngine.CompressionEngine
+/// Public alias for extractive compression delegate.
+public typealias ExtractiveFallbackDelegate = ContextCoreEngine.ExtractiveFallbackDelegate
+/// Public alias for consolidation engine.
+public typealias ConsolidationEngine = ContextCoreEngine.ConsolidationEngine
+/// Public alias for consolidation summary result.
+public typealias ConsolidationResult = ContextCoreEngine.ConsolidationResult
+/// Public alias for background consolidation scheduler.
+public typealias ConsolidationScheduler = ContextCoreEngine.ConsolidationScheduler
+
+/// Namespace marker for the `ContextCore` module.
+public enum ContextCoreModule {}

--- a/Sources/ContextCore/ContextStats.swift
+++ b/Sources/ContextCore/ContextStats.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// Runtime counters and latency snapshots for ``AgentContext``.
+public struct ContextStats: Sendable, Codable, Hashable {
+    /// Number of episodic chunks currently stored.
+    public var episodicCount: Int
+    /// Number of semantic chunks currently stored.
+    public var semanticCount: Int
+    /// Number of procedural patterns currently stored.
+    public var proceduralCount: Int
+    /// Total number of sessions started.
+    public var totalSessions: Int
+    /// Latest ``AgentContext/buildWindow(currentTask:maxTokens:)`` latency in milliseconds.
+    public var lastBuildWindowLatencyMs: Double
+    /// Latest consolidation latency in milliseconds.
+    public var lastConsolidationLatencyMs: Double
+    /// Average chunk score in the last built window.
+    public var averageRelevanceScore: Float
+    /// Ratio of compressed chunks in the last built window.
+    public var compressionRatio: Float
+
+    /// Creates a stats snapshot.
+    ///
+    /// - Parameters:
+    ///   - episodicCount: Episodic chunk count.
+    ///   - semanticCount: Semantic chunk count.
+    ///   - proceduralCount: Procedural pattern count.
+    ///   - totalSessions: Started session count.
+    ///   - lastBuildWindowLatencyMs: Last build latency in milliseconds.
+    ///   - lastConsolidationLatencyMs: Last consolidation latency in milliseconds.
+    ///   - averageRelevanceScore: Mean score in last window.
+    ///   - compressionRatio: Ratio of compressed chunks in last window.
+    public init(
+        episodicCount: Int = 0,
+        semanticCount: Int = 0,
+        proceduralCount: Int = 0,
+        totalSessions: Int = 0,
+        lastBuildWindowLatencyMs: Double = 0,
+        lastConsolidationLatencyMs: Double = 0,
+        averageRelevanceScore: Float = 0,
+        compressionRatio: Float = 0
+    ) {
+        self.episodicCount = episodicCount
+        self.semanticCount = semanticCount
+        self.proceduralCount = proceduralCount
+        self.totalSessions = totalSessions
+        self.lastBuildWindowLatencyMs = lastBuildWindowLatencyMs
+        self.lastConsolidationLatencyMs = lastConsolidationLatencyMs
+        self.averageRelevanceScore = averageRelevanceScore
+        self.compressionRatio = compressionRatio
+    }
+}

--- a/Sources/ContextCore/ContextWindow.swift
+++ b/Sources/ContextCore/ContextWindow.swift
@@ -1,0 +1,182 @@
+import Foundation
+
+/// Compression intensity applied to a context chunk.
+public enum CompressionLevel: Int, Codable, Sendable, Hashable, Comparable {
+    /// No compression was applied.
+    case none = 0
+    /// Mild compression preserving most content.
+    case light = 1
+    /// Aggressive compression preserving only high-signal content.
+    case heavy = 2
+    /// Chunk was dropped to satisfy budget constraints.
+    case dropped = 3
+
+    /// Compares compression levels by intensity.
+    public static func < (lhs: CompressionLevel, rhs: CompressionLevel) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}
+
+/// Formatting styles for serializing a ``ContextWindow``.
+public enum FormatStyle: Sendable {
+    /// Concatenates chunk text as raw paragraphs.
+    case raw
+    /// Emits ChatML tags.
+    case chatML
+    /// Emits Alpaca-style instruction blocks.
+    case alpaca
+    /// Uses a custom per-chunk template containing `{role}` and `{content}` tokens.
+    case custom(template: String)
+}
+
+/// A single chunk included in the final context window.
+public struct ContextChunk: Identifiable, Codable, Sendable, Hashable {
+    /// Stable identifier for this chunk.
+    public let id: UUID
+    /// Chunk content as injected into the model prompt.
+    public let content: String
+    /// Role label for formatting.
+    public let role: TurnRole
+    /// Token count used for budget accounting.
+    public let tokenCount: Int
+    /// Relevance score assigned during ranking.
+    public let score: Float
+    /// Memory tier that produced this chunk.
+    public let source: MemoryType
+    /// Compression level applied before packing.
+    public var compressionLevel: CompressionLevel
+    /// Source timestamp used for ordering.
+    public let timestamp: Date
+    /// Indicates chunk is guaranteed by recency policy.
+    public let isGuaranteedRecent: Bool
+    /// Indicates chunk is the active system prompt.
+    public let isSystemPrompt: Bool
+
+    /// Creates a context chunk.
+    ///
+    /// - Parameters:
+    ///   - id: Chunk identifier.
+    ///   - content: Prompt text.
+    ///   - role: Formatting role.
+    ///   - tokenCount: Token count estimate.
+    ///   - score: Ranking score.
+    ///   - source: Memory source.
+    ///   - compressionLevel: Applied compression level.
+    ///   - timestamp: Source timestamp.
+    ///   - isGuaranteedRecent: `true` for guaranteed recent turns.
+    ///   - isSystemPrompt: `true` for system prompt chunk.
+    public init(
+        id: UUID = UUID(),
+        content: String,
+        role: TurnRole,
+        tokenCount: Int,
+        score: Float,
+        source: MemoryType,
+        compressionLevel: CompressionLevel = .none,
+        timestamp: Date = .now,
+        isGuaranteedRecent: Bool = false,
+        isSystemPrompt: Bool = false
+    ) {
+        self.id = id
+        self.content = content
+        self.role = role
+        self.tokenCount = tokenCount
+        self.score = score
+        self.source = source
+        self.compressionLevel = compressionLevel
+        self.timestamp = timestamp
+        self.isGuaranteedRecent = isGuaranteedRecent
+        self.isSystemPrompt = isSystemPrompt
+    }
+}
+
+/// Final packed context sent to the model.
+public struct ContextWindow: Codable, Sendable, Hashable {
+    /// Ordered chunks included in the window.
+    public let chunks: [ContextChunk]
+    /// Total tokens consumed by `chunks`.
+    public let totalTokens: Int
+    /// Fraction of budget consumed in `[0, 1]`.
+    public let budgetUsed: Float
+    /// Effective token budget for this window.
+    public let budget: Int
+    /// Number of chunks retrieved from episodic or semantic memory.
+    public let retrievedFromMemory: Int
+    /// Number of chunks that were compressed.
+    public let compressedChunks: Int
+
+    /// Creates a context window from packed chunks.
+    ///
+    /// - Parameters:
+    ///   - chunks: Packed chunks in final order.
+    ///   - budget: Effective token budget.
+    public init(chunks: [ContextChunk], budget: Int) {
+        self.chunks = chunks
+        self.budget = budget
+        self.totalTokens = chunks.reduce(into: 0) { partial, chunk in
+            partial += chunk.tokenCount
+        }
+
+        if budget > 0 {
+            let ratio = Float(totalTokens) / Float(budget)
+            self.budgetUsed = min(max(ratio, 0), 1)
+        } else {
+            self.budgetUsed = totalTokens == 0 ? 0 : 1
+        }
+
+        self.retrievedFromMemory = chunks.reduce(into: 0) { partial, chunk in
+            let isRetrievedMemory = (chunk.source == .episodic || chunk.source == .semantic)
+                && !chunk.isGuaranteedRecent
+                && !chunk.isSystemPrompt
+            if isRetrievedMemory {
+                partial += 1
+            }
+        }
+
+        self.compressedChunks = chunks.reduce(into: 0) { partial, chunk in
+            if chunk.compressionLevel > .none {
+                partial += 1
+            }
+        }
+    }
+
+    /// Serializes the window for model injection.
+    ///
+    /// - Parameter style: Output formatting style.
+    /// - Returns: Formatted prompt string.
+    public func formatted(style: FormatStyle) -> String {
+        switch style {
+        case .raw:
+            return chunks.map(\ .content).joined(separator: "\n\n")
+        case .chatML:
+            return chunks
+                .map { chunk in
+                    "<|im_start|>\(chunk.role.rawValue)\n\(chunk.content)<|im_end|>"
+                }
+                .joined(separator: "\n")
+        case .alpaca:
+            return chunks
+                .map { chunk in
+                    switch chunk.role {
+                    case .system:
+                        return "### Instruction:\n\(chunk.content)\n\n"
+                    case .user:
+                        return "### Input:\n\(chunk.content)\n\n"
+                    case .assistant:
+                        return "### Response:\n\(chunk.content)\n\n"
+                    case .tool:
+                        return "### Tool Output:\n\(chunk.content)\n\n"
+                    }
+                }
+                .joined()
+        case .custom(let template):
+            return chunks
+                .map { chunk in
+                    template
+                        .replacingOccurrences(of: "{role}", with: chunk.role.rawValue)
+                        .replacingOccurrences(of: "{content}", with: chunk.content)
+                }
+                .joined(separator: "\n")
+        }
+    }
+}

--- a/Sources/ContextCore/EmbeddingProviders.swift
+++ b/Sources/ContextCore/EmbeddingProviders.swift
@@ -1,0 +1,218 @@
+import ContextCoreEngine
+import CoreML
+import Foundation
+
+internal struct CoreMLEmbeddingProvider: EmbeddingProvider, Sendable {
+    internal let dimension: Int = 384
+
+    internal init() {}
+
+    func embed(_ text: String) async throws -> [Float] {
+#if targetEnvironment(simulator)
+        return Self.deterministicVector(for: text, dimension: dimension)
+#else
+        do {
+            let model = try Self.loadModel()
+            let inputName = try Self.resolveInputName(for: model)
+            let provider = try MLDictionaryFeatureProvider(dictionary: [inputName: text])
+            let output = try await model.prediction(from: provider)
+            return try Self.extractEmbedding(from: output, model: model)
+        } catch {
+            return Self.deterministicVector(for: text, dimension: dimension)
+        }
+#endif
+    }
+
+    func embedBatch(_ texts: [String]) async throws -> [[Float]] {
+        guard !texts.isEmpty else {
+            return []
+        }
+
+#if targetEnvironment(simulator)
+        return texts.map { Self.deterministicVector(for: $0, dimension: dimension) }
+#else
+        do {
+            let model = try Self.loadModel()
+            let inputName = try Self.resolveInputName(for: model)
+            let providers = try texts.map { text in
+                try MLDictionaryFeatureProvider(dictionary: [inputName: text]) as MLFeatureProvider
+            }
+            let batch = MLArrayBatchProvider(array: providers)
+            let outputs = try model.predictions(fromBatch: batch)
+
+            var vectors: [[Float]] = []
+            vectors.reserveCapacity(outputs.count)
+            for index in 0..<outputs.count {
+                let output = outputs.features(at: index)
+                vectors.append(try Self.extractEmbedding(from: output, model: model))
+            }
+            return vectors
+        } catch {
+            return texts.map { Self.deterministicVector(for: $0, dimension: dimension) }
+        }
+#endif
+    }
+
+    private static func loadModel() throws -> MLModel {
+        let candidates: [URL?] = [
+            Bundle.module.url(forResource: "minilm-l6-v2", withExtension: "mlpackage", subdirectory: "Embeddings"),
+            Bundle.module.url(forResource: "minilm-l6-v2", withExtension: "mlpackage", subdirectory: "Resources/Embeddings"),
+            Bundle.module.url(forResource: "minilm-l6-v2", withExtension: "mlpackage"),
+        ]
+
+        guard let modelURL = candidates.compactMap({ $0 }).first else {
+            throw ContextCoreError.embeddingFailed("Missing minilm-l6-v2.mlpackage in bundle resources")
+        }
+
+        return try MLModel(contentsOf: modelURL)
+    }
+
+    private static func resolveInputName(for model: MLModel) throws -> String {
+        guard let inputName = model.modelDescription.inputDescriptionsByName.keys.first else {
+            throw ContextCoreError.embeddingFailed("Model input description is missing")
+        }
+        return inputName
+    }
+
+    private static func resolveOutputName(for model: MLModel) throws -> String {
+        guard let outputName = model.modelDescription.outputDescriptionsByName.keys.first else {
+            throw ContextCoreError.embeddingFailed("Model output description is missing")
+        }
+        return outputName
+    }
+
+    private static func extractEmbedding(from provider: MLFeatureProvider, model: MLModel) throws -> [Float] {
+        let outputName = try resolveOutputName(for: model)
+        guard let featureValue = provider.featureValue(for: outputName) else {
+            throw ContextCoreError.embeddingFailed("Prediction output is missing embedding feature")
+        }
+
+        if let multiArray = featureValue.multiArrayValue {
+            let vector = Self.vector(from: multiArray)
+            return Self.l2Normalize(vector)
+        }
+
+        throw ContextCoreError.embeddingFailed("Unsupported embedding feature type")
+    }
+
+    private static func vector(from multiArray: MLMultiArray) -> [Float] {
+        var vector = [Float]()
+        vector.reserveCapacity(multiArray.count)
+
+        switch multiArray.dataType {
+        case .float32:
+            let pointer = multiArray.dataPointer.bindMemory(to: Float.self, capacity: multiArray.count)
+            vector = Array(UnsafeBufferPointer(start: pointer, count: multiArray.count))
+        case .double:
+            let pointer = multiArray.dataPointer.bindMemory(to: Double.self, capacity: multiArray.count)
+            vector = Array(UnsafeBufferPointer(start: pointer, count: multiArray.count)).map(Float.init)
+        default:
+            for index in 0..<multiArray.count {
+                vector.append(multiArray[index].floatValue)
+            }
+        }
+
+        return vector
+    }
+
+    private static func l2Normalize(_ vector: [Float]) -> [Float] {
+        let norm = vector.reduce(0) { partial, value in
+            partial + (value * value)
+        }.squareRoot()
+
+        guard norm > 0 else {
+            return vector
+        }
+
+        return vector.map { $0 / norm }
+    }
+
+    private static func deterministicVector(for text: String, dimension: Int) -> [Float] {
+        var state = stableSeed(from: text)
+        var values = [Float](repeating: 0, count: dimension)
+
+        for index in values.indices {
+            state &*= 6364136223846793005
+            state &+= 1442695040888963407
+            let component = Float(Int64(bitPattern: state & 0x0000_FFFF_FFFF_FFFF) % 10_000) / 5_000.0 - 1.0
+            values[index] = component
+        }
+
+        return l2Normalize(values)
+    }
+
+    private static func stableSeed(from text: String) -> UInt64 {
+        var hash: UInt64 = 1469598103934665603
+        for byte in text.utf8 {
+            hash ^= UInt64(byte)
+            hash &*= 1099511628211
+        }
+        return hash
+    }
+}
+
+internal struct CachingEmbeddingProvider: EmbeddingProvider, Sendable {
+    private let base: any EmbeddingProvider
+    private let cache: EmbeddingCache
+
+    internal init(
+        base: any EmbeddingProvider,
+        cache: EmbeddingCache = EmbeddingCache(capacity: 512)
+    ) {
+        self.base = base
+        self.cache = cache
+    }
+
+    var dimension: Int {
+        base.dimension
+    }
+
+    func embed(_ text: String) async throws -> [Float] {
+        if let cached = await cache.get(text) {
+            return cached
+        }
+
+        let embedded = try await base.embed(text)
+        await cache.set(text, value: embedded)
+        return embedded
+    }
+
+    func embedBatch(_ texts: [String]) async throws -> [[Float]] {
+        guard !texts.isEmpty else {
+            return []
+        }
+
+        var orderedResults = Array(repeating: [Float](), count: texts.count)
+        var missOrder: [String] = []
+        var missPositions: [String: [Int]] = [:]
+
+        for (index, text) in texts.enumerated() {
+            if let cached = await cache.get(text) {
+                orderedResults[index] = cached
+                continue
+            }
+
+            missPositions[text, default: []].append(index)
+            if missPositions[text]?.count == 1 {
+                missOrder.append(text)
+            }
+        }
+
+        if !missOrder.isEmpty {
+            let embeddedMisses = try await base.embedBatch(missOrder)
+            guard embeddedMisses.count == missOrder.count else {
+                throw ContextCoreError.embeddingFailed("embedBatch returned mismatched result count")
+            }
+
+            for (offset, text) in missOrder.enumerated() {
+                let vector = embeddedMisses[offset]
+                await cache.set(text, value: vector)
+                for position in missPositions[text] ?? [] {
+                    orderedResults[position] = vector
+                }
+            }
+        }
+
+        return orderedResults
+    }
+}

--- a/Sources/ContextCore/Errors.swift
+++ b/Sources/ContextCore/Errors.swift
@@ -1,0 +1,4 @@
+import ContextCoreTypes
+
+/// Public alias for `ContextCoreTypes.ContextCoreError`.
+public typealias ContextCoreError = ContextCoreTypes.ContextCoreError

--- a/Sources/ContextCore/Memory/EpisodicStore.swift
+++ b/Sources/ContextCore/Memory/EpisodicStore.swift
@@ -1,0 +1,174 @@
+import Foundation
+import MetalANNS
+
+/// Vector-backed episodic memory store for turn-level history.
+public actor EpisodicStore: ConsolidationEpisodicStore {
+    private let index: Advanced.StreamingIndex
+    private var chunksByID: [String: MemoryChunk] = [:]
+    private let sourceSessionID: UUID
+    private var embeddingDimension: Int?
+    private let consolidatedMarkerKey = "consolidated.phase4"
+
+    /// Creates an episodic store for a source session.
+    ///
+    /// - Parameter sourceSessionID: Session identifier attached to inserted chunks.
+    public init(sourceSessionID: UUID = UUID()) {
+        self.sourceSessionID = sourceSessionID
+        let config = StreamingConfiguration(
+            deltaCapacity: 1_024,
+            mergeStrategy: .blocking,
+            indexConfiguration: IndexConfiguration(metric: .cosine)
+        )
+        self.index = Advanced.StreamingIndex(config: config)
+    }
+
+    /// Number of chunks currently stored.
+    public var count: Int {
+        chunksByID.count
+    }
+
+    /// Inserts a turn into episodic memory.
+    ///
+    /// - Parameter turn: Turn to index and store.
+    /// - Throws: `ContextCoreError.embeddingFailed` when turn embedding is missing.
+    public func insert(turn: Turn) async throws {
+        guard let embedding = turn.embedding else {
+            throw ContextCoreError.embeddingFailed("Turn embedding is nil")
+        }
+
+        try validateDimension(embedding)
+
+        var metadata = turn.metadata
+        metadata["turnRole"] = turn.role.rawValue
+        metadata["turnID"] = turn.id.uuidString
+
+        let chunk = MemoryChunk(
+            id: turn.id,
+            content: turn.content,
+            embedding: embedding,
+            type: .episodic,
+            createdAt: turn.timestamp,
+            lastAccessedAt: .now,
+            accessCount: 1,
+            retentionScore: 0.5,
+            sourceSessionID: sourceSessionID,
+            metadata: metadata
+        )
+
+        try await insert(chunk: chunk)
+    }
+
+    /// Inserts an already constructed memory chunk.
+    ///
+    /// - Parameter chunk: Chunk to index.
+    /// - Throws: `ContextCoreError.dimensionMismatch` for inconsistent dimensions.
+    public func insert(chunk: MemoryChunk) async throws {
+        try validateDimension(chunk.embedding)
+
+        let chunkID = chunk.id.uuidString
+        try await index.insert(chunk.embedding, id: chunkID)
+        chunksByID[chunkID] = chunk
+    }
+
+    /// Retrieves nearest episodic chunks for a query vector.
+    ///
+    /// - Parameters:
+    ///   - query: Query embedding.
+    ///   - k: Maximum number of chunks to return.
+    /// - Returns: Retrieved chunks ordered by ANN distance.
+    /// - Throws: `ContextCoreError.dimensionMismatch` for inconsistent dimensions.
+    public func retrieve(query: [Float], k: Int) async throws -> [MemoryChunk] {
+        guard !chunksByID.isEmpty else {
+            return []
+        }
+        guard k > 0 else {
+            return []
+        }
+
+        try validateDimension(query)
+        let results = try await index.search(query: query, k: k)
+
+        var retrieved: [MemoryChunk] = []
+        for result in results {
+            guard let chunk = chunksByID[result.id] else {
+                continue
+            }
+            retrieved.append(chunk)
+        }
+
+        return retrieved
+    }
+
+    /// Returns all chunks sorted by creation time.
+    public func allChunks() async -> [MemoryChunk] {
+        chunksByID.values.sorted { lhs, rhs in
+            if lhs.createdAt != rhs.createdAt {
+                return lhs.createdAt < rhs.createdAt
+            }
+            return lhs.id.uuidString < rhs.id.uuidString
+        }
+    }
+
+    /// Applies a retention score delta to a chunk.
+    ///
+    /// - Parameters:
+    ///   - id: Chunk identifier.
+    ///   - delta: Signed score delta.
+    /// - Throws: `ContextCoreError.chunkNotFound` if no chunk exists.
+    public func updateRetentionScore(id: UUID, delta: Float) async throws {
+        let key = id.uuidString
+        guard var chunk = chunksByID[key] else {
+            throw ContextCoreError.chunkNotFound(id: id)
+        }
+        let updated = max(0, min(1, chunk.retentionScore + delta))
+        chunk.retentionScore = updated
+        chunksByID[key] = chunk
+    }
+
+    /// Evicts a chunk from episodic storage and ANN index.
+    ///
+    /// - Parameter id: Chunk identifier.
+    /// - Throws: `ContextCoreError.chunkNotFound` if no chunk exists.
+    public func evict(id: UUID) async throws {
+        let key = id.uuidString
+        guard chunksByID[key] != nil else {
+            throw ContextCoreError.chunkNotFound(id: id)
+        }
+        try await index.delete(id: key)
+        chunksByID.removeValue(forKey: key)
+    }
+
+    /// Marks a chunk as consolidated.
+    ///
+    /// - Parameter id: Chunk identifier.
+    /// - Throws: `ContextCoreError.chunkNotFound` if no chunk exists.
+    public func markConsolidated(id: UUID) async throws {
+        let key = id.uuidString
+        guard var chunk = chunksByID[key] else {
+            throw ContextCoreError.chunkNotFound(id: id)
+        }
+        chunk.metadata[consolidatedMarkerKey] = "true"
+        chunksByID[key] = chunk
+    }
+
+    /// Returns whether a chunk has been marked as consolidated.
+    ///
+    /// - Parameter id: Chunk identifier.
+    /// - Returns: `true` when consolidated marker is present.
+    public func isConsolidated(id: UUID) async -> Bool {
+        let key = id.uuidString
+        guard let chunk = chunksByID[key] else {
+            return false
+        }
+        return chunk.metadata[consolidatedMarkerKey] == "true"
+    }
+
+    private func validateDimension(_ embedding: [Float]) throws {
+        if let expected = embeddingDimension, expected != embedding.count {
+            throw ContextCoreError.dimensionMismatch(expected: expected, got: embedding.count)
+        }
+        if embeddingDimension == nil {
+            embeddingDimension = embedding.count
+        }
+    }
+}

--- a/Sources/ContextCore/Memory/MemoryChunk.swift
+++ b/Sources/ContextCore/Memory/MemoryChunk.swift
@@ -1,0 +1,6 @@
+import ContextCoreTypes
+
+/// Public alias for `ContextCoreTypes.MemoryType`.
+public typealias MemoryType = ContextCoreTypes.MemoryType
+/// Public alias for `ContextCoreTypes.MemoryChunk`.
+public typealias MemoryChunk = ContextCoreTypes.MemoryChunk

--- a/Sources/ContextCore/Memory/ProceduralStore.swift
+++ b/Sources/ContextCore/Memory/ProceduralStore.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// LRU-bounded store of tool usage patterns keyed by task type.
+public actor ProceduralStore {
+    private let capacity: Int
+    private var entries: [String: [ToolCall]] = [:]
+    private var lastAccessedAt: [String: Date] = [:]
+
+    /// Creates a procedural store.
+    ///
+    /// - Parameter capacity: Maximum number of task-type keys retained.
+    public init(capacity: Int = 1_000) {
+        self.capacity = capacity
+    }
+
+    /// Number of task-type entries currently retained.
+    public var count: Int {
+        entries.count
+    }
+
+    /// Records tool calls for a task type.
+    ///
+    /// - Parameters:
+    ///   - taskType: Task key.
+    ///   - tools: Tool-call sequence to retain.
+    public func record(taskType: String, tools: [ToolCall]) async {
+        let now = Date()
+        let isNewKey = entries[taskType] == nil
+
+        if isNewKey && entries.count >= capacity {
+            evictLeastRecentlyAccessed()
+        }
+
+        entries[taskType] = tools
+        lastAccessedAt[taskType] = now
+    }
+
+    /// Retrieves tool calls by prefix-matching task type.
+    ///
+    /// - Parameter taskType: Prefix used to match stored task keys.
+    /// - Returns: Flattened tool calls from matched entries.
+    public func retrieve(taskType: String) async -> [ToolCall] {
+        let matchingKeys = entries.keys.filter { $0.hasPrefix(taskType) }.sorted()
+        guard !matchingKeys.isEmpty else {
+            return []
+        }
+
+        let now = Date()
+        for key in matchingKeys {
+            lastAccessedAt[key] = now
+        }
+
+        return matchingKeys.flatMap { entries[$0] ?? [] }
+    }
+
+    /// Returns all stored task patterns.
+    public func allPatterns() async -> [String: [ToolCall]] {
+        entries
+    }
+
+    private func evictLeastRecentlyAccessed() {
+        guard let oldestKey = lastAccessedAt.min(by: { $0.value < $1.value })?.key else {
+            return
+        }
+        entries.removeValue(forKey: oldestKey)
+        lastAccessedAt.removeValue(forKey: oldestKey)
+    }
+}

--- a/Sources/ContextCore/Memory/SemanticStore.swift
+++ b/Sources/ContextCore/Memory/SemanticStore.swift
@@ -1,0 +1,199 @@
+import Foundation
+import MetalANNS
+
+/// Vector-backed semantic memory store for durable facts.
+public actor SemanticStore: ConsolidationSemanticStore {
+    private let index: Advanced.StreamingIndex
+    private var chunksByID: [String: MemoryChunk] = [:]
+    private let sourceSessionID: UUID
+    private var embeddingDimension: Int?
+
+    /// Creates a semantic store for a source session.
+    ///
+    /// - Parameter sourceSessionID: Session identifier attached to inserted chunks.
+    public init(sourceSessionID: UUID = UUID()) {
+        self.sourceSessionID = sourceSessionID
+        let config = StreamingConfiguration(
+            deltaCapacity: 1_024,
+            mergeStrategy: .blocking,
+            indexConfiguration: IndexConfiguration(metric: .cosine)
+        )
+        self.index = Advanced.StreamingIndex(config: config)
+    }
+
+    /// Number of semantic chunks currently stored.
+    public var count: Int {
+        chunksByID.count
+    }
+
+    /// Inserts a semantic chunk from raw content and embedding.
+    ///
+    /// - Parameters:
+    ///   - content: Fact content.
+    ///   - embedding: Fact embedding.
+    ///   - metadata: Optional metadata.
+    /// - Throws: `ContextCoreError.dimensionMismatch` for inconsistent dimensions.
+    public func insert(
+        content: String,
+        embedding: [Float],
+        metadata: [String: String] = [:]
+    ) async throws {
+        try validateDimension(embedding)
+
+        let chunk = MemoryChunk(
+            content: content,
+            embedding: embedding,
+            type: .semantic,
+            createdAt: .now,
+            lastAccessedAt: .now,
+            accessCount: 1,
+            retentionScore: 1.0,
+            sourceSessionID: sourceSessionID,
+            metadata: metadata
+        )
+
+        let chunkID = chunk.id.uuidString
+        try await index.insert(embedding, id: chunkID)
+        chunksByID[chunkID] = chunk
+    }
+
+    /// Inserts a pre-built semantic chunk.
+    ///
+    /// - Parameter chunk: Chunk to insert.
+    /// - Throws: `ContextCoreError.dimensionMismatch` for inconsistent dimensions.
+    public func insert(chunk: MemoryChunk) async throws {
+        try validateDimension(chunk.embedding)
+        let chunkID = chunk.id.uuidString
+        try await index.insert(chunk.embedding, id: chunkID)
+        chunksByID[chunkID] = chunk
+    }
+
+    /// Retrieves nearest semantic chunks for a query vector.
+    ///
+    /// - Parameters:
+    ///   - query: Query embedding.
+    ///   - k: Maximum number of chunks to return.
+    /// - Returns: Retrieved chunks ordered by ANN distance.
+    /// - Throws: `ContextCoreError.dimensionMismatch` for inconsistent dimensions.
+    public func retrieve(query: [Float], k: Int) async throws -> [MemoryChunk] {
+        guard !chunksByID.isEmpty else {
+            return []
+        }
+        guard k > 0 else {
+            return []
+        }
+
+        try validateDimension(query)
+        let results = try await index.search(query: query, k: k)
+
+        var retrieved: [MemoryChunk] = []
+        for result in results {
+            guard let chunk = chunksByID[result.id] else {
+                continue
+            }
+            retrieved.append(chunk)
+        }
+
+        return retrieved
+    }
+
+    /// Upserts a semantic fact using cosine similarity deduplication.
+    ///
+    /// - Parameters:
+    ///   - fact: Fact string to retain.
+    ///   - embedding: Fact embedding.
+    /// - Throws: `ContextCoreError.dimensionMismatch` for inconsistent dimensions.
+    public func upsert(fact: String, embedding: [Float]) async throws {
+        try validateDimension(embedding)
+
+        if let existingID = bestMatchingChunkID(for: embedding, threshold: 0.9),
+           var existing = chunksByID[existingID]
+        {
+            existing.lastAccessedAt = .now
+            existing.accessCount += 1
+            chunksByID[existingID] = existing
+            return
+        }
+
+        try await insert(
+            content: fact,
+            embedding: embedding,
+            metadata: ["kind": "fact"]
+        )
+    }
+
+    /// Returns all semantic chunks sorted by creation time.
+    public func allChunks() async -> [MemoryChunk] {
+        chunksByID.values.sorted { lhs, rhs in
+            if lhs.createdAt != rhs.createdAt {
+                return lhs.createdAt < rhs.createdAt
+            }
+            return lhs.id.uuidString < rhs.id.uuidString
+        }
+    }
+
+    /// Applies a retention score delta to a semantic chunk.
+    ///
+    /// - Parameters:
+    ///   - id: Chunk identifier.
+    ///   - delta: Signed score delta.
+    /// - Throws: `ContextCoreError.chunkNotFound` if no chunk exists.
+    public func updateRetentionScore(id: UUID, delta: Float) async throws {
+        let key = id.uuidString
+        guard var chunk = chunksByID[key] else {
+            throw ContextCoreError.chunkNotFound(id: id)
+        }
+        let updated = max(0, min(1, chunk.retentionScore + delta))
+        chunk.retentionScore = updated
+        chunksByID[key] = chunk
+    }
+
+    private func validateDimension(_ embedding: [Float]) throws {
+        if let expected = embeddingDimension, expected != embedding.count {
+            throw ContextCoreError.dimensionMismatch(expected: expected, got: embedding.count)
+        }
+        if embeddingDimension == nil {
+            embeddingDimension = embedding.count
+        }
+    }
+
+    private func bestMatchingChunkID(for embedding: [Float], threshold: Float) -> String? {
+        var bestID: String?
+        var bestSimilarity: Float = -1
+
+        for (id, chunk) in chunksByID {
+            let similarity = cosineSimilarity(embedding, chunk.embedding)
+            if similarity > bestSimilarity {
+                bestSimilarity = similarity
+                bestID = id
+            }
+        }
+
+        guard let bestID, bestSimilarity > threshold else {
+            return nil
+        }
+        return bestID
+    }
+
+    private func cosineSimilarity(_ lhs: [Float], _ rhs: [Float]) -> Float {
+        guard lhs.count == rhs.count else {
+            return -1
+        }
+
+        var dot: Float = 0
+        var lhsNorm: Float = 0
+        var rhsNorm: Float = 0
+
+        for index in lhs.indices {
+            dot += lhs[index] * rhs[index]
+            lhsNorm += lhs[index] * lhs[index]
+            rhsNorm += rhs[index] * rhs[index]
+        }
+
+        let denominator = (lhsNorm.squareRoot() * rhsNorm.squareRoot())
+        guard denominator > 0 else {
+            return -1
+        }
+        return dot / denominator
+    }
+}

--- a/Sources/ContextCore/Persistence/ContextCheckpoint.swift
+++ b/Sources/ContextCore/Persistence/ContextCheckpoint.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+/// Serializable snapshot of ContextCore runtime state.
+public struct ContextCheckpoint: Codable, Sendable {
+    /// Serializable subset of ``ContextConfiguration`` persisted in checkpoints.
+    public struct ConfigurationSnapshot: Codable, Sendable {
+        /// Persisted `maxTokens`.
+        public let maxTokens: Int
+        /// Persisted `tokenBudgetSafetyMargin`.
+        public let tokenBudgetSafetyMargin: Float
+        /// Persisted `episodicMemoryK`.
+        public let episodicMemoryK: Int
+        /// Persisted `semanticMemoryK`.
+        public let semanticMemoryK: Int
+        /// Persisted `recentTurnsGuaranteed`.
+        public let recentTurnsGuaranteed: Int
+        /// Persisted `episodicHalfLifeDays`.
+        public let episodicHalfLifeDays: Double
+        /// Persisted `semanticHalfLifeDays`.
+        public let semanticHalfLifeDays: Double
+        /// Persisted `consolidationThreshold`.
+        public let consolidationThreshold: Int
+        /// Persisted `similarityMergeThreshold`.
+        public let similarityMergeThreshold: Float
+        /// Persisted `relevanceWeight`.
+        public let relevanceWeight: Float
+        /// Persisted `centralityWeight`.
+        public let centralityWeight: Float
+        /// Persisted `efSearch`.
+        public let efSearch: Int
+
+        /// Creates a configuration snapshot from runtime config.
+        ///
+        /// - Parameter configuration: Source configuration.
+        public init(configuration: ContextConfiguration) {
+            self.maxTokens = configuration.maxTokens
+            self.tokenBudgetSafetyMargin = configuration.tokenBudgetSafetyMargin
+            self.episodicMemoryK = configuration.episodicMemoryK
+            self.semanticMemoryK = configuration.semanticMemoryK
+            self.recentTurnsGuaranteed = configuration.recentTurnsGuaranteed
+            self.episodicHalfLifeDays = configuration.episodicHalfLifeDays
+            self.semanticHalfLifeDays = configuration.semanticHalfLifeDays
+            self.consolidationThreshold = configuration.consolidationThreshold
+            self.similarityMergeThreshold = configuration.similarityMergeThreshold
+            self.relevanceWeight = configuration.relevanceWeight
+            self.centralityWeight = configuration.centralityWeight
+            self.efSearch = configuration.efSearch
+        }
+
+        /// Applies persisted scalar values onto a base configuration.
+        ///
+        /// - Parameter base: Base configuration providing runtime dependencies.
+        /// - Returns: Reconstructed configuration.
+        public func apply(to base: ContextConfiguration) -> ContextConfiguration {
+            ContextConfiguration(
+                maxTokens: maxTokens,
+                tokenBudgetSafetyMargin: tokenBudgetSafetyMargin,
+                episodicMemoryK: episodicMemoryK,
+                semanticMemoryK: semanticMemoryK,
+                recentTurnsGuaranteed: recentTurnsGuaranteed,
+                episodicHalfLifeDays: episodicHalfLifeDays,
+                semanticHalfLifeDays: semanticHalfLifeDays,
+                consolidationThreshold: consolidationThreshold,
+                similarityMergeThreshold: similarityMergeThreshold,
+                relevanceWeight: relevanceWeight,
+                centralityWeight: centralityWeight,
+                efSearch: efSearch,
+                embeddingProvider: base.embeddingProvider,
+                tokenCounter: base.tokenCounter,
+                compressionDelegate: base.compressionDelegate
+            )
+        }
+    }
+
+    /// Checkpoint schema version.
+    public let version: Int
+    /// Checkpoint creation timestamp.
+    public let createdAt: Date
+    /// Persisted episodic chunks.
+    public let episodicChunks: [MemoryChunk]
+    /// Persisted semantic chunks.
+    public let semanticChunks: [MemoryChunk]
+    /// Persisted procedural patterns.
+    public let proceduralPatterns: [String: [ToolCall]]
+    /// Last active session identifier.
+    public let lastSessionID: UUID?
+    /// Persisted system prompt.
+    public let systemPrompt: String?
+    /// Recent turn buffer.
+    public let recentTurns: [Turn]
+    /// Total session counter.
+    public let totalSessions: Int
+    /// Persisted configuration snapshot.
+    public let configuration: ConfigurationSnapshot
+
+    /// Creates a checkpoint snapshot.
+    ///
+    /// - Parameters:
+    ///   - version: Checkpoint schema version.
+    ///   - createdAt: Creation timestamp.
+    ///   - episodicChunks: Episodic chunks to persist.
+    ///   - semanticChunks: Semantic chunks to persist.
+    ///   - proceduralPatterns: Procedural patterns to persist.
+    ///   - lastSessionID: Last active session identifier.
+    ///   - systemPrompt: Active system prompt.
+    ///   - recentTurns: Recent turn buffer.
+    ///   - totalSessions: Total sessions started.
+    ///   - configuration: Configuration snapshot.
+    public init(
+        version: Int = 1,
+        createdAt: Date = .now,
+        episodicChunks: [MemoryChunk],
+        semanticChunks: [MemoryChunk],
+        proceduralPatterns: [String: [ToolCall]],
+        lastSessionID: UUID?,
+        systemPrompt: String?,
+        recentTurns: [Turn],
+        totalSessions: Int,
+        configuration: ConfigurationSnapshot
+    ) {
+        self.version = version
+        self.createdAt = createdAt
+        self.episodicChunks = episodicChunks
+        self.semanticChunks = semanticChunks
+        self.proceduralPatterns = proceduralPatterns
+        self.lastSessionID = lastSessionID
+        self.systemPrompt = systemPrompt
+        self.recentTurns = recentTurns
+        self.totalSessions = totalSessions
+        self.configuration = configuration
+    }
+}

--- a/Sources/ContextCore/Persistence/SessionStore.swift
+++ b/Sources/ContextCore/Persistence/SessionStore.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+struct SessionStore: Codable, Sendable {
+    var currentSessionID: UUID?
+    var systemPrompt: String?
+    var recentTurns: [Turn]
+    var totalSessions: Int
+
+    init(
+        currentSessionID: UUID? = nil,
+        systemPrompt: String? = nil,
+        recentTurns: [Turn] = [],
+        totalSessions: Int = 0
+    ) {
+        self.currentSessionID = currentSessionID
+        self.systemPrompt = systemPrompt
+        self.recentTurns = recentTurns
+        self.totalSessions = totalSessions
+    }
+
+    var isSessionActive: Bool {
+        currentSessionID != nil
+    }
+
+    mutating func begin(id: UUID, systemPrompt: String?) {
+        currentSessionID = id
+        self.systemPrompt = systemPrompt
+        recentTurns.removeAll(keepingCapacity: true)
+        totalSessions += 1
+    }
+
+    mutating func end() {
+        currentSessionID = nil
+        systemPrompt = nil
+        recentTurns.removeAll(keepingCapacity: true)
+    }
+
+    mutating func appendRecent(_ turn: Turn, maxBufferSize: Int) {
+        recentTurns.append(turn)
+        if recentTurns.count > maxBufferSize {
+            recentTurns.removeFirst(recentTurns.count - maxBufferSize)
+        }
+    }
+
+    func guaranteedRecentTurns(count: Int) -> [Turn] {
+        guard count > 0 else {
+            return []
+        }
+        return Array(recentTurns.suffix(count))
+    }
+}

--- a/Sources/ContextCore/ProgressiveCompressor.swift
+++ b/Sources/ContextCore/ProgressiveCompressor.swift
@@ -1,0 +1,194 @@
+import Foundation
+
+/// Compression outcome for a single candidate chunk.
+public struct ProgressiveCompressionResult: Sendable {
+    /// Original uncompressed chunk.
+    public let originalChunk: MemoryChunk
+    /// Compressed content when retained; `nil` when dropped.
+    public let compressedContent: String?
+    /// Compression level applied.
+    public let compressionLevel: CompressionLevel
+    /// Original token count.
+    public let originalTokens: Int
+    /// Token count after compression.
+    public let compressedTokens: Int
+    /// Tokens removed by compression or dropping.
+    public let tokensSaved: Int
+
+    /// Creates a progressive compression result.
+    ///
+    /// - Parameters:
+    ///   - originalChunk: Source chunk.
+    ///   - compressedContent: Compressed content or `nil` when dropped.
+    ///   - compressionLevel: Applied compression level.
+    ///   - originalTokens: Original token count.
+    ///   - compressedTokens: Compressed token count.
+    ///   - tokensSaved: Tokens removed.
+    public init(
+        originalChunk: MemoryChunk,
+        compressedContent: String?,
+        compressionLevel: CompressionLevel,
+        originalTokens: Int,
+        compressedTokens: Int,
+        tokensSaved: Int
+    ) {
+        self.originalChunk = originalChunk
+        self.compressedContent = compressedContent
+        self.compressionLevel = compressionLevel
+        self.originalTokens = originalTokens
+        self.compressedTokens = compressedTokens
+        self.tokensSaved = tokensSaved
+    }
+
+    /// Converts the result into a context chunk when retained.
+    ///
+    /// - Parameters:
+    ///   - score: Score assigned to this candidate.
+    ///   - source: Memory source for the resulting context chunk.
+    /// - Returns: A context chunk or `nil` when compression level is `.dropped`.
+    public func toContextChunk(score: Float, source: MemoryType) -> ContextChunk? {
+        guard compressionLevel != .dropped else {
+            return nil
+        }
+
+        let content = compressedContent ?? originalChunk.content
+        return ContextChunk(
+            id: originalChunk.id,
+            content: content,
+            role: .system,
+            tokenCount: compressedTokens,
+            score: score,
+            source: source,
+            compressionLevel: compressionLevel,
+            timestamp: originalChunk.createdAt,
+            isGuaranteedRecent: false,
+            isSystemPrompt: false
+        )
+    }
+}
+
+/// Applies progressive, score-aware compression to satisfy budget deficits.
+public actor ProgressiveCompressor {
+    private let compressionEngine: CompressionEngine
+    private let tokenCounter: any TokenCounter
+
+    /// Creates a progressive compressor.
+    ///
+    /// - Parameters:
+    ///   - compressionEngine: Engine used for light/heavy compression passes.
+    ///   - tokenCounter: Token counter used for deficit accounting.
+    public init(
+        compressionEngine: CompressionEngine,
+        tokenCounter: any TokenCounter
+    ) {
+        self.compressionEngine = compressionEngine
+        self.tokenCounter = tokenCounter
+    }
+
+    /// Progressively compresses low-priority candidates until deficit is recovered.
+    ///
+    /// - Parameters:
+    ///   - candidates: Candidates ordered by eviction preference.
+    ///   - tokenDeficit: Number of tokens that must be removed.
+    /// - Returns: Compression outcomes aligned with input order.
+    /// - Throws: Propagates compression-engine failures.
+    public func compress(
+        candidates: [(chunk: MemoryChunk, evictionScore: Float)],
+        tokenDeficit: Int
+    ) async throws -> [ProgressiveCompressionResult] {
+        if tokenDeficit <= 0 {
+            return candidates.map { makeUnchangedResult(for: $0.chunk) }
+        }
+
+        var remainingDeficit = tokenDeficit
+        var results: [ProgressiveCompressionResult] = []
+        results.reserveCapacity(candidates.count)
+
+        for candidate in candidates {
+            let chunk = candidate.chunk
+
+            if remainingDeficit <= 0 {
+                results.append(makeUnchangedResult(for: chunk))
+                continue
+            }
+
+            let originalTokens = tokenCounter.count(chunk.content)
+            if originalTokens == 0 {
+                results.append(makeUnchangedResult(for: chunk))
+                continue
+            }
+
+            let lightTarget = max(1, originalTokens / 2)
+            let lightCompressed = try await compressionEngine.compress(
+                chunk: chunk,
+                targetTokens: lightTarget
+            )
+            let lightTokens = min(originalTokens, tokenCounter.count(lightCompressed.content))
+            let lightSaved = max(0, originalTokens - lightTokens)
+
+            if lightSaved >= remainingDeficit {
+                remainingDeficit -= lightSaved
+                results.append(
+                    ProgressiveCompressionResult(
+                        originalChunk: chunk,
+                        compressedContent: lightCompressed.content,
+                        compressionLevel: .light,
+                        originalTokens: originalTokens,
+                        compressedTokens: lightTokens,
+                        tokensSaved: lightSaved
+                    )
+                )
+                continue
+            }
+
+            let heavyTarget = max(1, originalTokens / 4)
+            let heavyCompressed = try await compressionEngine.compress(
+                chunk: chunk,
+                targetTokens: heavyTarget
+            )
+            let heavyTokens = min(originalTokens, tokenCounter.count(heavyCompressed.content))
+            let heavySaved = max(0, originalTokens - heavyTokens)
+
+            if heavySaved >= remainingDeficit {
+                remainingDeficit -= heavySaved
+                results.append(
+                    ProgressiveCompressionResult(
+                        originalChunk: chunk,
+                        compressedContent: heavyCompressed.content,
+                        compressionLevel: .heavy,
+                        originalTokens: originalTokens,
+                        compressedTokens: heavyTokens,
+                        tokensSaved: heavySaved
+                    )
+                )
+                continue
+            }
+
+            remainingDeficit -= originalTokens
+            results.append(
+                ProgressiveCompressionResult(
+                    originalChunk: chunk,
+                    compressedContent: nil,
+                    compressionLevel: .dropped,
+                    originalTokens: originalTokens,
+                    compressedTokens: 0,
+                    tokensSaved: originalTokens
+                )
+            )
+        }
+
+        return results
+    }
+
+    private func makeUnchangedResult(for chunk: MemoryChunk) -> ProgressiveCompressionResult {
+        let originalTokens = tokenCounter.count(chunk.content)
+        return ProgressiveCompressionResult(
+            originalChunk: chunk,
+            compressedContent: chunk.content,
+            compressionLevel: .none,
+            originalTokens: originalTokens,
+            compressedTokens: originalTokens,
+            tokensSaved: 0
+        )
+    }
+}

--- a/Sources/ContextCore/Protocols/ConsolidationStores.swift
+++ b/Sources/ContextCore/Protocols/ConsolidationStores.swift
@@ -1,0 +1,6 @@
+import ContextCoreTypes
+
+/// Public alias for `ContextCoreTypes.ConsolidationEpisodicStore`.
+public typealias ConsolidationEpisodicStore = ContextCoreTypes.ConsolidationEpisodicStore
+/// Public alias for `ContextCoreTypes.ConsolidationSemanticStore`.
+public typealias ConsolidationSemanticStore = ContextCoreTypes.ConsolidationSemanticStore

--- a/Sources/ContextCore/Protocols/EmbeddingProvider.swift
+++ b/Sources/ContextCore/Protocols/EmbeddingProvider.swift
@@ -1,0 +1,4 @@
+import ContextCoreTypes
+
+/// Public alias for `ContextCoreTypes.EmbeddingProvider`.
+public typealias EmbeddingProvider = ContextCoreTypes.EmbeddingProvider

--- a/Sources/ContextCore/Protocols/TokenCounter.swift
+++ b/Sources/ContextCore/Protocols/TokenCounter.swift
@@ -1,0 +1,6 @@
+import ContextCoreTypes
+
+/// Public alias for `ContextCoreTypes.TokenCounter`.
+public typealias TokenCounter = ContextCoreTypes.TokenCounter
+/// Public alias for `ContextCoreTypes.ApproximateTokenCounter`.
+public typealias ApproximateTokenCounter = ContextCoreTypes.ApproximateTokenCounter

--- a/Sources/ContextCore/Resources/Embeddings/README.md
+++ b/Sources/ContextCore/Resources/Embeddings/README.md
@@ -3,3 +3,8 @@
 [![Discord](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fdiscord.com%2Fapi%2Fv10%2Finvites%2FNHgNh7HJ6M%3Fwith_counts%3Dtrue&query=%24.approximate_presence_count&suffix=%20online&logo=discord&label=Discord&color=5865F2)](https://discord.gg/NHgNh7HJ6M)
 
 Phase 1 expects `minilm-l6-v2.mlpackage` to be bundled here.
+
+The package is **not** shipped with Swarm. When the model is missing,
+`CoreMLEmbeddingProvider` falls back to deterministic pseudo-embeddings so
+Integrations builds and tests still run; supply the `.mlpackage` for real
+on-device embeddings.

--- a/Sources/ContextCore/Resources/Embeddings/README.md
+++ b/Sources/ContextCore/Resources/Embeddings/README.md
@@ -1,0 +1,5 @@
+# Embedding Resources
+
+[![Discord](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fdiscord.com%2Fapi%2Fv10%2Finvites%2FNHgNh7HJ6M%3Fwith_counts%3Dtrue&query=%24.approximate_presence_count&suffix=%20online&logo=discord&label=Discord&color=5865F2)](https://discord.gg/NHgNh7HJ6M)
+
+Phase 1 expects `minilm-l6-v2.mlpackage` to be bundled here.

--- a/Sources/ContextCore/Turn.swift
+++ b/Sources/ContextCore/Turn.swift
@@ -1,0 +1,8 @@
+import ContextCoreTypes
+
+/// Public alias for `ContextCoreTypes.TurnRole`.
+public typealias TurnRole = ContextCoreTypes.TurnRole
+/// Public alias for `ContextCoreTypes.Turn`.
+public typealias Turn = ContextCoreTypes.Turn
+/// Public alias for `ContextCoreTypes.ToolCall`.
+public typealias ToolCall = ContextCoreTypes.ToolCall

--- a/Sources/ContextCore/WindowPacker.swift
+++ b/Sources/ContextCore/WindowPacker.swift
@@ -1,0 +1,297 @@
+import Foundation
+
+protocol SentenceRanker: Sendable {
+    func rankSentences(
+        in chunk: String,
+        chunkEmbedding: [Float]
+    ) async throws -> [(sentence: String, importance: Float)]
+}
+
+extension CompressionEngine: SentenceRanker {}
+
+/// Packs system prompt, recent turns, and ranked memory into a token budget.
+public actor WindowPacker {
+    private let sentenceRanker: any SentenceRanker
+    private let tokenCounter: any TokenCounter
+    private let minimumChunkSize: Int
+    private let recentTurnsGuaranteed: Int
+    private let progressiveCompressor: ProgressiveCompressor?
+
+    /// Creates a production window packer.
+    ///
+    /// - Parameters:
+    ///   - compressionEngine: Compression engine used for sentence ranking and fallback compression.
+    ///   - tokenCounter: Token counter used for budget accounting.
+    ///   - minimumChunkSize: Remaining budget threshold below which packing stops.
+    ///   - recentTurnsGuaranteed: Number of latest turns that must always be included.
+    public init(
+        compressionEngine: CompressionEngine,
+        tokenCounter: any TokenCounter,
+        minimumChunkSize: Int = 50,
+        recentTurnsGuaranteed: Int = 3
+    ) {
+        self.sentenceRanker = compressionEngine
+        self.tokenCounter = tokenCounter
+        self.minimumChunkSize = max(0, minimumChunkSize)
+        self.recentTurnsGuaranteed = max(0, recentTurnsGuaranteed)
+        self.progressiveCompressor = ProgressiveCompressor(
+            compressionEngine: compressionEngine,
+            tokenCounter: tokenCounter
+        )
+    }
+
+    init(
+        sentenceRanker: any SentenceRanker,
+        tokenCounter: any TokenCounter,
+        minimumChunkSize: Int = 50,
+        recentTurnsGuaranteed: Int = 3,
+        progressiveCompressor: ProgressiveCompressor? = nil
+    ) {
+        self.sentenceRanker = sentenceRanker
+        self.tokenCounter = tokenCounter
+        self.minimumChunkSize = max(0, minimumChunkSize)
+        self.recentTurnsGuaranteed = max(0, recentTurnsGuaranteed)
+        self.progressiveCompressor = progressiveCompressor
+    }
+
+    /// Packs context candidates into a budget-constrained ``ContextWindow``.
+    ///
+    /// - Parameters:
+    ///   - systemPrompt: Optional system instruction to pin at the top.
+    ///   - recentTurns: Turn buffer eligible for guaranteed inclusion.
+    ///   - scoredMemory: Ranked memory candidates.
+    ///   - budget: Effective token budget.
+    /// - Returns: Packed context window.
+    /// - Throws: Propagates compression and embedding errors from dependencies.
+    ///
+    /// - Complexity: O(n log n) for candidate sorting plus optional compression work.
+    public func pack(
+        systemPrompt: String?,
+        recentTurns: [Turn],
+        scoredMemory: [(chunk: MemoryChunk, score: Float)],
+        budget: Int
+    ) async throws -> ContextWindow {
+        var remainingTokens = budget
+        var packedChunks: [ContextChunk] = []
+
+        if let systemPrompt {
+            let chunk = makeSystemPromptChunk(from: systemPrompt)
+            remainingTokens -= chunk.tokenCount
+            packedChunks.append(chunk)
+        }
+
+        let guaranteedTurns = recentTurns.suffix(recentTurnsGuaranteed)
+        for turn in guaranteedTurns {
+            let chunk = makeChunk(from: turn, isGuaranteedRecent: true)
+            remainingTokens -= chunk.tokenCount
+            packedChunks.append(chunk)
+        }
+
+        let sortedMemory = scoredMemory.sorted { lhs, rhs in
+            if lhs.score == rhs.score {
+                if lhs.chunk.createdAt == rhs.chunk.createdAt {
+                    return lhs.chunk.id.uuidString < rhs.chunk.id.uuidString
+                }
+                return lhs.chunk.createdAt < rhs.chunk.createdAt
+            }
+            return lhs.score > rhs.score
+        }
+
+        var index = 0
+        while index < sortedMemory.count {
+            if remainingTokens < minimumChunkSize {
+                break
+            }
+
+            let candidate = sortedMemory[index]
+            let fullChunk = makeChunk(from: candidate.chunk, score: candidate.score)
+            if fullChunk.tokenCount <= remainingTokens {
+                packedChunks.append(fullChunk)
+                remainingTokens -= fullChunk.tokenCount
+                index += 1
+                continue
+            }
+
+            if let progressiveCompressor {
+                let tail = Array(sortedMemory[index...])
+                let tailTotalTokens = tail.reduce(into: 0) { partial, value in
+                    partial += tokenCounter.count(value.chunk.content)
+                }
+                let deficit = max(0, tailTotalTokens - remainingTokens)
+
+                let ascendingCandidates = tail.sorted(by: ascendingScoreOrder)
+                let progressiveResults = try await progressiveCompressor.compress(
+                    candidates: ascendingCandidates.map { (chunk: $0.chunk, evictionScore: $0.score) },
+                    tokenDeficit: deficit
+                )
+                let resultByID = Dictionary(
+                    uniqueKeysWithValues: progressiveResults.map { ($0.originalChunk.id, $0) }
+                )
+
+                for memoryCandidate in tail {
+                    guard let result = resultByID[memoryCandidate.chunk.id] else {
+                        continue
+                    }
+                    guard let contextChunk = result.toContextChunk(
+                        score: memoryCandidate.score,
+                        source: memoryCandidate.chunk.type
+                    ) else {
+                        continue
+                    }
+                    guard contextChunk.tokenCount <= remainingTokens else {
+                        break
+                    }
+
+                    packedChunks.append(contextChunk)
+                    remainingTokens -= contextChunk.tokenCount
+                }
+                break
+            } else if let compressedChunk = try await attemptCompression(
+                from: candidate.chunk,
+                score: candidate.score,
+                targetTokens: remainingTokens
+            ), compressedChunk.tokenCount <= remainingTokens {
+                packedChunks.append(compressedChunk)
+                remainingTokens -= compressedChunk.tokenCount
+            }
+
+            index += 1
+        }
+
+        return ContextWindow(chunks: packedChunks, budget: budget)
+    }
+
+    private func ascendingScoreOrder(
+        _ lhs: (chunk: MemoryChunk, score: Float),
+        _ rhs: (chunk: MemoryChunk, score: Float)
+    ) -> Bool {
+        if lhs.score == rhs.score {
+            if lhs.chunk.createdAt == rhs.chunk.createdAt {
+                return lhs.chunk.id.uuidString < rhs.chunk.id.uuidString
+            }
+            return lhs.chunk.createdAt < rhs.chunk.createdAt
+        }
+        return lhs.score < rhs.score
+    }
+
+    private func makeSystemPromptChunk(from prompt: String) -> ContextChunk {
+        ContextChunk(
+            content: prompt,
+            role: .system,
+            tokenCount: tokenCounter.count(prompt),
+            score: 1.0,
+            source: .semantic,
+            compressionLevel: .none,
+            timestamp: .now,
+            isGuaranteedRecent: false,
+            isSystemPrompt: true
+        )
+    }
+
+    private func makeChunk(
+        from turn: Turn,
+        isGuaranteedRecent: Bool = false
+    ) -> ContextChunk {
+        ContextChunk(
+            id: turn.id,
+            content: turn.content,
+            role: turn.role,
+            tokenCount: tokenCounter.count(turn.content),
+            score: 1.0,
+            source: .episodic,
+            compressionLevel: .none,
+            timestamp: turn.timestamp,
+            isGuaranteedRecent: isGuaranteedRecent,
+            isSystemPrompt: false
+        )
+    }
+
+    private func makeChunk(
+        from memory: MemoryChunk,
+        score: Float,
+        content: String? = nil,
+        compressionLevel: CompressionLevel = .none
+    ) -> ContextChunk {
+        let resolvedContent = content ?? memory.content
+        return ContextChunk(
+            id: memory.id,
+            content: resolvedContent,
+            role: .system,
+            tokenCount: tokenCounter.count(resolvedContent),
+            score: score,
+            source: memory.type,
+            compressionLevel: compressionLevel,
+            timestamp: memory.createdAt,
+            isGuaranteedRecent: false,
+            isSystemPrompt: false
+        )
+    }
+
+    private func attemptCompression(
+        from memory: MemoryChunk,
+        score: Float,
+        targetTokens: Int
+    ) async throws -> ContextChunk? {
+        guard targetTokens > 0 else {
+            return nil
+        }
+
+        let ranked = try await sentenceRanker.rankSentences(
+            in: memory.content,
+            chunkEmbedding: memory.embedding
+        )
+
+        guard !ranked.isEmpty else {
+            return nil
+        }
+
+        let topSentence = ranked[0].sentence.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !topSentence.isEmpty else {
+            return nil
+        }
+
+        if tokenCounter.count(topSentence) > targetTokens {
+            return nil
+        }
+
+        var selectedSentences: [String] = []
+        var runningTokenTotal = 0
+
+        for candidate in ranked {
+            let sentence = candidate.sentence.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !sentence.isEmpty else {
+                continue
+            }
+
+            let sentenceTokens = tokenCounter.count(sentence)
+            if runningTokenTotal + sentenceTokens <= targetTokens {
+                selectedSentences.append(sentence)
+                runningTokenTotal += sentenceTokens
+            }
+        }
+
+        guard !selectedSentences.isEmpty else {
+            return nil
+        }
+
+        var compressedContent = selectedSentences.joined(separator: " ")
+        var compressedTokens = tokenCounter.count(compressedContent)
+
+        while compressedTokens > targetTokens && !selectedSentences.isEmpty {
+            selectedSentences.removeLast()
+            compressedContent = selectedSentences.joined(separator: " ")
+            compressedTokens = tokenCounter.count(compressedContent)
+        }
+
+        guard !selectedSentences.isEmpty else {
+            return nil
+        }
+
+        return makeChunk(
+            from: memory,
+            score: score,
+            content: compressedContent,
+            compressionLevel: .light
+        )
+    }
+}

--- a/Sources/ContextCoreEngine/AttentionEngine.swift
+++ b/Sources/ContextCoreEngine/AttentionEngine.swift
@@ -1,0 +1,187 @@
+import ContextCoreTypes
+import Foundation
+import Metal
+
+/// GPU-backed attention centrality and eviction scoring engine.
+public actor AttentionEngine {
+    private let device: MTLDevice
+    private let commandQueue: MTLCommandQueue
+    private let centralityPipeline: MTLComputePipelineState
+    private let crossAttentionPipeline: MTLComputePipelineState
+
+    /// Creates an attention engine and compiles required Metal pipelines.
+    ///
+    /// - Parameter device: Optional Metal device override.
+    /// - Throws: ``ContextCoreError/metalDeviceUnavailable`` or pipeline creation failures.
+    public init(device: MTLDevice? = nil) throws {
+        self.device = try device ?? MetalContext.device()
+        self.commandQueue = try MetalContext.commandQueue(device: self.device)
+
+        let library = try MetalContext.library(device: self.device)
+
+        guard let centralityFunction = library.makeFunction(name: "token_centrality") else {
+            throw ContextCoreError.compressionFailed("Missing token_centrality function")
+        }
+
+        guard let crossAttentionFunction = library.makeFunction(name: "cross_attention_score") else {
+            throw ContextCoreError.compressionFailed("Missing cross_attention_score function")
+        }
+
+        self.centralityPipeline = try self.device.makeComputePipelineState(function: centralityFunction)
+        self.crossAttentionPipeline = try self.device.makeComputePipelineState(function: crossAttentionFunction)
+    }
+
+    /// Computes centrality for each embedding within a candidate set.
+    ///
+    /// - Parameter embeddings: Candidate embeddings.
+    /// - Returns: Centrality score for each embedding.
+    /// - Throws: ``ContextCoreError/dimensionMismatch(expected:got:)`` for inconsistent dimensions.
+    public func computeCentrality(
+        embeddings: [[Float]]
+    ) async throws -> [Float] {
+        guard !embeddings.isEmpty else {
+            return []
+        }
+
+        let n = embeddings.count
+        if n == 1 {
+            return [0]
+        }
+
+        let dim = embeddings[0].count
+        guard embeddings.allSatisfy({ $0.count == dim }) else {
+            throw ContextCoreError.dimensionMismatch(expected: dim, got: embeddings.first(where: { $0.count != dim })?.count ?? 0)
+        }
+
+        let flattened = embeddings.flatMap { $0 }
+        var output = [Float](repeating: 0, count: n)
+
+        guard let embeddingsBuffer = device.makeBuffer(from: flattened),
+              let outputBuffer = device.makeBuffer(from: output),
+              let commandBuffer = commandQueue.makeCommandBuffer(),
+              let encoder = commandBuffer.makeComputeCommandEncoder()
+        else {
+            throw ContextCoreError.compressionFailed("Failed to allocate centrality buffers")
+        }
+
+        var dim32 = UInt32(dim)
+        var n32 = UInt32(n)
+
+        guard let dimBuffer = device.makeBuffer(bytes: &dim32, length: MemoryLayout<UInt32>.stride, options: .storageModeShared),
+              let nBuffer = device.makeBuffer(bytes: &n32, length: MemoryLayout<UInt32>.stride, options: .storageModeShared)
+        else {
+            throw ContextCoreError.compressionFailed("Failed to create centrality constants")
+        }
+
+        encoder.setComputePipelineState(centralityPipeline)
+        encoder.setBuffer(embeddingsBuffer, offset: 0, index: 0)
+        encoder.setBuffer(outputBuffer, offset: 0, index: 1)
+        encoder.setBuffer(dimBuffer, offset: 0, index: 2)
+        encoder.setBuffer(nBuffer, offset: 0, index: 3)
+
+        let threadWidth = max(1, min(16, min(centralityPipeline.maxTotalThreadsPerThreadgroup, n)))
+        let threads = MTLSize(width: threadWidth, height: 1, depth: 1)
+        let groups = MetalContext.threadgroups(threadsPerThreadgroup: threads, count: n)
+        encoder.dispatchThreadgroups(groups, threadsPerThreadgroup: threads)
+        encoder.endEncoding()
+
+        try await MetalContext.awaitCompletion(of: commandBuffer)
+
+        let raw = outputBuffer.contents().bindMemory(to: Float.self, capacity: n)
+        output = Array(UnsafeBufferPointer(start: raw, count: n))
+        return output
+    }
+
+    /// Produces eviction scores by combining relevance and centrality.
+    ///
+    /// - Parameters:
+    ///   - taskQuery: Query embedding.
+    ///   - windowChunks: Candidate chunks already in the window.
+    ///   - relevanceWeight: Relevance contribution.
+    ///   - centralityWeight: Centrality contribution.
+    /// - Returns: Chunks sorted by ascending eviction score (lowest first).
+    /// - Throws: ``ContextCoreError/dimensionMismatch(expected:got:)`` for inconsistent dimensions.
+    public func scoreWindowForEviction(
+        taskQuery: [Float],
+        windowChunks: [MemoryChunk],
+        relevanceWeight: Float = 0.6,
+        centralityWeight: Float = 0.4
+    ) async throws -> [(chunk: MemoryChunk, evictionScore: Float)] {
+        guard !windowChunks.isEmpty else {
+            return []
+        }
+
+        let embeddings = windowChunks.map(\.embedding)
+        let dim = taskQuery.count
+        guard embeddings.allSatisfy({ $0.count == dim }) else {
+            throw ContextCoreError.dimensionMismatch(expected: dim, got: embeddings.first(where: { $0.count != dim })?.count ?? 0)
+        }
+
+        let centralityScores = try await computeCentrality(embeddings: embeddings)
+        let eviction = try await crossAttentionScores(
+            query: taskQuery,
+            embeddings: embeddings,
+            centrality: centralityScores,
+            relevanceWeight: relevanceWeight,
+            centralityWeight: centralityWeight
+        )
+
+        return zip(windowChunks, eviction)
+            .map { (chunk: $0.0, evictionScore: $0.1) }
+            .sorted(by: { $0.evictionScore < $1.evictionScore })
+    }
+
+    private func crossAttentionScores(
+        query: [Float],
+        embeddings: [[Float]],
+        centrality: [Float],
+        relevanceWeight: Float,
+        centralityWeight: Float
+    ) async throws -> [Float] {
+        let n = embeddings.count
+        let dim = query.count
+        let flattened = embeddings.flatMap { $0 }
+        var output = [Float](repeating: 0, count: n)
+        var weights = SIMD2<Float>(relevanceWeight, centralityWeight)
+
+        guard let queryBuffer = device.makeBuffer(from: query),
+              let embeddingsBuffer = device.makeBuffer(from: flattened),
+              let centralityBuffer = device.makeBuffer(from: centrality),
+              let weightsBuffer = device.makeBuffer(bytes: &weights, length: MemoryLayout<SIMD2<Float>>.stride, options: .storageModeShared),
+              let outputBuffer = device.makeBuffer(from: output),
+              let commandBuffer = commandQueue.makeCommandBuffer(),
+              let encoder = commandBuffer.makeComputeCommandEncoder()
+        else {
+            throw ContextCoreError.compressionFailed("Failed to allocate cross-attention buffers")
+        }
+
+        var dim32 = UInt32(dim)
+        var n32 = UInt32(n)
+
+        guard let dimBuffer = device.makeBuffer(bytes: &dim32, length: MemoryLayout<UInt32>.stride, options: .storageModeShared),
+              let nBuffer = device.makeBuffer(bytes: &n32, length: MemoryLayout<UInt32>.stride, options: .storageModeShared)
+        else {
+            throw ContextCoreError.compressionFailed("Failed to create cross-attention constants")
+        }
+
+        encoder.setComputePipelineState(crossAttentionPipeline)
+        encoder.setBuffer(queryBuffer, offset: 0, index: 0)
+        encoder.setBuffer(embeddingsBuffer, offset: 0, index: 1)
+        encoder.setBuffer(centralityBuffer, offset: 0, index: 2)
+        encoder.setBuffer(weightsBuffer, offset: 0, index: 3)
+        encoder.setBuffer(outputBuffer, offset: 0, index: 4)
+        encoder.setBuffer(dimBuffer, offset: 0, index: 5)
+        encoder.setBuffer(nBuffer, offset: 0, index: 6)
+
+        let threads = MetalContext.threadsPerThreadgroup(pipeline: crossAttentionPipeline, count: n)
+        let groups = MetalContext.threadgroups(threadsPerThreadgroup: threads, count: n)
+        encoder.dispatchThreadgroups(groups, threadsPerThreadgroup: threads)
+        encoder.endEncoding()
+
+        try await MetalContext.awaitCompletion(of: commandBuffer)
+
+        let raw = outputBuffer.contents().bindMemory(to: Float.self, capacity: n)
+        output = Array(UnsafeBufferPointer(start: raw, count: n))
+        return output
+    }
+}

--- a/Sources/ContextCoreEngine/CPUReference.swift
+++ b/Sources/ContextCoreEngine/CPUReference.swift
@@ -1,0 +1,263 @@
+import Accelerate
+import ContextCoreTypes
+import Foundation
+
+/// CPU reference implementations for parity checks and benchmarking.
+public enum CPUReference {
+    /// Computes combined relevance and recency scores on CPU.
+    public static func relevanceScores(
+        query: [Float],
+        chunks: [[Float]],
+        recencyWeights: [Float],
+        relevanceWeight: Float = 0.7,
+        recencyWeight: Float = 0.3
+    ) -> [Float] {
+        guard !chunks.isEmpty else {
+            return []
+        }
+        precondition(query.count == chunks[0].count, "Query dimension must match chunk dimension")
+        precondition(chunks.count == recencyWeights.count, "Chunk count must match recency weight count")
+
+        let dimension = query.count
+        var flattened: [Float] = []
+        flattened.reserveCapacity(chunks.count * dimension)
+        for chunk in chunks {
+            precondition(chunk.count == dimension, "Query dimension must match chunk dimension")
+            flattened.append(contentsOf: chunk)
+        }
+
+        return relevanceScores(
+            query: query,
+            flattenedChunks: flattened,
+            count: chunks.count,
+            dimension: dimension,
+            recencyWeights: recencyWeights,
+            relevanceWeight: relevanceWeight,
+            recencyWeight: recencyWeight
+        )
+    }
+
+    /// Computes combined relevance and recency scores on CPU over a flattened chunk matrix.
+    public static func relevanceScores(
+        query: [Float],
+        flattenedChunks: [Float],
+        count: Int,
+        dimension: Int,
+        recencyWeights: [Float],
+        relevanceWeight: Float = 0.7,
+        recencyWeight: Float = 0.3
+    ) -> [Float] {
+        guard count > 0 else {
+            return []
+        }
+        precondition(query.count == dimension, "Query dimension must match provided dimension")
+        precondition(flattenedChunks.count == count * dimension, "Flattened chunk matrix shape mismatch")
+        precondition(count == recencyWeights.count, "Chunk count must match recency weight count")
+
+        let queryNorm = l2Norm(query)
+
+        return flattenedChunks.withUnsafeBufferPointer { chunksPointer in
+            query.withUnsafeBufferPointer { queryPointer in
+                var scores = [Float](repeating: 0, count: count)
+
+                guard let chunksBase = chunksPointer.baseAddress,
+                      let queryBase = queryPointer.baseAddress
+                else {
+                    return scores
+                }
+
+                for index in 0..<count {
+                    let chunkBase = chunksBase.advanced(by: index * dimension)
+                    var dot: Float = 0
+                    var chunkNormSquared: Float = 0
+                    vDSP_dotpr(queryBase, 1, chunkBase, 1, &dot, vDSP_Length(dimension))
+                    vDSP_svesq(chunkBase, 1, &chunkNormSquared, vDSP_Length(dimension))
+
+                    let chunkNorm = sqrt(chunkNormSquared)
+                    let denom = queryNorm * chunkNorm
+                    let cosine: Float = denom > 0 ? dot / denom : 0
+                    scores[index] = cosine * relevanceWeight + recencyWeights[index] * recencyWeight
+                }
+
+                return scores
+            }
+        }
+    }
+
+    /// Computes exponential recency weights with half-life decay.
+    public static func recencyWeights(
+        timestamps: [Date],
+        currentTime: Date,
+        halfLife: TimeInterval
+    ) -> [Float] {
+        guard !timestamps.isEmpty else {
+            return []
+        }
+        precondition(halfLife > 0, "halfLife must be positive")
+
+        let now = Float(currentTime.timeIntervalSince1970)
+        let halfLifeF = Float(halfLife)
+        let ln2: Float = 0.693147
+
+        var exponents = timestamps.map { timestamp -> Float in
+            let age = now - Float(timestamp.timeIntervalSince1970)
+            return -ln2 * age / halfLifeF
+        }
+
+        var values = [Float](repeating: 0, count: exponents.count)
+        var count = Int32(exponents.count)
+        vvexpf(&values, &exponents, &count)
+
+        return values.map { min(max($0, 0), 1) }
+    }
+
+    /// Computes mean pairwise similarity centrality per embedding.
+    public static func centrality(embeddings: [[Float]]) -> [Float] {
+        guard !embeddings.isEmpty else {
+            return []
+        }
+
+        let n = embeddings.count
+        if n == 1 {
+            return [0]
+        }
+
+        return (0..<n).map { i in
+            var sum: Float = 0
+            for j in 0..<n where j != i {
+                sum += cosineSimilarity(embeddings[i], embeddings[j])
+            }
+            return sum / Float(n - 1)
+        }
+    }
+
+    /// Combines relevance and centrality into cross-attention scores.
+    public static func crossAttentionScores(
+        query: [Float],
+        embeddings: [[Float]],
+        centrality: [Float],
+        relevanceWeight: Float,
+        centralityWeight: Float
+    ) -> [Float] {
+        guard !embeddings.isEmpty else {
+            return []
+        }
+        precondition(embeddings.count == centrality.count, "Embedding and centrality count mismatch")
+
+        return embeddings.enumerated().map { index, embedding in
+            let relevance = cosineSimilarity(query, embedding)
+            return relevance * relevanceWeight + centrality[index] * centralityWeight
+        }
+    }
+
+    /// Computes sentence importance against a chunk embedding.
+    public static func sentenceImportance(
+        sentenceEmbeddings: [[Float]],
+        chunkEmbedding: [Float]
+    ) -> [Float] {
+        sentenceEmbeddings.map { sentence in
+            cosineSimilarity(sentence, chunkEmbedding)
+        }
+    }
+
+    /// Computes a dense pairwise cosine-similarity matrix.
+    public static func pairwiseSimilarity(embeddings: [[Float]]) -> [[Float]] {
+        guard !embeddings.isEmpty else {
+            return []
+        }
+        let n = embeddings.count
+        if n == 1 {
+            return [[1.0]]
+        }
+
+        let dim = embeddings[0].count
+        precondition(embeddings.allSatisfy { $0.count == dim }, "Embedding dimension mismatch")
+
+        var matrix = Array(repeating: Array(repeating: Float.zero, count: n), count: n)
+        for i in 0..<n {
+            matrix[i][i] = 1.0
+            guard i + 1 < n else { continue }
+            for j in (i + 1)..<n {
+                let value = cosineSimilarity(embeddings[i], embeddings[j])
+                matrix[i][j] = value
+                matrix[j][i] = value
+            }
+        }
+        return matrix
+    }
+
+    /// Finds merge-candidate index pairs above a threshold.
+    public static func findMergeCandidates(
+        similarities: [[Float]],
+        threshold: Float
+    ) -> [(Int, Int)] {
+        guard !similarities.isEmpty else {
+            return []
+        }
+        let n = similarities.count
+        precondition(similarities.allSatisfy { $0.count == n }, "Similarity matrix must be square")
+
+        var pairs: [(Int, Int)] = []
+        for i in 0..<n {
+            guard i + 1 < n else { continue }
+            for j in (i + 1)..<n where similarities[i][j] > threshold {
+                pairs.append((i, j))
+            }
+        }
+        return pairs
+    }
+
+    /// Computes the sign-flip fraction between two vectors.
+    public static func antipodalFraction(_ a: [Float], _ b: [Float]) -> Float {
+        precondition(a.count == b.count, "Vectors must match dimensions")
+        guard !a.isEmpty else {
+            return 0
+        }
+
+        var signDiffCount = 0
+        for idx in a.indices where (a[idx] >= 0) != (b[idx] >= 0) {
+            signDiffCount += 1
+        }
+
+        return Float(signDiffCount) / Float(a.count)
+    }
+
+    private static func cosineSimilarity(_ lhs: [Float], _ rhs: [Float]) -> Float {
+        guard lhs.count == rhs.count else {
+            return 0
+        }
+
+        var dot: Float = 0
+        var lhsNormSquared: Float = 0
+        var rhsNormSquared: Float = 0
+
+        lhs.withUnsafeBufferPointer { lhsPtr in
+            rhs.withUnsafeBufferPointer { rhsPtr in
+                vDSP_dotpr(lhsPtr.baseAddress!, 1, rhsPtr.baseAddress!, 1, &dot, vDSP_Length(lhs.count))
+                vDSP_svesq(lhsPtr.baseAddress!, 1, &lhsNormSquared, vDSP_Length(lhs.count))
+                vDSP_svesq(rhsPtr.baseAddress!, 1, &rhsNormSquared, vDSP_Length(rhs.count))
+            }
+        }
+
+        let denom = sqrt(lhsNormSquared) * sqrt(rhsNormSquared)
+        guard denom > 0 else {
+            return 0
+        }
+        return dot / denom
+    }
+
+    private static func l2Norm(_ vector: [Float]) -> Float {
+        guard !vector.isEmpty else {
+            return 0
+        }
+
+        var normSquared: Float = 0
+        vector.withUnsafeBufferPointer { pointer in
+            guard let baseAddress = pointer.baseAddress else {
+                return
+            }
+            vDSP_svesq(baseAddress, 1, &normSquared, vDSP_Length(pointer.count))
+        }
+        return sqrt(normSquared)
+    }
+}

--- a/Sources/ContextCoreEngine/CompressionEngine.swift
+++ b/Sources/ContextCoreEngine/CompressionEngine.swift
@@ -1,0 +1,214 @@
+import ContextCoreTypes
+import Foundation
+import Metal
+import NaturalLanguage
+
+/// GPU-assisted compression engine for ranking and reducing text chunks.
+public actor CompressionEngine {
+    private let device: MTLDevice
+    private let commandQueue: MTLCommandQueue
+    private let sentenceImportancePipeline: MTLComputePipelineState
+    private let embeddingProvider: any EmbeddingProvider
+    private let tokenCounter: any TokenCounter
+    private var compressionDelegate: (any CompressionDelegate)?
+
+    /// Creates a compression engine.
+    ///
+    /// - Parameters:
+    ///   - device: Optional Metal device override.
+    ///   - embeddingProvider: Embedding backend used for sentence and chunk embeddings.
+    ///   - tokenCounter: Token counter used for budget targets.
+    ///   - compressionDelegate: Optional delegate for custom compression behavior.
+    /// - Throws: Metal initialization or pipeline creation failures.
+    public init(
+        device: MTLDevice? = nil,
+        embeddingProvider: any EmbeddingProvider,
+        tokenCounter: any TokenCounter,
+        compressionDelegate: (any CompressionDelegate)? = nil
+    ) throws {
+        self.device = try device ?? MetalContext.device()
+        self.commandQueue = try MetalContext.commandQueue(device: self.device)
+        self.embeddingProvider = embeddingProvider
+        self.tokenCounter = tokenCounter
+        self.compressionDelegate = compressionDelegate
+
+        let library = try MetalContext.library(device: self.device)
+        guard let function = library.makeFunction(name: "sentence_importance") else {
+            throw ContextCoreError.compressionFailed("Missing sentence_importance function")
+        }
+
+        self.sentenceImportancePipeline = try self.device.makeComputePipelineState(function: function)
+    }
+
+    /// Ranks sentences in a chunk by semantic importance to the chunk embedding.
+    ///
+    /// - Parameters:
+    ///   - chunk: Input text chunk.
+    ///   - chunkEmbedding: Embedding for the full chunk.
+    /// - Returns: Sentences sorted by descending importance.
+    /// - Throws: Embedding and dimension mismatch errors.
+    public func rankSentences(
+        in chunk: String,
+        chunkEmbedding: [Float]
+    ) async throws -> [(sentence: String, importance: Float)] {
+        let sentences = splitSentences(from: chunk)
+        guard !sentences.isEmpty else {
+            return []
+        }
+
+        let sentenceEmbeddings = try await embeddingProvider.embedBatch(sentences)
+        let dim = chunkEmbedding.count
+
+        guard sentenceEmbeddings.count == sentences.count else {
+            throw ContextCoreError.embeddingFailed("embedBatch returned mismatched result count")
+        }
+
+        guard sentenceEmbeddings.allSatisfy({ $0.count == dim }) else {
+            throw ContextCoreError.dimensionMismatch(expected: dim, got: sentenceEmbeddings.first(where: { $0.count != dim })?.count ?? 0)
+        }
+
+        let flattened = sentenceEmbeddings.flatMap { $0 }
+        let m = sentences.count
+        var output = [Float](repeating: 0, count: m)
+
+        guard let sentenceBuffer = device.makeBuffer(from: flattened),
+              let chunkBuffer = device.makeBuffer(from: chunkEmbedding),
+              let outputBuffer = device.makeBuffer(from: output),
+              let commandBuffer = commandQueue.makeCommandBuffer(),
+              let encoder = commandBuffer.makeComputeCommandEncoder()
+        else {
+            throw ContextCoreError.compressionFailed("Failed to allocate compression buffers")
+        }
+
+        var dim32 = UInt32(dim)
+        var m32 = UInt32(m)
+
+        guard let dimBuffer = device.makeBuffer(bytes: &dim32, length: MemoryLayout<UInt32>.stride, options: .storageModeShared),
+              let mBuffer = device.makeBuffer(bytes: &m32, length: MemoryLayout<UInt32>.stride, options: .storageModeShared)
+        else {
+            throw ContextCoreError.compressionFailed("Failed to create compression constants")
+        }
+
+        encoder.setComputePipelineState(sentenceImportancePipeline)
+        encoder.setBuffer(sentenceBuffer, offset: 0, index: 0)
+        encoder.setBuffer(chunkBuffer, offset: 0, index: 1)
+        encoder.setBuffer(outputBuffer, offset: 0, index: 2)
+        encoder.setBuffer(dimBuffer, offset: 0, index: 3)
+        encoder.setBuffer(mBuffer, offset: 0, index: 4)
+
+        let threads = MetalContext.threadsPerThreadgroup(pipeline: sentenceImportancePipeline, count: m)
+        let groups = MetalContext.threadgroups(threadsPerThreadgroup: threads, count: m)
+        encoder.dispatchThreadgroups(groups, threadsPerThreadgroup: threads)
+        encoder.endEncoding()
+
+        try await MetalContext.awaitCompletion(of: commandBuffer)
+
+        let raw = outputBuffer.contents().bindMemory(to: Float.self, capacity: m)
+        output = Array(UnsafeBufferPointer(start: raw, count: m))
+
+        return zip(sentences, output)
+            .map { (sentence: $0.0, importance: $0.1) }
+            .sorted(by: { $0.importance > $1.importance })
+    }
+
+    /// Compresses a memory chunk to a target token budget.
+    ///
+    /// - Parameters:
+    ///   - chunk: Source chunk.
+    ///   - targetTokens: Desired token cap.
+    /// - Returns: Compressed chunk with refreshed embedding and metadata.
+    /// - Throws: Delegate compression or embedding failures.
+    public func compress(
+        chunk: MemoryChunk,
+        targetTokens: Int
+    ) async throws -> MemoryChunk {
+        let currentTokens = tokenCounter.count(chunk.content)
+        if currentTokens <= targetTokens {
+            return chunk
+        }
+
+        let delegate = compressionDelegate ?? makeDefaultExtractiveDelegate()
+        let compressedContent = try await delegate.compress(chunk.content, targetTokens: targetTokens)
+        let compressedTokens = tokenCounter.count(compressedContent)
+        let ratio = Float(currentTokens) / Float(max(compressedTokens, 1))
+
+        var compressed = chunk
+        compressed.content = compressedContent
+        compressed.embedding = try await embeddingProvider.embed(compressedContent)
+        compressed.metadata["compressionRatio"] = String(format: "%.2f", ratio)
+        compressed.metadata["originalTokenCount"] = "\(currentTokens)"
+
+        return compressed
+    }
+
+    /// Compresses a turn to a target token budget.
+    ///
+    /// - Parameters:
+    ///   - turn: Source turn.
+    ///   - targetTokens: Desired token cap.
+    /// - Returns: Compressed turn preserving identity fields.
+    /// - Throws: Delegate compression or embedding failures.
+    public func compressTurn(
+        turn: Turn,
+        targetTokens: Int
+    ) async throws -> Turn {
+        let currentTokens = tokenCounter.count(turn.content)
+        if currentTokens <= targetTokens {
+            return turn
+        }
+
+        let delegate = compressionDelegate ?? makeDefaultExtractiveDelegate()
+        let compressedContent = try await delegate.compress(turn.content, targetTokens: targetTokens)
+        let compressedTokens = tokenCounter.count(compressedContent)
+        let ratio = Float(currentTokens) / Float(max(compressedTokens, 1))
+        let compressedEmbedding = try await embeddingProvider.embed(compressedContent)
+
+        var metadata = turn.metadata
+        metadata["compressionRatio"] = String(format: "%.2f", ratio)
+        metadata["originalTokenCount"] = "\(currentTokens)"
+
+        return Turn(
+            id: turn.id,
+            role: turn.role,
+            content: compressedContent,
+            timestamp: turn.timestamp,
+            tokenCount: compressedTokens,
+            embedding: compressedEmbedding,
+            metadata: metadata
+        )
+    }
+
+    /// Replaces the active compression delegate.
+    ///
+    /// - Parameter delegate: New delegate implementation.
+    public func setCompressionDelegate(_ delegate: any CompressionDelegate) {
+        compressionDelegate = delegate
+    }
+
+    func embedForCompression(_ text: String) async throws -> [Float] {
+        try await embeddingProvider.embed(text)
+    }
+
+    private func makeDefaultExtractiveDelegate() -> ExtractiveFallbackDelegate {
+        ExtractiveFallbackDelegate(
+            compressionEngine: self,
+            tokenCounter: tokenCounter
+        )
+    }
+
+    private func splitSentences(from text: String) -> [String] {
+        let tokenizer = NLTokenizer(unit: .sentence)
+        tokenizer.string = text
+
+        var sentences: [String] = []
+        tokenizer.enumerateTokens(in: text.startIndex..<text.endIndex) { range, _ in
+            let sentence = text[range].trimmingCharacters(in: .whitespacesAndNewlines)
+            if !sentence.isEmpty {
+                sentences.append(sentence)
+            }
+            return true
+        }
+
+        return sentences
+    }
+}

--- a/Sources/ContextCoreEngine/ConsolidationEngine.swift
+++ b/Sources/ContextCoreEngine/ConsolidationEngine.swift
@@ -1,0 +1,808 @@
+import ContextCoreTypes
+import Foundation
+import Metal
+
+/// Summary metrics from a consolidation pass.
+public struct ConsolidationResult: Sendable, Equatable {
+    /// Number of duplicate pairs found.
+    public let duplicatePairsFound: Int
+    /// Number of facts promoted to semantic memory.
+    public let factsPromoted: Int
+    /// Number of episodic chunks evicted.
+    public let chunksEvicted: Int
+    /// Consolidation duration in milliseconds.
+    public let durationMs: Double
+
+    /// Creates a consolidation result.
+    public init(
+        duplicatePairsFound: Int,
+        factsPromoted: Int,
+        chunksEvicted: Int,
+        durationMs: Double
+    ) {
+        self.duplicatePairsFound = duplicatePairsFound
+        self.factsPromoted = factsPromoted
+        self.chunksEvicted = chunksEvicted
+        self.durationMs = durationMs
+    }
+}
+
+/// GPU-backed consolidation engine for deduplication, promotion, and contradiction detection.
+public actor ConsolidationEngine {
+    private let device: MTLDevice
+    private let commandQueue: MTLCommandQueue
+    private let pairwisePipeline: MTLComputePipelineState
+    private let pairwiseTiledPipeline: MTLComputePipelineState
+    private let mergeCandidatePipeline: MTLComputePipelineState
+    private let antipodalPipeline: MTLComputePipelineState
+    private let embeddingProvider: any EmbeddingProvider
+
+    /// Creates a consolidation engine and compiles required Metal pipelines.
+    ///
+    /// - Parameters:
+    ///   - device: Optional Metal device override.
+    ///   - embeddingProvider: Embedding provider used by downstream flows.
+    /// - Throws: Metal initialization or pipeline creation failures.
+    public init(
+        device: MTLDevice? = nil,
+        embeddingProvider: any EmbeddingProvider
+    ) throws {
+        self.device = try device ?? MetalContext.device()
+        self.commandQueue = try MetalContext.commandQueue(device: self.device)
+        self.embeddingProvider = embeddingProvider
+
+        let library = try MetalContext.library(device: self.device)
+
+        guard let pairwiseFunction = library.makeFunction(name: "pairwise_similarity") else {
+            throw ContextCoreError.compressionFailed("Missing pairwise_similarity function")
+        }
+        guard let pairwiseTiledFunction = library.makeFunction(name: "pairwise_similarity_tiled") else {
+            throw ContextCoreError.compressionFailed("Missing pairwise_similarity_tiled function")
+        }
+        guard let mergeFunction = library.makeFunction(name: "find_merge_candidates") else {
+            throw ContextCoreError.compressionFailed("Missing find_merge_candidates function")
+        }
+        guard let antipodalFunction = library.makeFunction(name: "antipodal_test") else {
+            throw ContextCoreError.compressionFailed("Missing antipodal_test function")
+        }
+
+        self.pairwisePipeline = try self.device.makeComputePipelineState(function: pairwiseFunction)
+        self.pairwiseTiledPipeline = try self.device.makeComputePipelineState(function: pairwiseTiledFunction)
+        self.mergeCandidatePipeline = try self.device.makeComputePipelineState(function: mergeFunction)
+        self.antipodalPipeline = try self.device.makeComputePipelineState(function: antipodalFunction)
+    }
+
+    /// Finds duplicate episodic chunk pairs above a similarity threshold.
+    ///
+    /// - Parameters:
+    ///   - store: Episodic store to scan.
+    ///   - threshold: Cosine similarity threshold for duplicate candidacy.
+    /// - Returns: Duplicate chunk ID pairs.
+    /// - Throws: Dimension mismatch and Metal execution errors.
+    public func findDuplicates(
+        in store: any ConsolidationEpisodicStore,
+        threshold: Float = 0.92
+    ) async throws -> [(UUID, UUID)] {
+        let allChunks = await store.allChunks()
+        let chunks = await unconsolidatedChunks(from: allChunks, store: store)
+
+        guard chunks.count > 1 else {
+            return []
+        }
+
+        let pairs = try await findDuplicateIndexPairs(in: chunks, threshold: threshold)
+
+        return pairs.map { (chunks[$0.0].id, chunks[$0.1].id) }
+    }
+
+    /// Computes pairwise cosine similarity for embedding vectors.
+    ///
+    /// - Parameter embeddings: Embeddings to compare.
+    /// - Returns: Dense symmetric similarity matrix.
+    /// - Throws: ``ContextCoreError/dimensionMismatch(expected:got:)`` for inconsistent dimensions.
+    public func pairwiseSimilarity(
+        embeddings: [[Float]]
+    ) async throws -> [[Float]] {
+        guard !embeddings.isEmpty else {
+            return []
+        }
+        if embeddings.count == 1 {
+            return [[1.0]]
+        }
+
+        let dim = embeddings[0].count
+        guard embeddings.allSatisfy({ $0.count == dim }) else {
+            throw ContextCoreError.dimensionMismatch(
+                expected: dim,
+                got: embeddings.first(where: { $0.count != dim })?.count ?? 0
+            )
+        }
+
+        let n = embeddings.count
+        var matrix = Array(repeating: Array(repeating: Float.zero, count: n), count: n)
+        for index in 0..<n {
+            matrix[index][index] = 1.0
+        }
+
+        if n <= 2048 {
+            let flattened = embeddings.flatMap { $0 }
+            let upper = try await computePairwiseUpperSimple(
+                flattenedEmbeddings: flattened,
+                dim: dim,
+                n: n
+            )
+
+            for i in 0..<n {
+                for j in (i + 1)..<n {
+                    let value = upper[(i * n) + j]
+                    matrix[i][j] = value
+                    matrix[j][i] = value
+                }
+            }
+            return matrix
+        }
+
+        let flattened = embeddings.flatMap { $0 }
+        guard let embeddingsBuffer = device.makeBuffer(from: flattened) else {
+            throw ContextCoreError.compressionFailed("Failed to allocate embeddings buffer")
+        }
+
+        for rowTile in stride(from: 0, to: n, by: 512) {
+            let rowCount = min(512, n - rowTile)
+            for colTile in stride(from: rowTile, to: n, by: 512) {
+                let colCount = min(512, n - colTile)
+                let tile = try await computeTileSimilarities(
+                    embeddingsBuffer: embeddingsBuffer,
+                    dim: dim,
+                    n: n,
+                    rowOffset: rowTile,
+                    colOffset: colTile,
+                    rowCount: rowCount,
+                    colCount: colCount
+                )
+
+                for localRow in 0..<rowCount {
+                    let globalRow = rowTile + localRow
+                    for localCol in 0..<colCount {
+                        let globalCol = colTile + localCol
+                        guard globalCol > globalRow else {
+                            continue
+                        }
+
+                        let value = tile[(localRow * colCount) + localCol]
+                        matrix[globalRow][globalCol] = value
+                        matrix[globalCol][globalRow] = value
+                    }
+                }
+            }
+        }
+
+        return matrix
+    }
+
+    /// Runs a full consolidation pass for the active session.
+    ///
+    /// - Parameters:
+    ///   - session: Session identifier used for bookkeeping.
+    ///   - episodicStore: Episodic memory store.
+    ///   - semanticStore: Semantic memory store.
+    ///   - threshold: Duplicate similarity threshold.
+    /// - Returns: Consolidation summary.
+    /// - Throws: Store, dimension, and Metal execution errors.
+    public func consolidate(
+        session _: UUID,
+        episodicStore: any ConsolidationEpisodicStore,
+        semanticStore: any ConsolidationSemanticStore,
+        threshold: Float = 0.92
+    ) async throws -> ConsolidationResult {
+        let start = Date()
+        let allChunks = await episodicStore.allChunks()
+        let unconsolidated = await unconsolidatedChunks(from: allChunks, store: episodicStore)
+        let pairs = try await findDuplicateIndexPairs(in: unconsolidated, threshold: threshold)
+
+        var chunkMap = Dictionary(uniqueKeysWithValues: allChunks.map { ($0.id, $0) })
+
+        var promotedIDs = Set<UUID>()
+        var processedChunkIDs = Set<UUID>()
+
+        for (indexA, indexB) in pairs {
+            let chunkA = unconsolidated[indexA]
+            let chunkB = unconsolidated[indexB]
+            guard !processedChunkIDs.contains(chunkA.id), !processedChunkIDs.contains(chunkB.id) else {
+                continue
+            }
+            guard await !episodicStore.isConsolidated(id: chunkA.id),
+                  await !episodicStore.isConsolidated(id: chunkB.id)
+            else {
+                continue
+            }
+
+            processedChunkIDs.insert(chunkA.id)
+            processedChunkIDs.insert(chunkB.id)
+
+            let factChunk = chunkA.content.count <= chunkB.content.count ? chunkA : chunkB
+            if !promotedIDs.contains(factChunk.id) {
+                try await semanticStore.upsert(fact: factChunk.content, embedding: factChunk.embedding)
+                promotedIDs.insert(factChunk.id)
+            }
+
+            try await episodicStore.updateRetentionScore(id: chunkA.id, delta: -0.2)
+            try await episodicStore.updateRetentionScore(id: chunkB.id, delta: -0.2)
+            if var updatedA = chunkMap[chunkA.id] {
+                updatedA.retentionScore = max(0, min(1, updatedA.retentionScore - 0.2))
+                chunkMap[chunkA.id] = updatedA
+            }
+            if var updatedB = chunkMap[chunkB.id] {
+                updatedB.retentionScore = max(0, min(1, updatedB.retentionScore - 0.2))
+                chunkMap[chunkB.id] = updatedB
+            }
+            try await episodicStore.markConsolidated(id: chunkA.id)
+            try await episodicStore.markConsolidated(id: chunkB.id)
+        }
+
+        var evicted = 0
+        for chunk in chunkMap.values where chunk.retentionScore < 0.1 {
+            try await episodicStore.evict(id: chunk.id)
+            evicted += 1
+        }
+
+        let durationMs = Date().timeIntervalSince(start) * 1000
+        return ConsolidationResult(
+            duplicatePairsFound: pairs.count,
+            factsPromoted: promotedIDs.count,
+            chunksEvicted: evicted,
+            durationMs: durationMs
+        )
+    }
+
+    /// Finds contradiction candidates from semantic memory.
+    ///
+    /// - Parameters:
+    ///   - store: Semantic store to scan.
+    ///   - similarityThreshold: Lower bound for pair similarity.
+    ///   - antipodalThreshold: Lower bound for sign-flip fraction.
+    /// - Returns: Candidate contradictory fact pairs.
+    /// - Throws: Pairwise similarity or antipodal computation errors.
+    public func contradictionCandidates(
+        in store: any ConsolidationSemanticStore,
+        similarityThreshold: Float = 0.75,
+        antipodalThreshold: Float = 0.30
+    ) async throws -> [(MemoryChunk, MemoryChunk)] {
+        let facts = await store.allChunks()
+        guard facts.count > 1 else {
+            return []
+        }
+
+        let embeddings = facts.map(\.embedding)
+        let similarities = try await pairwiseSimilarity(embeddings: embeddings)
+
+        var candidateIndices: [(Int, Int)] = []
+        for i in 0..<facts.count {
+            for j in (i + 1)..<facts.count where similarities[i][j] > similarityThreshold {
+                candidateIndices.append((i, j))
+            }
+        }
+
+        guard !candidateIndices.isEmpty else {
+            return []
+        }
+
+        let dim = embeddings[0].count
+        var embeddingsA: [Float] = []
+        var embeddingsB: [Float] = []
+        embeddingsA.reserveCapacity(candidateIndices.count * dim)
+        embeddingsB.reserveCapacity(candidateIndices.count * dim)
+
+        for (i, j) in candidateIndices {
+            embeddingsA.append(contentsOf: embeddings[i])
+            embeddingsB.append(contentsOf: embeddings[j])
+        }
+
+        let fractions = try await runAntipodalFractions(
+            embeddingsA: embeddingsA,
+            embeddingsB: embeddingsB,
+            dim: dim,
+            pairCount: candidateIndices.count
+        )
+
+        var matches: [(MemoryChunk, MemoryChunk)] = []
+        for idx in candidateIndices.indices where fractions[idx] > antipodalThreshold {
+            let (i, j) = candidateIndices[idx]
+            matches.append((facts[i], facts[j]))
+        }
+
+        return matches
+    }
+
+    /// Computes antipodal fractions for embedding pairs.
+    ///
+    /// - Parameters:
+    ///   - embeddingsA: First embedding list.
+    ///   - embeddingsB: Second embedding list.
+    /// - Returns: Sign-flip fractions per pair.
+    /// - Throws: ``ContextCoreError/dimensionMismatch(expected:got:)`` for inconsistent dimensions.
+    public func antipodalFractions(
+        embeddingsA: [[Float]],
+        embeddingsB: [[Float]]
+    ) async throws -> [Float] {
+        guard embeddingsA.count == embeddingsB.count else {
+            throw ContextCoreError.dimensionMismatch(expected: embeddingsA.count, got: embeddingsB.count)
+        }
+        guard !embeddingsA.isEmpty else {
+            return []
+        }
+
+        let dim = embeddingsA[0].count
+        guard embeddingsA.allSatisfy({ $0.count == dim }), embeddingsB.allSatisfy({ $0.count == dim }) else {
+            throw ContextCoreError.dimensionMismatch(
+                expected: dim,
+                got: embeddingsA.first(where: { $0.count != dim })?.count
+                    ?? embeddingsB.first(where: { $0.count != dim })?.count
+                    ?? 0
+            )
+        }
+
+        let flatA = embeddingsA.flatMap { $0 }
+        let flatB = embeddingsB.flatMap { $0 }
+        return try await runAntipodalFractions(
+            embeddingsA: flatA,
+            embeddingsB: flatB,
+            dim: dim,
+            pairCount: embeddingsA.count
+        )
+    }
+
+    private func validateDimensions(_ chunks: [MemoryChunk]) throws -> Int {
+        guard let dim = chunks.first?.embedding.count, dim > 0 else {
+            throw ContextCoreError.dimensionMismatch(expected: 1, got: 0)
+        }
+        guard chunks.allSatisfy({ $0.embedding.count == dim }) else {
+            throw ContextCoreError.dimensionMismatch(
+                expected: dim,
+                got: chunks.first(where: { $0.embedding.count != dim })?.embedding.count ?? 0
+            )
+        }
+        return dim
+    }
+
+    private func unconsolidatedChunks(
+        from allChunks: [MemoryChunk],
+        store: any ConsolidationEpisodicStore
+    ) async -> [MemoryChunk] {
+        var chunks: [MemoryChunk] = []
+        chunks.reserveCapacity(allChunks.count)
+
+        for chunk in allChunks {
+            if await store.isConsolidated(id: chunk.id) {
+                continue
+            }
+            chunks.append(chunk)
+        }
+
+        return chunks
+    }
+
+    private func findDuplicateIndexPairs(
+        in chunks: [MemoryChunk],
+        threshold: Float
+    ) async throws -> [(Int, Int)] {
+        guard chunks.count > 1 else {
+            return []
+        }
+
+        let dim = try validateDimensions(chunks)
+        if chunks.count <= 2048 {
+            return try await findCandidatesSimple(chunks: chunks, dim: dim, threshold: threshold)
+        }
+
+        return try await findCandidatesTiled(chunks: chunks, dim: dim, threshold: threshold, tileSize: 512)
+    }
+
+    private func findCandidatesSimple(
+        chunks: [MemoryChunk],
+        dim: Int,
+        threshold: Float
+    ) async throws -> [(Int, Int)] {
+        let n = chunks.count
+        let flattened = chunks.flatMap(\.embedding)
+        var candidateCountStorage: UInt32 = 0
+        let maxCandidates = max(1, n * 10)
+
+        let similarity = try await computePairwiseUpperSimple(
+            flattenedEmbeddings: flattened,
+            dim: dim,
+            n: n
+        )
+
+        guard let similarityBuffer = device.makeBuffer(from: similarity),
+              let candidatesBuffer = device.makeBuffer(
+                length: maxCandidates * MemoryLayout<SIMD2<UInt32>>.stride,
+                options: .storageModeShared
+              ),
+              let candidateCountBuffer = device.makeBuffer(
+                bytes: &candidateCountStorage,
+                length: MemoryLayout<UInt32>.stride,
+                options: .storageModeShared
+              ),
+              let commandBuffer = commandQueue.makeCommandBuffer(),
+              let mergeEncoder = commandBuffer.makeComputeCommandEncoder()
+        else {
+            throw ContextCoreError.compressionFailed("Failed to allocate consolidation buffers")
+        }
+
+        var n32 = UInt32(n)
+        var thresholdValue = threshold
+        var maxCandidates32 = UInt32(maxCandidates)
+
+        guard let nBuffer = device.makeBuffer(bytes: &n32, length: MemoryLayout<UInt32>.stride, options: .storageModeShared),
+              let thresholdBuffer = device.makeBuffer(bytes: &thresholdValue, length: MemoryLayout<Float>.stride, options: .storageModeShared),
+              let maxCandidatesBuffer = device.makeBuffer(bytes: &maxCandidates32, length: MemoryLayout<UInt32>.stride, options: .storageModeShared)
+        else {
+            throw ContextCoreError.compressionFailed("Failed to allocate consolidation constants")
+        }
+
+        mergeEncoder.setComputePipelineState(mergeCandidatePipeline)
+        mergeEncoder.setBuffer(similarityBuffer, offset: 0, index: 0)
+        mergeEncoder.setBuffer(candidatesBuffer, offset: 0, index: 1)
+        mergeEncoder.setBuffer(candidateCountBuffer, offset: 0, index: 2)
+        mergeEncoder.setBuffer(thresholdBuffer, offset: 0, index: 3)
+        mergeEncoder.setBuffer(nBuffer, offset: 0, index: 4)
+        mergeEncoder.setBuffer(maxCandidatesBuffer, offset: 0, index: 5)
+        dispatch2D(
+            encoder: mergeEncoder,
+            width: n,
+            height: n,
+            pipeline: mergeCandidatePipeline
+        )
+        mergeEncoder.endEncoding()
+
+        try await awaitCompletion(commandBuffer)
+
+        let countPointer = candidateCountBuffer.contents().bindMemory(to: UInt32.self, capacity: 1)
+        let rawCount = Int(countPointer[0])
+        let boundedCount = min(rawCount, maxCandidates)
+        if rawCount > maxCandidates {
+            print("ConsolidationEngine warning: merge candidate buffer capped at \(maxCandidates) of \(rawCount)")
+        }
+
+        let pairPointer = candidatesBuffer.contents().bindMemory(to: SIMD2<UInt32>.self, capacity: boundedCount)
+        return (0..<boundedCount).map { idx in
+            let pair = pairPointer[idx]
+            return (Int(pair.x), Int(pair.y))
+        }
+    }
+
+    private func computePairwiseUpperSimple(
+        flattenedEmbeddings: [Float],
+        dim: Int,
+        n: Int
+    ) async throws -> [Float] {
+        var output = [Float](repeating: 0, count: n * n)
+
+        guard let embeddingsBuffer = device.makeBuffer(from: flattenedEmbeddings),
+              let outputBuffer = device.makeBuffer(from: output),
+              let commandBuffer = commandQueue.makeCommandBuffer(),
+              let encoder = commandBuffer.makeComputeCommandEncoder()
+        else {
+            throw ContextCoreError.compressionFailed("Failed to allocate pairwise buffers")
+        }
+
+        var dim32 = UInt32(dim)
+        var n32 = UInt32(n)
+
+        guard let dimBuffer = device.makeBuffer(bytes: &dim32, length: MemoryLayout<UInt32>.stride, options: .storageModeShared),
+              let nBuffer = device.makeBuffer(bytes: &n32, length: MemoryLayout<UInt32>.stride, options: .storageModeShared)
+        else {
+            throw ContextCoreError.compressionFailed("Failed to allocate pairwise constants")
+        }
+
+        encoder.setComputePipelineState(pairwisePipeline)
+        encoder.setBuffer(embeddingsBuffer, offset: 0, index: 0)
+        encoder.setBuffer(outputBuffer, offset: 0, index: 1)
+        encoder.setBuffer(dimBuffer, offset: 0, index: 2)
+        encoder.setBuffer(nBuffer, offset: 0, index: 3)
+        dispatch2D(
+            encoder: encoder,
+            width: n,
+            height: n,
+            pipeline: pairwisePipeline
+        )
+        encoder.endEncoding()
+
+        try await awaitCompletion(commandBuffer)
+
+        let pointer = outputBuffer.contents().bindMemory(to: Float.self, capacity: output.count)
+        output = Array(UnsafeBufferPointer(start: pointer, count: output.count))
+        return output
+    }
+
+    private func findCandidatesTiled(
+        chunks: [MemoryChunk],
+        dim: Int,
+        threshold: Float,
+        tileSize: Int
+    ) async throws -> [(Int, Int)] {
+        let n = chunks.count
+        let flattened = chunks.flatMap(\.embedding)
+
+        guard let embeddingsBuffer = device.makeBuffer(from: flattened) else {
+            throw ContextCoreError.compressionFailed("Failed to allocate embeddings buffer for tiled path")
+        }
+
+        var candidates: [(Int, Int)] = []
+
+        for rowTile in stride(from: 0, to: n, by: tileSize) {
+            let rowCount = min(tileSize, n - rowTile)
+            for colTile in stride(from: rowTile, to: n, by: tileSize) {
+                let colCount = min(tileSize, n - colTile)
+                let tileSimilarities = try await computeTileSimilarities(
+                    embeddingsBuffer: embeddingsBuffer,
+                    dim: dim,
+                    n: n,
+                    rowOffset: rowTile,
+                    colOffset: colTile,
+                    rowCount: rowCount,
+                    colCount: colCount
+                )
+
+                for localRow in 0..<rowCount {
+                    let globalRow = rowTile + localRow
+                    for localCol in 0..<colCount {
+                        let globalCol = colTile + localCol
+                        guard globalCol > globalRow else {
+                            continue
+                        }
+                        let score = tileSimilarities[(localRow * colCount) + localCol]
+                        if score > threshold {
+                            candidates.append((globalRow, globalCol))
+                        }
+                    }
+                }
+            }
+        }
+
+        return candidates
+    }
+
+    private func computeTileSimilarities(
+        embeddingsBuffer: MTLBuffer,
+        dim: Int,
+        n: Int,
+        rowOffset: Int,
+        colOffset: Int,
+        rowCount: Int,
+        colCount: Int
+    ) async throws -> [Float] {
+        var output = [Float](repeating: 0, count: rowCount * colCount)
+
+        guard let tileBuffer = device.makeBuffer(from: output),
+              let commandBuffer = commandQueue.makeCommandBuffer(),
+              let encoder = commandBuffer.makeComputeCommandEncoder()
+        else {
+            throw ContextCoreError.compressionFailed("Failed to allocate tiled consolidation buffers")
+        }
+
+        var dim32 = UInt32(dim)
+        var n32 = UInt32(n)
+        var rowOffset32 = UInt32(rowOffset)
+        var colOffset32 = UInt32(colOffset)
+        var rowCount32 = UInt32(rowCount)
+        var colCount32 = UInt32(colCount)
+
+        guard let dimBuffer = device.makeBuffer(bytes: &dim32, length: MemoryLayout<UInt32>.stride, options: .storageModeShared),
+              let nBuffer = device.makeBuffer(bytes: &n32, length: MemoryLayout<UInt32>.stride, options: .storageModeShared),
+              let rowOffsetBuffer = device.makeBuffer(bytes: &rowOffset32, length: MemoryLayout<UInt32>.stride, options: .storageModeShared),
+              let colOffsetBuffer = device.makeBuffer(bytes: &colOffset32, length: MemoryLayout<UInt32>.stride, options: .storageModeShared),
+              let rowCountBuffer = device.makeBuffer(bytes: &rowCount32, length: MemoryLayout<UInt32>.stride, options: .storageModeShared),
+              let colCountBuffer = device.makeBuffer(bytes: &colCount32, length: MemoryLayout<UInt32>.stride, options: .storageModeShared)
+        else {
+            throw ContextCoreError.compressionFailed("Failed to allocate tiled consolidation constants")
+        }
+
+        encoder.setComputePipelineState(pairwiseTiledPipeline)
+        encoder.setBuffer(embeddingsBuffer, offset: 0, index: 0)
+        encoder.setBuffer(tileBuffer, offset: 0, index: 1)
+        encoder.setBuffer(dimBuffer, offset: 0, index: 2)
+        encoder.setBuffer(nBuffer, offset: 0, index: 3)
+        encoder.setBuffer(rowOffsetBuffer, offset: 0, index: 4)
+        encoder.setBuffer(colOffsetBuffer, offset: 0, index: 5)
+        encoder.setBuffer(rowCountBuffer, offset: 0, index: 6)
+        encoder.setBuffer(colCountBuffer, offset: 0, index: 7)
+
+        dispatch2D(
+            encoder: encoder,
+            width: rowCount,
+            height: colCount,
+            pipeline: pairwiseTiledPipeline
+        )
+        encoder.endEncoding()
+
+        try await awaitCompletion(commandBuffer)
+
+        let pointer = tileBuffer.contents().bindMemory(to: Float.self, capacity: output.count)
+        output = Array(UnsafeBufferPointer(start: pointer, count: output.count))
+        return output
+    }
+
+    private func runAntipodalFractions(
+        embeddingsA: [Float],
+        embeddingsB: [Float],
+        dim: Int,
+        pairCount: Int
+    ) async throws -> [Float] {
+        var output = [Float](repeating: 0, count: pairCount)
+
+        guard let embeddingsABuffer = device.makeBuffer(from: embeddingsA),
+              let embeddingsBBuffer = device.makeBuffer(from: embeddingsB),
+              let outputBuffer = device.makeBuffer(from: output),
+              let commandBuffer = commandQueue.makeCommandBuffer(),
+              let encoder = commandBuffer.makeComputeCommandEncoder()
+        else {
+            throw ContextCoreError.compressionFailed("Failed to allocate antipodal buffers")
+        }
+
+        var dim32 = UInt32(dim)
+        var pairCount32 = UInt32(pairCount)
+
+        guard let dimBuffer = device.makeBuffer(bytes: &dim32, length: MemoryLayout<UInt32>.stride, options: .storageModeShared),
+              let pairCountBuffer = device.makeBuffer(bytes: &pairCount32, length: MemoryLayout<UInt32>.stride, options: .storageModeShared)
+        else {
+            throw ContextCoreError.compressionFailed("Failed to allocate antipodal constants")
+        }
+
+        encoder.setComputePipelineState(antipodalPipeline)
+        encoder.setBuffer(embeddingsABuffer, offset: 0, index: 0)
+        encoder.setBuffer(embeddingsBBuffer, offset: 0, index: 1)
+        encoder.setBuffer(outputBuffer, offset: 0, index: 2)
+        encoder.setBuffer(dimBuffer, offset: 0, index: 3)
+        encoder.setBuffer(pairCountBuffer, offset: 0, index: 4)
+
+        let threads = MetalContext.threadsPerThreadgroup(pipeline: antipodalPipeline, count: pairCount)
+        let groups = MetalContext.threadgroups(threadsPerThreadgroup: threads, count: pairCount)
+        encoder.dispatchThreadgroups(groups, threadsPerThreadgroup: threads)
+        encoder.endEncoding()
+
+        try await awaitCompletion(commandBuffer)
+
+        let pointer = outputBuffer.contents().bindMemory(to: Float.self, capacity: pairCount)
+        output = Array(UnsafeBufferPointer(start: pointer, count: pairCount))
+        return output
+    }
+
+    private func dispatch2D(
+        encoder: MTLComputeCommandEncoder,
+        width: Int,
+        height: Int,
+        pipeline: MTLComputePipelineState
+    ) {
+        let maxThreads = max(1, pipeline.maxTotalThreadsPerThreadgroup)
+        let threadWidth = min(16, maxThreads)
+        let threadHeight = max(1, min(16, maxThreads / threadWidth))
+
+        let threadsPerThreadgroup = MTLSize(width: threadWidth, height: threadHeight, depth: 1)
+        let groups = MTLSize(
+            width: (width + threadWidth - 1) / threadWidth,
+            height: (height + threadHeight - 1) / threadHeight,
+            depth: 1
+        )
+
+        encoder.dispatchThreadgroups(groups, threadsPerThreadgroup: threadsPerThreadgroup)
+    }
+
+    private func awaitCompletion(_ commandBuffer: MTLCommandBuffer) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            commandBuffer.addCompletedHandler { buffer in
+                if let error = buffer.error {
+                    continuation.resume(
+                        throwing: ContextCoreError.compressionFailed(
+                            "Metal command failed: \(error.localizedDescription)"
+                        )
+                    )
+                    return
+                }
+                continuation.resume(returning: ())
+            }
+            commandBuffer.commit()
+        }
+    }
+}
+
+/// Background trigger that schedules consolidation after insertion thresholds.
+public actor ConsolidationScheduler {
+    private let engine: ConsolidationEngine
+    private let countThreshold: Int
+    private let insertionThreshold: Int
+    private let similarityThreshold: Float
+
+    private var insertionsSinceLastConsolidation = 0
+    private var isConsolidating = false
+    private var triggerCountValue = 0
+    private var lastResultValue: ConsolidationResult?
+
+    /// Creates a consolidation scheduler.
+    ///
+    /// - Parameters:
+    ///   - engine: Consolidation engine to run.
+    ///   - countThreshold: Episodic count trigger threshold.
+    ///   - insertionThreshold: Insertion count trigger threshold.
+    ///   - similarityThreshold: Duplicate similarity threshold for scheduled runs.
+    public init(
+        engine: ConsolidationEngine,
+        countThreshold: Int = 200,
+        insertionThreshold: Int = 50,
+        similarityThreshold: Float = 0.92
+    ) {
+        self.engine = engine
+        self.countThreshold = countThreshold
+        self.insertionThreshold = insertionThreshold
+        self.similarityThreshold = similarityThreshold
+    }
+
+    /// Notifies scheduler that an insertion occurred and may trigger consolidation.
+    ///
+    /// - Parameters:
+    ///   - episodicCount: Current episodic chunk count.
+    ///   - session: Active session identifier.
+    ///   - episodicStore: Episodic store.
+    ///   - semanticStore: Semantic store.
+    public func notifyInsertion(
+        episodicCount: Int,
+        session: UUID,
+        episodicStore: any ConsolidationEpisodicStore,
+        semanticStore: any ConsolidationSemanticStore
+    ) async {
+        insertionsSinceLastConsolidation += 1
+
+        let shouldConsolidate = episodicCount > countThreshold || insertionsSinceLastConsolidation > insertionThreshold
+        guard shouldConsolidate, !isConsolidating else {
+            return
+        }
+
+        isConsolidating = true
+        triggerCountValue += 1
+
+        let engine = self.engine
+        let threshold = self.similarityThreshold
+
+        Task.detached(priority: .background) {
+            do {
+                let result = try await engine.consolidate(
+                    session: session,
+                    episodicStore: episodicStore,
+                    semanticStore: semanticStore,
+                    threshold: threshold
+                )
+                await self.finish(result: result)
+            } catch {
+                await self.finish(result: nil)
+            }
+        }
+    }
+
+    /// Number of consolidation triggers issued.
+    public func triggerCount() -> Int {
+        triggerCountValue
+    }
+
+    /// Indicates whether a background consolidation task is running.
+    public func isRunning() -> Bool {
+        isConsolidating
+    }
+
+    /// Latest successful consolidation result.
+    public func lastResult() -> ConsolidationResult? {
+        lastResultValue
+    }
+
+    private func finish(result: ConsolidationResult?) {
+        if let result {
+            lastResultValue = result
+            resetCounter()
+        }
+        isConsolidating = false
+    }
+
+    private func resetCounter() {
+        insertionsSinceLastConsolidation = 0
+    }
+}

--- a/Sources/ContextCoreEngine/ContextCoreEngine.swift
+++ b/Sources/ContextCoreEngine/ContextCoreEngine.swift
@@ -1,0 +1,2 @@
+/// Namespace marker for the `ContextCoreEngine` module.
+public enum ContextCoreEngineModule {}

--- a/Sources/ContextCoreEngine/EmbeddingCache.swift
+++ b/Sources/ContextCoreEngine/EmbeddingCache.swift
@@ -1,0 +1,74 @@
+import CryptoKit
+import Foundation
+
+/// Actor-isolated LRU cache for embedding vectors.
+public actor EmbeddingCache {
+    private let capacity: Int
+    private var storage: [String: [Float]] = [:]
+    private var lruOrder: [String] = []
+
+    /// Creates an embedding cache.
+    ///
+    /// - Parameter capacity: Maximum entry count retained.
+    public init(capacity: Int = 512) {
+        self.capacity = max(1, capacity)
+    }
+
+    /// Current number of cached entries.
+    public var count: Int {
+        storage.count
+    }
+
+    /// Retrieves a cached embedding for a key.
+    ///
+    /// - Parameter key: Raw cache key.
+    /// - Returns: Cached embedding when present.
+    public func get(_ key: String) -> [Float]? {
+        let digest = Self.sha256Hex(key)
+        guard let value = storage[digest] else {
+            return nil
+        }
+        touch(digest)
+        return value
+    }
+
+    /// Inserts or updates a cached embedding.
+    ///
+    /// - Parameters:
+    ///   - key: Raw cache key.
+    ///   - value: Embedding vector.
+    public func set(_ key: String, value: [Float]) {
+        let digest = Self.sha256Hex(key)
+
+        if storage[digest] != nil {
+            storage[digest] = value
+            touch(digest)
+            return
+        }
+
+        if storage.count >= capacity, let leastRecent = lruOrder.first {
+            storage.removeValue(forKey: leastRecent)
+            lruOrder.removeFirst()
+        }
+
+        storage[digest] = value
+        lruOrder.append(digest)
+    }
+
+    private func touch(_ digest: String) {
+        guard let index = lruOrder.firstIndex(of: digest) else {
+            lruOrder.append(digest)
+            return
+        }
+        if index == lruOrder.index(before: lruOrder.endIndex) {
+            return
+        }
+        lruOrder.remove(at: index)
+        lruOrder.append(digest)
+    }
+
+    private static func sha256Hex(_ key: String) -> String {
+        let digest = SHA256.hash(data: Data(key.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Sources/ContextCoreEngine/ExtractiveFallbackDelegate.swift
+++ b/Sources/ContextCoreEngine/ExtractiveFallbackDelegate.swift
@@ -1,0 +1,136 @@
+import ContextCoreTypes
+import Foundation
+import NaturalLanguage
+
+/// Default extractive compression delegate used when no custom delegate is provided.
+public actor ExtractiveFallbackDelegate: CompressionDelegate {
+    private let compressionEngine: CompressionEngine
+    private let tokenCounter: any TokenCounter
+
+    /// Creates an extractive fallback delegate.
+    ///
+    /// - Parameters:
+    ///   - compressionEngine: Compression engine used for sentence ranking.
+    ///   - tokenCounter: Token counter used for budget checks.
+    public init(
+        compressionEngine: CompressionEngine,
+        tokenCounter: any TokenCounter
+    ) {
+        self.compressionEngine = compressionEngine
+        self.tokenCounter = tokenCounter
+    }
+
+    /// Compresses text by selecting high-importance sentences within `targetTokens`.
+    ///
+    /// - Parameters:
+    ///   - text: Source text.
+    ///   - targetTokens: Token budget ceiling.
+    /// - Returns: Extractively compressed text.
+    /// - Throws: Sentence ranking failures from the compression engine.
+    public func compress(_ text: String, targetTokens: Int) async throws -> String {
+        let currentTokens = tokenCounter.count(text)
+        if currentTokens <= targetTokens {
+            return text
+        }
+
+        let textEmbedding = try await compressionEngine.embedForCompression(text)
+        let ranked = try await compressionEngine.rankSentences(in: text, chunkEmbedding: textEmbedding)
+
+        guard !ranked.isEmpty else {
+            return text
+        }
+
+        let originalSentences = splitSentences(from: text)
+        let indexedBySentence = sentenceIndicesByText(originalSentences)
+
+        var indices = indexedBySentence
+        var rankedWithIndices: [(sentence: String, importance: Float, originalIndex: Int)] = []
+        rankedWithIndices.reserveCapacity(ranked.count)
+
+        var fallbackIndex = originalSentences.count
+        for pair in ranked {
+            if var available = indices[pair.sentence], let index = available.first {
+                available.removeFirst()
+                indices[pair.sentence] = available
+                rankedWithIndices.append((sentence: pair.sentence, importance: pair.importance, originalIndex: index))
+            } else {
+                rankedWithIndices.append((sentence: pair.sentence, importance: pair.importance, originalIndex: fallbackIndex))
+                fallbackIndex += 1
+            }
+        }
+
+        let sortedByImportance = rankedWithIndices.sorted { lhs, rhs in
+            if lhs.importance == rhs.importance {
+                return lhs.originalIndex < rhs.originalIndex
+            }
+            return lhs.importance > rhs.importance
+        }
+
+        var selected: [(sentence: String, importance: Float, originalIndex: Int)] = []
+        var tokensUsed = 0
+
+        for item in sortedByImportance {
+            let sentenceTokens = tokenCounter.count(item.sentence)
+            if tokensUsed + sentenceTokens > targetTokens {
+                continue
+            }
+
+            selected.append(item)
+            tokensUsed += sentenceTokens
+        }
+
+        if selected.isEmpty, let topSentence = sortedByImportance.first {
+            return topSentence.sentence
+        }
+
+        selected.sort { $0.originalIndex < $1.originalIndex }
+        return selected.map(\.sentence).joined(separator: " ")
+    }
+
+    /// Extracts sentence-level factual statements from text.
+    ///
+    /// - Parameter text: Source text.
+    /// - Returns: Trimmed sentence facts.
+    public func extractFacts(from text: String) async throws -> [String] {
+        let tokenizer = NLTokenizer(unit: .sentence)
+        tokenizer.string = text
+
+        var facts: [String] = []
+        tokenizer.enumerateTokens(in: text.startIndex..<text.endIndex) { range, _ in
+            let sentence = String(text[range]).trimmingCharacters(in: .whitespacesAndNewlines)
+            if !sentence.isEmpty {
+                facts.append(sentence)
+            }
+            return true
+        }
+
+        return facts
+    }
+
+    private func splitSentences(from text: String) -> [String] {
+        let tokenizer = NLTokenizer(unit: .sentence)
+        tokenizer.string = text
+
+        var sentences: [String] = []
+        tokenizer.enumerateTokens(in: text.startIndex..<text.endIndex) { range, _ in
+            let sentence = text[range].trimmingCharacters(in: .whitespacesAndNewlines)
+            if !sentence.isEmpty {
+                sentences.append(sentence)
+            }
+            return true
+        }
+
+        return sentences
+    }
+
+    private func sentenceIndicesByText(_ sentences: [String]) -> [String: [Int]] {
+        var output: [String: [Int]] = [:]
+        output.reserveCapacity(sentences.count)
+
+        for (index, sentence) in sentences.enumerated() {
+            output[sentence, default: []].append(index)
+        }
+
+        return output
+    }
+}

--- a/Sources/ContextCoreEngine/MetalContext.swift
+++ b/Sources/ContextCoreEngine/MetalContext.swift
@@ -1,0 +1,105 @@
+import ContextCoreShaders
+import ContextCoreTypes
+import Foundation
+import Metal
+
+enum MetalContext {
+    static func device() throws -> MTLDevice {
+        guard let device = MTLCreateSystemDefaultDevice() else {
+            throw ContextCoreError.metalDeviceUnavailable
+        }
+        return device
+    }
+
+    static func commandQueue(device: MTLDevice) throws -> MTLCommandQueue {
+        guard let queue = device.makeCommandQueue() else {
+            throw ContextCoreError.compressionFailed("Failed to create Metal command queue")
+        }
+        return queue
+    }
+
+    static func library(device: MTLDevice) throws -> MTLLibrary {
+        let bundle = ContextCoreShadersModule.bundle
+
+        if let defaultLibrary = try? device.makeDefaultLibrary(bundle: bundle) {
+            return defaultLibrary
+        }
+
+        let shaderNames = ["Relevance", "Recency", "Attention", "Compression", "Consolidation"]
+        let source = try shaderNames.map { name -> String in
+            let url = bundle.url(forResource: name, withExtension: "metal")
+                ?? bundle.url(forResource: name, withExtension: "metal", subdirectory: "Shaders")
+
+            guard let url else {
+                throw ContextCoreError.compressionFailed("Missing shader resource: \(name).metal")
+            }
+            return try String(contentsOf: url)
+        }.joined(separator: "\n\n")
+
+        let options = MTLCompileOptions()
+        options.fastMathEnabled = false
+
+        do {
+            return try device.makeLibrary(source: source, options: options)
+        } catch {
+            throw ContextCoreError.compressionFailed("Failed to compile Metal shader sources: \(error)")
+        }
+    }
+
+    static func awaitCompletion(of commandBuffer: MTLCommandBuffer) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            commandBuffer.addCompletedHandler { buffer in
+                if let error = buffer.error {
+                    continuation.resume(throwing: ContextCoreError.compressionFailed("Metal command failed: \(error.localizedDescription)"))
+                    return
+                }
+                continuation.resume(returning: ())
+            }
+            commandBuffer.commit()
+        }
+    }
+
+    static func threadsPerThreadgroup(
+        pipeline: MTLComputePipelineState,
+        count: Int
+    ) -> MTLSize {
+        let width = max(1, min(pipeline.maxTotalThreadsPerThreadgroup, count))
+        return MTLSize(width: width, height: 1, depth: 1)
+    }
+
+    static func threadgroups(
+        threadsPerThreadgroup: MTLSize,
+        count: Int
+    ) -> MTLSize {
+        let groups = (count + threadsPerThreadgroup.width - 1) / threadsPerThreadgroup.width
+        return MTLSize(width: max(1, groups), height: 1, depth: 1)
+    }
+}
+
+extension MTLDevice {
+    func makeBuffer(from array: [Float]) -> MTLBuffer? {
+        array.withUnsafeBufferPointer { pointer in
+            guard let baseAddress = pointer.baseAddress else {
+                return nil
+            }
+            return makeBuffer(
+                bytes: baseAddress,
+                length: pointer.count * MemoryLayout<Float>.stride,
+                options: .storageModeShared
+            )
+        }
+    }
+
+    func makeBuffer(from array: [UInt32]) -> MTLBuffer? {
+        array.withUnsafeBufferPointer { pointer in
+            guard let baseAddress = pointer.baseAddress else {
+                return nil
+            }
+            return makeBuffer(
+                bytes: baseAddress,
+                length: pointer.count * MemoryLayout<UInt32>.stride,
+                options: .storageModeShared
+            )
+        }
+    }
+}

--- a/Sources/ContextCoreEngine/ScoringEngine.swift
+++ b/Sources/ContextCoreEngine/ScoringEngine.swift
@@ -1,0 +1,472 @@
+import ContextCoreTypes
+import Foundation
+import Metal
+
+/// GPU-backed relevance and recency scoring engine.
+public actor ScoringEngine {
+    package final class PreparedScoringInputs: @unchecked Sendable {
+        fileprivate let queryBuffer: MTLBuffer
+        fileprivate let chunksBuffer: MTLBuffer
+        fileprivate let recencyBuffer: MTLBuffer
+        fileprivate let outputBuffer: MTLBuffer
+        fileprivate let count: Int
+        fileprivate let dimension: Int
+        fileprivate let queryNorm: Float
+
+        fileprivate init(
+            queryBuffer: MTLBuffer,
+            chunksBuffer: MTLBuffer,
+            recencyBuffer: MTLBuffer,
+            outputBuffer: MTLBuffer,
+            count: Int,
+            dimension: Int,
+            queryNorm: Float
+        ) {
+            self.queryBuffer = queryBuffer
+            self.chunksBuffer = chunksBuffer
+            self.recencyBuffer = recencyBuffer
+            self.outputBuffer = outputBuffer
+            self.count = count
+            self.dimension = dimension
+            self.queryNorm = queryNorm
+        }
+    }
+
+    private let device: MTLDevice
+    private let commandQueue: MTLCommandQueue
+    private let relevancePipeline: MTLComputePipelineState
+    private let recencyPipeline: MTLComputePipelineState
+    private var scoringBuffers = ScoringBuffers()
+    private var recencyBuffers = RecencyBuffers()
+
+    private struct ScoringBuffers {
+        var query: MTLBuffer?
+        var chunks: MTLBuffer?
+        var recency: MTLBuffer?
+        var output: MTLBuffer?
+    }
+
+    private struct RecencyBuffers {
+        var timestamps: MTLBuffer?
+        var output: MTLBuffer?
+    }
+
+    /// Creates a scoring engine and compiles required Metal pipelines.
+    ///
+    /// - Parameter device: Optional Metal device override.
+    /// - Throws: ``ContextCoreError/metalDeviceUnavailable`` or pipeline creation failures.
+    public init(device: MTLDevice? = nil) throws {
+        self.device = try device ?? MetalContext.device()
+        self.commandQueue = try MetalContext.commandQueue(device: self.device)
+
+        let library = try MetalContext.library(device: self.device)
+
+        guard let relevanceFunction = library.makeFunction(name: "relevance_score") else {
+            throw ContextCoreError.compressionFailed("Missing relevance_score function")
+        }
+
+        guard let recencyFunction = library.makeFunction(name: "compute_recency_weights") else {
+            throw ContextCoreError.compressionFailed("Missing compute_recency_weights function")
+        }
+
+        self.relevancePipeline = try self.device.makeComputePipelineState(function: relevanceFunction)
+        self.recencyPipeline = try self.device.makeComputePipelineState(function: recencyFunction)
+    }
+
+    /// Scores candidate chunks against a query vector.
+    ///
+    /// - Parameters:
+    ///   - query: Query embedding.
+    ///   - chunks: Candidate chunks.
+    ///   - recencyWeights: Per-chunk recency weights.
+    ///   - relevanceWeight: Similarity contribution.
+    ///   - recencyWeight: Recency contribution.
+    /// - Returns: Scored chunks sorted by descending score.
+    /// - Throws: ``ContextCoreError/dimensionMismatch(expected:got:)`` for inconsistent dimensions.
+    public func scoreChunks(
+        query: [Float],
+        chunks: [MemoryChunk],
+        recencyWeights: [Float],
+        relevanceWeight: Float = 0.7,
+        recencyWeight: Float = 0.3
+    ) async throws -> [(chunk: MemoryChunk, score: Float)] {
+        let unsorted = try await scoreChunksUnsorted(
+            query: query,
+            chunks: chunks,
+            recencyWeights: recencyWeights,
+            relevanceWeight: relevanceWeight,
+            recencyWeight: recencyWeight
+        )
+
+        return unsorted.sorted(by: { $0.score > $1.score })
+    }
+
+    package func scoreChunksUnsorted(
+        query: [Float],
+        chunks: [MemoryChunk],
+        recencyWeights: [Float],
+        relevanceWeight: Float = 0.7,
+        recencyWeight: Float = 0.3
+    ) async throws -> [(chunk: MemoryChunk, score: Float)] {
+        guard !chunks.isEmpty else {
+            return []
+        }
+        guard chunks.count == recencyWeights.count else {
+            throw ContextCoreError.dimensionMismatch(expected: chunks.count, got: recencyWeights.count)
+        }
+
+        let dim = query.count
+        var flattened: [Float] = []
+        flattened.reserveCapacity(chunks.count * dim)
+        for chunk in chunks {
+            guard chunk.embedding.count == dim else {
+                throw ContextCoreError.dimensionMismatch(expected: dim, got: chunk.embedding.count)
+            }
+            flattened.append(contentsOf: chunk.embedding)
+        }
+
+        let scores = try await scoreFlattenedEmbeddings(
+            query: query,
+            flattenedEmbeddings: flattened,
+            count: chunks.count,
+            dimension: dim,
+            recencyWeights: recencyWeights,
+            relevanceWeight: relevanceWeight,
+            recencyWeight: recencyWeight
+        )
+
+        return zip(chunks, scores)
+            .map { (chunk: $0.0, score: $0.1) }
+    }
+
+    /// Returns indices of top-k values from a score vector using GPU selection.
+    ///
+    /// - Parameters:
+    ///   - scores: Score values.
+    ///   - k: Number of indices to return.
+    /// - Returns: Top-k score indices.
+    /// - Throws: Buffer and command construction failures.
+    public func topKIndices(
+        scores: [Float],
+        k: Int
+    ) async throws -> [Int] {
+        guard !scores.isEmpty, k > 0 else {
+            return []
+        }
+
+        let cappedK = min(k, scores.count)
+        return scores.enumerated()
+            .sorted { lhs, rhs in
+                if lhs.element == rhs.element {
+                    return lhs.offset < rhs.offset
+                }
+                return lhs.element > rhs.element
+            }
+            .prefix(cappedK)
+            .map(\.offset)
+    }
+
+    /// Computes exponential recency weights using a half-life decay function.
+    ///
+    /// - Parameters:
+    ///   - timestamps: Source timestamps.
+    ///   - halfLife: Half-life duration in seconds.
+    ///   - currentTime: Reference time for decay calculation.
+    /// - Returns: Recency weights in `[0, 1]`.
+    /// - Throws: ``ContextCoreError/compressionFailed(_:)`` when `halfLife <= 0` or buffer setup fails.
+    public func computeRecencyWeights(
+        timestamps: [Date],
+        halfLife: TimeInterval,
+        currentTime: Date = .now
+    ) async throws -> [Float] {
+        guard !timestamps.isEmpty else {
+            return []
+        }
+        guard halfLife > 0 else {
+            throw ContextCoreError.compressionFailed("halfLife must be positive")
+        }
+
+        let timestampValues = timestamps.map { Float($0.timeIntervalSince1970) }
+        let n = timestampValues.count
+        let timestampBuffer = try reusableBuffer(
+            current: &recencyBuffers.timestamps,
+            minimumLength: timestampValues.count * MemoryLayout<Float>.stride,
+            failureMessage: "Failed to allocate recency timestamp buffer"
+        )
+        let outputBuffer = try reusableBuffer(
+            current: &recencyBuffers.output,
+            minimumLength: n * MemoryLayout<Float>.stride,
+            failureMessage: "Failed to allocate recency output buffer"
+        )
+
+        write(timestampValues, to: timestampBuffer)
+
+        guard let commandBuffer = commandQueue.makeCommandBuffer(),
+              let encoder = commandBuffer.makeComputeCommandEncoder()
+        else {
+            throw ContextCoreError.compressionFailed("Failed to allocate recency buffers")
+        }
+
+        var currentTimeSeconds = Float(currentTime.timeIntervalSince1970)
+        var halfLifeF = Float(halfLife)
+        var n32 = UInt32(n)
+
+        encoder.setComputePipelineState(recencyPipeline)
+        encoder.setBuffer(timestampBuffer, offset: 0, index: 0)
+        encoder.setBuffer(outputBuffer, offset: 0, index: 1)
+        encoder.setBytes(&currentTimeSeconds, length: MemoryLayout<Float>.stride, index: 2)
+        encoder.setBytes(&halfLifeF, length: MemoryLayout<Float>.stride, index: 3)
+        encoder.setBytes(&n32, length: MemoryLayout<UInt32>.stride, index: 4)
+
+        let threads = MetalContext.threadsPerThreadgroup(pipeline: recencyPipeline, count: n)
+        let groups = MetalContext.threadgroups(threadsPerThreadgroup: threads, count: n)
+        encoder.dispatchThreadgroups(groups, threadsPerThreadgroup: threads)
+        encoder.endEncoding()
+
+        try await awaitCompletion(of: commandBuffer)
+
+        let raw = outputBuffer.contents().bindMemory(to: Float.self, capacity: n)
+        return Array(UnsafeBufferPointer(start: raw, count: n))
+    }
+
+    package func scoreFlattenedEmbeddings(
+        query: [Float],
+        flattenedEmbeddings: [Float],
+        count: Int,
+        dimension: Int,
+        recencyWeights: [Float],
+        relevanceWeight: Float,
+        recencyWeight: Float
+    ) async throws -> [Float] {
+        guard count > 0 else {
+            return []
+        }
+        guard query.count == dimension else {
+            throw ContextCoreError.dimensionMismatch(expected: dimension, got: query.count)
+        }
+        guard flattenedEmbeddings.count == count * dimension else {
+            throw ContextCoreError.dimensionMismatch(expected: count * dimension, got: flattenedEmbeddings.count)
+        }
+        guard recencyWeights.count == count else {
+            throw ContextCoreError.dimensionMismatch(expected: count, got: recencyWeights.count)
+        }
+
+        return try await scoreEmbeddings(
+            query: query,
+            flattenedEmbeddings: flattenedEmbeddings,
+            count: count,
+            dimension: dimension,
+            recencyWeights: recencyWeights,
+            relevanceWeight: relevanceWeight,
+            recencyWeight: recencyWeight
+        )
+    }
+
+    package func makePreparedScoringInputs(
+        query: [Float],
+        flattenedEmbeddings: [Float],
+        count: Int,
+        dimension: Int,
+        recencyWeights: [Float]
+    ) throws -> PreparedScoringInputs {
+        guard count > 0 else {
+            throw ContextCoreError.compressionFailed("Prepared scoring inputs require at least one chunk")
+        }
+        guard query.count == dimension else {
+            throw ContextCoreError.dimensionMismatch(expected: dimension, got: query.count)
+        }
+        guard flattenedEmbeddings.count == count * dimension else {
+            throw ContextCoreError.dimensionMismatch(expected: count * dimension, got: flattenedEmbeddings.count)
+        }
+        guard recencyWeights.count == count else {
+            throw ContextCoreError.dimensionMismatch(expected: count, got: recencyWeights.count)
+        }
+
+        guard let queryBuffer = device.makeBuffer(length: query.count * MemoryLayout<Float>.stride, options: .storageModeShared),
+              let chunksBuffer = device.makeBuffer(length: flattenedEmbeddings.count * MemoryLayout<Float>.stride, options: .storageModeShared),
+              let recencyBuffer = device.makeBuffer(length: recencyWeights.count * MemoryLayout<Float>.stride, options: .storageModeShared),
+              let outputBuffer = device.makeBuffer(length: count * MemoryLayout<Float>.stride, options: .storageModeShared)
+        else {
+            throw ContextCoreError.compressionFailed("Failed to allocate prepared scoring buffers")
+        }
+
+        write(query, to: queryBuffer)
+        write(flattenedEmbeddings, to: chunksBuffer)
+        write(recencyWeights, to: recencyBuffer)
+
+        return PreparedScoringInputs(
+            queryBuffer: queryBuffer,
+            chunksBuffer: chunksBuffer,
+            recencyBuffer: recencyBuffer,
+            outputBuffer: outputBuffer,
+            count: count,
+            dimension: dimension,
+            queryNorm: l2Norm(query)
+        )
+    }
+
+    package func scorePreparedEmbeddings(
+        _ prepared: PreparedScoringInputs,
+        relevanceWeight: Float,
+        recencyWeight: Float
+    ) async throws -> [Float] {
+        try await dispatchScore(
+            queryBuffer: prepared.queryBuffer,
+            chunksBuffer: prepared.chunksBuffer,
+            recencyBuffer: prepared.recencyBuffer,
+            outputBuffer: prepared.outputBuffer,
+            count: prepared.count,
+            dimension: prepared.dimension,
+            queryNorm: prepared.queryNorm,
+            relevanceWeight: relevanceWeight,
+            recencyWeight: recencyWeight
+        )
+    }
+
+    private func scoreEmbeddings(
+        query: [Float],
+        flattenedEmbeddings: [Float],
+        count: Int,
+        dimension: Int,
+        recencyWeights: [Float],
+        relevanceWeight: Float,
+        recencyWeight: Float
+    ) async throws -> [Float] {
+        let queryBuffer = try reusableBuffer(
+            current: &scoringBuffers.query,
+            minimumLength: query.count * MemoryLayout<Float>.stride,
+            failureMessage: "Failed to allocate query buffer"
+        )
+        let chunksBuffer = try reusableBuffer(
+            current: &scoringBuffers.chunks,
+            minimumLength: flattenedEmbeddings.count * MemoryLayout<Float>.stride,
+            failureMessage: "Failed to allocate chunk buffer"
+        )
+        let recencyBuffer = try reusableBuffer(
+            current: &scoringBuffers.recency,
+            minimumLength: recencyWeights.count * MemoryLayout<Float>.stride,
+            failureMessage: "Failed to allocate recency buffer"
+        )
+        let outputBuffer = try reusableBuffer(
+            current: &scoringBuffers.output,
+            minimumLength: count * MemoryLayout<Float>.stride,
+            failureMessage: "Failed to allocate scoring output buffer"
+        )
+
+        write(query, to: queryBuffer)
+        write(flattenedEmbeddings, to: chunksBuffer)
+        write(recencyWeights, to: recencyBuffer)
+
+        return try await dispatchScore(
+            queryBuffer: queryBuffer,
+            chunksBuffer: chunksBuffer,
+            recencyBuffer: recencyBuffer,
+            outputBuffer: outputBuffer,
+            count: count,
+            dimension: dimension,
+            queryNorm: l2Norm(query),
+            relevanceWeight: relevanceWeight,
+            recencyWeight: recencyWeight
+        )
+    }
+
+    private func dispatchScore(
+        queryBuffer: MTLBuffer,
+        chunksBuffer: MTLBuffer,
+        recencyBuffer: MTLBuffer,
+        outputBuffer: MTLBuffer,
+        count: Int,
+        dimension: Int,
+        queryNorm: Float,
+        relevanceWeight: Float,
+        recencyWeight: Float
+    ) async throws -> [Float] {
+        var weights = SIMD2<Float>(relevanceWeight, recencyWeight)
+        var dim32 = UInt32(dimension)
+        var n32 = UInt32(count)
+        var queryNorm = queryNorm
+
+        guard let commandBuffer = commandQueue.makeCommandBuffer(),
+              let encoder = commandBuffer.makeComputeCommandEncoder()
+        else {
+            throw ContextCoreError.compressionFailed("Failed to allocate scoring buffers")
+        }
+
+        encoder.setComputePipelineState(relevancePipeline)
+        encoder.setBuffer(queryBuffer, offset: 0, index: 0)
+        encoder.setBuffer(chunksBuffer, offset: 0, index: 1)
+        encoder.setBuffer(recencyBuffer, offset: 0, index: 2)
+        encoder.setBytes(&weights, length: MemoryLayout<SIMD2<Float>>.stride, index: 3)
+        encoder.setBuffer(outputBuffer, offset: 0, index: 4)
+        encoder.setBytes(&dim32, length: MemoryLayout<UInt32>.stride, index: 5)
+        encoder.setBytes(&n32, length: MemoryLayout<UInt32>.stride, index: 6)
+        encoder.setBytes(&queryNorm, length: MemoryLayout<Float>.stride, index: 7)
+
+        let threads = scoringThreadsPerThreadgroup(for: count)
+        let groups = MetalContext.threadgroups(threadsPerThreadgroup: threads, count: count)
+        encoder.dispatchThreadgroups(groups, threadsPerThreadgroup: threads)
+        encoder.endEncoding()
+
+        try await awaitCompletion(of: commandBuffer)
+
+        let raw = outputBuffer.contents().bindMemory(to: Float.self, capacity: count)
+        return Array(UnsafeBufferPointer(start: raw, count: count))
+    }
+
+    private func scoringThreadsPerThreadgroup(for count: Int) -> MTLSize {
+        let executionWidth = max(1, relevancePipeline.threadExecutionWidth)
+        let preferredWidth = min(relevancePipeline.maxTotalThreadsPerThreadgroup, executionWidth * 4)
+        let width = max(1, min(preferredWidth, count))
+        return MTLSize(width: width, height: 1, depth: 1)
+    }
+
+    private func reusableBuffer(
+        current: inout MTLBuffer?,
+        minimumLength: Int,
+        failureMessage: String
+    ) throws -> MTLBuffer {
+        if let current, current.length >= minimumLength {
+            return current
+        }
+
+        guard let replacement = device.makeBuffer(length: minimumLength, options: .storageModeShared) else {
+            throw ContextCoreError.compressionFailed(failureMessage)
+        }
+        current = replacement
+        return replacement
+    }
+
+    private func write(_ values: [Float], to buffer: MTLBuffer) {
+        values.withUnsafeBytes { rawBuffer in
+            guard let baseAddress = rawBuffer.baseAddress else {
+                return
+            }
+            memcpy(buffer.contents(), baseAddress, rawBuffer.count)
+        }
+    }
+
+    private func l2Norm(_ vector: [Float]) -> Float {
+        guard !vector.isEmpty else {
+            return 0
+        }
+
+        var sum: Float = 0
+        for value in vector {
+            sum += value * value
+        }
+        return sum.squareRoot()
+    }
+
+    private func awaitCompletion(of commandBuffer: MTLCommandBuffer) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            commandBuffer.addCompletedHandler { buffer in
+                if let error = buffer.error {
+                    continuation.resume(throwing: ContextCoreError.compressionFailed("Metal command failed: \(error.localizedDescription)"))
+                    return
+                }
+                continuation.resume(returning: ())
+            }
+            commandBuffer.commit()
+        }
+    }
+}

--- a/Sources/ContextCoreShaders/ContextCoreShaders.swift
+++ b/Sources/ContextCoreShaders/ContextCoreShaders.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// Accessor namespace for the ContextCore shader resource bundle.
+public enum ContextCoreShadersModule {
+    /// Resource bundle containing Metal shader sources used by the engine targets.
+    public static var bundle: Bundle {
+        .module
+    }
+}

--- a/Sources/ContextCoreShaders/Shaders/Attention.metal
+++ b/Sources/ContextCoreShaders/Shaders/Attention.metal
@@ -1,0 +1,98 @@
+#include <metal_stdlib>
+using namespace metal;
+
+kernel void token_centrality(
+    device const float* embeddings   [[buffer(0)]],
+    device float* centrality         [[buffer(1)]],
+    constant uint& dim               [[buffer(2)]],
+    constant uint& n                 [[buffer(3)]],
+    uint gid                         [[thread_position_in_grid]],
+    uint tid                         [[thread_index_in_threadgroup]]
+) {
+    threadgroup float shared_data[1];
+    if (tid == 0) {
+        shared_data[0] = 0.0f;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    if (gid >= n) {
+        return;
+    }
+
+    if (n <= 1) {
+        centrality[gid] = 0.0f;
+        return;
+    }
+
+    const uint base = gid * dim;
+
+    float normSelfSq = 0.0f;
+    for (uint d = 0; d < dim; ++d) {
+        const float v = embeddings[base + d];
+        normSelfSq += v * v;
+    }
+    const float normSelf = sqrt(normSelfSq);
+
+    float sum = 0.0f;
+
+    for (uint j = 0; j < n; ++j) {
+        if (j == gid) {
+            continue;
+        }
+
+        const uint otherBase = j * dim;
+        float dot = 0.0f;
+        float normOtherSq = 0.0f;
+
+        for (uint d = 0; d < dim; ++d) {
+            const float self = embeddings[base + d];
+            const float other = embeddings[otherBase + d];
+            dot += self * other;
+            normOtherSq += other * other;
+        }
+
+        const float denom = normSelf * sqrt(normOtherSq);
+        if (denom > 0.0f) {
+            sum += dot / denom;
+        }
+    }
+
+    centrality[gid] = sum / float(n - 1);
+}
+
+kernel void cross_attention_score(
+    device const float* taskQuery      [[buffer(0)]],
+    device const float* embeddings     [[buffer(1)]],
+    device const float* centrality     [[buffer(2)]],
+    device const float2* weights       [[buffer(3)]],
+    device float* evictionScores       [[buffer(4)]],
+    constant uint& dim                 [[buffer(5)]],
+    constant uint& n                   [[buffer(6)]],
+    uint gid                           [[thread_position_in_grid]]
+) {
+    if (gid >= n) {
+        return;
+    }
+
+    const uint base = gid * dim;
+
+    float dot = 0.0f;
+    float queryNormSq = 0.0f;
+    float chunkNormSq = 0.0f;
+
+    for (uint d = 0; d < dim; ++d) {
+        const float q = taskQuery[d];
+        const float c = embeddings[base + d];
+        dot += q * c;
+        queryNormSq += q * q;
+        chunkNormSq += c * c;
+    }
+
+    const float denom = sqrt(queryNormSq) * sqrt(chunkNormSq);
+    float relevance = 0.0f;
+    if (denom > 0.0f) {
+        relevance = dot / denom;
+    }
+
+    evictionScores[gid] = relevance * weights[0].x + centrality[gid] * weights[0].y;
+}

--- a/Sources/ContextCoreShaders/Shaders/Compression.metal
+++ b/Sources/ContextCoreShaders/Shaders/Compression.metal
@@ -1,0 +1,37 @@
+#include <metal_stdlib>
+using namespace metal;
+
+kernel void sentence_importance(
+    device const float* sentenceEmbs  [[buffer(0)]],
+    device const float* chunkQuery    [[buffer(1)]],
+    device float* importance          [[buffer(2)]],
+    constant uint& dim                [[buffer(3)]],
+    constant uint& m                  [[buffer(4)]],
+    uint gid                          [[thread_position_in_grid]]
+) {
+    if (gid >= m) {
+        return;
+    }
+
+    const uint base = gid * dim;
+
+    float dot = 0.0f;
+    float sentenceNormSq = 0.0f;
+    float queryNormSq = 0.0f;
+
+    for (uint d = 0; d < dim; ++d) {
+        const float s = sentenceEmbs[base + d];
+        const float q = chunkQuery[d];
+        dot += s * q;
+        sentenceNormSq += s * s;
+        queryNormSq += q * q;
+    }
+
+    const float denom = sqrt(sentenceNormSq) * sqrt(queryNormSq);
+    float cosine = 0.0f;
+    if (denom > 0.0f) {
+        cosine = dot / denom;
+    }
+
+    importance[gid] = cosine;
+}

--- a/Sources/ContextCoreShaders/Shaders/Consolidation.metal
+++ b/Sources/ContextCoreShaders/Shaders/Consolidation.metal
@@ -1,0 +1,140 @@
+#include <metal_stdlib>
+using namespace metal;
+
+kernel void pairwise_similarity(
+    device const float* embeddings         [[buffer(0)]],
+    device float* similarity               [[buffer(1)]],
+    constant uint& dim                     [[buffer(2)]],
+    constant uint& n                       [[buffer(3)]],
+    uint2 gid                              [[thread_position_in_grid]]
+) {
+    const uint i = gid.x;
+    const uint j = gid.y;
+
+    if (i >= n || j >= n || j <= i) {
+        return;
+    }
+
+    const uint baseI = i * dim;
+    const uint baseJ = j * dim;
+
+    float dot = 0.0f;
+    float normISq = 0.0f;
+    float normJSq = 0.0f;
+
+    for (uint d = 0; d < dim; ++d) {
+        const float a = embeddings[baseI + d];
+        const float b = embeddings[baseJ + d];
+        dot += a * b;
+        normISq += a * a;
+        normJSq += b * b;
+    }
+
+    float cosine = 0.0f;
+    const float denom = sqrt(normISq) * sqrt(normJSq);
+    if (denom > 0.0f) {
+        cosine = dot / denom;
+    }
+
+    similarity[i * n + j] = cosine;
+}
+
+kernel void find_merge_candidates(
+    device const float* similarity         [[buffer(0)]],
+    device uint2* candidates               [[buffer(1)]],
+    device atomic_uint* candidateCount     [[buffer(2)]],
+    constant float& threshold              [[buffer(3)]],
+    constant uint& n                       [[buffer(4)]],
+    constant uint& maxCandidates           [[buffer(5)]],
+    uint2 gid                              [[thread_position_in_grid]]
+) {
+    const uint i = gid.x;
+    const uint j = gid.y;
+
+    if (i >= n || j >= n || j <= i) {
+        return;
+    }
+
+    const float value = similarity[i * n + j];
+    if (value <= threshold) {
+        return;
+    }
+
+    const uint idx = atomic_fetch_add_explicit(candidateCount, 1u, memory_order_relaxed);
+    if (idx < maxCandidates) {
+        candidates[idx] = uint2(i, j);
+    }
+}
+
+kernel void pairwise_similarity_tiled(
+    device const float* embeddings         [[buffer(0)]],
+    device float* similarityTile           [[buffer(1)]],
+    constant uint& dim                     [[buffer(2)]],
+    constant uint& n                       [[buffer(3)]],
+    constant uint& rowOffset               [[buffer(4)]],
+    constant uint& colOffset               [[buffer(5)]],
+    constant uint& rowCount                [[buffer(6)]],
+    constant uint& colCount                [[buffer(7)]],
+    uint2 gid                              [[thread_position_in_grid]]
+) {
+    const uint localI = gid.x;
+    const uint localJ = gid.y;
+    if (localI >= rowCount || localJ >= colCount) {
+        return;
+    }
+
+    const uint i = rowOffset + localI;
+    const uint j = colOffset + localJ;
+    if (i >= n || j >= n || j <= i) {
+        return;
+    }
+
+    const uint baseI = i * dim;
+    const uint baseJ = j * dim;
+
+    float dot = 0.0f;
+    float normISq = 0.0f;
+    float normJSq = 0.0f;
+
+    for (uint d = 0; d < dim; ++d) {
+        const float a = embeddings[baseI + d];
+        const float b = embeddings[baseJ + d];
+        dot += a * b;
+        normISq += a * a;
+        normJSq += b * b;
+    }
+
+    float cosine = 0.0f;
+    const float denom = sqrt(normISq) * sqrt(normJSq);
+    if (denom > 0.0f) {
+        cosine = dot / denom;
+    }
+
+    similarityTile[localI * colCount + localJ] = cosine;
+}
+
+kernel void antipodal_test(
+    device const float* embeddingsA         [[buffer(0)]],
+    device const float* embeddingsB         [[buffer(1)]],
+    device float* antipodalFraction         [[buffer(2)]],
+    constant uint& dim                      [[buffer(3)]],
+    constant uint& pairCount                [[buffer(4)]],
+    uint gid                                [[thread_position_in_grid]]
+) {
+    if (gid >= pairCount) {
+        return;
+    }
+
+    const uint base = gid * dim;
+    uint signDiffCount = 0;
+
+    for (uint d = 0; d < dim; ++d) {
+        const bool signA = embeddingsA[base + d] >= 0.0f;
+        const bool signB = embeddingsB[base + d] >= 0.0f;
+        if (signA != signB) {
+            signDiffCount += 1;
+        }
+    }
+
+    antipodalFraction[gid] = float(signDiffCount) / float(dim);
+}

--- a/Sources/ContextCoreShaders/Shaders/Recency.metal
+++ b/Sources/ContextCoreShaders/Shaders/Recency.metal
@@ -1,0 +1,20 @@
+#include <metal_stdlib>
+using namespace metal;
+
+kernel void compute_recency_weights(
+    device const float* timestamps     [[buffer(0)]],
+    device float* weights              [[buffer(1)]],
+    constant float& currentTime        [[buffer(2)]],
+    constant float& halfLifeSeconds    [[buffer(3)]],
+    constant uint& n                   [[buffer(4)]],
+    uint gid                           [[thread_position_in_grid]]
+) {
+    if (gid >= n) {
+        return;
+    }
+
+    const float age = currentTime - timestamps[gid];
+    float value = exp(-0.693147f * age / halfLifeSeconds);
+    value = clamp(value, 0.0f, 1.0f);
+    weights[gid] = value;
+}

--- a/Sources/ContextCoreShaders/Shaders/Relevance.metal
+++ b/Sources/ContextCoreShaders/Shaders/Relevance.metal
@@ -1,0 +1,127 @@
+#include <metal_stdlib>
+using namespace metal;
+
+constant uint relevance_shared_query_capacity = 1024;
+
+kernel void relevance_score(
+    device const float* query        [[buffer(0)]],
+    device const float* chunks       [[buffer(1)]],
+    device const float* recencyWts   [[buffer(2)]],
+    constant float2& weights         [[buffer(3)]],
+    device float* scores             [[buffer(4)]],
+    constant uint& dim               [[buffer(5)]],
+    constant uint& n                 [[buffer(6)]],
+    constant float& queryNorm        [[buffer(7)]],
+    uint3 gid                        [[thread_position_in_grid]],
+    uint3 tid                        [[thread_position_in_threadgroup]],
+    uint3 threadsPerThreadgroup      [[threads_per_threadgroup]]
+) {
+    threadgroup float sharedQuery[relevance_shared_query_capacity];
+    const bool useSharedQuery = dim <= relevance_shared_query_capacity;
+    if (useSharedQuery) {
+        const uint threadCount = max(1u, threadsPerThreadgroup.x);
+        for (uint index = tid.x; index < dim; index += threadCount) {
+            sharedQuery[index] = query[index];
+        }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    if (gid.x >= n) {
+        return;
+    }
+
+    const uint base = gid.x * dim;
+
+    float dotProduct = 0.0f;
+    float chunkNormSq = 0.0f;
+    uint index = 0;
+
+    if (useSharedQuery) {
+        for (; index + 3 < dim; index += 4) {
+            const float4 q = float4(sharedQuery[index], sharedQuery[index + 1], sharedQuery[index + 2], sharedQuery[index + 3]);
+            const float4 c = float4(chunks[base + index], chunks[base + index + 1], chunks[base + index + 2], chunks[base + index + 3]);
+            dotProduct += dot(q, c);
+            chunkNormSq += dot(c, c);
+        }
+
+        for (; index < dim; ++index) {
+            const float q = sharedQuery[index];
+            const float c = chunks[base + index];
+            dotProduct += q * c;
+            chunkNormSq += c * c;
+        }
+    } else {
+        for (; index + 3 < dim; index += 4) {
+            const float4 q = float4(query[index], query[index + 1], query[index + 2], query[index + 3]);
+            const float4 c = float4(chunks[base + index], chunks[base + index + 1], chunks[base + index + 2], chunks[base + index + 3]);
+            dotProduct += dot(q, c);
+            chunkNormSq += dot(c, c);
+        }
+
+        for (; index < dim; ++index) {
+            const float q = query[index];
+            const float c = chunks[base + index];
+            dotProduct += q * c;
+            chunkNormSq += c * c;
+        }
+    }
+
+    const float chunkNorm = sqrt(chunkNormSq);
+
+    float cosine = 0.0f;
+    const float denom = queryNorm * chunkNorm;
+    if (denom > 0.0f) {
+        cosine = dotProduct / denom;
+    }
+
+    scores[gid.x] = cosine * weights.x + recencyWts[gid.x] * weights.y;
+}
+
+kernel void topk_indices(
+    device const float* scores   [[buffer(0)]],
+    device uint* indices         [[buffer(1)]],
+    constant uint& n             [[buffer(2)]],
+    constant uint& k             [[buffer(3)]],
+    uint gid                     [[thread_position_in_grid]]
+) {
+    if (gid != 0) {
+        return;
+    }
+
+    if (n == 0 || k == 0) {
+        return;
+    }
+
+    const uint outCount = min(n, k);
+
+    for (uint rank = 0; rank < outCount; ++rank) {
+        float bestScore = -INFINITY;
+        uint bestIndex = 0;
+
+        for (uint i = 0; i < n; ++i) {
+            bool selected = false;
+            for (uint prev = 0; prev < rank; ++prev) {
+                if (indices[prev] == i) {
+                    selected = true;
+                    break;
+                }
+            }
+
+            if (selected) {
+                continue;
+            }
+
+            const float score = scores[i];
+            if (score > bestScore) {
+                bestScore = score;
+                bestIndex = i;
+            }
+        }
+
+        indices[rank] = bestIndex;
+    }
+
+    for (uint rank = outCount; rank < k; ++rank) {
+        indices[rank] = 0;
+    }
+}

--- a/Sources/ContextCoreShaders/Shaders/placeholder.txt
+++ b/Sources/ContextCoreShaders/Shaders/placeholder.txt
@@ -1,0 +1,1 @@
+// Placeholder shader resource for Phase 1.

--- a/Sources/ContextCoreTypes/ContextCoreTypes.swift
+++ b/Sources/ContextCoreTypes/ContextCoreTypes.swift
@@ -1,0 +1,2 @@
+/// Namespace marker for the `ContextCoreTypes` module.
+public enum ContextCoreTypesModule {}

--- a/Sources/ContextCoreTypes/Errors.swift
+++ b/Sources/ContextCoreTypes/Errors.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// Error surface for ContextCore operations.
+public enum ContextCoreError: Error, Sendable, Equatable {
+    /// Embedding generation failed.
+    case embeddingFailed(String)
+    /// A store reached capacity and cannot accept more entries.
+    case storeFull
+    /// The effective token budget is too small to fit required content.
+    case tokenBudgetTooSmall
+    /// A session-scoped API was called before starting a session.
+    case sessionNotStarted
+    /// Compression processing failed.
+    case compressionFailed(String)
+    /// Checkpoint data is missing or malformed.
+    case checkpointCorrupt
+    /// No Metal-capable device is available.
+    case metalDeviceUnavailable
+    /// Input vectors had inconsistent dimensionality.
+    case dimensionMismatch(expected: Int, got: Int)
+    /// Requested chunk ID was not found.
+    case chunkNotFound(id: UUID)
+}

--- a/Sources/ContextCoreTypes/Memory/MemoryChunk.swift
+++ b/Sources/ContextCoreTypes/Memory/MemoryChunk.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// Logical memory tier used by ContextCore.
+public enum MemoryType: String, Codable, Sendable, Hashable {
+    /// Turn-level conversational memory.
+    case episodic
+    /// Consolidated long-lived factual memory.
+    case semantic
+    /// Tool-usage and procedural memory.
+    case procedural
+}
+
+/// A retrievable memory item stored in ContextCore.
+public struct MemoryChunk: Identifiable, Codable, Sendable, Hashable {
+    /// Stable chunk identifier.
+    public let id: UUID
+    /// Raw chunk text.
+    public var content: String
+    /// Embedding vector used for semantic operations.
+    public var embedding: [Float]
+    /// Memory tier classification.
+    public let type: MemoryType
+    /// Original creation timestamp.
+    public let createdAt: Date
+    /// Last access timestamp.
+    public var lastAccessedAt: Date
+    /// Access count used for retention heuristics.
+    public var accessCount: Int
+    /// Retention score in `[0, 1]`.
+    public var retentionScore: Float
+    /// Session identifier where this chunk originated.
+    public let sourceSessionID: UUID
+    /// Arbitrary metadata associated with the chunk.
+    public var metadata: [String: String]
+
+    /// Creates a memory chunk.
+    ///
+    /// - Parameters:
+    ///   - id: Stable chunk identifier.
+    ///   - content: Text content.
+    ///   - embedding: Embedding vector.
+    ///   - type: Memory tier.
+    ///   - createdAt: Creation timestamp.
+    ///   - lastAccessedAt: Last access timestamp.
+    ///   - accessCount: Access counter.
+    ///   - retentionScore: Retention score in `[0, 1]`.
+    ///   - sourceSessionID: Source session identifier.
+    ///   - metadata: Optional metadata.
+    public init(
+        id: UUID = UUID(),
+        content: String,
+        embedding: [Float],
+        type: MemoryType,
+        createdAt: Date = .now,
+        lastAccessedAt: Date = .now,
+        accessCount: Int = 1,
+        retentionScore: Float,
+        sourceSessionID: UUID,
+        metadata: [String: String] = [:]
+    ) {
+        self.id = id
+        self.content = content
+        self.embedding = embedding
+        self.type = type
+        self.createdAt = createdAt
+        self.lastAccessedAt = lastAccessedAt
+        self.accessCount = accessCount
+        self.retentionScore = retentionScore
+        self.sourceSessionID = sourceSessionID
+        self.metadata = metadata
+    }
+}

--- a/Sources/ContextCoreTypes/Protocols/CompressionDelegate.swift
+++ b/Sources/ContextCoreTypes/Protocols/CompressionDelegate.swift
@@ -1,0 +1,19 @@
+/// Optional delegate for higher-level text compression and fact extraction.
+public protocol CompressionDelegate: Sendable {
+    /// Compress text to fit within targetTokens.
+    /// Implementations can be extractive or abstractive.
+    ///
+    /// - Parameters:
+    ///   - text: Input text to compress.
+    ///   - targetTokens: Desired token ceiling for output.
+    /// - Returns: Compressed text.
+    /// - Throws: Delegate-specific compression failures.
+    func compress(_ text: String, targetTokens: Int) async throws -> String
+
+    /// Extract standalone factual statements from text.
+    ///
+    /// - Parameter text: Source text.
+    /// - Returns: Extracted fact strings.
+    /// - Throws: Delegate-specific extraction failures.
+    func extractFacts(from text: String) async throws -> [String]
+}

--- a/Sources/ContextCoreTypes/Protocols/ConsolidationStores.swift
+++ b/Sources/ContextCoreTypes/Protocols/ConsolidationStores.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Episodic-store capabilities required by the consolidation pipeline.
+public protocol ConsolidationEpisodicStore: Sendable {
+    /// Current chunk count.
+    var count: Int { get async }
+    /// Returns all episodic chunks.
+    func allChunks() async -> [MemoryChunk]
+    /// Applies a retention-score delta to a chunk.
+    func updateRetentionScore(id: UUID, delta: Float) async throws
+    /// Removes a chunk by identifier.
+    func evict(id: UUID) async throws
+    /// Marks a chunk as consolidated.
+    func markConsolidated(id: UUID) async throws
+    /// Returns `true` when the chunk has already been consolidated.
+    func isConsolidated(id: UUID) async -> Bool
+}
+
+/// Semantic-store capabilities required by the consolidation pipeline.
+public protocol ConsolidationSemanticStore: Sendable {
+    /// Current chunk count.
+    var count: Int { get async }
+    /// Returns all semantic chunks.
+    func allChunks() async -> [MemoryChunk]
+    /// Upserts a fact and embedding into semantic memory.
+    func upsert(fact: String, embedding: [Float]) async throws
+}

--- a/Sources/ContextCoreTypes/Protocols/EmbeddingProvider.swift
+++ b/Sources/ContextCoreTypes/Protocols/EmbeddingProvider.swift
@@ -1,0 +1,17 @@
+/// Abstraction over embedding backends used by ContextCore.
+public protocol EmbeddingProvider: Sendable {
+    /// Produces an embedding for a single text input.
+    ///
+    /// - Parameter text: Input text to embed.
+    /// - Returns: A vector with fixed length ``dimension``.
+    /// - Throws: Any provider-specific embedding failure.
+    func embed(_ text: String) async throws -> [Float]
+    /// Produces embeddings for multiple inputs.
+    ///
+    /// - Parameter texts: Input texts.
+    /// - Returns: Embeddings in the same order as `texts`.
+    /// - Throws: Any provider-specific embedding failure.
+    func embedBatch(_ texts: [String]) async throws -> [[Float]]
+    /// Dimensionality produced by this provider.
+    var dimension: Int { get }
+}

--- a/Sources/ContextCoreTypes/Protocols/TokenCounter.swift
+++ b/Sources/ContextCoreTypes/Protocols/TokenCounter.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Counts tokens for a text string under a model-specific scheme.
+public protocol TokenCounter: Sendable {
+    /// Returns the token count for a text input.
+    ///
+    /// - Parameter text: Input text.
+    /// - Returns: Estimated token count.
+    func count(_ text: String) -> Int
+}
+
+/// Lightweight heuristic token counter used by default.
+public struct ApproximateTokenCounter: TokenCounter, Sendable {
+    /// Creates a default approximate token counter.
+    public init() {}
+
+    /// Estimates token count from alphanumeric segments.
+    ///
+    /// - Parameter text: Input text.
+    /// - Returns: Approximate count scaled by `1.3`.
+    public func count(_ text: String) -> Int {
+        guard !text.isEmpty else {
+            return 0
+        }
+
+        let words = text.split { character in
+            !(character.isLetter || character.isNumber)
+        }
+
+        guard !words.isEmpty else {
+            return 0
+        }
+
+        return Int(ceil(Double(words.count) * 1.3))
+    }
+}

--- a/Sources/ContextCoreTypes/Turn.swift
+++ b/Sources/ContextCoreTypes/Turn.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+/// Identifies the speaker or producer of a conversational turn.
+public enum TurnRole: String, Codable, Sendable, Hashable {
+    /// A user-authored turn.
+    case user
+    /// A model-authored assistant turn.
+    case assistant
+    /// Output emitted by a tool invocation.
+    case tool
+    /// A system instruction or policy turn.
+    case system
+}
+
+/// A single conversational event tracked by ContextCore.
+public struct Turn: Identifiable, Codable, Sendable, Hashable {
+    /// Stable identifier used for deduplication and retrieval tracking.
+    public let id: UUID
+    /// Role associated with this turn.
+    public let role: TurnRole
+    /// Raw textual content of the turn.
+    public let content: String
+    /// Timestamp when the turn was produced.
+    public let timestamp: Date
+    /// Token count estimate used for budgeting.
+    public var tokenCount: Int
+    /// Optional embedding vector for semantic retrieval.
+    public var embedding: [Float]?
+    /// Arbitrary metadata associated with the turn.
+    public var metadata: [String: String]
+
+    /// Creates a turn with optional precomputed metadata and embedding.
+    ///
+    /// - Parameters:
+    ///   - id: Stable identifier for the turn.
+    ///   - role: Logical speaker role.
+    ///   - content: Textual content.
+    ///   - timestamp: Creation time. Defaults to the current time.
+    ///   - tokenCount: Token estimate. Defaults to `0` and can be computed later.
+    ///   - embedding: Optional embedding vector.
+    ///   - metadata: Additional key-value metadata.
+    public init(
+        id: UUID = UUID(),
+        role: TurnRole,
+        content: String,
+        timestamp: Date = .now,
+        tokenCount: Int = 0,
+        embedding: [Float]? = nil,
+        metadata: [String: String] = [:]
+    ) {
+        self.id = id
+        self.role = role
+        self.content = content
+        self.timestamp = timestamp
+        self.tokenCount = tokenCount
+        self.embedding = embedding
+        self.metadata = metadata
+    }
+
+    /// Compares two turns by identity.
+    public static func == (lhs: Turn, rhs: Turn) -> Bool {
+        lhs.id == rhs.id
+    }
+
+    /// Hashes the turn by identity.
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+}
+
+/// Captures a single tool execution summary.
+public struct ToolCall: Codable, Sendable, Hashable {
+    /// Tool name.
+    public let name: String
+    /// Serialized input passed to the tool.
+    public let input: String
+    /// Serialized output returned by the tool.
+    public let output: String
+    /// Wall-clock duration of the call, in milliseconds.
+    public let durationMs: Double
+
+    /// Creates a tool call summary.
+    ///
+    /// - Parameters:
+    ///   - name: Tool name.
+    ///   - input: Serialized tool input.
+    ///   - output: Serialized tool output.
+    ///   - durationMs: Tool call duration in milliseconds.
+    public init(name: String, input: String, output: String, durationMs: Double) {
+        self.name = name
+        self.input = input
+        self.output = output
+        self.durationMs = durationMs
+    }
+}

--- a/Sources/HiveCore/Checkpointing/HiveCheckpointTypes.swift
+++ b/Sources/HiveCore/Checkpointing/HiveCheckpointTypes.swift
@@ -1,0 +1,395 @@
+import Foundation
+
+/// Optional fork lineage metadata persisted alongside checkpoints.
+public struct HiveCheckpointLineage: Codable, Sendable, Equatable {
+    public let lineageID: String
+    public let sourceThreadID: HiveThreadID
+    public let sourceCheckpointID: HiveCheckpointID
+    public let targetThreadID: HiveThreadID
+    public let sourceRunID: HiveRunID
+    public let targetRunID: HiveRunID
+    public let schemaVersion: String
+    public let graphVersion: String
+    public let createdAtNanoseconds: UInt64
+
+    public init(
+        lineageID: String,
+        sourceThreadID: HiveThreadID,
+        sourceCheckpointID: HiveCheckpointID,
+        targetThreadID: HiveThreadID,
+        sourceRunID: HiveRunID,
+        targetRunID: HiveRunID,
+        schemaVersion: String,
+        graphVersion: String,
+        createdAtNanoseconds: UInt64
+    ) {
+        self.lineageID = lineageID
+        self.sourceThreadID = sourceThreadID
+        self.sourceCheckpointID = sourceCheckpointID
+        self.targetThreadID = targetThreadID
+        self.sourceRunID = sourceRunID
+        self.targetRunID = targetRunID
+        self.schemaVersion = schemaVersion
+        self.graphVersion = graphVersion
+        self.createdAtNanoseconds = createdAtNanoseconds
+    }
+}
+
+/// Stable identifier for a checkpoint.
+public struct HiveCheckpointID: Hashable, Codable, Sendable {
+    public let rawValue: String
+
+    public init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+}
+
+/// Lightweight metadata describing an available checkpoint in a store.
+public struct HiveCheckpointSummary: Codable, Sendable, Equatable {
+    public let id: HiveCheckpointID
+    public let threadID: HiveThreadID
+    public let runID: HiveRunID
+    public let stepIndex: Int
+
+    public let schemaVersion: String?
+    public let graphVersion: String?
+    public let createdAt: Date?
+    public let backendID: String?
+
+    public init(
+        id: HiveCheckpointID,
+        threadID: HiveThreadID,
+        runID: HiveRunID,
+        stepIndex: Int,
+        schemaVersion: String? = nil,
+        graphVersion: String? = nil,
+        createdAt: Date? = nil,
+        backendID: String? = nil
+    ) {
+        self.id = id
+        self.threadID = threadID
+        self.runID = runID
+        self.stepIndex = stepIndex
+        self.schemaVersion = schemaVersion
+        self.graphVersion = graphVersion
+        self.createdAt = createdAt
+        self.backendID = backendID
+    }
+}
+
+/// Persisted frontier task snapshot.
+public struct HiveCheckpointTask: Codable, Sendable {
+    public let provenance: HiveTaskProvenance
+    public let nodeID: HiveNodeID
+    public let localFingerprint: Data
+    public let localDataByChannelID: [String: Data]
+
+    public init(
+        provenance: HiveTaskProvenance,
+        nodeID: HiveNodeID,
+        localFingerprint: Data,
+        localDataByChannelID: [String: Data]
+    ) {
+        self.provenance = provenance
+        self.nodeID = nodeID
+        self.localFingerprint = localFingerprint
+        self.localDataByChannelID = localDataByChannelID
+    }
+}
+
+/// Persisted snapshot of runtime state for resume.
+public struct HiveCheckpoint<Schema: HiveSchema>: Codable, Sendable {
+    public let id: HiveCheckpointID
+    public let threadID: HiveThreadID
+    public let runID: HiveRunID
+    public let stepIndex: Int
+    public let schemaVersion: String
+    public let graphVersion: String
+    /// Checkpoint format tag for forwards/backwards compatibility.
+    ///
+    /// - `"HCP1"`: v1 format without channel-versioning fields.
+    /// - `"HCP2"`: v1.1 format with channel versioning + triggers state.
+    public let checkpointFormatVersion: String
+    /// Version counters for global channels (missing entry implies version 0).
+    public let channelVersionsByChannelID: [String: UInt64]
+    /// Per-node versionsSeen snapshots for trigger channels.
+    public let versionsSeenByNodeID: [String: [String: UInt64]]
+    /// Optional convenience field for debugging: channels written in the last committed step.
+    public let updatedChannelsLastCommit: [String]
+    public let globalDataByChannelID: [String: Data]
+    public let frontier: [HiveCheckpointTask]
+    public let deferredFrontier: [HiveCheckpointTask]
+    public let joinBarrierSeenByJoinID: [String: [String]]
+    public let interruption: HiveInterrupt<Schema>?
+    public let lineage: HiveCheckpointLineage?
+
+    public init(
+        id: HiveCheckpointID,
+        threadID: HiveThreadID,
+        runID: HiveRunID,
+        stepIndex: Int,
+        schemaVersion: String,
+        graphVersion: String,
+        globalDataByChannelID: [String: Data],
+        frontier: [HiveCheckpointTask],
+        deferredFrontier: [HiveCheckpointTask] = [],
+        joinBarrierSeenByJoinID: [String: [String]],
+        interruption: HiveInterrupt<Schema>?,
+        lineage: HiveCheckpointLineage?
+    ) {
+        self.id = id
+        self.threadID = threadID
+        self.runID = runID
+        self.stepIndex = stepIndex
+        self.schemaVersion = schemaVersion
+        self.graphVersion = graphVersion
+        self.checkpointFormatVersion = "HCP2"
+        self.channelVersionsByChannelID = [:]
+        self.versionsSeenByNodeID = [:]
+        self.updatedChannelsLastCommit = []
+        self.globalDataByChannelID = globalDataByChannelID
+        self.frontier = frontier
+        self.deferredFrontier = deferredFrontier
+        self.joinBarrierSeenByJoinID = joinBarrierSeenByJoinID
+        self.interruption = interruption
+        self.lineage = lineage
+    }
+
+    public init(
+        id: HiveCheckpointID,
+        threadID: HiveThreadID,
+        runID: HiveRunID,
+        stepIndex: Int,
+        schemaVersion: String,
+        graphVersion: String,
+        globalDataByChannelID: [String: Data],
+        frontier: [HiveCheckpointTask],
+        deferredFrontier: [HiveCheckpointTask] = [],
+        joinBarrierSeenByJoinID: [String: [String]],
+        interruption: HiveInterrupt<Schema>?
+    ) {
+        self.init(
+            id: id,
+            threadID: threadID,
+            runID: runID,
+            stepIndex: stepIndex,
+            schemaVersion: schemaVersion,
+            graphVersion: graphVersion,
+            globalDataByChannelID: globalDataByChannelID,
+            frontier: frontier,
+            deferredFrontier: deferredFrontier,
+            joinBarrierSeenByJoinID: joinBarrierSeenByJoinID,
+            interruption: interruption,
+            lineage: nil
+        )
+    }
+
+    public init(
+        id: HiveCheckpointID,
+        threadID: HiveThreadID,
+        runID: HiveRunID,
+        stepIndex: Int,
+        schemaVersion: String,
+        graphVersion: String,
+        checkpointFormatVersion: String,
+        channelVersionsByChannelID: [String: UInt64],
+        versionsSeenByNodeID: [String: [String: UInt64]],
+        updatedChannelsLastCommit: [String],
+        globalDataByChannelID: [String: Data],
+        frontier: [HiveCheckpointTask],
+        deferredFrontier: [HiveCheckpointTask] = [],
+        joinBarrierSeenByJoinID: [String: [String]],
+        interruption: HiveInterrupt<Schema>?,
+        lineage: HiveCheckpointLineage?
+    ) {
+        self.id = id
+        self.threadID = threadID
+        self.runID = runID
+        self.stepIndex = stepIndex
+        self.schemaVersion = schemaVersion
+        self.graphVersion = graphVersion
+        self.checkpointFormatVersion = checkpointFormatVersion
+        self.channelVersionsByChannelID = channelVersionsByChannelID
+        self.versionsSeenByNodeID = versionsSeenByNodeID
+        self.updatedChannelsLastCommit = updatedChannelsLastCommit
+        self.globalDataByChannelID = globalDataByChannelID
+        self.frontier = frontier
+        self.deferredFrontier = deferredFrontier
+        self.joinBarrierSeenByJoinID = joinBarrierSeenByJoinID
+        self.interruption = interruption
+        self.lineage = lineage
+    }
+
+    public init(
+        id: HiveCheckpointID,
+        threadID: HiveThreadID,
+        runID: HiveRunID,
+        stepIndex: Int,
+        schemaVersion: String,
+        graphVersion: String,
+        checkpointFormatVersion: String,
+        channelVersionsByChannelID: [String: UInt64],
+        versionsSeenByNodeID: [String: [String: UInt64]],
+        updatedChannelsLastCommit: [String],
+        globalDataByChannelID: [String: Data],
+        frontier: [HiveCheckpointTask],
+        deferredFrontier: [HiveCheckpointTask] = [],
+        joinBarrierSeenByJoinID: [String: [String]],
+        interruption: HiveInterrupt<Schema>?
+    ) {
+        self.init(
+            id: id,
+            threadID: threadID,
+            runID: runID,
+            stepIndex: stepIndex,
+            schemaVersion: schemaVersion,
+            graphVersion: graphVersion,
+            checkpointFormatVersion: checkpointFormatVersion,
+            channelVersionsByChannelID: channelVersionsByChannelID,
+            versionsSeenByNodeID: versionsSeenByNodeID,
+            updatedChannelsLastCommit: updatedChannelsLastCommit,
+            globalDataByChannelID: globalDataByChannelID,
+            frontier: frontier,
+            deferredFrontier: deferredFrontier,
+            joinBarrierSeenByJoinID: joinBarrierSeenByJoinID,
+            interruption: interruption,
+            lineage: nil
+        )
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case threadID
+        case runID
+        case stepIndex
+        case schemaVersion
+        case graphVersion
+        case checkpointFormatVersion
+        case channelVersionsByChannelID
+        case versionsSeenByNodeID
+        case updatedChannelsLastCommit
+        case globalDataByChannelID
+        case frontier
+        case deferredFrontier
+        case joinBarrierSeenByJoinID
+        case interruption
+        case lineage
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.id = try container.decode(HiveCheckpointID.self, forKey: .id)
+        self.threadID = try container.decode(HiveThreadID.self, forKey: .threadID)
+        self.runID = try container.decode(HiveRunID.self, forKey: .runID)
+        self.stepIndex = try container.decode(Int.self, forKey: .stepIndex)
+        self.schemaVersion = try container.decode(String.self, forKey: .schemaVersion)
+        self.graphVersion = try container.decode(String.self, forKey: .graphVersion)
+
+        self.checkpointFormatVersion = try container.decodeIfPresent(String.self, forKey: .checkpointFormatVersion) ?? "HCP1"
+        self.channelVersionsByChannelID = try container.decodeIfPresent([String: UInt64].self, forKey: .channelVersionsByChannelID) ?? [:]
+        self.versionsSeenByNodeID = try container.decodeIfPresent([String: [String: UInt64]].self, forKey: .versionsSeenByNodeID) ?? [:]
+        self.updatedChannelsLastCommit = try container.decodeIfPresent([String].self, forKey: .updatedChannelsLastCommit) ?? []
+
+        self.globalDataByChannelID = try container.decode([String: Data].self, forKey: .globalDataByChannelID)
+        self.frontier = try container.decode([HiveCheckpointTask].self, forKey: .frontier)
+        self.deferredFrontier = try container.decodeIfPresent([HiveCheckpointTask].self, forKey: .deferredFrontier) ?? []
+        self.joinBarrierSeenByJoinID = try container.decode([String: [String]].self, forKey: .joinBarrierSeenByJoinID)
+        self.interruption = try container.decodeIfPresent(HiveInterrupt<Schema>.self, forKey: .interruption)
+        self.lineage = try container.decodeIfPresent(HiveCheckpointLineage.self, forKey: .lineage)
+    }
+}
+
+/// Storage backend for checkpoints.
+public protocol HiveCheckpointStore: Sendable {
+    associatedtype Schema: HiveSchema
+    func save(_ checkpoint: HiveCheckpoint<Schema>) async throws
+    func loadLatest(threadID: HiveThreadID) async throws -> HiveCheckpoint<Schema>?
+}
+
+/// Discoverable capabilities for a configured checkpoint store.
+public struct HiveCheckpointStoreCapabilities: Sendable, Equatable {
+    public let supportsListCheckpoints: Bool
+    public let supportsLoadCheckpointByID: Bool
+
+    public init(
+        supportsListCheckpoints: Bool,
+        supportsLoadCheckpointByID: Bool
+    ) {
+        self.supportsListCheckpoints = supportsListCheckpoints
+        self.supportsLoadCheckpointByID = supportsLoadCheckpointByID
+    }
+
+    public static let none = HiveCheckpointStoreCapabilities(
+        supportsListCheckpoints: false,
+        supportsLoadCheckpointByID: false
+    )
+
+    public static let queryable = HiveCheckpointStoreCapabilities(
+        supportsListCheckpoints: true,
+        supportsLoadCheckpointByID: true
+    )
+}
+
+/// Optional checkpoint store capability: list and load checkpoints by identifier.
+public protocol HiveCheckpointQueryableStore: HiveCheckpointStore {
+    func listCheckpoints(threadID: HiveThreadID, limit: Int?) async throws -> [HiveCheckpointSummary]
+    func loadCheckpoint(threadID: HiveThreadID, id: HiveCheckpointID) async throws -> HiveCheckpoint<Schema>?
+}
+
+/// Type-erased checkpoint store wrapper.
+public struct AnyHiveCheckpointStore<Schema: HiveSchema>: Sendable {
+    private let _save: @Sendable (HiveCheckpoint<Schema>) async throws -> Void
+    private let _loadLatest: @Sendable (HiveThreadID) async throws -> HiveCheckpoint<Schema>?
+    private let _listCheckpoints: (@Sendable (HiveThreadID, Int?) async throws -> [HiveCheckpointSummary])?
+    private let _loadCheckpoint: (@Sendable (HiveThreadID, HiveCheckpointID) async throws -> HiveCheckpoint<Schema>?)?
+    public let capabilities: HiveCheckpointStoreCapabilities
+
+    public init<S: HiveCheckpointStore>(_ store: S) where S.Schema == Schema {
+        self._save = store.save
+        self._loadLatest = store.loadLatest
+        self._listCheckpoints = nil
+        self._loadCheckpoint = nil
+        self.capabilities = .none
+    }
+
+    public init<Q: HiveCheckpointQueryableStore>(_ store: Q) where Q.Schema == Schema {
+        self._save = store.save
+        self._loadLatest = store.loadLatest
+        self._listCheckpoints = { threadID, limit in
+            try await store.listCheckpoints(threadID: threadID, limit: limit)
+        }
+        self._loadCheckpoint = { threadID, checkpointID in
+            try await store.loadCheckpoint(threadID: threadID, id: checkpointID)
+        }
+        self.capabilities = .queryable
+    }
+
+    public func save(_ checkpoint: HiveCheckpoint<Schema>) async throws {
+        try await _save(checkpoint)
+    }
+
+    public func loadLatest(threadID: HiveThreadID) async throws -> HiveCheckpoint<Schema>? {
+        try await _loadLatest(threadID)
+    }
+
+    public func listCheckpoints(
+        threadID: HiveThreadID,
+        limit: Int? = nil
+    ) async throws -> [HiveCheckpointSummary] {
+        guard let _listCheckpoints else {
+            throw HiveCheckpointQueryError.unsupported(operation: .listCheckpoints)
+        }
+        return try await _listCheckpoints(threadID, limit)
+    }
+
+    public func loadCheckpoint(
+        threadID: HiveThreadID,
+        id: HiveCheckpointID
+    ) async throws -> HiveCheckpoint<Schema>? {
+        guard let _loadCheckpoint else {
+            throw HiveCheckpointQueryError.unsupported(operation: .loadCheckpointByID)
+        }
+        return try await _loadCheckpoint(threadID, id)
+    }
+}

--- a/Sources/HiveCore/DataStructures/HiveBitset.swift
+++ b/Sources/HiveCore/DataStructures/HiveBitset.swift
@@ -1,0 +1,43 @@
+/// Compact dynamic bitset backed by 64-bit machine words.
+///
+/// The bitset size is fixed at initialization by `wordCount`.
+struct HiveBitset: Sendable, Equatable {
+    private var words: [UInt64]
+
+    init(wordCount: Int) {
+        self.words = Array(repeating: 0, count: max(wordCount, 0))
+    }
+
+    init(bitCapacity: Int) {
+        let wordsNeeded = max((max(bitCapacity, 0) + 63) / 64, 1)
+        self.init(wordCount: wordsNeeded)
+    }
+
+    var isEmpty: Bool {
+        words.allSatisfy { $0 == 0 }
+    }
+
+    mutating func removeAll() {
+        for index in words.indices {
+            words[index] = 0
+        }
+    }
+
+    mutating func insert(_ bitIndex: Int) {
+        guard let location = wordLocation(for: bitIndex) else { return }
+        words[location.word] |= location.mask
+    }
+
+    func contains(_ bitIndex: Int) -> Bool {
+        guard let location = wordLocation(for: bitIndex) else { return false }
+        return (words[location.word] & location.mask) != 0
+    }
+
+    private func wordLocation(for bitIndex: Int) -> (word: Int, mask: UInt64)? {
+        guard bitIndex >= 0 else { return nil }
+        let word = bitIndex / 64
+        guard words.indices.contains(word) else { return nil }
+        let bitOffset = bitIndex % 64
+        return (word: word, mask: UInt64(1) << UInt64(bitOffset))
+    }
+}

--- a/Sources/HiveCore/Errors/HiveCheckpointQueryError.swift
+++ b/Sources/HiveCore/Errors/HiveCheckpointQueryError.swift
@@ -1,0 +1,11 @@
+/// Checkpoint query operations exposed by optional checkpoint-store query APIs.
+public enum HiveCheckpointQueryOperation: Sendable, Equatable {
+    case listCheckpoints
+    case loadCheckpointByID
+}
+
+/// Errors related to optional checkpoint query capabilities.
+public enum HiveCheckpointQueryError: Error, Sendable, Equatable {
+    /// The configured checkpoint store does not support the requested query operation.
+    case unsupported(operation: HiveCheckpointQueryOperation)
+}

--- a/Sources/HiveCore/Errors/HiveErrorDescription.swift
+++ b/Sources/HiveCore/Errors/HiveErrorDescription.swift
@@ -1,0 +1,9 @@
+/// Shared error description formatting for redaction and debug payloads.
+internal enum HiveErrorDescription {
+    static func describe(_ error: Error, debugPayloads: Bool) -> String {
+        if debugPayloads {
+            return String(reflecting: error)
+        }
+        return String(describing: type(of: error))
+    }
+}

--- a/Sources/HiveCore/Errors/HiveEventReplayCompatibilityError.swift
+++ b/Sources/HiveCore/Errors/HiveEventReplayCompatibilityError.swift
@@ -1,0 +1,3 @@
+public enum HiveEventReplayCompatibilityError: Error, Sendable, Equatable {
+    case incompatibleSchemaVersion(expected: HiveEventSchemaVersion, found: HiveEventSchemaVersion)
+}

--- a/Sources/HiveCore/Errors/HiveExternalWriteError.swift
+++ b/Sources/HiveCore/Errors/HiveExternalWriteError.swift
@@ -1,0 +1,6 @@
+public enum HiveExternalWriteError: Error, Sendable, Equatable {
+    case unknownChannel(channelID: HiveChannelID)
+    case scopeMismatch(channelID: HiveChannelID, expected: HiveChannelScope, actual: HiveChannelScope)
+    case payloadTypeMismatch(channelID: HiveChannelID, expectedValueTypeID: String, actualValueTypeID: String)
+    case updatePolicyViolation(channelID: HiveChannelID, policy: HiveUpdatePolicy, writeCount: Int)
+}

--- a/Sources/HiveCore/Errors/HiveRunOptionsValidationError.swift
+++ b/Sources/HiveCore/Errors/HiveRunOptionsValidationError.swift
@@ -1,0 +1,5 @@
+public enum HiveRunOptionsValidationError: Error, Sendable, Equatable {
+    case invalidBounds(option: String, reason: String)
+    case unsupportedCombination(reason: String)
+    case missingRequiredComponent(component: String, reason: String)
+}

--- a/Sources/HiveCore/Errors/HiveRuntimeError.swift
+++ b/Sources/HiveCore/Errors/HiveRuntimeError.swift
@@ -1,0 +1,67 @@
+/// Runtime errors thrown during Hive execution.
+public enum HiveRuntimeError: Error, Sendable {
+    case invalidRunOptions(String)
+
+    case stepIndexOutOfRange(stepIndex: Int)
+    case taskOrdinalOutOfRange(ordinal: Int)
+    case invalidTaskLocalFingerprintLength(expected: Int, actual: Int)
+
+    case checkpointStoreMissing
+    case checkpointOverrideNotCheckpointed(channelID: HiveChannelID)
+    case checkpointVersionMismatch(
+        expectedSchema: String,
+        expectedGraph: String,
+        foundSchema: String,
+        foundGraph: String
+    )
+    case checkpointDecodeFailed(channelID: HiveChannelID, errorDescription: String)
+    case checkpointEncodeFailed(channelID: HiveChannelID, errorDescription: String)
+    case checkpointCorrupt(field: String, errorDescription: String)
+    case interruptPending(interruptID: HiveInterruptID)
+    case noCheckpointToResume
+    case checkpointNotFound(id: HiveCheckpointID)
+    case noInterruptToResume
+    case resumeInterruptMismatch(expected: HiveInterruptID, found: HiveInterruptID)
+    case forkSourceCheckpointMissing(threadID: HiveThreadID, checkpointID: HiveCheckpointID?)
+    case forkCheckpointStoreMissing
+    case forkCheckpointQueryUnsupported
+    case forkTargetThreadConflict(threadID: HiveThreadID)
+    case forkSchemaGraphMismatch(
+        expectedSchema: String,
+        expectedGraph: String,
+        foundSchema: String,
+        foundGraph: String
+    )
+    case forkMalformedCheckpoint(field: String, errorDescription: String)
+
+    case unknownNodeID(HiveNodeID)
+    /// Attempted to access a channel ID that is not present in the schema.
+    case unknownChannelID(HiveChannelID)
+    /// A required store/cache value for a declared channel was missing.
+    case storeValueMissing(channelID: HiveChannelID)
+    /// Stored value type does not match the expected channel value type.
+    case channelTypeMismatch(
+        channelID: HiveChannelID,
+        expectedValueTypeID: String,
+        actualValueTypeID: String
+    )
+    /// Channel scope does not match the store being accessed.
+    case scopeMismatch(
+        channelID: HiveChannelID,
+        expected: HiveChannelScope,
+        actual: HiveChannelScope
+    )
+    /// Required codec is missing for a channel.
+    case missingCodec(channelID: HiveChannelID)
+    /// Task-local fingerprint encoding failed for the selected channel.
+    case taskLocalFingerprintEncodeFailed(
+        channelID: HiveChannelID,
+        errorDescription: String
+    )
+
+    case updatePolicyViolation(channelID: HiveChannelID, policy: HiveUpdatePolicy, writeCount: Int)
+    case taskLocalWriteNotAllowed
+    case missingTaskLocalValue(channelID: HiveChannelID)
+
+    case internalInvariantViolation(String)
+}

--- a/Sources/HiveCore/Graph/HiveGraphBuilder.swift
+++ b/Sources/HiveCore/Graph/HiveGraphBuilder.swift
@@ -1,0 +1,457 @@
+/// Composable flags for node execution behavior.
+public struct HiveNodeOptions: OptionSet, Sendable {
+    public let rawValue: UInt8
+    public init(rawValue: UInt8) { self.rawValue = rawValue }
+
+    /// Run after all non-deferred frontier nodes complete in the current superstep.
+    /// Useful for cleanup, finalization, and summary nodes.
+    /// Deferred nodes execute only when the graph would otherwise finish (empty next frontier).
+    public static let deferred = HiveNodeOptions(rawValue: 1 << 0)
+}
+
+/// Compiled node configuration used by the runtime.
+public struct HiveCompiledNode<Schema: HiveSchema>: Sendable {
+    public let id: HiveNodeID
+    public let retryPolicy: HiveRetryPolicy
+    public let runWhen: HiveNodeRunWhen
+    public let options: HiveNodeOptions
+    public let cachePolicy: HiveCachePolicy<Schema>?
+    public let run: NodeAction<Schema>
+
+    public init(
+        id: HiveNodeID,
+        retryPolicy: HiveRetryPolicy,
+        runWhen: HiveNodeRunWhen = .always,
+        options: HiveNodeOptions = [],
+        cachePolicy: HiveCachePolicy<Schema>? = nil,
+        run: @escaping NodeAction<Schema>
+    ) {
+        self.id = id
+        self.retryPolicy = retryPolicy
+        self.runWhen = runWhen.normalized
+        self.options = options
+        self.cachePolicy = cachePolicy
+        self.run = run
+    }
+}
+
+struct HiveStaticEdge: Hashable, Sendable {
+    let from: HiveNodeID
+    let to: HiveNodeID
+}
+
+/// Join edge with canonical ID and sorted parent list.
+public struct HiveJoinEdge: Hashable, Sendable {
+    public let id: String
+    public let parents: [HiveNodeID]
+    public let target: HiveNodeID
+
+    public init(parents: [HiveNodeID], target: HiveNodeID) {
+        let sorted = parents.sorted { HiveOrdering.lexicographicallyPrecedes($0.rawValue, $1.rawValue) }
+        self.parents = sorted
+        self.target = target
+        self.id = HiveJoinEdge.canonicalID(parents: sorted, target: target)
+    }
+
+    static func canonicalID(parents: [HiveNodeID], target: HiveNodeID) -> String {
+        let parentIDs = parents.map { $0.rawValue }.joined(separator: "+")
+        return "join:\(parentIDs):\(target.rawValue)"
+    }
+}
+
+/// Fully compiled, validated graph for execution.
+public struct CompiledHiveGraph<Schema: HiveSchema>: Sendable {
+    public let schemaVersion: String
+    public let graphVersion: String
+    public let start: [HiveNodeID]
+    public let outputProjection: HiveOutputProjection
+    public let nodesByID: [HiveNodeID: HiveCompiledNode<Schema>]
+    let staticEdgesInOrder: [HiveStaticEdge]
+    public let staticEdgesByFrom: [HiveNodeID: [HiveNodeID]]
+    public let joinEdges: [HiveJoinEdge]
+    public let routersByFrom: [HiveNodeID: HiveRouter<Schema>]
+    let nodeOrdinalByID: [HiveNodeID: Int]
+    let joinEdgeByID: [String: HiveJoinEdge]
+    let joinEdgeOrderByID: [String: Int]
+    let joinEdgesByTarget: [HiveNodeID: [HiveJoinEdge]]
+    let joinEdgesByParent: [HiveNodeID: [HiveJoinEdge]]
+    let joinParentMaskByJoinID: [String: HiveBitset]
+    let joinBitsetWordCount: Int
+    let staticLayersByNodeID: [HiveNodeID: Int]
+    let maxStaticDepth: Int
+}
+
+/// Builder for assembling and compiling graphs.
+public struct HiveGraphBuilder<Schema: HiveSchema> {
+    private var start: [HiveNodeID]
+    private var nodes: [HiveNodeID: HiveCompiledNode<Schema>] = [:]
+    private var nodeInsertions: [HiveNodeID] = []
+    private var staticEdges: [(from: HiveNodeID, to: HiveNodeID)] = []
+    private var joinEdges: [(parents: [HiveNodeID], target: HiveNodeID)] = []
+    private var routers: [(from: HiveNodeID, router: HiveRouter<Schema>)] = []
+    private var outputProjection: HiveOutputProjection = .fullStore
+
+    public init(start: [HiveNodeID]) {
+        self.start = start
+    }
+
+    public mutating func addNode(
+        _ id: HiveNodeID,
+        retryPolicy: HiveRetryPolicy = .none,
+        runWhen: HiveNodeRunWhen = .always,
+        options: HiveNodeOptions = [],
+        cachePolicy: HiveCachePolicy<Schema>? = nil,
+        _ node: @escaping NodeAction<Schema>
+    ) {
+        nodeInsertions.append(id)
+        nodes[id] = HiveCompiledNode(
+            id: id, retryPolicy: retryPolicy, runWhen: runWhen,
+            options: options, cachePolicy: cachePolicy, run: node
+        )
+    }
+
+    public mutating func addEdge(from: HiveNodeID, to: HiveNodeID) {
+        staticEdges.append((from: from, to: to))
+    }
+
+    public mutating func addJoinEdge(parents: [HiveNodeID], target: HiveNodeID) {
+        joinEdges.append((parents: parents, target: target))
+    }
+
+    public mutating func addRouter(from: HiveNodeID, _ router: @escaping HiveRouter<Schema>) {
+        routers.append((from: from, router: router))
+    }
+
+    public mutating func setOutputProjection(_ projection: HiveOutputProjection) {
+        outputProjection = projection
+    }
+
+    public func compile(graphVersionOverride: String? = nil) throws -> CompiledHiveGraph<Schema> {
+        let registry = try HiveSchemaRegistry<Schema>()
+
+        try validateGraphStructure()
+        try validateNodeRunWhen(registry: registry)
+
+        let normalizedProjection = outputProjection.normalized()
+        try validateOutputProjection(normalizedProjection, registry: registry)
+
+        var edgesByFrom: [HiveNodeID: [HiveNodeID]] = [:]
+        for edge in staticEdges {
+            edgesByFrom[edge.from, default: []].append(edge.to)
+        }
+        let staticEdgesInOrder = staticEdges.map { HiveStaticEdge(from: $0.from, to: $0.to) }
+
+        var routersByFrom: [HiveNodeID: HiveRouter<Schema>] = [:]
+        for entry in routers {
+            routersByFrom[entry.from] = entry.router
+        }
+
+        let compiledJoinEdges = joinEdges.map { HiveJoinEdge(parents: $0.parents, target: $0.target) }
+        let sortedNodeIDs = nodes.keys.sorted { HiveOrdering.lexicographicallyPrecedes($0.rawValue, $1.rawValue) }
+        let nodeOrdinalByID = Dictionary(uniqueKeysWithValues: zip(sortedNodeIDs, sortedNodeIDs.indices))
+        let joinBitsetWordCount = max((sortedNodeIDs.count + 63) / 64, 1)
+
+        var joinEdgeByID: [String: HiveJoinEdge] = [:]
+        var joinEdgeOrderByID: [String: Int] = [:]
+        var joinEdgesByTarget: [HiveNodeID: [HiveJoinEdge]] = [:]
+        var joinEdgesByParent: [HiveNodeID: [HiveJoinEdge]] = [:]
+        var joinParentMaskByJoinID: [String: HiveBitset] = [:]
+
+        joinEdgeByID.reserveCapacity(compiledJoinEdges.count)
+        joinEdgeOrderByID.reserveCapacity(compiledJoinEdges.count)
+        joinParentMaskByJoinID.reserveCapacity(compiledJoinEdges.count)
+        for (index, edge) in compiledJoinEdges.enumerated() {
+            joinEdgeByID[edge.id] = edge
+            joinEdgeOrderByID[edge.id] = index
+            joinEdgesByTarget[edge.target, default: []].append(edge)
+
+            var parentMask = HiveBitset(wordCount: joinBitsetWordCount)
+            for parent in edge.parents {
+                if let ordinal = nodeOrdinalByID[parent] {
+                    parentMask.insert(ordinal)
+                }
+                joinEdgesByParent[parent, default: []].append(edge)
+            }
+            joinParentMaskByJoinID[edge.id] = parentMask
+        }
+
+        let staticLayerAnalysis = try computeStaticLayers()
+
+        let schemaVersion = HiveVersioning.schemaVersion(registry: registry)
+        let graphVersion = graphVersionOverride ?? HiveVersioning.graphVersion(
+            start: start,
+            nodesByID: nodes,
+            routerFrom: routers.map { $0.from },
+            staticEdges: staticEdges,
+            joinEdges: joinEdges,
+            outputProjection: normalizedProjection
+        )
+
+        return CompiledHiveGraph(
+            schemaVersion: schemaVersion,
+            graphVersion: graphVersion,
+            start: start,
+            outputProjection: normalizedProjection,
+            nodesByID: nodes,
+            staticEdgesInOrder: staticEdgesInOrder,
+            staticEdgesByFrom: edgesByFrom,
+            joinEdges: compiledJoinEdges,
+            routersByFrom: routersByFrom,
+            nodeOrdinalByID: nodeOrdinalByID,
+            joinEdgeByID: joinEdgeByID,
+            joinEdgeOrderByID: joinEdgeOrderByID,
+            joinEdgesByTarget: joinEdgesByTarget,
+            joinEdgesByParent: joinEdgesByParent,
+            joinParentMaskByJoinID: joinParentMaskByJoinID,
+            joinBitsetWordCount: joinBitsetWordCount,
+            staticLayersByNodeID: staticLayerAnalysis.layersByNodeID,
+            maxStaticDepth: staticLayerAnalysis.maxDepth
+        )
+    }
+
+    private func validateGraphStructure() throws {
+        if start.isEmpty {
+            throw HiveCompilationError.startEmpty
+        }
+
+        var startSeen: Set<HiveNodeID> = []
+        for node in start {
+            if startSeen.contains(node) {
+                throw HiveCompilationError.duplicateStartNode(node)
+            }
+            startSeen.insert(node)
+        }
+
+        if let duplicateNode = smallestDuplicateNodeID() {
+            throw HiveCompilationError.duplicateNodeID(duplicateNode)
+        }
+
+        if let invalidNode = smallestInvalidNodeID() {
+            throw HiveCompilationError.invalidNodeIDContainsReservedJoinCharacters(nodeID: invalidNode)
+        }
+
+        for node in start {
+            guard nodes[node] != nil else {
+                throw HiveCompilationError.unknownStartNode(node)
+            }
+        }
+
+        for edge in staticEdges {
+            if nodes[edge.from] == nil {
+                throw HiveCompilationError.unknownEdgeEndpoint(from: edge.from, to: edge.to, unknown: edge.from)
+            }
+            if nodes[edge.to] == nil {
+                throw HiveCompilationError.unknownEdgeEndpoint(from: edge.from, to: edge.to, unknown: edge.to)
+            }
+        }
+
+        var routersByFrom: Set<HiveNodeID> = []
+        for entry in routers {
+            if nodes[entry.from] == nil {
+                throw HiveCompilationError.unknownRouterFrom(entry.from)
+            }
+            if routersByFrom.contains(entry.from) {
+                throw HiveCompilationError.duplicateRouter(from: entry.from)
+            }
+            routersByFrom.insert(entry.from)
+        }
+
+        var seenJoinIDs: Set<String> = []
+        for edge in joinEdges {
+            let parents = edge.parents
+            if parents.isEmpty {
+                throw HiveCompilationError.invalidJoinEdgeParentsEmpty(target: edge.target)
+            }
+
+            var parentSeen: Set<HiveNodeID> = []
+            for parent in parents {
+                if parentSeen.contains(parent) {
+                    throw HiveCompilationError.invalidJoinEdgeParentsContainsDuplicate(
+                        parent: parent,
+                        target: edge.target
+                    )
+                }
+                parentSeen.insert(parent)
+            }
+
+            if parentSeen.contains(edge.target) {
+                throw HiveCompilationError.invalidJoinEdgeParentsContainsTarget(target: edge.target)
+            }
+
+            for parent in parents {
+                if nodes[parent] == nil {
+                    throw HiveCompilationError.unknownJoinParent(parent: parent, target: edge.target)
+                }
+            }
+
+            if nodes[edge.target] == nil {
+                throw HiveCompilationError.unknownJoinTarget(target: edge.target)
+            }
+
+            let joinID = HiveJoinEdge.canonicalID(
+                parents: parents.sorted { HiveOrdering.lexicographicallyPrecedes($0.rawValue, $1.rawValue) },
+                target: edge.target
+            )
+            if seenJoinIDs.contains(joinID) {
+                throw HiveCompilationError.duplicateJoinEdge(joinID: joinID)
+            }
+            seenJoinIDs.insert(joinID)
+        }
+    }
+
+    private func validateNodeRunWhen(registry: HiveSchemaRegistry<Schema>) throws {
+        let sortedNodeIDs = nodes.keys.sorted { HiveOrdering.lexicographicallyPrecedes($0.rawValue, $1.rawValue) }
+        for nodeID in sortedNodeIDs {
+            guard let node = nodes[nodeID] else { continue }
+            let normalized = node.runWhen.normalized
+            switch normalized {
+            case .always:
+                continue
+            case .anyOf(let channels), .allOf(let channels):
+                if channels.isEmpty {
+                    throw HiveCompilationError.invalidNodeRunWhenChannelsEmpty(nodeID: nodeID)
+                }
+                for channelID in channels {
+                    guard let spec = registry.channelSpecsByID[channelID] else {
+                        throw HiveCompilationError.invalidNodeRunWhenUnknownChannel(nodeID: nodeID, channelID: channelID)
+                    }
+                    if spec.scope != .global {
+                        throw HiveCompilationError.invalidNodeRunWhenIncludesTaskLocalChannel(
+                            nodeID: nodeID,
+                            channelID: channelID
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private func smallestDuplicateNodeID() -> HiveNodeID? {
+        var counts: [String: Int] = [:]
+        for id in nodeInsertions {
+            counts[id.rawValue, default: 0] += 1
+        }
+        var smallest: String?
+        for (raw, count) in counts where count > 1 {
+            if let current = smallest {
+                if HiveOrdering.lexicographicallyPrecedes(raw, current) {
+                    smallest = raw
+                }
+            } else {
+                smallest = raw
+            }
+        }
+        if let smallest {
+            return HiveNodeID(smallest)
+        }
+        return nil
+    }
+
+    private func smallestInvalidNodeID() -> HiveNodeID? {
+        var smallest: String?
+        for id in nodeInsertions {
+            let raw = id.rawValue
+            if raw.contains(":") || raw.contains("+") {
+                if let current = smallest {
+                    if HiveOrdering.lexicographicallyPrecedes(raw, current) {
+                        smallest = raw
+                    }
+                } else {
+                    smallest = raw
+                }
+            }
+        }
+        if let smallest {
+            return HiveNodeID(smallest)
+        }
+        return nil
+    }
+
+    private func validateOutputProjection(
+        _ projection: HiveOutputProjection,
+        registry: HiveSchemaRegistry<Schema>
+    ) throws {
+        switch projection {
+        case .fullStore:
+            return
+        case .channels(let ids):
+            for id in ids {
+                guard let spec = registry.channelSpecsByID[id] else {
+                    throw HiveCompilationError.outputProjectionUnknownChannel(id)
+                }
+                if spec.scope == .taskLocal {
+                    throw HiveCompilationError.outputProjectionIncludesTaskLocal(id)
+                }
+            }
+        }
+    }
+
+    private func computeStaticLayers() throws -> (layersByNodeID: [HiveNodeID: Int], maxDepth: Int) {
+        var inDegreeByNode: [HiveNodeID: Int] = [:]
+        var outgoingByNode: [HiveNodeID: [HiveNodeID]] = [:]
+        inDegreeByNode.reserveCapacity(nodes.count)
+        outgoingByNode.reserveCapacity(nodes.count)
+
+        for nodeID in nodes.keys {
+            inDegreeByNode[nodeID] = 0
+            outgoingByNode[nodeID] = []
+        }
+
+        for edge in staticEdges {
+            outgoingByNode[edge.from, default: []].append(edge.to)
+            inDegreeByNode[edge.to, default: 0] += 1
+        }
+
+        for (nodeID, neighbors) in outgoingByNode {
+            outgoingByNode[nodeID] = neighbors.sorted {
+                HiveOrdering.lexicographicallyPrecedes($0.rawValue, $1.rawValue)
+            }
+        }
+
+        var frontier = inDegreeByNode
+            .filter { $0.value == 0 }
+            .map(\.key)
+            .sorted { HiveOrdering.lexicographicallyPrecedes($0.rawValue, $1.rawValue) }
+        var remainingInDegree = inDegreeByNode
+        var maxParentDepthByNode: [HiveNodeID: Int] = [:]
+        var layersByNodeID: [HiveNodeID: Int] = [:]
+        layersByNodeID.reserveCapacity(nodes.count)
+        var visitedCount = 0
+
+        while frontier.isEmpty == false {
+            var nextFrontier: [HiveNodeID] = []
+            for nodeID in frontier {
+                visitedCount += 1
+                let depth = maxParentDepthByNode[nodeID] ?? 0
+                layersByNodeID[nodeID] = depth
+
+                for neighbor in outgoingByNode[nodeID] ?? [] {
+                    let candidateDepth = depth + 1
+                    if candidateDepth > (maxParentDepthByNode[neighbor] ?? 0) {
+                        maxParentDepthByNode[neighbor] = candidateDepth
+                    }
+                    guard let currentInDegree = remainingInDegree[neighbor] else { continue }
+                    let nextInDegree = currentInDegree - 1
+                    remainingInDegree[neighbor] = nextInDegree
+                    if nextInDegree == 0 {
+                        nextFrontier.append(neighbor)
+                    }
+                }
+            }
+
+            frontier = nextFrontier.sorted {
+                HiveOrdering.lexicographicallyPrecedes($0.rawValue, $1.rawValue)
+            }
+        }
+
+        if visitedCount != nodes.count {
+            let cycleNodes = remainingInDegree
+                .filter { $0.value > 0 }
+                .map(\.key)
+                .sorted { HiveOrdering.lexicographicallyPrecedes($0.rawValue, $1.rawValue) }
+            throw HiveCompilationError.staticGraphCycleDetected(nodes: cycleNodes)
+        }
+
+        return (layersByNodeID: layersByNodeID, maxDepth: layersByNodeID.values.max() ?? 0)
+    }
+}

--- a/Sources/HiveCore/Graph/HiveGraphDescription.swift
+++ b/Sources/HiveCore/Graph/HiveGraphDescription.swift
@@ -1,0 +1,137 @@
+import Foundation
+
+/// A stable, deterministic description of a compiled Hive graph.
+public struct HiveGraphDescription: Codable, Sendable, Equatable {
+    public struct StaticEdge: Codable, Sendable, Equatable {
+        public let from: HiveNodeID
+        public let to: HiveNodeID
+
+        public init(from: HiveNodeID, to: HiveNodeID) {
+            self.from = from
+            self.to = to
+        }
+    }
+
+    public struct JoinEdge: Codable, Sendable, Equatable {
+        public let id: String
+        public let parents: [HiveNodeID]
+        public let target: HiveNodeID
+
+        public init(id: String, parents: [HiveNodeID], target: HiveNodeID) {
+            self.id = id
+            self.parents = parents
+            self.target = target
+        }
+    }
+
+    public enum OutputProjection: Codable, Sendable, Equatable {
+        case fullStore
+        case channels([String])
+
+        private enum CodingKeys: String, CodingKey {
+            case fullStore
+            case channels
+        }
+
+        private struct Empty: Codable, Sendable {}
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            if container.contains(.fullStore) {
+                _ = try container.decode(Empty.self, forKey: .fullStore)
+                self = .fullStore
+                return
+            }
+            if container.contains(.channels) {
+                let ids = try container.decode([String].self, forKey: .channels)
+                self = .channels(ids)
+                return
+            }
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Expected one of: fullStore, channels"
+                )
+            )
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            switch self {
+            case .fullStore:
+                try container.encode(Empty(), forKey: .fullStore)
+            case .channels(let ids):
+                try container.encode(ids, forKey: .channels)
+            }
+        }
+    }
+
+    public let schemaVersion: String
+    public let graphVersion: String
+    /// Start node IDs in builder order.
+    public let start: [HiveNodeID]
+    /// All node IDs sorted lexicographically by UTF-8 on `rawValue`.
+    public let nodes: [HiveNodeID]
+    /// Static edges in builder insertion order.
+    public let staticEdges: [StaticEdge]
+    /// Join edges in builder insertion order, with canonical join IDs and sorted parents.
+    public let joinEdges: [JoinEdge]
+    /// Router "from" nodes sorted lexicographically by UTF-8 on `rawValue`.
+    public let routers: [HiveNodeID]
+    public let outputProjection: OutputProjection
+
+    public init(
+        schemaVersion: String,
+        graphVersion: String,
+        start: [HiveNodeID],
+        nodes: [HiveNodeID],
+        staticEdges: [StaticEdge],
+        joinEdges: [JoinEdge],
+        routers: [HiveNodeID],
+        outputProjection: OutputProjection
+    ) {
+        self.schemaVersion = schemaVersion
+        self.graphVersion = graphVersion
+        self.start = start
+        self.nodes = nodes
+        self.staticEdges = staticEdges
+        self.joinEdges = joinEdges
+        self.routers = routers
+        self.outputProjection = outputProjection
+    }
+}
+
+public extension CompiledHiveGraph {
+    /// Returns a deterministic description of the compiled graph.
+    ///
+    /// Determinism rules:
+    /// - Node listing order: lexicographic UTF-8 by `nodeID.rawValue`.
+    /// - Router listing order: lexicographic UTF-8 by `nodeID.rawValue`.
+    /// - Edge listing order: preserves builder insertion order for static and join edges.
+    func graphDescription() -> HiveGraphDescription {
+        let sortedNodes = nodesByID.keys.sorted { HiveOrdering.lexicographicallyPrecedes($0.rawValue, $1.rawValue) }
+        let staticEdges = staticEdgesInOrder.map { HiveGraphDescription.StaticEdge(from: $0.from, to: $0.to) }
+        let joinEdges = joinEdges.map {
+            HiveGraphDescription.JoinEdge(id: $0.id, parents: $0.parents, target: $0.target)
+        }
+        let sortedRouters = routersByFrom.keys.sorted { HiveOrdering.lexicographicallyPrecedes($0.rawValue, $1.rawValue) }
+
+        let projection: HiveGraphDescription.OutputProjection = switch outputProjection {
+        case .fullStore:
+            .fullStore
+        case .channels(let ids):
+            .channels(ids.map(\.rawValue))
+        }
+
+        return HiveGraphDescription(
+            schemaVersion: schemaVersion,
+            graphVersion: graphVersion,
+            start: start,
+            nodes: sortedNodes,
+            staticEdges: staticEdges,
+            joinEdges: joinEdges,
+            routers: sortedRouters,
+            outputProjection: projection
+        )
+    }
+}

--- a/Sources/HiveCore/Graph/HiveGraphMermaidExporter.swift
+++ b/Sources/HiveCore/Graph/HiveGraphMermaidExporter.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+public enum HiveGraphMermaidExporter {
+    public static func export(_ description: HiveGraphDescription) -> String {
+        var lines: [String] = []
+        lines.append("flowchart LR")
+
+        let nodeIDs = description.nodes
+        var mermaidIDByNodeID: [HiveNodeID: String] = [:]
+        mermaidIDByNodeID.reserveCapacity(nodeIDs.count)
+
+        for (index, nodeID) in nodeIDs.enumerated() {
+            let mermaidID = "node_\(index)"
+            mermaidIDByNodeID[nodeID] = mermaidID
+            lines.append("  \(mermaidID)[\"\(escapeMermaidLabel(nodeID.rawValue))\"]")
+        }
+
+        if !description.routers.isEmpty {
+            lines.append("  classDef router fill:#fff7ed,stroke:#c2410c,stroke-width:1px;")
+            for routerNodeID in description.routers {
+                guard let mermaidID = mermaidIDByNodeID[routerNodeID] else { continue }
+                lines.append("  class \(mermaidID) router")
+            }
+        }
+
+        for edge in description.staticEdges {
+            guard let from = mermaidIDByNodeID[edge.from],
+                  let to = mermaidIDByNodeID[edge.to] else { continue }
+            lines.append("  \(from) --> \(to)")
+        }
+
+        if !description.joinEdges.isEmpty {
+            lines.append("  classDef join fill:#eff6ff,stroke:#1d4ed8,stroke-width:1px;")
+        }
+
+        for (index, join) in description.joinEdges.enumerated() {
+            let joinID = "join_\(index + 1)"
+            lines.append("  \(joinID){\"\(escapeMermaidLabel(join.id))\"}")
+            lines.append("  class \(joinID) join")
+
+            for parent in join.parents {
+                guard let parentID = mermaidIDByNodeID[parent] else { continue }
+                lines.append("  \(parentID) --> \(joinID)")
+            }
+            if let targetID = mermaidIDByNodeID[join.target] {
+                lines.append("  \(joinID) --> \(targetID)")
+            }
+        }
+
+        return lines.joined(separator: "\n")
+    }
+
+    private static func escapeMermaidLabel(_ value: String) -> String {
+        value.replacingOccurrences(of: "\"", with: "\\\"")
+    }
+}

--- a/Sources/HiveCore/Graph/HiveNodeRunWhen.swift
+++ b/Sources/HiveCore/Graph/HiveNodeRunWhen.swift
@@ -1,0 +1,39 @@
+/// Compile-time trigger configuration for whether a node should be scheduled.
+///
+/// Triggers are evaluated deterministically at commit boundaries and must depend only on
+/// committed state (e.g., channel version counters), not dynamic read-tracking.
+public enum HiveNodeRunWhen: Sendable, Hashable {
+    /// v1 behavior: always schedule when a seed exists.
+    case always
+    /// Schedule when any referenced channel has advanced since the node last ran.
+    case anyOf(channels: [HiveChannelID])
+    /// Schedule when all referenced channels have advanced since the node last ran.
+    case allOf(channels: [HiveChannelID])
+
+    var normalized: HiveNodeRunWhen {
+        switch self {
+        case .always:
+            return .always
+        case .anyOf(let channels):
+            return .anyOf(channels: HiveOrdering.uniqueChannelIDs(channels))
+        case .allOf(let channels):
+            return .allOf(channels: HiveOrdering.uniqueChannelIDs(channels))
+        }
+    }
+
+    var triggerChannels: [HiveChannelID] {
+        switch normalized {
+        case .always:
+            return []
+        case .anyOf(let channels):
+            return channels
+        case .allOf(let channels):
+            return channels
+        }
+    }
+
+    var isDefaultAlways: Bool {
+        if case .always = self { return true }
+        return false
+    }
+}

--- a/Sources/HiveCore/Graph/HiveOrdering.swift
+++ b/Sources/HiveCore/Graph/HiveOrdering.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+enum HiveOrdering {
+    static func lexicographicallyPrecedes(_ lhs: String, _ rhs: String) -> Bool {
+        lhs.utf8.lexicographicallyPrecedes(rhs.utf8)
+    }
+
+    static func uniqueChannelIDs(_ ids: [HiveChannelID]) -> [HiveChannelID] {
+        var seen: Set<String> = []
+        var unique: [HiveChannelID] = []
+        unique.reserveCapacity(ids.count)
+        for id in ids {
+            let raw = id.rawValue
+            if seen.insert(raw).inserted {
+                unique.append(id)
+            }
+        }
+        unique.sort { lexicographicallyPrecedes($0.rawValue, $1.rawValue) }
+        return unique
+    }
+
+    static func uniqueNodeIDs(_ ids: [HiveNodeID]) -> [HiveNodeID] {
+        var seen: Set<String> = []
+        var unique: [HiveNodeID] = []
+        unique.reserveCapacity(ids.count)
+        for id in ids {
+            let raw = id.rawValue
+            if seen.insert(raw).inserted {
+                unique.append(id)
+            }
+        }
+        unique.sort { lexicographicallyPrecedes($0.rawValue, $1.rawValue) }
+        return unique
+    }
+}

--- a/Sources/HiveCore/Graph/HiveOutputProjection.swift
+++ b/Sources/HiveCore/Graph/HiveOutputProjection.swift
@@ -1,0 +1,17 @@
+/// Controls which parts of the global store are returned as output.
+public enum HiveOutputProjection: Sendable {
+    case fullStore
+    case channels([HiveChannelID])
+}
+
+extension HiveOutputProjection {
+    func normalized() -> HiveOutputProjection {
+        switch self {
+        case .fullStore:
+            return .fullStore
+        case .channels(let ids):
+            let unique = HiveOrdering.uniqueChannelIDs(ids)
+            return .channels(unique)
+        }
+    }
+}

--- a/Sources/HiveCore/Graph/HiveRouting.swift
+++ b/Sources/HiveCore/Graph/HiveRouting.swift
@@ -1,0 +1,39 @@
+/// Identifier for a graph node.
+public struct HiveNodeID: Hashable, Codable, Sendable {
+    public let rawValue: String
+
+    public init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+}
+
+/// Routing decision for the next frontier.
+public enum Route: Sendable, Equatable {
+    case useGraphEdges
+    case end
+    case to([HiveNodeID])
+
+    var normalized: Route {
+        switch self {
+        case .to(let nodes) where nodes.isEmpty:
+            return .end
+        default:
+            return self
+        }
+    }
+}
+
+extension Route: ExpressibleByStringLiteral {
+    public init(stringLiteral value: String) {
+        self = .to([HiveNodeID(value)])
+    }
+}
+
+extension Route: ExpressibleByArrayLiteral {
+    public init(arrayLiteral elements: HiveNodeID...) {
+        self = .to(elements)
+    }
+}
+
+/// Deterministic router used to select next nodes for a task.
+public typealias HiveRouter<Schema: HiveSchema> = @Sendable (HiveStoreView<Schema>) -> Route

--- a/Sources/HiveCore/Graph/HiveVersioning.swift
+++ b/Sources/HiveCore/Graph/HiveVersioning.swift
@@ -1,0 +1,224 @@
+import Foundation
+
+enum HiveVersioning {
+    static func schemaVersion<Schema: HiveSchema>(registry: HiveSchemaRegistry<Schema>) -> String {
+        var bytes = Data()
+        bytes.append(contentsOf: [0x48, 0x53, 0x56, 0x32]) // HSV2
+        bytes.append(0x43)
+        appendUInt32BE(UInt32(registry.sortedChannelSpecs.count), to: &bytes)
+
+        for spec in registry.sortedChannelSpecs {
+            let idData = Data(spec.id.rawValue.utf8)
+            appendUInt32BE(UInt32(idData.count), to: &bytes)
+            bytes.append(idData)
+            bytes.append(scopeByte(spec.scope))
+            bytes.append(persistenceByte(spec.persistence))
+            bytes.append(updatePolicyByte(spec.updatePolicy))
+            let valueTypeData = Data(spec.valueTypeID.utf8)
+            appendUInt32BE(UInt32(valueTypeData.count), to: &bytes)
+            bytes.append(valueTypeData)
+            let codecID = spec.codecID ?? ""
+            let codecData = Data(codecID.utf8)
+            appendUInt32BE(UInt32(codecData.count), to: &bytes)
+            bytes.append(codecData)
+        }
+
+        return sha256Hex(bytes)
+    }
+
+    static func graphVersion<Schema: HiveSchema>(
+        start: [HiveNodeID],
+        nodesByID: [HiveNodeID: HiveCompiledNode<Schema>],
+        routerFrom: [HiveNodeID],
+        staticEdges: [(from: HiveNodeID, to: HiveNodeID)],
+        joinEdges: [(parents: [HiveNodeID], target: HiveNodeID)],
+        outputProjection: HiveOutputProjection
+    ) -> String {
+        let usesTriggers = nodesByID.values.contains { $0.runWhen.isDefaultAlways == false }
+
+        var bytes = Data()
+        if usesTriggers {
+            bytes.append(contentsOf: [0x48, 0x47, 0x56, 0x34]) // HGV4
+        } else {
+            bytes.append(contentsOf: [0x48, 0x47, 0x56, 0x33]) // HGV3
+        }
+
+        appendGraphCore(
+            start: start,
+            nodesByID: nodesByID,
+            routerFrom: routerFrom,
+            staticEdges: staticEdges,
+            joinEdges: joinEdges,
+            outputProjection: outputProjection,
+            to: &bytes
+        )
+
+        if usesTriggers {
+            appendTriggerConfig(nodesByID: nodesByID, to: &bytes)
+        }
+
+        return sha256Hex(bytes)
+    }
+
+    private static func appendGraphCore<Schema: HiveSchema>(
+        start: [HiveNodeID],
+        nodesByID: [HiveNodeID: HiveCompiledNode<Schema>],
+        routerFrom: [HiveNodeID],
+        staticEdges: [(from: HiveNodeID, to: HiveNodeID)],
+        joinEdges: [(parents: [HiveNodeID], target: HiveNodeID)],
+        outputProjection: HiveOutputProjection,
+        to bytes: inout Data
+    ) {
+        bytes.append(0x53) // S
+        appendUInt32BE(UInt32(start.count), to: &bytes)
+        for id in start {
+            appendID(id.rawValue, to: &bytes)
+        }
+
+        bytes.append(0x4E) // N
+        let sortedNodes = nodesByID.keys.sorted { HiveOrdering.lexicographicallyPrecedes($0.rawValue, $1.rawValue) }
+        appendUInt32BE(UInt32(sortedNodes.count), to: &bytes)
+        for id in sortedNodes {
+            appendID(id.rawValue, to: &bytes)
+            if let node = nodesByID[id] {
+                appendRetryPolicy(node.retryPolicy, to: &bytes)
+            }
+        }
+
+        bytes.append(0x52) // R
+        let sortedRouters = routerFrom.sorted { HiveOrdering.lexicographicallyPrecedes($0.rawValue, $1.rawValue) }
+        appendUInt32BE(UInt32(sortedRouters.count), to: &bytes)
+        for id in sortedRouters {
+            appendID(id.rawValue, to: &bytes)
+        }
+
+        bytes.append(0x45) // E
+        appendUInt32BE(UInt32(staticEdges.count), to: &bytes)
+        for edge in staticEdges {
+            appendID(edge.from.rawValue, to: &bytes)
+            appendID(edge.to.rawValue, to: &bytes)
+        }
+
+        bytes.append(0x4A) // J
+        appendUInt32BE(UInt32(joinEdges.count), to: &bytes)
+        for edge in joinEdges {
+            appendID(edge.target.rawValue, to: &bytes)
+            let parents = edge.parents.sorted { HiveOrdering.lexicographicallyPrecedes($0.rawValue, $1.rawValue) }
+            appendUInt32BE(UInt32(parents.count), to: &bytes)
+            for parent in parents {
+                appendID(parent.rawValue, to: &bytes)
+            }
+        }
+
+        bytes.append(0x4F) // O
+        switch outputProjection {
+        case .fullStore:
+            bytes.append(0)
+        case .channels(let ids):
+            bytes.append(1)
+            let normalized = HiveOrdering.uniqueChannelIDs(ids)
+            appendUInt32BE(UInt32(normalized.count), to: &bytes)
+            for id in normalized {
+                appendID(id.rawValue, to: &bytes)
+            }
+        }
+    }
+
+    private static func appendTriggerConfig<Schema: HiveSchema>(
+        nodesByID: [HiveNodeID: HiveCompiledNode<Schema>],
+        to bytes: inout Data
+    ) {
+        bytes.append(0x54) // T
+        let triggerNodes = nodesByID.values
+            .filter { $0.runWhen.isDefaultAlways == false }
+            .sorted { HiveOrdering.lexicographicallyPrecedes($0.id.rawValue, $1.id.rawValue) }
+
+        appendUInt32BE(UInt32(triggerNodes.count), to: &bytes)
+        for node in triggerNodes {
+            appendID(node.id.rawValue, to: &bytes)
+            switch node.runWhen.normalized {
+            case .always:
+                bytes.append(0)
+                appendUInt32BE(0, to: &bytes)
+            case .anyOf(let channels):
+                bytes.append(1)
+                appendUInt32BE(UInt32(channels.count), to: &bytes)
+                for id in channels {
+                    appendID(id.rawValue, to: &bytes)
+                }
+            case .allOf(let channels):
+                bytes.append(2)
+                appendUInt32BE(UInt32(channels.count), to: &bytes)
+                for id in channels {
+                    appendID(id.rawValue, to: &bytes)
+                }
+            }
+        }
+    }
+
+    private static func appendID(_ value: String, to data: inout Data) {
+        let bytes = Data(value.utf8)
+        appendUInt32BE(UInt32(bytes.count), to: &data)
+        data.append(bytes)
+    }
+
+    private static func appendUInt32BE(_ value: UInt32, to data: inout Data) {
+        var bigEndian = value.bigEndian
+        withUnsafeBytes(of: &bigEndian) { data.append(contentsOf: $0) }
+    }
+
+    private static func appendUInt64BE(_ value: UInt64, to data: inout Data) {
+        var bigEndian = value.bigEndian
+        withUnsafeBytes(of: &bigEndian) { data.append(contentsOf: $0) }
+    }
+
+    private static func appendInt64BE(_ value: Int64, to data: inout Data) {
+        var bigEndian = value.bigEndian
+        withUnsafeBytes(of: &bigEndian) { data.append(contentsOf: $0) }
+    }
+
+    private static func appendRetryPolicy(_ policy: HiveRetryPolicy, to bytes: inout Data) {
+        switch policy {
+        case .none:
+            bytes.append(0)
+        case .exponentialBackoff(
+            let initialNanoseconds,
+            let factor,
+            let maxAttempts,
+            let maxNanoseconds
+        ):
+            bytes.append(1)
+            appendUInt64BE(initialNanoseconds, to: &bytes)
+            appendUInt64BE(factor.bitPattern, to: &bytes)
+            appendInt64BE(Int64(maxAttempts), to: &bytes)
+            appendUInt64BE(maxNanoseconds, to: &bytes)
+        }
+    }
+
+    private static func scopeByte(_ scope: HiveChannelScope) -> UInt8 {
+        switch scope {
+        case .global: return 0
+        case .taskLocal: return 1
+        }
+    }
+
+    private static func persistenceByte(_ persistence: HiveChannelPersistence) -> UInt8 {
+        switch persistence {
+        case .checkpointed: return 0
+        case .untracked: return 1
+        case .ephemeral: return 2
+        }
+    }
+
+    private static func updatePolicyByte(_ policy: HiveUpdatePolicy) -> UInt8 {
+        switch policy {
+        case .single: return 0
+        case .multi: return 1
+        }
+    }
+
+    private static func sha256Hex(_ data: Data) -> String {
+        let hash = HiveSHA256.hash(data: data)
+        return hash.compactMap { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Sources/HiveCore/HiveCore.docc/BuildingGraphs.md
+++ b/Sources/HiveCore/HiveCore.docc/BuildingGraphs.md
@@ -1,0 +1,113 @@
+# Building Graphs
+
+Construct workflow graphs with the imperative graph builder, validate them, and export visualizations.
+
+## Overview
+
+A compiled graph is the executable representation of a workflow. It contains nodes, edges, routers, and join barriers validated by the compiler. Build graphs explicitly with ``HiveGraphBuilder``.
+
+## HiveGraphBuilder
+
+``HiveGraphBuilder`` provides the imperative API for constructing graphs:
+
+```swift
+var builder = HiveGraphBuilder<Schema>(
+    start: [HiveNodeID("A")]
+)
+
+builder.addNode(HiveNodeID("A")) { input in
+    HiveNodeOutput(
+        writes: [AnyHiveWrite(key, value)],
+        next: .useGraphEdges
+    )
+}
+
+builder.addNode(HiveNodeID("B")) { _ in
+    HiveNodeOutput(next: .end)
+}
+
+builder.addEdge(from: HiveNodeID("A"), to: HiveNodeID("B"))
+```
+
+### Join edges
+
+Join barriers wait for all parent nodes to complete before firing:
+
+```swift
+builder.addJoinEdge(
+    parents: [HiveNodeID("W1"), HiveNodeID("W2")],
+    target: HiveNodeID("Gate")
+)
+```
+
+### Routers
+
+Routers provide dynamic routing based on post-commit state:
+
+```swift
+builder.addRouter(from: HiveNodeID("A")) { storeView in
+    .to([HiveNodeID("B")])
+}
+```
+
+## Compilation
+
+Call `compile()` to produce a validated, immutable ``CompiledHiveGraph``:
+
+```swift
+let graph = try builder.compile()
+```
+
+### Validation rules
+
+`compile()` validates:
+
+- No duplicate node IDs
+- All edge targets reference existing nodes
+- Start nodes exist in the graph
+- No cycles in static edges (throws `staticGraphCycleDetected`)
+- Router-only cycles are allowed (they're dynamic)
+
+## CompiledHiveGraph
+
+The compiled graph is immutable and `Sendable`:
+
+```swift
+public struct CompiledHiveGraph<Schema: HiveSchema>: Sendable {
+    public let start: [HiveNodeID]
+    public let staticLayersByNodeID: [HiveNodeID: Int]
+    public let maxStaticDepth: Int
+}
+```
+
+## Graph description
+
+`graphDescription()` produces a deterministic JSON representation with a SHA-256 version hash. Identical graphs always produce identical JSON — enabling golden tests:
+
+```swift
+let description = graph.graphDescription()
+// description.versionHash is a stable SHA-256
+```
+
+## Mermaid export
+
+``HiveGraphMermaidExporter`` converts a graph description to a Mermaid flowchart for visualization:
+
+```swift
+let mermaid = HiveGraphMermaidExporter.export(description)
+```
+
+Produces output like:
+
+```
+flowchart TD
+    Start --> WorkerA
+    Start --> WorkerB
+    WorkerA --> Gate
+    WorkerB --> Gate
+    Gate --> Finalize
+```
+
+## Static layer analysis
+
+The compiler computes static layer depths via topological ordering. This enables optimizations and visualization of the graph's parallel structure. Access via `staticLayersByNodeID` and `maxStaticDepth` on the compiled graph.

--- a/Sources/HiveCore/HiveCore.docc/CheckpointingAndResume.md
+++ b/Sources/HiveCore/HiveCore.docc/CheckpointingAndResume.md
@@ -1,0 +1,120 @@
+# Checkpointing and Resume
+
+Save workflow state, resume from interrupts, and implement persistent checkpoint stores.
+
+## Overview
+
+Hive's checkpointing system captures complete runtime state snapshots — store values, frontier tasks, join barriers, and pending interrupts. Combined with the interrupt/resume protocol, this enables long-running workflows that pause for human approval and resume with typed payloads.
+
+## Checkpoint format
+
+``HiveCheckpoint`` captures a complete runtime state snapshot:
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `id` | ``HiveCheckpointID`` | Deterministic identifier |
+| `threadID` | ``HiveThreadID`` | Thread this belongs to |
+| `stepIndex` | `Int` | Superstep index at save time |
+| `globalDataByChannelID` | `[String: Data]` | Encoded global store values |
+| `frontier` | `[HiveCheckpointTask]` | Persisted frontier tasks |
+| `joinBarrierSeenByJoinID` | `[String: [String]]` | Join barrier state |
+| `interruption` | `HiveInterrupt?` | Pending interrupt |
+| `channelVersionsByChannelID` | `[String: UInt64]` | Version counters |
+
+## Checkpoint store protocol
+
+Implement ``HiveCheckpointStore`` to persist checkpoints:
+
+```swift
+public protocol HiveCheckpointStore: Sendable {
+    associatedtype Schema: HiveSchema
+    func save(_ checkpoint: HiveCheckpoint<Schema>) async throws
+    func loadLatest(
+        threadID: HiveThreadID
+    ) async throws -> HiveCheckpoint<Schema>?
+}
+```
+
+For history browsing, ``HiveCheckpointQueryableStore`` adds `listCheckpoints` and `loadCheckpoint`.
+
+`fork` uses these capabilities as follows:
+- Explicit checkpoint fork (`from: checkpointID`) requires `loadCheckpoint` support.
+- Latest-checkpoint fork (`from: nil`) uses `loadLatest`.
+- If query support is unavailable for explicit ID lookup, fork fails with typed runtime error.
+
+## Checkpoint policies
+
+``HiveCheckpointPolicy`` controls when checkpoints are saved:
+
+```swift
+public enum HiveCheckpointPolicy: Sendable {
+    case disabled
+    case everyStep
+    case every(steps: Int)
+    case onInterrupt
+}
+```
+
+## Interrupt flow
+
+1. A node returns a ``HiveInterruptRequest`` with a typed payload
+2. The runtime selects the interrupt from the lowest-ordinal task (deterministic)
+3. A checkpoint is saved with the interrupt embedded
+4. The run outcome is `.interrupted` with a ``HiveInterruption``
+
+```swift
+Node("review") { _ in
+    Effects { Interrupt("Approve results?") }
+}
+
+// Handle the interrupt
+let handle = await runtime.run(
+    threadID: tid, input: (), options: opts
+)
+let outcome = try await handle.outcome.value
+guard case let .interrupted(interruption) = outcome else { return }
+```
+
+## Resume flow
+
+1. Call `runtime.resume(threadID:interruptID:payload:options:)`
+2. The runtime loads the latest checkpoint and verifies the interrupt ID matches
+3. A ``HiveResume`` is delivered to nodes via `input.run.resume`
+4. Execution continues from the saved frontier
+
+```swift
+let resumed = await runtime.resume(
+    threadID: tid,
+    interruptID: interruption.interrupt.id,
+    payload: "approved",
+    options: opts
+)
+let final = try await resumed.outcome.value
+```
+
+## Interrupt type system
+
+| Type | Direction | Purpose |
+|------|-----------|---------|
+| ``HiveInterruptRequest`` | Node to runtime | Request to pause |
+| ``HiveInterrupt`` | Persisted | Saved in checkpoint (id + payload) |
+| ``HiveResume`` | Runtime to node | Resume data for next execution |
+| ``HiveInterruption`` | Run outcome | Interrupt + checkpoint ID |
+
+## Fork contract
+
+Use `runtime.fork(threadID:to:from:options:)` to branch a new thread lineage from checkpoint state.
+
+API-level guarantees:
+- deterministic checkpoint selection (`from` explicit ID or latest)
+- explicit source/target thread identity in ``HiveForkResult``
+- optional durable target checkpoint when `options?.checkpointPolicy != .disabled`
+- independent target lineage (future target writes do not mutate source)
+
+Failure semantics (fail-closed, typed errors):
+- `forkCheckpointStoreMissing`
+- `forkSourceCheckpointMissing`
+- `forkCheckpointQueryUnsupported`
+- `forkTargetThreadConflict`
+- `forkSchemaGraphMismatch`
+- `forkMalformedCheckpoint`

--- a/Sources/HiveCore/HiveCore.docc/DefiningASchema.md
+++ b/Sources/HiveCore/HiveCore.docc/DefiningASchema.md
@@ -1,0 +1,160 @@
+# Defining a Schema
+
+Declare typed state channels with reducers, scopes, codecs, and persistence levels.
+
+## Overview
+
+Every Hive workflow is parameterized by a schema — an enum conforming to ``HiveSchema`` — that declares the typed channels nodes read from and write to. The schema defines what data flows through the graph, how concurrent writes merge, and what state survives checkpointing.
+
+## The HiveSchema protocol
+
+```swift
+public protocol HiveSchema: Sendable {
+    associatedtype Context: Sendable = Void
+    associatedtype Input: Sendable = Void
+    associatedtype InterruptPayload: Codable & Sendable = String
+    associatedtype ResumePayload: Codable & Sendable = String
+
+    static var channelSpecs: [AnyHiveChannelSpec<Self>] { get }
+    static func inputWrites(_ input: Input, inputContext: HiveInputContext) throws -> [AnyHiveWrite<Self>]
+}
+```
+
+| Associated Type | Purpose |
+|----------------|---------|
+| `Context` | User-defined context passed to every node via ``HiveEnvironment`` |
+| `Input` | Typed input for `runtime.run()` — converted to writes before step 0 |
+| `InterruptPayload` | Data type attached to interrupt requests |
+| `ResumePayload` | Data type provided when resuming from an interrupt |
+
+## Channel specs
+
+Each channel is declared via ``HiveChannelSpec``:
+
+```swift
+public struct HiveChannelSpec<Schema: HiveSchema, Value: Sendable>: Sendable {
+    public let key: HiveChannelKey<Schema, Value>
+    public let scope: HiveChannelScope
+    public let reducer: HiveReducer<Value>
+    public let updatePolicy: HiveUpdatePolicy
+    public let initial: @Sendable () -> Value
+    public let codec: HiveAnyCodec<Value>?
+    public let persistence: HiveChannelPersistence
+}
+```
+
+## Channel keys
+
+``HiveChannelKey`` provides type-safe references to channels:
+
+```swift
+let messages = HiveChannelKey<MySchema, [String]>(HiveChannelID("messages"))
+let score = HiveChannelKey<MySchema, Int>(HiveChannelID("score"))
+```
+
+## Scopes
+
+| Scope | Store | Visibility |
+|-------|-------|-----------|
+| `.global` | ``HiveGlobalStore`` | Shared across all tasks in a thread |
+| `.taskLocal` | ``HiveTaskLocalStore`` | Isolated per spawned task (fan-out) |
+
+## Persistence modes
+
+| Level | Checkpointed? | Reset behavior |
+|-------|--------------|----------------|
+| `.checkpointed` | Yes | Survives across interrupt/resume |
+| `.untracked` | No | Preserved across supersteps, not saved |
+| `.ephemeral` | No | Reset to `initial()` after each superstep |
+
+## Reducers
+
+When multiple nodes write to the same channel in one superstep, the ``HiveReducer`` defines how writes merge:
+
+| Reducer | Constraint | Behavior |
+|---------|-----------|----------|
+| `.lastWriteWins()` | Any | Replaces current with update |
+| `.append()` | `RangeReplaceableCollection` | Appends update to current |
+| `.appendNonNil()` | Optional collection | Nil-safe append |
+| `.setUnion()` | `Set<Hashable>` | Union of current and update |
+| `.dictionaryMerge(valueReducer:)` | `[String: V]` | Merges dicts, resolving via inner reducer |
+| `.sum()` | `Numeric` | Adds current + update |
+| `.min()` | `Comparable` | Keeps the lesser value |
+| `.max()` | `Comparable` | Keeps the greater value |
+| `.binaryOp(_:)` | Any | Custom binary operator |
+
+You can also provide a fully custom reducer:
+
+```swift
+HiveReducer { current, update in
+    // your merge logic
+}
+```
+
+## Codecs
+
+Channels that are checkpointed or task-local require a ``HiveCodec`` for serialization:
+
+```swift
+public protocol HiveCodec: Sendable {
+    associatedtype Value: Sendable
+    var id: String { get }
+    func encode(_ value: Value) throws -> Data
+    func decode(_ data: Data) throws -> Value
+}
+```
+
+The built-in ``HiveJSONCodec`` provides JSON serialization for any `Codable` type. ``HiveAnyCodec`` wraps any concrete codec with type erasure.
+
+## Type erasure
+
+``AnyHiveChannelSpec`` erases the `Value` generic from `HiveChannelSpec<Schema, Value>`, allowing heterogeneous channel specs in the `channelSpecs` array. It uses boxed closures to maintain type safety at runtime.
+
+## Complete example
+
+```swift
+enum MySchema: HiveSchema {
+    typealias Input = String
+    typealias InterruptPayload = String
+    typealias ResumePayload = String
+
+    enum Channels {
+        static let messages = HiveChannelKey<MySchema, [String]>(
+            HiveChannelID("messages")
+        )
+        static let item = HiveChannelKey<MySchema, String>(
+            HiveChannelID("item")
+        )
+    }
+
+    static var channelSpecs: [AnyHiveChannelSpec<MySchema>] {
+        [
+            AnyHiveChannelSpec(HiveChannelSpec(
+                key: Channels.messages,
+                scope: .global,
+                reducer: .append(),
+                updatePolicy: .multi,
+                initial: { [] },
+                codec: HiveAnyCodec(HiveJSONCodec<[String]>()),
+                persistence: .checkpointed
+            )),
+            AnyHiveChannelSpec(HiveChannelSpec(
+                key: Channels.item,
+                scope: .taskLocal,
+                reducer: .lastWriteWins(),
+                updatePolicy: .single,
+                initial: { "" },
+                codec: HiveAnyCodec(HiveJSONCodec<String>()),
+                persistence: .checkpointed
+            )),
+        ]
+    }
+
+    static func inputWrites(
+        _ input: String,
+        inputContext: HiveInputContext
+    ) throws -> [AnyHiveWrite<MySchema>] {
+        [AnyHiveWrite(Channels.messages, [input])]
+    }
+}
+```

--- a/Sources/HiveCore/HiveCore.docc/DeterminismGuarantees.md
+++ b/Sources/HiveCore/HiveCore.docc/DeterminismGuarantees.md
@@ -1,0 +1,86 @@
+# Determinism Guarantees
+
+Understand how Hive ensures reproducible execution for golden testing and debugging.
+
+## Overview
+
+Hive's core invariant is that **the same input always produces the same output and the same event trace**. This article explains the mechanisms that achieve this guarantee and how to leverage them for testing.
+
+## Ordering guarantees
+
+### Lexicographic node ordering
+
+Frontier nodes execute in sorted order by ``HiveNodeID``. This means task ordinals are assigned deterministically — node `"A"` always gets ordinal 0 before node `"B"` at ordinal 1. Use lexicographically sortable names for predictable ordering.
+
+### Deterministic write application
+
+All writes within a superstep are sorted by `(taskOrdinal, emissionIndex)` before reduction. This means the order in which reducers see values is always the same, regardless of which task finishes first at the concurrency level.
+
+### Sorted channel iteration
+
+`registry.sortedChannelSpecs` ensures channels are processed in a consistent order during commit, reset, and checkpoint operations.
+
+## Deterministic identifiers
+
+Hive computes all identifiers deterministically using SHA-256:
+
+| Identifier | Formula |
+|-----------|---------|
+| Task ID | SHA-256 of `(runID, stepIndex, nodeID, ordinal, fingerprint)` |
+| Interrupt ID | SHA-256 of `"HINT1" + taskID` |
+| Checkpoint ID | SHA-256 of `"HCP1" + runID + stepIndex` |
+
+This means that replaying the same workflow produces the same IDs, enabling checkpoint compatibility across runs.
+
+## Atomic superstep commits
+
+All writes from a superstep apply together in a single atomic commit. No node ever sees a partially committed state — it reads the full pre-commit snapshot from the previous step.
+
+## Deterministic stream buffering
+
+When `deterministicStreamBuffering` is enabled in ``HiveRunOptions``, custom stream events are buffered per-task and replayed in ordinal order. This ensures that even with concurrent nodes, the event stream is deterministic.
+
+## Golden testing
+
+Graph descriptions produce immutable JSON with SHA-256 version hashes:
+
+```swift
+let description = graph.graphDescription()
+// description.versionHash is a stable SHA-256
+```
+
+Identical graphs always produce identical JSON. Use this for regression testing:
+
+```swift
+#expect(description.versionHash == "expected-hash")
+```
+
+## Writing deterministic tests
+
+When writing tests, assert **exact event ordering**, not just presence:
+
+```swift
+let taskStarts = events.compactMap { e -> HiveNodeID? in
+    guard case let .taskStarted(n, _) = e.kind else { return nil }
+    return n
+}
+#expect(taskStarts == [HiveNodeID("A"), HiveNodeID("B")])
+```
+
+Two parallel writers produce a deterministic append order because `"A"` sorts before `"B"`:
+
+```swift
+#expect(try store.get(valuesKey) == [1, 2, 3])
+// A writes [1, 2], B writes [3] — A before B (lexicographic)
+```
+
+## Reducers and determinism
+
+Built-in reducers are associative and produce deterministic results when writes are applied in order:
+
+- `.lastWriteWins()` — the last write in `(taskOrdinal, emissionIndex)` order wins
+- `.append()` — elements appear in sorted task order
+- `.setUnion()` — set union is commutative, so order doesn't matter
+- `.sum()`, `.min()`, `.max()` — commutative operations
+
+Custom reducers should be designed to produce deterministic output when given deterministic input ordering.

--- a/Sources/HiveCore/HiveCore.docc/HiveCore.md
+++ b/Sources/HiveCore/HiveCore.docc/HiveCore.md
@@ -1,0 +1,99 @@
+# ``HiveCore``
+
+Core runtime for deterministic graph execution.
+
+@Metadata {
+    @DisplayName("HiveCore")
+}
+
+## Overview
+
+HiveCore provides the schema system, graph compiler, store model, checkpoint protocols, and superstep runtime that power Hive's deterministic graph execution.
+
+| Subsystem | Responsibility |
+|-----------|---------------|
+| Schema | Channel specs, keys, reducers, codecs, schema registry, type erasure |
+| Store | Global store, task-local store, store view, initial cache, fingerprinting |
+| Graph | Graph builder, compile, validation, versioning, Mermaid export |
+| Runtime | Superstep execution, frontier computation, event streaming, interrupts, retry |
+| Checkpointing | Checkpoint format, store protocol, policies |
+
+## Topics
+
+### Essentials
+
+- <doc:DefiningASchema>
+- <doc:UnderstandingTheStore>
+- <doc:BuildingGraphs>
+- <doc:RuntimeExecution>
+
+### Schema
+
+- ``HiveSchema``
+- ``HiveChannelSpec``
+- ``HiveChannelKey``
+- ``HiveChannelID``
+- ``HiveChannelScope``
+- ``HiveChannelPersistence``
+- ``HiveReducer``
+- ``HiveCodec``
+- ``HiveJSONCodec``
+- ``HiveAnyCodec``
+- ``AnyHiveChannelSpec``
+- ``HiveUpdatePolicy``
+
+### Store
+
+- ``HiveGlobalStore``
+- ``HiveTaskLocalStore``
+- ``HiveStoreView``
+- ``HiveSchemaRegistry``
+
+### Graph
+
+- ``HiveGraphBuilder``
+- ``CompiledHiveGraph``
+- ``HiveGraphDescription``
+- ``HiveGraphMermaidExporter``
+- ``HiveNodeID``
+
+### Runtime
+
+- <doc:RuntimeExecution>
+- <doc:CheckpointingAndResume>
+- ``HiveRuntime``
+- ``HiveEnvironment``
+- ``HiveRunHandle``
+- ``HiveRunOutcome``
+- ``HiveRunOptions``
+- ``HiveRunOutput``
+- ``HiveRunID``
+- ``HiveThreadID``
+- ``HiveEvent``
+- ``HiveRetryPolicy``
+
+### Checkpointing
+
+- <doc:CheckpointingAndResume>
+- ``HiveCheckpoint``
+- ``HiveCheckpointID``
+- ``HiveCheckpointStore``
+- ``HiveCheckpointPolicy``
+- ``HiveCheckpointQueryableStore``
+
+### Interrupts
+
+- ``HiveInterruptRequest``
+- ``HiveInterrupt``
+- ``HiveResume``
+- ``HiveInterruption``
+
+### Errors
+
+- ``HiveRuntimeError``
+- ``HiveCompilationError``
+- ``HiveCheckpointQueryError``
+
+### Advanced
+
+- <doc:DeterminismGuarantees>

--- a/Sources/HiveCore/HiveCore.docc/RuntimeExecution.md
+++ b/Sources/HiveCore/HiveCore.docc/RuntimeExecution.md
@@ -1,0 +1,203 @@
+# Runtime Execution
+
+Understand the HiveRuntime actor, superstep execution loop, event streaming, and run options.
+
+## Overview
+
+``HiveRuntime`` is the central execution engine — a Swift `actor` that ensures data-race-free state management. It executes compiled graphs using the BSP superstep model, providing rich event streams and configurable execution options.
+
+## HiveRuntime
+
+```swift
+public actor HiveRuntime<Schema: HiveSchema>: Sendable {
+    public init(
+        graph: CompiledHiveGraph<Schema>,
+        environment: HiveEnvironment<Schema>
+    ) throws
+
+    public func run(
+        threadID: HiveThreadID,
+        input: Schema.Input,
+        options: HiveRunOptions
+    ) -> HiveRunHandle<Schema>
+
+    public func resume(
+        threadID: HiveThreadID,
+        interruptID: HiveInterruptID,
+        payload: Schema.ResumePayload,
+        options: HiveRunOptions
+    ) -> HiveRunHandle<Schema>
+
+    public func fork(
+        threadID sourceThreadID: HiveThreadID,
+        to newThreadID: HiveThreadID,
+        from checkpointID: HiveCheckpointID? = nil,
+        options: HiveRunOptions? = nil
+    ) async throws -> HiveForkResult<Schema>
+
+    public func getForkEventHistory(
+        limit: Int? = nil
+    ) -> [HiveEvent]
+
+    public func getState(
+        threadID: HiveThreadID
+    ) async throws -> HiveRuntimeStateSnapshot<Schema>?
+
+    public func getLatestStore(
+        threadID: HiveThreadID
+    ) -> HiveGlobalStore<Schema>?
+}
+```
+
+## HiveEnvironment
+
+``HiveEnvironment`` is the dependency injection container provided to the runtime:
+
+```swift
+public struct HiveEnvironment<Schema: HiveSchema>: Sendable {
+    public let context: Schema.Context
+    public let clock: any HiveClock
+    public let logger: any HiveLogger
+    public let checkpointStore: AnyHiveCheckpointStore<Schema>?
+}
+```
+
+## HiveRunHandle
+
+Every entry point returns a ``HiveRunHandle`` with both an event stream and a terminal outcome:
+
+```swift
+public struct HiveRunHandle<Schema: HiveSchema>: Sendable {
+    public let runID: HiveRunID
+    public let events: AsyncThrowingStream<HiveEvent, Error>
+    public let outcome: Task<HiveRunOutcome<Schema>, Error>
+}
+```
+
+`runID` is the canonical identifier for that handle's execution lineage. If a run cold-starts by restoring
+checkpoint state, the restored state is rebound to this `runID` so event IDs, task IDs, and newly saved
+checkpoints remain consistent for the active handle.
+
+`fork` is intentionally different: it is an atomic state-branch operation that returns ``HiveForkResult``
+after cloning (and optionally persisting) target state. It does not execute steps.
+
+## Fork guarantees
+
+- Source state is decoded from a single checkpoint (explicit ID or latest).
+- Target receives an independent lineage (new run ID + optional fork lineage metadata).
+- Global store, frontier/deferred frontier, join barrier state, interruption, channel versions,
+  and versionsSeen are preserved.
+- Fail-closed behavior: no partial target state commit on fork failure.
+
+Fork lifecycle observability is emitted as runtime events:
+- `forkStarted`
+- `forkCompleted`
+- `forkFailed`
+
+## Run outcomes
+
+```swift
+public enum HiveRunOutcome<Schema: HiveSchema>: Sendable {
+    case finished(output: HiveRunOutput<Schema>, checkpointID: HiveCheckpointID?)
+    case interrupted(interruption: HiveInterruption<Schema>)
+    case cancelled(output:, checkpointID:)
+    case outOfSteps(maxSteps:, output:, checkpointID:)
+}
+```
+
+## The superstep loop
+
+Each superstep has three phases:
+
+### Phase 1: Concurrent node execution
+
+All frontier nodes execute concurrently within a `TaskGroup`, bounded by `maxConcurrentTasks`. Each node reads from a pre-step snapshot — no node sees another's writes from the same step.
+
+### Phase 2: Atomic commit
+
+Writes are collected, ordered by `(taskOrdinal, emissionIndex)`, and reduced through each channel's reducer. Ephemeral channels reset to initial values.
+
+### Phase 3: Frontier scheduling
+
+Routers run on post-commit state. Join barriers update. The next frontier is assembled, deduplicated, and optionally filtered by trigger conditions.
+
+### Run loop pseudocode
+
+```
+while true:
+    1. Check cancellation → return .cancelled
+    2. Check frontier empty → promote deferred or return .finished
+    3. Check maxSteps → return .outOfSteps
+    4. Execute one superstep
+    5. Save checkpoint if policy requires
+    6. Emit events
+    7. Check for interrupt → return .interrupted
+    8. Task.yield() for cancellation observation
+```
+
+## Frontier computation
+
+Sources for the next frontier:
+
+1. **Static edges** — `graph.staticEdgesByFrom[nodeID]`
+2. **Routers** — dynamic routing on post-commit state
+3. **Node output `next`** — `.end`, `.to([...])`, or `.useGraphEdges`
+4. **Spawn seeds** — fan-out tasks with task-local state
+5. **Join barriers** — fire when all parents complete
+
+Seeds are deduplicated by `(nodeID, taskLocalFingerprint)`.
+
+## Event streaming
+
+``HiveEvent`` covers the full lifecycle:
+
+| Category | Events |
+|----------|--------|
+| Run lifecycle | `runStarted`, `runFinished`, `runInterrupted`, `runResumed`, `runCancelled(cause)` |
+| Superstep | `stepStarted`, `stepFinished` |
+| Task | `taskStarted`, `taskFinished`, `taskFailed` |
+| Writes | `writeApplied` |
+| Checkpoint | `checkpointSaved`, `checkpointLoaded` |
+| Snapshots | `storeSnapshot`, `channelUpdates` |
+| Debug | `customDebug`, `streamBackpressure` |
+
+### Streaming modes
+
+Configure via ``HiveRunOptions``:
+
+- `.events` — standard events only
+- `.values` — full store snapshots after each step
+- `.updates` — only written channels
+- `.combined` — both values and updates
+
+## Run options
+
+```swift
+let options = HiveRunOptions(
+    maxSteps: 50,
+    maxConcurrentTasks: 4,
+    checkpointPolicy: .everyStep,
+    debugPayloads: true,
+    deterministicStreamBuffering: true,
+    eventBufferCapacity: 2048,
+    streamingMode: .combined
+)
+```
+
+## Retry policies
+
+``HiveRetryPolicy`` supports exponential backoff:
+
+```swift
+public enum HiveRetryPolicy: Sendable {
+    case none
+    case exponentialBackoff(
+        initialNanoseconds: UInt64,
+        factor: Double,
+        maxAttempts: Int,
+        maxNanoseconds: UInt64
+    )
+}
+```
+
+Delay formula: `min(maxNanoseconds, floor(initialNanoseconds * pow(factor, attempt - 1)))`

--- a/Sources/HiveCore/HiveCore.docc/UnderstandingTheStore.md
+++ b/Sources/HiveCore/HiveCore.docc/UnderstandingTheStore.md
@@ -1,0 +1,133 @@
+# Understanding the Store
+
+Learn how Hive manages state through global stores, task-local overlays, and merged read-only views.
+
+## Overview
+
+Hive's store model separates shared state from per-task state and presents nodes with a unified read-only view. This architecture enables deterministic concurrent execution — nodes in the same superstep all read from the same pre-commit snapshot while their writes accumulate independently.
+
+## Store architecture
+
+```
+                +---------------------+
+                |   HiveSchemaRegistry |
+                |   (channel specs)    |
+                +----------+----------+
+                           |
+                +----------v----------+
+                |  HiveInitialCache    |
+                |  (default values)    |
+                +----+-------+--------+
+                     |       |
+      +--------------+       +-------------+
+      |                                    |
++-----v-----------+          +-------------v-----------+
+|  HiveGlobalStore |          |  HiveTaskLocalStore      |
+|  (global channels)|         |  (task-local overlays)   |
++-----+-----------+          +-------------+-----------+
+      |                                    |
+      +--+------+--------------------------+
+         |      |
++--------v------v--------+
+|    HiveStoreView        |
+|  (read-only merged)     |
+|  given to node closures |
++-------------------------+
+```
+
+## HiveGlobalStore
+
+``HiveGlobalStore`` holds the current value for every global-scoped channel. One instance exists per thread. All tasks in a superstep see the same pre-commit snapshot.
+
+```swift
+public struct HiveGlobalStore<Schema: HiveSchema>: Sendable {
+    public func get<Value: Sendable>(
+        _ key: HiveChannelKey<Schema, Value>
+    ) throws -> Value
+}
+```
+
+During the atomic commit phase, the runtime:
+
+1. Collects all writes, grouped by channel ID
+2. Sorts writes deterministically by `(taskOrdinal, emissionIndex)`
+3. Reduces using each channel's ``HiveReducer``
+4. Resets `.ephemeral` channels to `initial()` after all reductions
+
+## HiveTaskLocalStore
+
+``HiveTaskLocalStore`` is a sparse overlay for task-local channels. Each spawned task carries its own instance, isolated from siblings.
+
+```swift
+public struct HiveTaskLocalStore<Schema: HiveSchema>: Sendable {
+    public static var empty: HiveTaskLocalStore<Schema>
+    public func get<Value: Sendable>(
+        _ key: HiveChannelKey<Schema, Value>
+    ) throws -> Value?
+}
+```
+
+Key differences from the global store:
+
+- `get` returns `Optional<Value>` — `nil` means use the initial value
+- Only stores channels that have been explicitly written
+- The channel's scope must be `.taskLocal`
+
+## HiveStoreView
+
+``HiveStoreView`` is a read-only merged view composed from the global store, task-local overlay, and initial cache. Every node receives one via `input.store`.
+
+```swift
+public struct HiveStoreView<Schema: HiveSchema>: Sendable {
+    public func get<Value: Sendable>(
+        _ key: HiveChannelKey<Schema, Value>
+    ) throws -> Value
+}
+```
+
+Resolution logic:
+
+- **Global channels** — delegate to ``HiveGlobalStore``
+- **Task-local channels** — check the overlay first, fall back to the initial cache
+
+## Initial cache
+
+The initial cache eagerly evaluates and caches `initial()` for every channel at construction time. It provides fallback values for task-local channels and reset values for ephemeral channels.
+
+## Fingerprinting
+
+The task-local fingerprint computes a SHA-256 digest of the effective task-local state (overlay merged with initial values). The runtime uses this to detect identical task-local states and deduplicate frontier entries.
+
+## Code examples
+
+### Reading from the store in a node
+
+```swift
+Node("worker") { input in
+    let results: [String] = try input.store.get(MySchema.Channels.results)
+    let item: String = try input.store.get(MySchema.Channels.item)
+    return Effects {
+        Set(MySchema.Channels.results, [item.uppercased()])
+        End()
+    }
+}
+```
+
+### Fan-out with task-local state
+
+```swift
+SpawnEach(["a", "b", "c"], node: "worker") { item in
+    var local = HiveTaskLocalStore<Schema>.empty
+    try! local.set(MySchema.Channels.item, item)
+    return local
+}
+```
+
+### Accessing final state after a run
+
+```swift
+guard let store = await runtime.getLatestStore(
+    threadID: threadID
+) else { return }
+let finalResults = try store.get(MySchema.Channels.results)
+```

--- a/Sources/HiveCore/HiveCoreVersion.swift
+++ b/Sources/HiveCore/HiveCoreVersion.swift
@@ -1,0 +1,26 @@
+/// Namespace for the Hive framework version information.
+public enum HiveVersion {
+    /// Semantic version string for the Hive umbrella module.
+    public static let string = "0.2.1"
+
+    /// Semantic version string for HiveCore.
+    public static let core = "0.2.1"
+
+    /// All module versions as a dictionary.
+    public static var all: [String: String] {
+        [
+            "umbrella": string,
+            "core": core
+        ]
+    }
+}
+
+// MARK: - Deprecated Module-Specific Version Types
+
+/// Deprecated: Use `HiveVersion.core` instead.
+@available(*, deprecated, renamed: "HiveVersion")
+public enum HiveCoreVersion {
+    /// Deprecated: Use `HiveVersion.core` instead.
+    @available(*, deprecated, renamed: "HiveVersion.core")
+    public static let string = HiveVersion.core
+}

--- a/Sources/HiveCore/README.md
+++ b/Sources/HiveCore/README.md
@@ -1,0 +1,193 @@
+# HiveCore
+
+[![Discord](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fdiscord.com%2Fapi%2Fv10%2Finvites%2FNHgNh7HJ6M%3Fwith_counts%3Dtrue&query=%24.approximate_presence_count&suffix=%20online&logo=discord&label=Discord&color=5865F2)](https://discord.gg/NHgNh7HJ6M)
+
+HiveCore provides the schema, graph builder, and deterministic runtime for Hive.
+
+## Mental Model
+- Channels are typed state slots declared in a `HiveSchema`.
+- Reducers define how multiple writes to a channel merge within a superstep.
+- Supersteps run the current frontier of tasks, then commit writes and schedule the next frontier.
+- Send and join: tasks emit writes and routing decisions; join edges wait until all parents have run since the last join before scheduling the target.
+- Checkpoint/resume persists global state, frontier, and join barriers so a thread can resume with an interrupt payload.
+
+## Define a Schema
+```swift
+import HiveCore
+
+enum DemoSchema: HiveSchema {
+    typealias Context = Void
+    typealias Input = String
+
+    enum Channels {
+        static let messages = HiveChannelKey<DemoSchema, [String]>(HiveChannelID("messages"))
+    }
+
+    static let channelSpecs: [AnyHiveChannelSpec<DemoSchema>] = [
+        AnyHiveChannelSpec(
+            HiveChannelSpec(
+                key: Channels.messages,
+                scope: .global,
+                reducer: .append(),
+                updatePolicy: .multi,
+                initial: { [] },
+                persistence: .untracked
+            )
+        )
+    ]
+
+    static func inputWrites(
+        _ input: String,
+        inputContext: HiveInputContext
+    ) throws -> [AnyHiveWrite<DemoSchema>] {
+        [AnyHiveWrite(Channels.messages, [input])]
+    }
+}
+```
+
+Notes:
+- Task-local channels must be `checkpointed` and require a `HiveCodec`.
+- Global channels require a codec when `persistence: .checkpointed`.
+
+## Build a Graph
+```swift
+var builder = HiveGraphBuilder<DemoSchema>(start: [HiveNodeID("Start")])
+
+builder.addNode(HiveNodeID("Start")) { input in
+    let messages = try input.store.get(DemoSchema.Channels.messages)
+    return HiveNodeOutput(
+        writes: [AnyHiveWrite(DemoSchema.Channels.messages, messages + ["done"])],
+        next: .end
+    )
+}
+
+let graph = try builder.compile()
+```
+
+To model joins, add a join edge:
+`builder.addJoinEdge(parents: [HiveNodeID("A"), HiveNodeID("B")], target: HiveNodeID("Join"))`
+
+## Export a Graph Description
+Generate a deterministic description of a compiled graph for tooling and inspection.
+
+```swift
+let description = graph.graphDescription()
+let encoder = JSONEncoder()
+encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+let json = try encoder.encode(description)
+```
+
+Determinism rules:
+- Node listing order: lexicographic UTF-8 by `nodeID.rawValue`.
+- Router listing order: lexicographic UTF-8 by `nodeID.rawValue`.
+- Edge listing order: preserves builder insertion order for static and join edges.
+
+## Generate Mermaid
+Render a compiled graph to Mermaid `flowchart` syntax.
+
+```swift
+let mermaid = HiveGraphMermaidExporter.export(graph.graphDescription())
+print(mermaid)
+```
+
+## Run in an App
+Provide `HiveClock` and `HiveLogger` implementations from your app/runtime.
+
+```swift
+let environment = HiveEnvironment<DemoSchema>(
+    context: (),
+    clock: appClock,
+    logger: appLogger,
+    checkpointStore: nil
+)
+
+let runtime = HiveRuntime(graph: graph, environment: environment)
+let handle = await runtime.run(
+    threadID: HiveThreadID("thread-1"),
+    input: "hello",
+    options: HiveRunOptions(maxSteps: 50)
+)
+
+Task {
+    for try await event in handle.events {
+        // Inspect `event.kind` for step/task/write/checkpoint updates.
+    }
+}
+
+let outcome = try await handle.outcome.value
+```
+
+Checkpoint/resume flow:
+- Provide a `HiveCheckpointStore` in `HiveEnvironment` and enable a checkpoint policy in `HiveRunOptions`.
+- On `.interrupted`, resume with `runtime.resume(threadID:interruptID:payload:options:)` using the provided `HiveInterruptID`.
+- `HiveRuntime.validateRunOptions(_:)` is available as a public preflight API and is used by `run`, `resume`, and `applyExternalWrites`.
+
+## Runtime State Snapshot
+Use `getState(threadID:)` for a typed deterministic state snapshot:
+
+```swift
+let state = try await runtime.getState(threadID: HiveThreadID("thread-1"))
+```
+
+`HiveRuntimeStateSnapshot` includes:
+- `threadID`, `runID`, `stepIndex`
+- interruption metadata (`interruptID` + payload hash)
+- `checkpointID`
+- `globalChannelPayloadHashesByID`
+- `frontierSummary` for deterministic comparisons
+- typed `store` projection for channel reads
+
+## Checkpoint Inspection
+Some checkpoint stores support optional history and load-by-id operations.
+
+Using `HiveRuntime` helpers:
+```swift
+let history = try await runtime.getCheckpointHistory(threadID: HiveThreadID("thread-1"), limit: 10)
+let checkpoint = try await runtime.getCheckpoint(threadID: HiveThreadID("thread-1"), id: history[0].id)
+```
+
+Use `runtime.checkpointCapabilities()` to discover query support.
+If the configured store does not support query operations, these calls throw typed unsupported errors:
+- `HiveCheckpointQueryError.unsupported(operation: .listCheckpoints)`
+- `HiveCheckpointQueryError.unsupported(operation: .loadCheckpointByID)`
+
+## Transcript + Hash Utilities
+Use `HiveEventTranscript` and `HiveTranscriptHasher` for deterministic replay checks:
+
+```swift
+let transcript = HiveEventTranscript(events: events)
+let transcriptHash = try transcript.transcriptHash()
+let stateHash = HiveTranscriptHasher.finalStateHash(stateSnapshot: state)
+let diff = transcript.firstDiff(comparedTo: baseline)
+```
+
+`HiveEventTranscript` normalizes volatile identifiers by default so seeded repeated runs can be compared across attempts.
+
+## Event Schema Versioning
+Every event carries `HiveEvent.schemaVersion` (`HiveEventSchemaVersion`), and replay compatibility can be validated with:
+- `HiveEventTranscript.validateReplayCompatibility(expected:)`
+
+## Stream Views
+`HiveEventStreamViews` provides typed, filtered views over a `HiveEvent` stream.
+
+Progress UI (steps):
+```swift
+let views = HiveEventStreamViews(handle.events)
+for try await event in views.steps() {
+    // event.kind: .started(stepIndex:, frontierCount:) or .finished(stepIndex:, nextFrontierCount:)
+}
+```
+
+Debug stream:
+```swift
+let views = HiveEventStreamViews(handle.events)
+for try await event in views.debug() {
+    // event.kind: .customDebug(name:) or .streamBackpressure(droppedDebugEvents:)
+}
+```
+
+## Examples
+- `../../Examples/README.md`
+- `../../Tests/HiveCoreTests/Runtime/HiveRuntimeStepAlgorithmTests.swift`
+- `../../Tests/HiveCoreTests/Runtime/HiveRuntimeCheckpointTests.swift`
+- `../../Tests/HiveCoreTests/Runtime/HiveRuntimeInterruptResumeExternalWritesTests.swift`

--- a/Sources/HiveCore/Runtime/HiveCachePolicy.swift
+++ b/Sources/HiveCore/Runtime/HiveCachePolicy.swift
@@ -1,0 +1,226 @@
+import Foundation
+
+// MARK: - Protocol
+
+/// Protocol for custom cache key generation.
+/// Implement to control which store values influence whether a cached output is reused.
+public protocol HiveCacheKeyProviding<Schema>: Sendable {
+    associatedtype Schema: HiveSchema
+    func cacheKey(forNode nodeID: HiveNodeID, store: HiveStoreView<Schema>) throws -> String
+}
+
+// MARK: - Type-erased key provider
+
+/// Type-erased wrapper for `HiveCacheKeyProviding`, following `AnyHiveCheckpointStore` pattern.
+public struct AnyHiveCacheKeyProvider<Schema: HiveSchema>: Sendable {
+    private let _cacheKey: @Sendable (HiveNodeID, HiveStoreView<Schema>) throws -> String
+
+    public init<P: HiveCacheKeyProviding>(_ provider: P) where P.Schema == Schema {
+        self._cacheKey = { node, store in try provider.cacheKey(forNode: node, store: store) }
+    }
+
+    /// Closure-based convenience initializer.
+    public init(_ keyFunction: @escaping @Sendable (HiveNodeID, HiveStoreView<Schema>) throws -> String) {
+        self._cacheKey = keyFunction
+    }
+
+    public func cacheKey(forNode nodeID: HiveNodeID, store: HiveStoreView<Schema>) throws -> String {
+        try _cacheKey(nodeID, store)
+    }
+}
+
+// MARK: - Cache entry
+
+/// A single cached node output.
+struct HiveCacheEntry<Schema: HiveSchema>: Sendable {
+    let key: String
+    let output: HiveNodeOutput<Schema>
+    let expiresAt: UInt64?  // ContinuousClock.Instant nanoseconds; nil = no expiry
+    var lastUsedOrder: UInt64  // for LRU eviction
+}
+
+// MARK: - Cache policy
+
+/// Per-node result caching configuration.
+/// Reuses the SHA-256 key derivation approach from `HiveTaskLocalFingerprint`.
+public struct HiveCachePolicy<Schema: HiveSchema>: Sendable {
+    public let maxEntries: Int
+    public let ttlNanoseconds: UInt64?
+    public let keyProvider: AnyHiveCacheKeyProvider<Schema>
+
+    public init(
+        maxEntries: Int,
+        ttlNanoseconds: UInt64?,
+        keyProvider: AnyHiveCacheKeyProvider<Schema>
+    ) {
+        self.maxEntries = max(1, maxEntries)
+        self.ttlNanoseconds = ttlNanoseconds
+        self.keyProvider = keyProvider
+    }
+
+    /// LRU cache keyed by SHA-256 of all global channel version counters.
+    /// Zero I/O overhead — uses version counters already maintained by the runtime.
+    public static func lru(maxEntries: Int = 128) -> HiveCachePolicy<Schema> {
+        // Capture sorted global specs at factory time — once, not per call.
+        // If registry construction fails the specs list is empty, producing a per-nodeID
+        // constant key rather than a store-content-aware key. This is a safe degradation
+        // (no cross-node collisions) but caching becomes less selective.
+        let sortedGlobalSpecs = (try? HiveSchemaRegistry<Schema>())?
+            .sortedChannelSpecs.filter { $0.scope == .global } ?? []
+        return HiveCachePolicy(
+            maxEntries: maxEntries,
+            ttlNanoseconds: nil,
+            keyProvider: AnyHiveCacheKeyProvider { nodeID, store in
+                Self.versionBasedKey(nodeID: nodeID, store: store, sortedGlobalSpecs: sortedGlobalSpecs)
+            }
+        )
+    }
+
+    /// LRU cache with a time-to-live. Entries older than `ttl` are invalidated.
+    public static func lruTTL(maxEntries: Int = 128, ttl: Duration) -> HiveCachePolicy<Schema> {
+        // Cap seconds at ~292 years before converting to avoid UInt64 overflow.
+        let cappedSeconds = min(UInt64(max(0, ttl.components.seconds)), 9_000_000_000)
+        let subSecondNs = UInt64(ttl.components.attoseconds / 1_000_000_000)
+        let ttlNs = cappedSeconds &* 1_000_000_000 &+ subSecondNs
+        // Capture sorted global specs at factory time — same rationale as lru().
+        let sortedGlobalSpecs = (try? HiveSchemaRegistry<Schema>())?
+            .sortedChannelSpecs.filter { $0.scope == .global } ?? []
+        return HiveCachePolicy(
+            maxEntries: maxEntries,
+            ttlNanoseconds: ttlNs,
+            keyProvider: AnyHiveCacheKeyProvider { nodeID, store in
+                Self.versionBasedKey(nodeID: nodeID, store: store, sortedGlobalSpecs: sortedGlobalSpecs)
+            }
+        )
+    }
+
+    /// Cache keyed by a specific subset of channels (cheaper than hashing the full store).
+    public static func channels(
+        _ channelIDs: HiveChannelID...,
+        maxEntries: Int = 128
+    ) -> HiveCachePolicy<Schema> {
+        let ids = channelIDs
+        return HiveCachePolicy(
+            maxEntries: maxEntries,
+            ttlNanoseconds: nil,
+            keyProvider: AnyHiveCacheKeyProvider { nodeID, store in
+                Self.channelSubsetKey(nodeID: nodeID, channelIDs: ids, store: store)
+            }
+        )
+    }
+
+    // MARK: - Key helpers
+
+    private static func versionBasedKey(
+        nodeID: HiveNodeID,
+        store: HiveStoreView<Schema>,
+        sortedGlobalSpecs: [AnyHiveChannelSpec<Schema>]
+    ) -> String {
+        // Use nodeID as salt so two different nodes with identical state produce different keys.
+        nodeID.rawValue + ":" + storeHashKey(store: store, sortedGlobalSpecs: sortedGlobalSpecs)
+    }
+
+    private static func channelSubsetKey(
+        nodeID: HiveNodeID,
+        channelIDs: [HiveChannelID],
+        store: HiveStoreView<Schema>
+    ) -> String {
+        var hasher = HiveSHA256.Hasher()
+        hasher.update(data: Data(nodeID.rawValue.utf8))
+        for id in channelIDs.sorted(by: { $0.rawValue < $1.rawValue }) {
+            hasher.update(data: Data(id.rawValue.utf8))
+            // Best-effort: encode to data if codec available, else use channel ID only.
+            if let value = try? store.valueAny(for: id),
+               let data = try? _sharedCacheKeyEncoder.encode(AnySendableWrapper(value)) {
+                hasher.update(data: data)
+            }
+        }
+        return hasher.finalize().compactMap { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Hashes the store's current values via best-effort JSON encoding.
+    /// `sortedGlobalSpecs` must be pre-computed at factory time (not per call) to avoid
+    /// per-invocation registry construction and the silent-empty-hash failure mode.
+    private static func storeHashKey(
+        store: HiveStoreView<Schema>,
+        sortedGlobalSpecs: [AnyHiveChannelSpec<Schema>]
+    ) -> String {
+        var hasher = HiveSHA256.Hasher()
+        for spec in sortedGlobalSpecs {
+            hasher.update(data: Data(spec.id.rawValue.utf8))
+            if let encodeBox = spec._encodeBox,
+               let value = try? store.valueAny(for: spec.id),
+               let encoded = try? encodeBox(value) {
+                hasher.update(data: encoded)
+            }
+        }
+        return hasher.finalize().compactMap { String(format: "%02x", $0) }.joined()
+    }
+}
+
+// MARK: - Internal helpers
+
+/// Shared encoder used for cache key hashing — avoids per-call allocation.
+private let _sharedCacheKeyEncoder = JSONEncoder()
+
+/// Thin `Encodable` wrapper for `any Sendable` — used only in cache key hashing.
+private struct AnySendableWrapper: Encodable {
+    let value: any Sendable
+    init(_ value: any Sendable) { self.value = value }
+    func encode(to encoder: Encoder) throws {
+        if let encodable = value as? any Encodable {
+            try encodable.encode(to: encoder)
+        }
+    }
+}
+
+// MARK: - Per-node cache store (used by HiveRuntime)
+
+/// In-memory LRU cache for a single node's outputs.
+struct HiveNodeCache<Schema: HiveSchema>: Sendable {
+    private(set) var entries: [HiveCacheEntry<Schema>] = []
+    private var accessOrder: UInt64 = 0
+
+    init() {}
+
+    mutating func lookup(
+        key: String,
+        policy: HiveCachePolicy<Schema>,
+        nowNanoseconds: UInt64
+    ) -> HiveNodeOutput<Schema>? {
+        guard let index = entries.firstIndex(where: { $0.key == key }) else { return nil }
+        let entry = entries[index]
+        if let expiry = entry.expiresAt, nowNanoseconds > expiry {
+            entries.remove(at: index)
+            return nil
+        }
+        accessOrder &+= 1
+        entries[index].lastUsedOrder = accessOrder
+        return entry.output
+    }
+
+    mutating func store(
+        key: String,
+        output: HiveNodeOutput<Schema>,
+        policy: HiveCachePolicy<Schema>,
+        nowNanoseconds: UInt64
+    ) {
+        let expiry = policy.ttlNanoseconds.map { nowNanoseconds &+ $0 }
+        accessOrder &+= 1
+        if let index = entries.firstIndex(where: { $0.key == key }) {
+            entries[index] = HiveCacheEntry(key: key, output: output, expiresAt: expiry, lastUsedOrder: accessOrder)
+        } else {
+            if entries.count >= policy.maxEntries {
+                evictLRU()
+            }
+            entries.append(HiveCacheEntry(key: key, output: output, expiresAt: expiry, lastUsedOrder: accessOrder))
+        }
+    }
+
+    private mutating func evictLRU() {
+        guard !entries.isEmpty else { return }
+        if let idx = entries.indices.min(by: { entries[$0].lastUsedOrder < entries[$1].lastUsedOrder }) {
+            entries.remove(at: idx)
+        }
+    }
+}

--- a/Sources/HiveCore/Runtime/HiveEnvironment.swift
+++ b/Sources/HiveCore/Runtime/HiveEnvironment.swift
@@ -1,0 +1,32 @@
+/// Monotonic time source for retries and durations.
+public protocol HiveClock: Sendable {
+    func nowNanoseconds() -> UInt64
+    func sleep(nanoseconds: UInt64) async throws
+}
+
+/// Minimal logging surface for runtime diagnostics.
+public protocol HiveLogger: Sendable {
+    func debug(_ message: String, metadata: [String: String])
+    func info(_ message: String, metadata: [String: String])
+    func error(_ message: String, metadata: [String: String])
+}
+
+/// Execution environment injected into nodes.
+public struct HiveEnvironment<Schema: HiveSchema>: Sendable {
+    public let context: Schema.Context
+    public let clock: any HiveClock
+    public let logger: any HiveLogger
+    public let checkpointStore: AnyHiveCheckpointStore<Schema>?
+
+    public init(
+        context: Schema.Context,
+        clock: any HiveClock,
+        logger: any HiveLogger,
+        checkpointStore: AnyHiveCheckpointStore<Schema>? = nil
+    ) {
+        self.context = context
+        self.clock = clock
+        self.logger = logger
+        self.checkpointStore = checkpointStore
+    }
+}

--- a/Sources/HiveCore/Runtime/HiveEventStreamController.swift
+++ b/Sources/HiveCore/Runtime/HiveEventStreamController.swift
@@ -1,0 +1,308 @@
+import Foundation
+
+internal enum HiveEventEnqueueResult: Sendable {
+    case enqueued
+    case droppedDebug
+    case terminated
+}
+
+internal final class HiveEventStreamController: @unchecked Sendable {
+    // Uses NSCondition for synchronous producer backpressure and consumer wakeups.
+    // NSCondition is not statically Sendable, so this class requires manual synchronization.
+    private enum FinishState {
+        case finished
+        case failed(Error)
+    }
+
+    private enum DrainState {
+        case hasEvent
+        case finished
+        case failed(Error)
+    }
+
+    private struct EventRingQueue {
+        private let capacity: Int
+        private var storage: [HiveEvent?]
+        private var headIndex: Int = 0
+        private(set) var count: Int = 0
+
+        init(capacity: Int) {
+            self.capacity = capacity
+            self.storage = Array(repeating: nil, count: capacity)
+        }
+
+        var isEmpty: Bool {
+            count == 0
+        }
+
+        var first: HiveEvent? {
+            guard count > 0 else { return nil }
+            return storage[headIndex]
+        }
+
+        var last: HiveEvent? {
+            guard count > 0 else { return nil }
+            return storage[physicalIndex(offset: count - 1)]
+        }
+
+        mutating func append(_ event: HiveEvent) -> Bool {
+            guard count < capacity else { return false }
+            storage[physicalIndex(offset: count)] = event
+            count += 1
+            return true
+        }
+
+        mutating func replaceLast(with event: HiveEvent) {
+            guard count > 0 else { return }
+            storage[physicalIndex(offset: count - 1)] = event
+        }
+
+        mutating func removeFirst() {
+            guard count > 0 else { return }
+            storage[headIndex] = nil
+            count -= 1
+            if count == 0 {
+                headIndex = 0
+                return
+            }
+            headIndex = nextIndex(after: headIndex)
+        }
+
+        mutating func removeAll(keepingCapacity: Bool) {
+            if keepingCapacity {
+                if count > 0 {
+                    var index = headIndex
+                    for _ in 0..<count {
+                        storage[index] = nil
+                        index = nextIndex(after: index)
+                    }
+                }
+            } else {
+                storage = Array(repeating: nil, count: capacity)
+            }
+            headIndex = 0
+            count = 0
+        }
+
+        private func physicalIndex(offset: Int) -> Int {
+            let raw = headIndex + offset
+            return raw < capacity ? raw : raw - capacity
+        }
+
+        private func nextIndex(after index: Int) -> Int {
+            let next = index + 1
+            return next == capacity ? 0 : next
+        }
+    }
+
+    private let capacity: Int
+    private let condition = NSCondition()
+    private let pumpQueue: DispatchQueue
+
+    private var queue: EventRingQueue
+    private var finishState: FinishState?
+
+    init(capacity: Int) {
+        let normalizedCapacity = max(1, capacity)
+        self.capacity = normalizedCapacity
+        self.pumpQueue = DispatchQueue(
+            label: "HiveEventStreamController.pump.\(UUID().uuidString)",
+            qos: .userInitiated
+        )
+        self.queue = EventRingQueue(capacity: normalizedCapacity)
+    }
+
+    func makeStream() -> AsyncThrowingStream<HiveEvent, Error> {
+        // Use a `.bufferingOldest(...)` continuation so already-buffered events are preserved.
+        // When the continuation buffer is full, `yield` reports `.dropped` and the new element was not accepted.
+        //
+        // NOTE: We keep a minimum continuation buffer to avoid small `eventBufferCapacity` values causing
+        // excessive drops of important events in tests and UI streams.
+        AsyncThrowingStream(HiveEvent.self, bufferingPolicy: .bufferingOldest(max(64, capacity))) { continuation in
+            continuation.onTermination = { [weak self] _ in
+                self?.terminateStreamAndUnblockProducers()
+            }
+            pumpQueue.async { [weak self] in
+                self?.pump(into: continuation)
+            }
+        }
+    }
+
+    func finish() {
+        condition.lock()
+        if finishState == nil {
+            finishState = .finished
+        }
+        condition.broadcast()
+        condition.unlock()
+    }
+
+    func finish(throwing error: Error) {
+        condition.lock()
+        if finishState == nil {
+            finishState = .failed(error)
+        }
+        condition.broadcast()
+        condition.unlock()
+    }
+
+    func enqueue(
+        eventIndex: UInt64,
+        runID: HiveRunID,
+        attemptID: HiveRunAttemptID,
+        kind: HiveEventKind,
+        stepIndex: Int?,
+        taskOrdinal: Int?,
+        metadata: [String: String],
+        treatAsNonDroppable: Bool = false
+    ) -> HiveEventEnqueueResult {
+        condition.lock()
+        defer { condition.unlock() }
+
+        if finishState != nil {
+            return .terminated
+        }
+
+        if treatAsNonDroppable == false, isDroppable(kind) {
+            if queue.count >= capacity {
+                return .droppedDebug
+            }
+
+            let id = HiveEventID(
+                runID: runID,
+                attemptID: attemptID,
+                eventIndex: eventIndex,
+                stepIndex: stepIndex,
+                taskOrdinal: taskOrdinal
+            )
+            _ = queue.append(HiveEvent(id: id, kind: kind, metadata: metadata))
+            condition.signal()
+            return .enqueued
+        }
+
+        while queue.count >= capacity, finishState == nil {
+            condition.wait()
+        }
+
+        if finishState != nil {
+            return .terminated
+        }
+
+        let id = HiveEventID(
+            runID: runID,
+            attemptID: attemptID,
+            eventIndex: eventIndex,
+            stepIndex: stepIndex,
+            taskOrdinal: taskOrdinal
+        )
+        _ = queue.append(HiveEvent(id: id, kind: kind, metadata: metadata))
+        condition.signal()
+        return .enqueued
+    }
+
+    func pump(into continuation: AsyncThrowingStream<HiveEvent, Error>.Continuation) {
+        while true {
+            let state = drainState()
+            switch state {
+            case .hasEvent:
+                while true {
+                    guard let event = snapshotFirst() else { break }
+                    switch continuation.yield(event) {
+                    case .enqueued:
+                        consumeFirst()
+                        break
+                    case .dropped:
+                        // `.bufferingOldest` reports `.dropped` when this event could not be delivered.
+                        // Droppable events are intentionally discarded; non-droppable events must stay queued
+                        // and retry until a consumer makes space. Once the run has finished, an unconsumed
+                        // stream must be allowed to terminate instead of keeping the pump alive forever.
+                        if isDroppable(event.kind) || isFinished {
+                            consumeFirst()
+                        } else {
+                            Thread.sleep(forTimeInterval: 0.00025)
+                        }
+                        break
+                    case .terminated:
+                        terminateStreamAndUnblockProducers()
+                        return
+                    @unknown default:
+                        consumeFirst()
+                        break
+                    }
+                }
+            case .finished:
+                continuation.finish()
+                return
+            case .failed(let error):
+                continuation.finish(throwing: error)
+                return
+            }
+        }
+    }
+
+    private func drainState() -> DrainState {
+        condition.lock()
+        while queue.isEmpty, finishState == nil {
+            condition.wait()
+        }
+
+        if !queue.isEmpty {
+            condition.unlock()
+            return .hasEvent
+        }
+
+        let state = finishState
+        condition.unlock()
+
+        switch state {
+        case .none, .some(.finished):
+            return .finished
+        case .some(.failed(let error)):
+            return .failed(error)
+        }
+    }
+
+    private func snapshotFirst() -> HiveEvent? {
+        condition.lock()
+        let first = queue.first
+        condition.unlock()
+        return first
+    }
+
+    private func consumeFirst() {
+        condition.lock()
+        if !queue.isEmpty {
+            queue.removeFirst()
+            condition.broadcast()
+        }
+        condition.unlock()
+    }
+
+    private func isDroppable(_ kind: HiveEventKind) -> Bool {
+        isDroppableDebug(kind)
+    }
+
+    private func isDroppableDebug(_ kind: HiveEventKind) -> Bool {
+        if case .customDebug = kind { return true }
+        return false
+    }
+
+    private func terminateStreamAndUnblockProducers() {
+        condition.lock()
+        if finishState == nil {
+            finishState = .finished
+        }
+        if !queue.isEmpty {
+            queue.removeAll(keepingCapacity: true)
+        }
+        condition.broadcast()
+        condition.unlock()
+    }
+
+    private var isFinished: Bool {
+        condition.lock()
+        let finished = finishState != nil
+        condition.unlock()
+        return finished
+    }
+}

--- a/Sources/HiveCore/Runtime/HiveEventStreamViews.swift
+++ b/Sources/HiveCore/Runtime/HiveEventStreamViews.swift
@@ -1,0 +1,279 @@
+import Foundation
+
+public struct HiveRunEvent: Sendable, Equatable {
+    public enum Kind: Sendable, Equatable {
+        case started(threadID: HiveThreadID)
+        case finished
+        case interrupted(interruptID: HiveInterruptID)
+        case resumed(interruptID: HiveInterruptID)
+        case cancelled(cause: HiveRunCancellationCause)
+    }
+
+    public let id: HiveEventID
+    public let metadata: [String: String]
+    public let kind: Kind
+}
+
+public struct HiveStepEvent: Sendable, Equatable {
+    public enum Kind: Sendable, Equatable {
+        case started(stepIndex: Int, frontierCount: Int)
+        case finished(stepIndex: Int, nextFrontierCount: Int)
+    }
+
+    public let id: HiveEventID
+    public let metadata: [String: String]
+    public let kind: Kind
+}
+
+public struct HiveTaskEvent: Sendable, Equatable {
+    public enum Kind: Sendable, Equatable {
+        case started(node: HiveNodeID, taskID: HiveTaskID)
+        case finished(node: HiveNodeID, taskID: HiveTaskID)
+        case failed(node: HiveNodeID, taskID: HiveTaskID, errorDescription: String)
+    }
+
+    public let id: HiveEventID
+    public let metadata: [String: String]
+    public let kind: Kind
+}
+
+public struct HiveWriteEvent: Sendable, Equatable {
+    public let id: HiveEventID
+    public let metadata: [String: String]
+    public let channelID: HiveChannelID
+    public let payloadHash: String
+}
+
+public struct HiveCheckpointEvent: Sendable, Equatable {
+    public enum Kind: Sendable, Equatable {
+        case saved(checkpointID: HiveCheckpointID)
+        case loaded(checkpointID: HiveCheckpointID)
+    }
+
+    public let id: HiveEventID
+    public let metadata: [String: String]
+    public let kind: Kind
+}
+
+public struct HiveDebugEvent: Sendable, Equatable {
+    public enum Kind: Sendable, Equatable {
+        case streamBackpressure(droppedDebugEvents: Int)
+        case customDebug(name: String)
+    }
+
+    public let id: HiveEventID
+    public let metadata: [String: String]
+    public let kind: Kind
+}
+
+public struct HiveEventStreamViews: Sendable {
+    private let hub: HiveEventStreamViewsHub
+
+    public init(_ source: AsyncThrowingStream<HiveEvent, Error>) {
+        self.hub = HiveEventStreamViewsHub(source: source)
+    }
+
+    public func runs() -> AsyncThrowingStream<HiveRunEvent, Error> {
+        makeViewStream { event in
+            switch event.kind {
+            case .runStarted(let threadID):
+                return HiveRunEvent(id: event.id, metadata: event.metadata, kind: .started(threadID: threadID))
+            case .runFinished:
+                return HiveRunEvent(id: event.id, metadata: event.metadata, kind: .finished)
+            case .runInterrupted(let interruptID):
+                return HiveRunEvent(id: event.id, metadata: event.metadata, kind: .interrupted(interruptID: interruptID))
+            case .runResumed(let interruptID):
+                return HiveRunEvent(id: event.id, metadata: event.metadata, kind: .resumed(interruptID: interruptID))
+            case .runCancelled(let cause):
+                return HiveRunEvent(id: event.id, metadata: event.metadata, kind: .cancelled(cause: cause))
+            default:
+                return nil
+            }
+        }
+    }
+
+    public func steps() -> AsyncThrowingStream<HiveStepEvent, Error> {
+        makeViewStream { event in
+            switch event.kind {
+            case .stepStarted(let stepIndex, let frontierCount):
+                return HiveStepEvent(
+                    id: event.id,
+                    metadata: event.metadata,
+                    kind: .started(stepIndex: stepIndex, frontierCount: frontierCount)
+                )
+            case .stepFinished(let stepIndex, let nextFrontierCount):
+                return HiveStepEvent(
+                    id: event.id,
+                    metadata: event.metadata,
+                    kind: .finished(stepIndex: stepIndex, nextFrontierCount: nextFrontierCount)
+                )
+            default:
+                return nil
+            }
+        }
+    }
+
+    public func tasks() -> AsyncThrowingStream<HiveTaskEvent, Error> {
+        makeViewStream { event in
+            switch event.kind {
+            case .taskStarted(let node, let taskID):
+                return HiveTaskEvent(id: event.id, metadata: event.metadata, kind: .started(node: node, taskID: taskID))
+            case .taskFinished(let node, let taskID):
+                return HiveTaskEvent(id: event.id, metadata: event.metadata, kind: .finished(node: node, taskID: taskID))
+            case .taskFailed(let node, let taskID, let errorDescription):
+                return HiveTaskEvent(
+                    id: event.id,
+                    metadata: event.metadata,
+                    kind: .failed(node: node, taskID: taskID, errorDescription: errorDescription)
+                )
+            default:
+                return nil
+            }
+        }
+    }
+
+    public func writes() -> AsyncThrowingStream<HiveWriteEvent, Error> {
+        makeViewStream { event in
+            guard case .writeApplied(let channelID, let payloadHash) = event.kind else { return nil }
+            return HiveWriteEvent(id: event.id, metadata: event.metadata, channelID: channelID, payloadHash: payloadHash)
+        }
+    }
+
+    public func checkpoints() -> AsyncThrowingStream<HiveCheckpointEvent, Error> {
+        makeViewStream { event in
+            switch event.kind {
+            case .checkpointSaved(let checkpointID):
+                return HiveCheckpointEvent(id: event.id, metadata: event.metadata, kind: .saved(checkpointID: checkpointID))
+            case .checkpointLoaded(let checkpointID):
+                return HiveCheckpointEvent(id: event.id, metadata: event.metadata, kind: .loaded(checkpointID: checkpointID))
+            default:
+                return nil
+            }
+        }
+    }
+
+    public func debug() -> AsyncThrowingStream<HiveDebugEvent, Error> {
+        makeViewStream { event in
+            switch event.kind {
+            case .streamBackpressure(let droppedDebugEvents):
+                return HiveDebugEvent(
+                    id: event.id,
+                    metadata: event.metadata,
+                    kind: .streamBackpressure(droppedDebugEvents: droppedDebugEvents)
+                )
+            case .customDebug(let name):
+                return HiveDebugEvent(id: event.id, metadata: event.metadata, kind: .customDebug(name: name))
+            default:
+                return nil
+            }
+        }
+    }
+
+    private func makeViewStream<T: Sendable>(
+        _ transform: @escaping @Sendable (HiveEvent) -> T?
+    ) -> AsyncThrowingStream<T, Error> {
+        AsyncThrowingStream { continuation in
+            let id = UUID()
+            Task {
+                await hub.addSubscriber(
+                    id: id,
+                    onEvent: { event in
+                        if let mapped = transform(event) {
+                            continuation.yield(mapped)
+                        }
+                    },
+                    onFinish: { result in
+                        switch result {
+                        case .success:
+                            continuation.finish()
+                        case .failure(let error):
+                            continuation.finish(throwing: error)
+                        }
+                    }
+                )
+            }
+            continuation.onTermination = { _ in
+                Task { await hub.removeSubscriber(id: id) }
+            }
+        }
+    }
+}
+
+actor HiveEventStreamViewsHub {
+    private struct Subscriber {
+        let onEvent: (HiveEvent) -> Void
+        let onFinish: (Result<Void, Error>) -> Void
+    }
+
+    private let source: AsyncThrowingStream<HiveEvent, Error>
+    private var subscribers: [UUID: Subscriber] = [:]
+    private var pumpTask: Task<Void, Never>?
+    private var finished: Result<Void, Error>?
+
+    init(source: AsyncThrowingStream<HiveEvent, Error>) {
+        self.source = source
+    }
+
+    deinit {
+        pumpTask?.cancel()
+    }
+
+    func addSubscriber(
+        id: UUID,
+        onEvent: @escaping (HiveEvent) -> Void,
+        onFinish: @escaping (Result<Void, Error>) -> Void
+    ) {
+        if let finished {
+            onFinish(finished)
+            return
+        }
+
+        subscribers[id] = Subscriber(onEvent: onEvent, onFinish: onFinish)
+        startPumpIfNeeded()
+    }
+
+    func removeSubscriber(id: UUID) {
+        subscribers.removeValue(forKey: id)
+    }
+
+    private func startPumpIfNeeded() {
+        guard pumpTask == nil else { return }
+        pumpTask = Task(priority: .userInitiated) { [weak self, source] in
+            do {
+                for try await event in source {
+                    guard let self else { return }
+                    await self.broadcast(event)
+                }
+                guard let self else { return }
+                await self.finishAll(.success(()))
+            } catch is CancellationError {
+                guard let self else { return }
+                await self.clearPumpTask()
+            } catch {
+                guard let self else { return }
+                await self.finishAll(.failure(error))
+            }
+        }
+    }
+
+    private func clearPumpTask() {
+        pumpTask = nil
+    }
+
+    private func broadcast(_ event: HiveEvent) {
+        for subscriber in subscribers.values {
+            subscriber.onEvent(event)
+        }
+    }
+
+    private func finishAll(_ result: Result<Void, Error>) {
+        finished = result
+        let current = subscribers.values
+        subscribers.removeAll()
+        pumpTask = nil
+
+        for subscriber in current {
+            subscriber.onFinish(result)
+        }
+    }
+}

--- a/Sources/HiveCore/Runtime/HiveEvents.swift
+++ b/Sources/HiveCore/Runtime/HiveEvents.swift
@@ -1,0 +1,109 @@
+/// Stable identifier for a run event.
+public struct HiveEventID: Hashable, Codable, Sendable {
+    public let runID: HiveRunID
+    public let attemptID: HiveRunAttemptID
+    public let eventIndex: UInt64
+    public let stepIndex: Int?
+    public let taskOrdinal: Int?
+
+    public init(
+        runID: HiveRunID,
+        attemptID: HiveRunAttemptID,
+        eventIndex: UInt64,
+        stepIndex: Int?,
+        taskOrdinal: Int?
+    ) {
+        self.runID = runID
+        self.attemptID = attemptID
+        self.eventIndex = eventIndex
+        self.stepIndex = stepIndex
+        self.taskOrdinal = taskOrdinal
+    }
+}
+
+/// Version marker for event-schema/replay compatibility checks.
+public enum HiveEventSchemaVersion: String, Codable, Sendable, Equatable {
+    case v0 = "HES0"
+    case v1 = "HES1"
+
+    public static let current: HiveEventSchemaVersion = .v1
+}
+
+/// Classified cancellation causes used by lifecycle events.
+public enum HiveRunCancellationCause: String, Codable, Sendable, Equatable {
+    case explicitRequest
+    case checkpointPersistenceRace
+    case executionObserved
+}
+
+/// Event emitted by the runtime event stream.
+public struct HiveEvent: Sendable {
+    public let schemaVersion: HiveEventSchemaVersion
+    public let id: HiveEventID
+    public let kind: HiveEventKind
+    public let metadata: [String: String]
+
+    public init(
+        schemaVersion: HiveEventSchemaVersion = .current,
+        id: HiveEventID,
+        kind: HiveEventKind,
+        metadata: [String: String]
+    ) {
+        self.schemaVersion = schemaVersion
+        self.id = id
+        self.kind = kind
+        self.metadata = metadata
+    }
+}
+
+/// A single channel's value in a store snapshot or channel update event.
+public struct HiveSnapshotValue: Sendable {
+    public let channelID: HiveChannelID
+    public let payloadHash: String
+    public let debugValue: (any Sendable)?
+
+    public init(channelID: HiveChannelID, payloadHash: String, debugValue: (any Sendable)? = nil) {
+        self.channelID = channelID
+        self.payloadHash = payloadHash
+        self.debugValue = debugValue
+    }
+}
+
+/// Event kinds emitted during a run.
+public enum HiveEventKind: Sendable {
+    case runStarted(threadID: HiveThreadID)
+    case runFinished
+    case runInterrupted(interruptID: HiveInterruptID)
+    case runResumed(interruptID: HiveInterruptID)
+    case runCancelled(cause: HiveRunCancellationCause)
+    case forkStarted(sourceThreadID: HiveThreadID, targetThreadID: HiveThreadID, sourceCheckpointID: HiveCheckpointID?)
+    case forkCompleted(
+        sourceThreadID: HiveThreadID,
+        targetThreadID: HiveThreadID,
+        sourceCheckpointID: HiveCheckpointID,
+        targetCheckpointID: HiveCheckpointID?
+    )
+    case forkFailed(
+        sourceThreadID: HiveThreadID,
+        targetThreadID: HiveThreadID,
+        sourceCheckpointID: HiveCheckpointID?,
+        errorCode: String
+    )
+
+    case stepStarted(stepIndex: Int, frontierCount: Int)
+    case stepFinished(stepIndex: Int, nextFrontierCount: Int)
+
+    case taskStarted(node: HiveNodeID, taskID: HiveTaskID)
+    case taskFinished(node: HiveNodeID, taskID: HiveTaskID)
+    case taskFailed(node: HiveNodeID, taskID: HiveTaskID, errorDescription: String)
+
+    case writeApplied(channelID: HiveChannelID, payloadHash: String)
+    case checkpointSaved(checkpointID: HiveCheckpointID)
+    case checkpointLoaded(checkpointID: HiveCheckpointID)
+
+    case storeSnapshot(channelValues: [HiveSnapshotValue])
+    case channelUpdates(channelValues: [HiveSnapshotValue])
+
+    case streamBackpressure(droppedDebugEvents: Int)
+    case customDebug(name: String)
+}

--- a/Sources/HiveCore/Runtime/HiveInterrupts.swift
+++ b/Sources/HiveCore/Runtime/HiveInterrupts.swift
@@ -1,0 +1,50 @@
+/// Stable identifier for an interrupt.
+public struct HiveInterruptID: Hashable, Codable, Sendable {
+    public let rawValue: String
+
+    public init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+}
+
+/// Interrupt request emitted by a node.
+public struct HiveInterruptRequest<Schema: HiveSchema>: Codable, Sendable {
+    public let payload: Schema.InterruptPayload
+
+    public init(payload: Schema.InterruptPayload) {
+        self.payload = payload
+    }
+}
+
+/// Selected interrupt value persisted for resume.
+public struct HiveInterrupt<Schema: HiveSchema>: Codable, Sendable {
+    public let id: HiveInterruptID
+    public let payload: Schema.InterruptPayload
+
+    public init(id: HiveInterruptID, payload: Schema.InterruptPayload) {
+        self.id = id
+        self.payload = payload
+    }
+}
+
+/// Resume payload delivered to the first step after resume.
+public struct HiveResume<Schema: HiveSchema>: Codable, Sendable {
+    public let interruptID: HiveInterruptID
+    public let payload: Schema.ResumePayload
+
+    public init(interruptID: HiveInterruptID, payload: Schema.ResumePayload) {
+        self.interruptID = interruptID
+        self.payload = payload
+    }
+}
+
+/// Interrupted run outcome payload.
+public struct HiveInterruption<Schema: HiveSchema>: Codable, Sendable {
+    public let interrupt: HiveInterrupt<Schema>
+    public let checkpointID: HiveCheckpointID
+
+    public init(interrupt: HiveInterrupt<Schema>, checkpointID: HiveCheckpointID) {
+        self.interrupt = interrupt
+        self.checkpointID = checkpointID
+    }
+}

--- a/Sources/HiveCore/Runtime/HiveRetryPolicy.swift
+++ b/Sources/HiveCore/Runtime/HiveRetryPolicy.swift
@@ -1,0 +1,10 @@
+/// Retry strategy for node execution.
+public enum HiveRetryPolicy: Sendable {
+    case none
+    case exponentialBackoff(
+        initialNanoseconds: UInt64,
+        factor: Double,
+        maxAttempts: Int,
+        maxNanoseconds: UInt64
+    )
+}

--- a/Sources/HiveCore/Runtime/HiveRunOptions.swift
+++ b/Sources/HiveCore/Runtime/HiveRunOptions.swift
@@ -1,0 +1,51 @@
+/// Policy controlling checkpoint save cadence.
+public enum HiveCheckpointPolicy: Sendable {
+    case disabled
+    case everyStep
+    case every(steps: Int)
+    case onInterrupt
+}
+
+/// Controls what additional events the runtime emits after each step.
+public enum HiveStreamingMode: Sendable, Equatable {
+    /// Default — no additional streaming events beyond the standard event stream.
+    case events
+    /// Emit a full store snapshot after each step.
+    case values
+    /// Emit only the channels that were written in each step.
+    case updates
+    /// Emit both a full store snapshot and channel updates after each step.
+    case combined
+}
+
+/// Runtime execution options for a run attempt.
+public struct HiveRunOptions: Sendable {
+    public let maxSteps: Int
+    public let maxConcurrentTasks: Int
+    public let checkpointPolicy: HiveCheckpointPolicy
+    public let debugPayloads: Bool
+    public let deterministicStreamBuffering: Bool
+    public let eventBufferCapacity: Int
+    public let outputProjectionOverride: HiveOutputProjection?
+    public let streamingMode: HiveStreamingMode
+
+    public init(
+        maxSteps: Int = 100,
+        maxConcurrentTasks: Int = 8,
+        checkpointPolicy: HiveCheckpointPolicy = .disabled,
+        debugPayloads: Bool = false,
+        deterministicStreamBuffering: Bool = false,
+        eventBufferCapacity: Int = 4096,
+        outputProjectionOverride: HiveOutputProjection? = nil,
+        streamingMode: HiveStreamingMode = .events
+    ) {
+        self.maxSteps = maxSteps
+        self.maxConcurrentTasks = maxConcurrentTasks
+        self.checkpointPolicy = checkpointPolicy
+        self.debugPayloads = debugPayloads
+        self.deterministicStreamBuffering = deterministicStreamBuffering
+        self.eventBufferCapacity = eventBufferCapacity
+        self.outputProjectionOverride = outputProjectionOverride
+        self.streamingMode = streamingMode
+    }
+}

--- a/Sources/HiveCore/Runtime/HiveRunTypes.swift
+++ b/Sources/HiveCore/Runtime/HiveRunTypes.swift
@@ -1,0 +1,121 @@
+/// Output value for a projected channel.
+public struct HiveProjectedChannelValue: Sendable {
+    public let id: HiveChannelID
+    public let value: any Sendable
+
+    public init(id: HiveChannelID, value: any Sendable) {
+        self.id = id
+        self.value = value
+    }
+}
+
+/// Output of a completed run attempt.
+public enum HiveRunOutput<Schema: HiveSchema>: Sendable {
+    case fullStore(HiveGlobalStore<Schema>)
+    case channels([HiveProjectedChannelValue])
+}
+
+/// Terminal result of a run attempt.
+public enum HiveRunOutcome<Schema: HiveSchema>: Sendable {
+    case finished(output: HiveRunOutput<Schema>, checkpointID: HiveCheckpointID?)
+    case interrupted(interruption: HiveInterruption<Schema>)
+    case cancelled(output: HiveRunOutput<Schema>, checkpointID: HiveCheckpointID?)
+    case outOfSteps(maxSteps: Int, output: HiveRunOutput<Schema>, checkpointID: HiveCheckpointID?)
+}
+
+/// Handle for observing a running attempt.
+public struct HiveRunHandle<Schema: HiveSchema>: Sendable {
+    public let runID: HiveRunID
+    public let attemptID: HiveRunAttemptID
+    public let events: AsyncThrowingStream<HiveEvent, Error>
+    public let outcome: Task<HiveRunOutcome<Schema>, Error>
+    private let streamController: HiveEventStreamController?
+
+    public init(
+        runID: HiveRunID,
+        attemptID: HiveRunAttemptID,
+        events: AsyncThrowingStream<HiveEvent, Error>,
+        outcome: Task<HiveRunOutcome<Schema>, Error>
+    ) {
+        self.runID = runID
+        self.attemptID = attemptID
+        self.events = events
+        self.outcome = outcome
+        self.streamController = nil
+    }
+
+    init(
+        runID: HiveRunID,
+        attemptID: HiveRunAttemptID,
+        events: AsyncThrowingStream<HiveEvent, Error>,
+        outcome: Task<HiveRunOutcome<Schema>, Error>,
+        streamController: HiveEventStreamController
+    ) {
+        self.runID = runID
+        self.attemptID = attemptID
+        self.events = events
+        self.outcome = outcome
+        self.streamController = streamController
+    }
+}
+
+/// Structured lineage metadata for a forked thread.
+public struct HiveForkLineage: Sendable, Codable, Equatable {
+    public let lineageID: String
+    public let sourceThreadID: HiveThreadID
+    public let sourceCheckpointID: HiveCheckpointID
+    public let targetThreadID: HiveThreadID
+    public let sourceRunID: HiveRunID
+    public let targetRunID: HiveRunID
+    public let schemaVersion: String
+    public let graphVersion: String
+    public let createdAtNanoseconds: UInt64
+
+    public init(
+        lineageID: String,
+        sourceThreadID: HiveThreadID,
+        sourceCheckpointID: HiveCheckpointID,
+        targetThreadID: HiveThreadID,
+        sourceRunID: HiveRunID,
+        targetRunID: HiveRunID,
+        schemaVersion: String,
+        graphVersion: String,
+        createdAtNanoseconds: UInt64
+    ) {
+        self.lineageID = lineageID
+        self.sourceThreadID = sourceThreadID
+        self.sourceCheckpointID = sourceCheckpointID
+        self.targetThreadID = targetThreadID
+        self.sourceRunID = sourceRunID
+        self.targetRunID = targetRunID
+        self.schemaVersion = schemaVersion
+        self.graphVersion = graphVersion
+        self.createdAtNanoseconds = createdAtNanoseconds
+    }
+}
+
+/// Result of forking a checkpoint/thread into a new thread lineage.
+public struct HiveForkResult<Schema: HiveSchema>: Sendable {
+    public let sourceThreadID: HiveThreadID
+    public let sourceCheckpointID: HiveCheckpointID
+    public let targetThreadID: HiveThreadID
+    public let targetCheckpointID: HiveCheckpointID?
+    public let runID: HiveRunID
+    public let lineage: HiveForkLineage?
+
+    public init(
+        sourceThreadID: HiveThreadID,
+        sourceCheckpointID: HiveCheckpointID,
+        targetThreadID: HiveThreadID,
+        targetCheckpointID: HiveCheckpointID?,
+        runID: HiveRunID,
+        lineage: HiveForkLineage?
+    ) {
+        self.sourceThreadID = sourceThreadID
+        self.sourceCheckpointID = sourceCheckpointID
+        self.targetThreadID = targetThreadID
+        self.targetCheckpointID = targetCheckpointID
+        self.runID = runID
+        self.lineage = lineage
+    }
+}

--- a/Sources/HiveCore/Runtime/HiveRuntime.swift
+++ b/Sources/HiveCore/Runtime/HiveRuntime.swift
@@ -1,0 +1,3330 @@
+import Foundation
+import Mutex
+
+// MARK: - HiveRuntime
+
+/// Deterministic runtime for executing a compiled graph.
+public actor HiveRuntime<Schema: HiveSchema>: Sendable {
+    public init(graph: CompiledHiveGraph<Schema>, environment: HiveEnvironment<Schema>) throws {
+        self.graph = graph
+        self.environment = environment
+        self.environmentSnapshot = environment
+        let registry = try HiveSchemaRegistry<Schema>()
+        self.registry = registry
+        self.initialCache = HiveInitialCache(registry: registry)
+        self.storeSupport = HiveStoreSupport(registry: registry)
+        self.threadStates = [:]
+        self.threadQueues = [:]
+    }
+
+    public func run(
+        threadID: HiveThreadID,
+        input: Schema.Input,
+        options: HiveRunOptions
+    ) -> HiveRunHandle<Schema> {
+        do {
+            try validateRunOptions(options)
+            try validateRetryPolicies()
+            try validateRequiredCodecs()
+        } catch {
+            return makeFailFastHandle(threadID: threadID, options: options, error: error)
+        }
+
+        let attemptID = HiveRunAttemptID(UUID())
+        let runID = threadStates[threadID]?.runID ?? HiveRunID(UUID())
+        let capacity = max(1, options.eventBufferCapacity)
+        let streamController = HiveEventStreamController(capacity: capacity)
+        let events = streamController.makeStream()
+
+        let previous = threadQueues[threadID]
+        let outcome = Task { [weak self] in
+            if let previous {
+                await previous.value
+            }
+            guard let self else {
+                throw CancellationError()
+            }
+            return try await self.runAttempt(
+                threadID: threadID,
+                input: input,
+                options: options,
+                runID: runID,
+                attemptID: attemptID,
+                streamController: streamController
+            )
+        }
+
+        threadQueues[threadID] = Task {
+            _ = try? await outcome.value
+        }
+
+        return HiveRunHandle(
+            runID: runID,
+            attemptID: attemptID,
+            events: events,
+            outcome: outcome,
+            streamController: streamController
+        )
+    }
+
+    public func resume(
+        threadID: HiveThreadID,
+        interruptID: HiveInterruptID,
+        payload: Schema.ResumePayload,
+        options: HiveRunOptions
+    ) -> HiveRunHandle<Schema> {
+        do {
+            try validateRunOptions(options)
+            try validateRetryPolicies()
+            try validateRequiredCodecs()
+        } catch {
+            return makeFailFastHandle(threadID: threadID, options: options, error: error)
+        }
+
+        let attemptID = HiveRunAttemptID(UUID())
+        let runID = threadStates[threadID]?.runID ?? HiveRunID(UUID())
+        let capacity = max(1, options.eventBufferCapacity)
+        let streamController = HiveEventStreamController(capacity: capacity)
+        let events = streamController.makeStream()
+
+        let previous = threadQueues[threadID]
+        let outcome = Task { [weak self] in
+            if let previous {
+                await previous.value
+            }
+            guard let self else { throw CancellationError() }
+            return try await self.resumeAttempt(
+                threadID: threadID,
+                interruptID: interruptID,
+                payload: payload,
+                options: options,
+                runID: runID,
+                attemptID: attemptID,
+                streamController: streamController
+            )
+        }
+
+        threadQueues[threadID] = Task {
+            _ = try? await outcome.value
+        }
+
+        return HiveRunHandle(
+            runID: runID,
+            attemptID: attemptID,
+            events: events,
+            outcome: outcome,
+            streamController: streamController
+        )
+    }
+
+    public func applyExternalWrites(
+        threadID: HiveThreadID,
+        writes: [AnyHiveWrite<Schema>],
+        options: HiveRunOptions
+    ) -> HiveRunHandle<Schema> {
+        do {
+            try validateRunOptions(options)
+            try validateRetryPolicies()
+            try validateRequiredCodecs()
+        } catch {
+            return makeFailFastHandle(threadID: threadID, options: options, error: error)
+        }
+
+        let attemptID = HiveRunAttemptID(UUID())
+        let runID = threadStates[threadID]?.runID ?? HiveRunID(UUID())
+        let capacity = max(1, options.eventBufferCapacity)
+        let streamController = HiveEventStreamController(capacity: capacity)
+        let events = streamController.makeStream()
+
+        let previous = threadQueues[threadID]
+        let outcome = Task { [weak self] in
+            if let previous {
+                await previous.value
+            }
+            guard let self else { throw CancellationError() }
+            return try await self.applyExternalWritesAttempt(
+                threadID: threadID,
+                writes: writes,
+                options: options,
+                runID: runID,
+                attemptID: attemptID,
+                streamController: streamController
+            )
+        }
+
+        threadQueues[threadID] = Task {
+            _ = try? await outcome.value
+        }
+
+        return HiveRunHandle(
+            runID: runID,
+            attemptID: attemptID,
+            events: events,
+            outcome: outcome,
+            streamController: streamController
+        )
+    }
+
+    public func getCheckpointHistory(
+        threadID: HiveThreadID,
+        limit: Int? = nil
+    ) async throws -> [HiveCheckpointSummary] {
+        guard let store = environment.checkpointStore else {
+            throw HiveCheckpointQueryError.unsupported(operation: .listCheckpoints)
+        }
+        return try await store.listCheckpoints(threadID: threadID, limit: limit)
+    }
+
+    public func getCheckpoint(
+        threadID: HiveThreadID,
+        id: HiveCheckpointID
+    ) async throws -> HiveCheckpoint<Schema>? {
+        guard let store = environment.checkpointStore else {
+            throw HiveCheckpointQueryError.unsupported(operation: .loadCheckpointByID)
+        }
+        return try await store.loadCheckpoint(threadID: threadID, id: id)
+    }
+
+    /// Returns discoverable checkpoint-query capabilities for the configured store.
+    public func checkpointCapabilities() -> HiveCheckpointStoreCapabilities {
+        environment.checkpointStore?.capabilities ?? .none
+    }
+
+    public func getLatestStore(threadID: HiveThreadID) -> HiveGlobalStore<Schema>? {
+        threadStates[threadID]?.global
+    }
+
+    public func getLatestCheckpoint(threadID: HiveThreadID) async throws -> HiveCheckpoint<Schema>? {
+        guard let store = environment.checkpointStore else { return nil }
+        return try await store.loadLatest(threadID: threadID)
+    }
+
+    /// Returns a unified state snapshot for the given thread.
+    /// Checks in-memory state first (O(1)), then falls back to the checkpoint store.
+    /// Returns `nil` when no state exists for the thread.
+    public func getState(threadID: HiveThreadID) async throws -> HiveRuntimeStateSnapshot<Schema>? {
+        if let state = threadStates[threadID] {
+            return try snapshot(
+                threadID: threadID,
+                state: state,
+                checkpointSummary: nil
+            )
+        }
+
+        guard let store = environment.checkpointStore else { return nil }
+        guard let checkpoint = try await store.loadLatest(threadID: threadID) else { return nil }
+        let state = try decodeCheckpoint(checkpoint, debugPayloads: false)
+        let summary = HiveCheckpointSummary(
+            id: checkpoint.id,
+            threadID: checkpoint.threadID,
+            runID: checkpoint.runID,
+            stepIndex: checkpoint.stepIndex,
+            schemaVersion: checkpoint.schemaVersion,
+            graphVersion: checkpoint.graphVersion
+        )
+        return try snapshot(
+            threadID: threadID,
+            state: state,
+            checkpointSummary: summary
+        )
+    }
+
+    /// Returns accumulated fork lifecycle events emitted by this runtime instance.
+    public func getForkEventHistory(limit: Int? = nil) -> [HiveEvent] {
+        guard let limit else { return forkEventHistory }
+        if limit <= 0 { return [] }
+        if limit >= forkEventHistory.count { return forkEventHistory }
+        return Array(forkEventHistory.suffix(limit))
+    }
+
+    /// Returns deduplicated, lexicographically sorted node IDs from a frontier.
+    /// A node can appear multiple times in the frontier (scheduled by both a router and a static
+    /// edge). `nextNodes` must deduplicate for a consistent API contract.
+    private func deduplicatedNextNodes(from frontier: [HiveFrontierTask<Schema>]) -> [HiveNodeID] {
+        Array(Set(frontier.map(\.seed.nodeID))).sorted {
+            HiveOrdering.lexicographicallyPrecedes($0.rawValue, $1.rawValue)
+        }
+    }
+
+    private func snapshot(
+        threadID: HiveThreadID,
+        state: ThreadState<Schema>,
+        checkpointSummary: HiveCheckpointSummary?
+    ) throws -> HiveRuntimeStateSnapshot<Schema> {
+        let globalHashes = try makeGlobalChannelPayloadHashes(from: state.global)
+        let frontierSummary = try makeFrontierSummary(from: state.frontier)
+        let interruption = try makeInterruptionSnapshot(from: state.interruption)
+        return HiveRuntimeStateSnapshot(
+            threadID: threadID,
+            runID: state.runID,
+            stepIndex: state.stepIndex,
+            interruption: interruption,
+            checkpointID: checkpointSummary?.id ?? state.latestCheckpointID,
+            checkpoint: checkpointSummary,
+            globalChannelPayloadHashesByID: globalHashes,
+            frontierSummary: frontierSummary,
+            store: state.global
+        )
+    }
+
+    /// Creates an independent target thread lineage from a source checkpoint.
+    public func fork(
+        threadID sourceThreadID: HiveThreadID,
+        to newThreadID: HiveThreadID,
+        from checkpointID: HiveCheckpointID? = nil,
+        options: HiveRunOptions? = nil
+    ) async throws -> HiveForkResult<Schema> {
+        if let options {
+            try validateRunOptions(options)
+            try validateRequiredCodecs()
+        }
+
+        let attemptID = makeForkAttemptID(
+            sourceThreadID: sourceThreadID,
+            targetThreadID: newThreadID,
+            requestedCheckpointID: checkpointID
+        )
+        let provisionalRunID = makeForkRunID(
+            sourceThreadID: sourceThreadID,
+            targetThreadID: newThreadID,
+            sourceCheckpointID: checkpointID
+        )
+        var eventIndex: UInt64 = 0
+        emitForkLifecycleEvent(
+            runID: provisionalRunID,
+            attemptID: attemptID,
+            eventIndex: &eventIndex,
+            kind: .forkStarted(
+                sourceThreadID: sourceThreadID,
+                targetThreadID: newThreadID,
+                sourceCheckpointID: checkpointID
+            )
+        )
+
+        do {
+            guard let store = environment.checkpointStore else {
+                throw HiveRuntimeError.forkCheckpointStoreMissing
+            }
+
+            try await validateForkTargetAvailability(newThreadID, store: store)
+
+            let sourceCheckpoint = try await resolveForkSourceCheckpoint(
+                sourceThreadID: sourceThreadID,
+                checkpointID: checkpointID,
+                store: store
+            )
+            let sourceCheckpointID = sourceCheckpoint.id
+            let targetRunID = provisionalRunID
+
+            var targetState = try decodeCheckpointForFork(sourceCheckpoint, debugPayloads: options?.debugPayloads ?? false)
+            targetState.runID = targetRunID
+            targetState.latestCheckpointID = nil
+
+            let lineage = makeForkLineage(
+                sourceThreadID: sourceThreadID,
+                sourceCheckpoint: sourceCheckpoint,
+                targetThreadID: newThreadID,
+                targetRunID: targetRunID
+            )
+
+            var targetCheckpointID: HiveCheckpointID?
+            if shouldPersistForkCheckpoint(options: options) {
+                let targetCheckpoint = try makeCheckpoint(
+                    threadID: newThreadID,
+                    state: targetState,
+                    debugPayloads: options?.debugPayloads ?? false,
+                    lineage: checkpointLineage(from: lineage)
+                )
+                try await saveCheckpoint(targetCheckpoint, to: store)
+                targetCheckpointID = targetCheckpoint.id
+                targetState.latestCheckpointID = targetCheckpoint.id
+            }
+
+            threadStates[newThreadID] = targetState
+
+            emitForkLifecycleEvent(
+                runID: targetRunID,
+                attemptID: attemptID,
+                eventIndex: &eventIndex,
+                kind: .forkCompleted(
+                    sourceThreadID: sourceThreadID,
+                    targetThreadID: newThreadID,
+                    sourceCheckpointID: sourceCheckpointID,
+                    targetCheckpointID: targetCheckpointID
+                )
+            )
+
+            return HiveForkResult(
+                sourceThreadID: sourceThreadID,
+                sourceCheckpointID: sourceCheckpointID,
+                targetThreadID: newThreadID,
+                targetCheckpointID: targetCheckpointID,
+                runID: targetRunID,
+                lineage: lineage
+            )
+        } catch let runtimeError as HiveRuntimeError {
+            emitForkLifecycleEvent(
+                runID: provisionalRunID,
+                attemptID: attemptID,
+                eventIndex: &eventIndex,
+                kind: .forkFailed(
+                    sourceThreadID: sourceThreadID,
+                    targetThreadID: newThreadID,
+                    sourceCheckpointID: checkpointID,
+                    errorCode: forkRuntimeErrorCode(runtimeError)
+                ),
+                metadata: ["errorCode": forkRuntimeErrorCode(runtimeError)]
+            )
+            throw runtimeError
+        } catch {
+            emitForkLifecycleEvent(
+                runID: provisionalRunID,
+                attemptID: attemptID,
+                eventIndex: &eventIndex,
+                kind: .forkFailed(
+                    sourceThreadID: sourceThreadID,
+                    targetThreadID: newThreadID,
+                    sourceCheckpointID: checkpointID,
+                    errorCode: "fork_unknown_error"
+                ),
+                metadata: ["errorCode": "fork_unknown_error"]
+            )
+            throw error
+        }
+    }
+
+    // MARK: - Private
+
+    private let graph: CompiledHiveGraph<Schema>
+    private let environment: HiveEnvironment<Schema>
+    public nonisolated let environmentSnapshot: HiveEnvironment<Schema>
+    private let registry: HiveSchemaRegistry<Schema>
+    private let initialCache: HiveInitialCache<Schema>
+    private let storeSupport: HiveStoreSupport<Schema>
+
+    private var threadStates: [HiveThreadID: ThreadState<Schema>]
+    private var threadQueues: [HiveThreadID: Task<Void, Never>]
+    private var forkEventHistory: [HiveEvent] = []
+
+    // MARK: - Streaming Mode Helpers
+
+    /// Builds a snapshot of all global channel values for streaming.
+    private func buildStoreSnapshot(state: ThreadState<Schema>, debugPayloads: Bool) throws -> [HiveSnapshotValue] {
+        try registry.sortedChannelSpecs.compactMap { spec -> HiveSnapshotValue? in
+            guard spec.scope == .global else { return nil }
+            let hash = try payloadHash(for: spec.id, in: state.global)
+            let debugVal: (any Sendable)? = debugPayloads ? (try? state.global.valueAny(for: spec.id)) : nil
+            return HiveSnapshotValue(channelID: spec.id, payloadHash: hash, debugValue: debugVal)
+        }
+    }
+
+    /// Builds channel update values for only the channels written in this step.
+    private func buildChannelUpdates(writtenChannels: [HiveChannelID], state: ThreadState<Schema>, debugPayloads: Bool) throws -> [HiveSnapshotValue] {
+        try writtenChannels.sorted(by: { $0.rawValue < $1.rawValue }).compactMap { channelID -> HiveSnapshotValue? in
+            let hash = try payloadHash(for: channelID, in: state.global)
+            let debugVal: (any Sendable)? = debugPayloads ? (try? state.global.valueAny(for: channelID)) : nil
+            return HiveSnapshotValue(channelID: channelID, payloadHash: hash, debugValue: debugVal)
+        }
+    }
+
+    /// Emits streaming mode events if enabled in options.
+    private func emitStreamingEvents(
+        mode: HiveStreamingMode,
+        state: ThreadState<Schema>,
+        writtenChannels: [HiveChannelID],
+        debugPayloads: Bool,
+        stepIndex: Int,
+        emitter: HiveEventEmitter
+    ) throws {
+        guard mode != .events else { return }
+
+        if mode == .values || mode == .combined {
+            let snapshot = try buildStoreSnapshot(state: state, debugPayloads: debugPayloads)
+            emitter.emit(
+                kind: .storeSnapshot(channelValues: snapshot),
+                stepIndex: stepIndex,
+                taskOrdinal: nil,
+                treatAsNonDroppable: true
+            )
+        }
+
+        if mode == .updates || mode == .combined {
+            let updates = try buildChannelUpdates(writtenChannels: writtenChannels, state: state, debugPayloads: debugPayloads)
+            emitter.emit(
+                kind: .channelUpdates(channelValues: updates),
+                stepIndex: stepIndex,
+                taskOrdinal: nil,
+                treatAsNonDroppable: true
+            )
+        }
+    }
+
+    private func emitForkLifecycleEvent(
+        runID: HiveRunID,
+        attemptID: HiveRunAttemptID,
+        eventIndex: inout UInt64,
+        kind: HiveEventKind,
+        metadata: [String: String] = [:]
+    ) {
+        let id = HiveEventID(
+            runID: runID,
+            attemptID: attemptID,
+            eventIndex: eventIndex,
+            stepIndex: nil,
+            taskOrdinal: nil
+        )
+        forkEventHistory.append(HiveEvent(id: id, kind: kind, metadata: metadata))
+        eventIndex &+= 1
+    }
+
+    private func validateForkTargetAvailability(
+        _ targetThreadID: HiveThreadID,
+        store: AnyHiveCheckpointStore<Schema>
+    ) async throws {
+        if threadStates[targetThreadID] != nil || threadQueues[targetThreadID] != nil {
+            throw HiveRuntimeError.forkTargetThreadConflict(threadID: targetThreadID)
+        }
+
+        if try await store.loadLatest(threadID: targetThreadID) != nil {
+            throw HiveRuntimeError.forkTargetThreadConflict(threadID: targetThreadID)
+        }
+    }
+
+    private func resolveForkSourceCheckpoint(
+        sourceThreadID: HiveThreadID,
+        checkpointID: HiveCheckpointID?,
+        store: AnyHiveCheckpointStore<Schema>
+    ) async throws -> HiveCheckpoint<Schema> {
+        if let checkpointID {
+            do {
+                guard let checkpoint = try await store.loadCheckpoint(threadID: sourceThreadID, id: checkpointID) else {
+                    throw HiveRuntimeError.forkSourceCheckpointMissing(
+                        threadID: sourceThreadID,
+                        checkpointID: checkpointID
+                    )
+                }
+                return checkpoint
+            } catch let queryError as HiveCheckpointQueryError {
+                switch queryError {
+                case .unsupported(operation: _):
+                    throw HiveRuntimeError.forkCheckpointQueryUnsupported
+                }
+            }
+        }
+
+        guard let latest = try await store.loadLatest(threadID: sourceThreadID) else {
+            throw HiveRuntimeError.forkSourceCheckpointMissing(threadID: sourceThreadID, checkpointID: nil)
+        }
+        return latest
+    }
+
+    private func decodeCheckpointForFork(
+        _ checkpoint: HiveCheckpoint<Schema>,
+        debugPayloads: Bool
+    ) throws -> ThreadState<Schema> {
+        do {
+            return try decodeCheckpoint(checkpoint, debugPayloads: debugPayloads)
+        } catch let runtimeError as HiveRuntimeError {
+            switch runtimeError {
+            case let .checkpointVersionMismatch(expectedSchema, expectedGraph, foundSchema, foundGraph):
+                throw HiveRuntimeError.forkSchemaGraphMismatch(
+                    expectedSchema: expectedSchema,
+                    expectedGraph: expectedGraph,
+                    foundSchema: foundSchema,
+                    foundGraph: foundGraph
+                )
+            case let .checkpointCorrupt(field, errorDescription):
+                throw HiveRuntimeError.forkMalformedCheckpoint(
+                    field: field,
+                    errorDescription: errorDescription
+                )
+            case let .checkpointDecodeFailed(channelID, errorDescription):
+                throw HiveRuntimeError.forkMalformedCheckpoint(
+                    field: "channel.\(channelID.rawValue)",
+                    errorDescription: errorDescription
+                )
+            case let .missingCodec(channelID):
+                throw HiveRuntimeError.forkMalformedCheckpoint(
+                    field: "codec.\(channelID.rawValue)",
+                    errorDescription: "missing codec"
+                )
+            default:
+                throw HiveRuntimeError.forkMalformedCheckpoint(
+                    field: "checkpoint",
+                    errorDescription: String(describing: runtimeError)
+                )
+            }
+        }
+    }
+
+    private func shouldPersistForkCheckpoint(options: HiveRunOptions?) -> Bool {
+        guard let options else { return false }
+        switch options.checkpointPolicy {
+        case .disabled:
+            return false
+        case .everyStep, .every, .onInterrupt:
+            return true
+        }
+    }
+
+    private func makeForkLineage(
+        sourceThreadID: HiveThreadID,
+        sourceCheckpoint: HiveCheckpoint<Schema>,
+        targetThreadID: HiveThreadID,
+        targetRunID: HiveRunID
+    ) -> HiveForkLineage {
+        var data = Data("HFL1".utf8)
+        data.append(0)
+        data.append(contentsOf: sourceThreadID.rawValue.utf8)
+        data.append(0)
+        data.append(contentsOf: sourceCheckpoint.id.rawValue.utf8)
+        data.append(0)
+        data.append(contentsOf: targetThreadID.rawValue.utf8)
+        data.append(0)
+        data.append(contentsOf: sourceCheckpoint.runID.rawValue.uuidString.utf8)
+        data.append(0)
+        data.append(contentsOf: targetRunID.rawValue.uuidString.utf8)
+        data.append(0)
+        data.append(contentsOf: graph.schemaVersion.utf8)
+        data.append(0)
+        data.append(contentsOf: graph.graphVersion.utf8)
+        let lineageID = HiveSHA256.hash(data: data).compactMap { String(format: "%02x", $0) }.joined()
+
+        return HiveForkLineage(
+            lineageID: lineageID,
+            sourceThreadID: sourceThreadID,
+            sourceCheckpointID: sourceCheckpoint.id,
+            targetThreadID: targetThreadID,
+            sourceRunID: sourceCheckpoint.runID,
+            targetRunID: targetRunID,
+            schemaVersion: graph.schemaVersion,
+            graphVersion: graph.graphVersion,
+            createdAtNanoseconds: environment.clock.nowNanoseconds()
+        )
+    }
+
+    private func checkpointLineage(from lineage: HiveForkLineage) -> HiveCheckpointLineage {
+        HiveCheckpointLineage(
+            lineageID: lineage.lineageID,
+            sourceThreadID: lineage.sourceThreadID,
+            sourceCheckpointID: lineage.sourceCheckpointID,
+            targetThreadID: lineage.targetThreadID,
+            sourceRunID: lineage.sourceRunID,
+            targetRunID: lineage.targetRunID,
+            schemaVersion: lineage.schemaVersion,
+            graphVersion: lineage.graphVersion,
+            createdAtNanoseconds: lineage.createdAtNanoseconds
+        )
+    }
+
+    private func makeForkRunID(
+        sourceThreadID: HiveThreadID,
+        targetThreadID: HiveThreadID,
+        sourceCheckpointID: HiveCheckpointID?
+    ) -> HiveRunID {
+        HiveRunID(
+            deterministicUUID(
+                prefix: "HFORK_RUN1",
+                parts: [
+                    sourceThreadID.rawValue,
+                    targetThreadID.rawValue,
+                    sourceCheckpointID?.rawValue ?? "latest"
+                ]
+            )
+        )
+    }
+
+    private func makeForkAttemptID(
+        sourceThreadID: HiveThreadID,
+        targetThreadID: HiveThreadID,
+        requestedCheckpointID: HiveCheckpointID?
+    ) -> HiveRunAttemptID {
+        HiveRunAttemptID(
+            deterministicUUID(
+                prefix: "HFORK_ATTEMPT1",
+                parts: [
+                    sourceThreadID.rawValue,
+                    targetThreadID.rawValue,
+                    requestedCheckpointID?.rawValue ?? "latest"
+                ]
+            )
+        )
+    }
+
+    private func deterministicUUID(prefix: String, parts: [String]) -> UUID {
+        var data = Data(prefix.utf8)
+        for part in parts {
+            data.append(0)
+            data.append(contentsOf: part.utf8)
+        }
+        let digest = HiveSHA256.hash(data: data)
+        var bytes = Array(digest.prefix(16))
+        bytes[6] = (bytes[6] & 0x0F) | 0x50
+        bytes[8] = (bytes[8] & 0x3F) | 0x80
+        let uuidBytes = uuid_t(
+            bytes[0], bytes[1], bytes[2], bytes[3],
+            bytes[4], bytes[5], bytes[6], bytes[7],
+            bytes[8], bytes[9], bytes[10], bytes[11],
+            bytes[12], bytes[13], bytes[14], bytes[15]
+        )
+        return UUID(uuid: uuidBytes)
+    }
+
+    private func forkRuntimeErrorCode(_ runtimeError: HiveRuntimeError) -> String {
+        switch runtimeError {
+        case .forkSourceCheckpointMissing:
+            return "fork_source_checkpoint_missing"
+        case .forkCheckpointStoreMissing:
+            return "fork_checkpoint_store_missing"
+        case .forkCheckpointQueryUnsupported:
+            return "fork_checkpoint_query_unsupported"
+        case .forkTargetThreadConflict:
+            return "fork_target_thread_conflict"
+        case .forkSchemaGraphMismatch:
+            return "fork_schema_graph_mismatch"
+        case .forkMalformedCheckpoint:
+            return "fork_malformed_checkpoint"
+        default:
+            return "fork_runtime_error"
+        }
+    }
+
+    private func makeFailFastHandle(
+        threadID: HiveThreadID,
+        options: HiveRunOptions,
+        error: Error
+    ) -> HiveRunHandle<Schema> {
+        let attemptID = HiveRunAttemptID(UUID())
+        let runID: HiveRunID
+        if let existing = threadStates[threadID] {
+            runID = existing.runID
+        } else {
+            runID = HiveRunID(UUID())
+        }
+        let capacity = max(1, options.eventBufferCapacity)
+        let streamController = HiveEventStreamController(capacity: capacity)
+        let events = streamController.makeStream()
+        streamController.finish(throwing: error)
+
+        let outcome = Task<HiveRunOutcome<Schema>, Error> {
+            throw error
+        }
+
+        return HiveRunHandle(
+            runID: runID,
+            attemptID: attemptID,
+            events: events,
+            outcome: outcome,
+            streamController: streamController
+        )
+    }
+
+    private func ensureThreadState(for threadID: HiveThreadID) throws -> ThreadState<Schema> {
+        if let existing = threadStates[threadID] {
+            return existing
+        }
+
+        let state = try makeFreshThreadState(for: threadID)
+        threadStates[threadID] = state
+        return state
+    }
+
+    private func makeFreshThreadState(for _: HiveThreadID) throws -> ThreadState<Schema> {
+        let runID = HiveRunID(UUID())
+        let global = try HiveGlobalStore(registry: registry, initialCache: initialCache)
+        let joinSeen = Dictionary(
+            uniqueKeysWithValues: graph.joinEdges.map {
+                ($0.id, HiveBitset(wordCount: graph.joinBitsetWordCount))
+            }
+        )
+        return ThreadState(
+            runID: runID,
+            stepIndex: 0,
+            global: global,
+            frontier: [],
+            deferredFrontier: [],
+            joinSeenParents: joinSeen,
+            interruption: nil,
+            latestCheckpointID: nil,
+            channelVersionsByChannelID: [:],
+            versionsSeenByNodeID: [:],
+            updatedChannelsLastCommit: [],
+            nodeCaches: [:]
+        )
+    }
+
+    private func resolveBaselineState(
+        threadID: HiveThreadID,
+        debugPayloads: Bool,
+        emitter: HiveEventEmitter
+    ) async throws -> ThreadState<Schema> {
+        if let existing = threadStates[threadID] {
+            return existing
+        }
+
+        guard let store = environment.checkpointStore else {
+            let fresh = try makeFreshThreadState(for: threadID)
+            threadStates[threadID] = fresh
+            return fresh
+        }
+
+        let checkpoint = try await store.loadLatest(threadID: threadID)
+        guard let checkpoint else {
+            let fresh = try makeFreshThreadState(for: threadID)
+            threadStates[threadID] = fresh
+            return fresh
+        }
+
+        let state = try decodeCheckpoint(checkpoint, debugPayloads: debugPayloads)
+        threadStates[threadID] = state
+        emitter.emit(kind: .checkpointLoaded(checkpointID: checkpoint.id), stepIndex: nil, taskOrdinal: nil)
+        return state
+    }
+
+    private func loadCheckpointStateForResume(
+        threadID: HiveThreadID,
+        interruptID: HiveInterruptID,
+        debugPayloads: Bool,
+        emitter: HiveEventEmitter
+    ) async throws -> ThreadState<Schema> {
+        guard let store = environment.checkpointStore else {
+            throw HiveRuntimeError.checkpointStoreMissing
+        }
+
+        let checkpoint = try await store.loadLatest(threadID: threadID)
+        guard let checkpoint else {
+            throw HiveRuntimeError.noCheckpointToResume
+        }
+
+        let state = try decodeCheckpoint(checkpoint, debugPayloads: debugPayloads)
+        guard let interruption = state.interruption else {
+            throw HiveRuntimeError.noInterruptToResume
+        }
+        guard interruption.id == interruptID else {
+            throw HiveRuntimeError.resumeInterruptMismatch(expected: interruption.id, found: interruptID)
+        }
+
+        threadStates[threadID] = state
+        emitter.emit(kind: .checkpointLoaded(checkpointID: checkpoint.id), stepIndex: nil, taskOrdinal: nil)
+        return state
+    }
+
+    private func decodeCheckpoint(
+        _ checkpoint: HiveCheckpoint<Schema>,
+        debugPayloads: Bool
+    ) throws -> ThreadState<Schema> {
+        guard checkpoint.schemaVersion == graph.schemaVersion,
+              checkpoint.graphVersion == graph.graphVersion else {
+            throw HiveRuntimeError.checkpointVersionMismatch(
+                expectedSchema: graph.schemaVersion,
+                expectedGraph: graph.graphVersion,
+                foundSchema: checkpoint.schemaVersion,
+                foundGraph: checkpoint.graphVersion
+            )
+        }
+
+        let globalSpecs = registry.sortedChannelSpecs.filter { spec in
+            spec.scope == .global && spec.persistence == .checkpointed
+        }
+        let allowedGlobalIDs = Set(globalSpecs.map { $0.id.rawValue })
+        if let unexpected = checkpoint.globalDataByChannelID.keys
+            .filter({ !allowedGlobalIDs.contains($0) })
+            .sorted(by: HiveOrdering.lexicographicallyPrecedes)
+            .first {
+            throw HiveRuntimeError.checkpointCorrupt(
+                field: "globalDataByChannelID",
+                errorDescription: "unexpected channel id \(unexpected)"
+            )
+        }
+
+        var checkpointedGlobals: [HiveChannelID: any Sendable] = [:]
+        checkpointedGlobals.reserveCapacity(globalSpecs.count)
+        for spec in globalSpecs {
+            guard let data = checkpoint.globalDataByChannelID[spec.id.rawValue] else {
+                throw HiveRuntimeError.checkpointDecodeFailed(
+                    channelID: spec.id,
+                    errorDescription: "missing entry"
+                )
+            }
+            guard let decode = spec._decodeBox else {
+                throw HiveRuntimeError.missingCodec(channelID: spec.id)
+            }
+            do {
+                let value = try decode(data)
+                try storeSupport.validateValueType(value, spec: spec)
+                checkpointedGlobals[spec.id] = value
+            } catch {
+                throw HiveRuntimeError.checkpointDecodeFailed(
+                    channelID: spec.id,
+                    errorDescription: HiveErrorDescription.describe(error, debugPayloads: debugPayloads)
+                )
+            }
+        }
+
+        let global = try HiveGlobalStore(
+            registry: registry,
+            initialCache: initialCache,
+            checkpointedValuesByID: checkpointedGlobals
+        )
+
+        func decodeFrontier(
+            _ entries: [HiveCheckpointTask],
+            fieldPrefix: String
+        ) throws -> [HiveFrontierTask<Schema>] {
+            var frontier: [HiveFrontierTask<Schema>] = []
+            frontier.reserveCapacity(entries.count)
+
+            for entry in entries {
+                guard entry.localFingerprint.count == 32 else {
+                    throw HiveRuntimeError.checkpointCorrupt(
+                        field: "\(fieldPrefix).localFingerprint",
+                        errorDescription: "expected 32 bytes"
+                    )
+                }
+
+                var overlay = HiveTaskLocalStore<Schema>(registry: registry)
+                let sortedKeys = entry.localDataByChannelID.keys.sorted(by: HiveOrdering.lexicographicallyPrecedes)
+                for key in sortedKeys {
+                    let channelID = HiveChannelID(key)
+                    guard let spec = registry.channelSpecsByID[channelID],
+                          spec.scope == .taskLocal else {
+                        throw HiveRuntimeError.checkpointDecodeFailed(
+                            channelID: channelID,
+                            errorDescription: "unknown task-local channel"
+                        )
+                    }
+                    guard let decode = spec._decodeBox else {
+                        throw HiveRuntimeError.missingCodec(channelID: channelID)
+                    }
+                    guard let data = entry.localDataByChannelID[key] else { continue }
+                    do {
+                        let value = try decode(data)
+                        try overlay.setAny(value, for: channelID)
+                    } catch {
+                        throw HiveRuntimeError.checkpointDecodeFailed(
+                            channelID: channelID,
+                            errorDescription: HiveErrorDescription.describe(error, debugPayloads: debugPayloads)
+                        )
+                    }
+                }
+
+                let recomputed = try HiveTaskLocalFingerprint.digest(
+                    registry: registry,
+                    initialCache: initialCache,
+                    overlay: overlay,
+                    debugPayloads: debugPayloads
+                )
+                guard recomputed == entry.localFingerprint else {
+                    throw HiveRuntimeError.checkpointCorrupt(
+                        field: "\(fieldPrefix).localFingerprint",
+                        errorDescription: "fingerprint mismatch"
+                    )
+                }
+
+                frontier.append(
+                    HiveFrontierTask(
+                        seed: HiveTaskSeed(nodeID: entry.nodeID, local: overlay),
+                        provenance: entry.provenance,
+                        isJoinSeed: false
+                    )
+                )
+            }
+
+            return frontier
+        }
+
+        let frontier = try decodeFrontier(checkpoint.frontier, fieldPrefix: "frontier")
+        let deferredFrontier = try decodeFrontier(checkpoint.deferredFrontier, fieldPrefix: "deferredFrontier")
+
+        let expectedJoinIDs = Set(graph.joinEdges.map(\.id))
+        let actualJoinIDs = Set(checkpoint.joinBarrierSeenByJoinID.keys)
+        if expectedJoinIDs != actualJoinIDs {
+            let missing = expectedJoinIDs.subtracting(actualJoinIDs)
+                .sorted(by: HiveOrdering.lexicographicallyPrecedes)
+                .first
+            let extra = actualJoinIDs.subtracting(expectedJoinIDs)
+                .sorted(by: HiveOrdering.lexicographicallyPrecedes)
+                .first
+            let description: String
+            if let missing {
+                description = "missing join id \(missing)"
+            } else if let extra {
+                description = "unexpected join id \(extra)"
+            } else {
+                description = "join keys mismatch"
+            }
+            throw HiveRuntimeError.checkpointCorrupt(
+                field: "joinBarrierSeenByJoinID",
+                errorDescription: description
+            )
+        }
+
+        var joinSeenParents: [String: HiveBitset] = [:]
+        joinSeenParents.reserveCapacity(graph.joinEdges.count)
+        for edge in graph.joinEdges {
+            guard let seenParents = checkpoint.joinBarrierSeenByJoinID[edge.id] else {
+                throw HiveRuntimeError.checkpointCorrupt(
+                    field: "joinBarrierSeenByJoinID",
+                    errorDescription: "missing join id \(edge.id)"
+                )
+            }
+            let allowed = Set(edge.parents.map(\.rawValue))
+            var previous: String?
+            for parent in seenParents {
+                guard allowed.contains(parent) else {
+                    throw HiveRuntimeError.checkpointCorrupt(
+                        field: "joinBarrierSeenByJoinID",
+                        errorDescription: "unexpected parent \(parent)"
+                    )
+                }
+                if let previous,
+                   !HiveOrdering.lexicographicallyPrecedes(previous, parent) {
+                    throw HiveRuntimeError.checkpointCorrupt(
+                        field: "joinBarrierSeenByJoinID",
+                        errorDescription: "parents not strictly sorted"
+                    )
+                }
+                previous = parent
+            }
+
+            var seenMask = HiveBitset(wordCount: graph.joinBitsetWordCount)
+            for parent in seenParents {
+                let parentID = HiveNodeID(parent)
+                guard let ordinal = graph.nodeOrdinalByID[parentID] else {
+                    throw HiveRuntimeError.checkpointCorrupt(
+                        field: "joinBarrierSeenByJoinID",
+                        errorDescription: "unknown parent \(parent)"
+                    )
+                }
+                seenMask.insert(ordinal)
+            }
+            joinSeenParents[edge.id] = seenMask
+        }
+
+        var channelVersionsByChannelID: [HiveChannelID: UInt64] = [:]
+        channelVersionsByChannelID.reserveCapacity(checkpoint.channelVersionsByChannelID.count)
+        for (rawID, version) in checkpoint.channelVersionsByChannelID {
+            let channelID = HiveChannelID(rawID)
+            guard let spec = registry.channelSpecsByID[channelID], spec.scope == .global else {
+                throw HiveRuntimeError.checkpointCorrupt(
+                    field: "channelVersionsByChannelID",
+                    errorDescription: "unknown or non-global channel id \(rawID)"
+                )
+            }
+            if version > 0 {
+                channelVersionsByChannelID[channelID] = version
+            }
+        }
+
+        var versionsSeenByNodeID: [HiveNodeID: [HiveChannelID: UInt64]] = [:]
+        versionsSeenByNodeID.reserveCapacity(checkpoint.versionsSeenByNodeID.count)
+        for (rawNodeID, rawChannelVersions) in checkpoint.versionsSeenByNodeID {
+            let nodeID = HiveNodeID(rawNodeID)
+            guard graph.nodesByID[nodeID] != nil else {
+                throw HiveRuntimeError.checkpointCorrupt(
+                    field: "versionsSeenByNodeID",
+                    errorDescription: "unknown node id \(rawNodeID)"
+                )
+            }
+            var perChannel: [HiveChannelID: UInt64] = [:]
+            perChannel.reserveCapacity(rawChannelVersions.count)
+            for (rawChannelID, seenVersion) in rawChannelVersions {
+                let channelID = HiveChannelID(rawChannelID)
+                guard let spec = registry.channelSpecsByID[channelID], spec.scope == .global else {
+                    throw HiveRuntimeError.checkpointCorrupt(
+                        field: "versionsSeenByNodeID",
+                        errorDescription: "unknown or non-global channel id \(rawChannelID)"
+                    )
+                }
+                perChannel[channelID] = seenVersion
+            }
+            versionsSeenByNodeID[nodeID] = perChannel
+        }
+
+        var updatedChannelsLastCommit: [HiveChannelID] = []
+        updatedChannelsLastCommit.reserveCapacity(checkpoint.updatedChannelsLastCommit.count)
+        for rawID in checkpoint.updatedChannelsLastCommit {
+            let channelID = HiveChannelID(rawID)
+            guard let spec = registry.channelSpecsByID[channelID], spec.scope == .global else {
+                throw HiveRuntimeError.checkpointCorrupt(
+                    field: "updatedChannelsLastCommit",
+                    errorDescription: "unknown or non-global channel id \(rawID)"
+                )
+            }
+            updatedChannelsLastCommit.append(channelID)
+        }
+
+        return ThreadState(
+            runID: checkpoint.runID,
+            stepIndex: checkpoint.stepIndex,
+            global: global,
+            frontier: frontier,
+            deferredFrontier: deferredFrontier,
+            joinSeenParents: joinSeenParents,
+            interruption: checkpoint.interruption,
+            latestCheckpointID: checkpoint.id,
+            channelVersionsByChannelID: channelVersionsByChannelID,
+            versionsSeenByNodeID: versionsSeenByNodeID,
+            updatedChannelsLastCommit: updatedChannelsLastCommit,
+            nodeCaches: [:]
+        )
+    }
+
+    private func runAttempt(
+        threadID: HiveThreadID,
+        input: Schema.Input,
+        options: HiveRunOptions,
+        runID: HiveRunID,
+        attemptID: HiveRunAttemptID,
+        streamController: HiveEventStreamController
+    ) async throws -> HiveRunOutcome<Schema> {
+        let emitter = HiveEventEmitter(
+            runID: runID,
+            attemptID: attemptID,
+            streamController: streamController
+        )
+
+        emitter.emit(kind: .runStarted(threadID: threadID), stepIndex: nil, taskOrdinal: nil)
+
+        do {
+            try validateRunOptions(options)
+            try validateRetryPolicies()
+            try validateRequiredCodecs()
+
+            var state = try await resolveBaselineState(
+                threadID: threadID,
+                debugPayloads: options.debugPayloads,
+                emitter: emitter
+            )
+            rebindLoadedStateRunIDIfNeeded(state: &state, to: runID, threadID: threadID)
+
+            let inputContext = HiveInputContext(threadID: threadID, runID: state.runID, stepIndex: state.stepIndex)
+            let inputWrites = try Schema.inputWrites(input, inputContext: inputContext)
+
+            if let interruption = state.interruption {
+                // A pending interrupt can only be superseded by explicit new input writes.
+                // If there is no new input payload, fail closed and keep interruption pending.
+                guard inputWrites.isEmpty == false else {
+                    throw HiveRuntimeError.interruptPending(interruptID: interruption.id)
+                }
+
+                state.interruption = nil
+                state.frontier = []
+                state.joinSeenParents = [:]
+            }
+
+            if state.frontier.isEmpty {
+                state.frontier = graph.start.map {
+                    HiveFrontierTask(seed: HiveTaskSeed(nodeID: $0), provenance: .graph, isJoinSeed: false)
+                }
+            }
+
+            if !inputWrites.isEmpty {
+                var global = state.global
+                let writtenChannels = try applyInputWrites(inputWrites, to: &global)
+                state.global = global
+                state.updatedChannelsLastCommit = writtenChannels
+                if !writtenChannels.isEmpty {
+                    for channelID in writtenChannels {
+                        let currentVersion = state.channelVersionsByChannelID[channelID] ?? 0
+                        state.channelVersionsByChannelID[channelID] = currentVersion &+ 1
+                    }
+                }
+            }
+            threadStates[threadID] = state
+
+            return try await executeRunLoop(
+                initialState: state,
+                threadID: threadID,
+                options: options,
+                attemptID: attemptID,
+                emitter: emitter,
+                streamController: streamController
+            )
+        } catch let cancellation as RuntimeCancellation {
+            throw cancellation
+        } catch {
+            streamController.finish(throwing: error)
+            throw error
+        }
+    }
+
+    private func resumeAttempt(
+        threadID: HiveThreadID,
+        interruptID: HiveInterruptID,
+        payload: Schema.ResumePayload,
+        options: HiveRunOptions,
+        runID: HiveRunID,
+        attemptID: HiveRunAttemptID,
+        streamController: HiveEventStreamController
+    ) async throws -> HiveRunOutcome<Schema> {
+        let emitter = HiveEventEmitter(
+            runID: runID,
+            attemptID: attemptID,
+            streamController: streamController
+        )
+
+        emitter.emit(kind: .runStarted(threadID: threadID), stepIndex: nil, taskOrdinal: nil)
+
+        do {
+            try validateRunOptions(options)
+            try validateRetryPolicies()
+            try validateRequiredCodecs()
+
+            var state = try await loadCheckpointStateForResume(
+                threadID: threadID,
+                interruptID: interruptID,
+                debugPayloads: options.debugPayloads,
+                emitter: emitter
+            )
+            rebindLoadedStateRunIDIfNeeded(state: &state, to: runID, threadID: threadID)
+
+            emitter.emit(kind: .runResumed(interruptID: interruptID), stepIndex: nil, taskOrdinal: nil)
+
+            let resume = HiveResume<Schema>(interruptID: interruptID, payload: payload)
+
+            return try await executeRunLoop(
+                initialState: state,
+                threadID: threadID,
+                options: options,
+                attemptID: attemptID,
+                emitter: emitter,
+                streamController: streamController,
+                firstStepResume: resume,
+                clearInterruptionAfterFirstStep: true
+            )
+        } catch let cancellation as RuntimeCancellation {
+            throw cancellation
+        } catch {
+            streamController.finish(throwing: error)
+            throw error
+        }
+    }
+
+    /// Shared run-loop extracted from `runAttempt` and `resumeAttempt`.
+    ///
+    /// Executes supersteps in a `while true` loop until the graph finishes, is interrupted,
+    /// runs out of steps, or is cancelled. Handles `RuntimeCancellation` internally (returns
+    /// `.cancelled`); all other errors propagate to the caller.
+    ///
+    /// - Parameters:
+    ///   - initialState: Thread state with frontier already populated.
+    ///   - threadID: The thread ID used for `threadStates[threadID] = state`.
+    ///   - options: Run options (maxSteps, checkpoint policy, streaming mode, etc.).
+    ///   - attemptID: Current attempt ID passed through to `executeStep`.
+    ///   - emitter: Event emitter for lifecycle events.
+    ///   - streamController: Stream controller to finish on terminal outcomes.
+    ///   - firstStepResume: If non-nil, passed to `executeStep` only on the first iteration
+    ///     (used by `resumeAttempt` to deliver the resume payload).
+    ///   - clearInterruptionAfterFirstStep: If `true`, clears `nextState.interruption` after
+    ///     the first step when no new interrupt was selected (used by `resumeAttempt`).
+    private func executeRunLoop(
+        initialState: ThreadState<Schema>,
+        threadID: HiveThreadID,
+        options: HiveRunOptions,
+        attemptID: HiveRunAttemptID,
+        emitter: HiveEventEmitter,
+        streamController: HiveEventStreamController,
+        firstStepResume: HiveResume<Schema>? = nil,
+        clearInterruptionAfterFirstStep: Bool = false
+    ) async throws -> HiveRunOutcome<Schema> {
+        var state = initialState
+        var stepsExecutedThisAttempt = 0
+        var firstStepDone = false
+
+        do {
+            while true {
+                if Task.isCancelled {
+                    let output = try buildOutput(options: options, state: state)
+                    emitter.emit(
+                        kind: .runCancelled(cause: .explicitRequest),
+                        stepIndex: nil,
+                        taskOrdinal: nil
+                    )
+                    streamController.finish()
+                    return .cancelled(output: output, checkpointID: state.latestCheckpointID)
+                }
+
+                if state.frontier.isEmpty {
+                    if !state.deferredFrontier.isEmpty {
+                        state.frontier = state.deferredFrontier
+                        state.deferredFrontier = []
+                        threadStates[threadID] = state
+                        continue
+                    }
+                    let output = try buildOutput(options: options, state: state)
+                    emitter.emit(kind: .runFinished, stepIndex: nil, taskOrdinal: nil)
+                    streamController.finish()
+                    return .finished(output: output, checkpointID: state.latestCheckpointID)
+                }
+
+                if stepsExecutedThisAttempt == options.maxSteps {
+                    let output = try buildOutput(options: options, state: state)
+                    emitter.emit(kind: .runFinished, stepIndex: nil, taskOrdinal: nil)
+                    streamController.finish()
+                    return .outOfSteps(maxSteps: options.maxSteps, output: output, checkpointID: state.latestCheckpointID)
+                }
+
+                let stepOutcome = try await executeStep(
+                    state: state,
+                    threadID: threadID,
+                    attemptID: attemptID,
+                    options: options,
+                    emitter: emitter,
+                    resume: (!firstStepDone) ? firstStepResume : nil
+                )
+
+                var nextState = stepOutcome.nextState
+
+                // For resumeAttempt: clear the pending interruption after the first successfully
+                // committed resumed step, unless a new interrupt is selected in that same commit.
+                if clearInterruptionAfterFirstStep && !firstStepDone {
+                    if stepOutcome.selectedInterrupt == nil {
+                        nextState.interruption = nil
+                    }
+                }
+                firstStepDone = true
+
+                if let checkpoint = stepOutcome.checkpointToSave {
+                    guard let store = environment.checkpointStore else {
+                        throw HiveRuntimeError.checkpointStoreMissing
+                    }
+                    try await saveCheckpoint(checkpoint, to: store)
+                    nextState.latestCheckpointID = checkpoint.id
+                }
+
+                state = nextState
+                threadStates[threadID] = nextState
+                stepsExecutedThisAttempt += 1
+
+                if !stepOutcome.writtenGlobalChannels.isEmpty {
+                    for channelID in stepOutcome.writtenGlobalChannels {
+                        let payloadHash = try payloadHash(for: channelID, in: state.global)
+                        emitter.emit(
+                            kind: .writeApplied(channelID: channelID, payloadHash: payloadHash),
+                            stepIndex: state.stepIndex - 1,
+                            taskOrdinal: nil,
+                            metadata: try writeAppliedMetadata(
+                                for: channelID,
+                                in: state.global,
+                                debugPayloads: options.debugPayloads
+                            )
+                        )
+                    }
+                }
+
+                if stepOutcome.dropped.droppedDebugEvents > 0 {
+                    emitter.emit(
+                        kind: .streamBackpressure(droppedDebugEvents: stepOutcome.dropped.droppedDebugEvents),
+                        stepIndex: state.stepIndex - 1,
+                        taskOrdinal: nil
+                    )
+                }
+
+                if let checkpoint = stepOutcome.checkpointToSave {
+                    emitter.emit(
+                        kind: .checkpointSaved(checkpointID: checkpoint.id),
+                        stepIndex: state.stepIndex - 1,
+                        taskOrdinal: nil
+                    )
+                }
+
+                try emitStreamingEvents(
+                    mode: options.streamingMode,
+                    state: state,
+                    writtenChannels: stepOutcome.writtenGlobalChannels,
+                    debugPayloads: options.debugPayloads,
+                    stepIndex: state.stepIndex - 1,
+                    emitter: emitter
+                )
+
+                emitter.emit(
+                    kind: .stepFinished(stepIndex: state.stepIndex - 1, nextFrontierCount: state.frontier.count),
+                    stepIndex: state.stepIndex - 1,
+                    taskOrdinal: nil
+                )
+
+                if let interrupt = stepOutcome.selectedInterrupt {
+                    let checkpointID = stepOutcome.checkpointToSave?.id ?? state.latestCheckpointID
+                    guard let checkpointID else {
+                        throw HiveRuntimeError.internalInvariantViolation(
+                            "Interrupted outcome requires a checkpoint ID."
+                        )
+                    }
+                    emitter.emit(kind: .runInterrupted(interruptID: interrupt.id), stepIndex: nil, taskOrdinal: nil)
+                    streamController.finish()
+                    return .interrupted(interruption: HiveInterruption(interrupt: interrupt, checkpointID: checkpointID))
+                }
+
+                if state.frontier.isEmpty && state.deferredFrontier.isEmpty {
+                    let output = try buildOutput(options: options, state: state)
+                    emitter.emit(kind: .runFinished, stepIndex: nil, taskOrdinal: nil)
+                    streamController.finish()
+                    return .finished(output: output, checkpointID: state.latestCheckpointID)
+                }
+
+                // Give the cancellation flag a fair observation point between committed steps.
+                await Task.yield()
+            }
+        } catch let cancellation as RuntimeCancellation {
+            guard let state = threadStates[threadID] else {
+                throw cancellation
+            }
+            let output = try buildOutput(options: options, state: state)
+            emitter.emit(
+                kind: .runCancelled(cause: cancellation.eventCause),
+                stepIndex: nil,
+                taskOrdinal: nil
+            )
+            streamController.finish()
+            return .cancelled(output: output, checkpointID: state.latestCheckpointID)
+        }
+    }
+
+    private func applyExternalWritesAttempt(
+        threadID: HiveThreadID,
+        writes: [AnyHiveWrite<Schema>],
+        options: HiveRunOptions,
+        runID: HiveRunID,
+        attemptID: HiveRunAttemptID,
+        streamController: HiveEventStreamController
+    ) async throws -> HiveRunOutcome<Schema> {
+        let emitter = HiveEventEmitter(
+            runID: runID,
+            attemptID: attemptID,
+            streamController: streamController
+        )
+        var cancellationState: ThreadState<Schema>? = threadStates[threadID]
+
+        emitter.emit(kind: .runStarted(threadID: threadID), stepIndex: nil, taskOrdinal: nil)
+
+        do {
+            try validateRunOptions(options)
+            try validateRetryPolicies()
+            try validateRequiredCodecs()
+
+            var state = try await resolveBaselineState(
+                threadID: threadID,
+                debugPayloads: options.debugPayloads,
+                emitter: emitter
+            )
+            rebindLoadedStateRunIDIfNeeded(state: &state, to: runID, threadID: threadID)
+            cancellationState = state
+            if let interruption = state.interruption {
+                throw HiveRuntimeError.interruptPending(interruptID: interruption.id)
+            }
+
+            let stepIndex = state.stepIndex
+            emitter.emit(kind: .stepStarted(stepIndex: stepIndex, frontierCount: 0), stepIndex: stepIndex, taskOrdinal: nil)
+
+            var postGlobal = state.global
+            let writtenChannels = try applyExternalWrites(writes, to: &postGlobal)
+
+            var nextState = state
+            nextState.stepIndex += 1
+            nextState.global = postGlobal
+            // Frontier and join barriers remain unchanged.
+            nextState.updatedChannelsLastCommit = writtenChannels
+            if !writtenChannels.isEmpty {
+                for channelID in writtenChannels {
+                    let currentVersion = nextState.channelVersionsByChannelID[channelID] ?? 0
+                    nextState.channelVersionsByChannelID[channelID] = currentVersion &+ 1
+                }
+            }
+
+            let checkpointToSave: HiveCheckpoint<Schema>?
+            if environment.checkpointStore != nil {
+                checkpointToSave = try makeCheckpoint(threadID: threadID, state: nextState, debugPayloads: options.debugPayloads)
+            } else {
+                checkpointToSave = nil
+            }
+
+            if let checkpointToSave {
+                guard let store = environment.checkpointStore else {
+                    throw HiveRuntimeError.checkpointStoreMissing
+                }
+                try await saveCheckpoint(checkpointToSave, to: store)
+                nextState.latestCheckpointID = checkpointToSave.id
+            }
+
+            state = nextState
+            threadStates[threadID] = nextState
+
+            if !writtenChannels.isEmpty {
+                for channelID in writtenChannels {
+                    let payloadHash = try payloadHash(for: channelID, in: state.global)
+                    emitter.emit(
+                        kind: .writeApplied(channelID: channelID, payloadHash: payloadHash),
+                        stepIndex: stepIndex,
+                        taskOrdinal: nil,
+                        metadata: try writeAppliedMetadata(
+                            for: channelID,
+                            in: state.global,
+                            debugPayloads: options.debugPayloads
+                        )
+                    )
+                }
+            }
+
+            if let checkpointToSave {
+                emitter.emit(
+                    kind: .checkpointSaved(checkpointID: checkpointToSave.id),
+                    stepIndex: stepIndex,
+                    taskOrdinal: nil
+                )
+            }
+
+            try emitStreamingEvents(
+                mode: options.streamingMode,
+                state: state,
+                writtenChannels: writtenChannels,
+                debugPayloads: options.debugPayloads,
+                stepIndex: stepIndex,
+                emitter: emitter
+            )
+
+            emitter.emit(
+                kind: .stepFinished(stepIndex: stepIndex, nextFrontierCount: state.frontier.count),
+                stepIndex: stepIndex,
+                taskOrdinal: nil
+            )
+
+            let output = try buildOutput(options: options, state: state)
+            emitter.emit(kind: .runFinished, stepIndex: nil, taskOrdinal: nil)
+            streamController.finish()
+            return .finished(output: output, checkpointID: state.latestCheckpointID)
+        } catch let cancellation as RuntimeCancellation {
+            guard let state = cancellationState ?? threadStates[threadID] else {
+                throw cancellation
+            }
+            let output = try buildOutput(options: options, state: state)
+            emitter.emit(
+                kind: .runCancelled(cause: cancellation.eventCause),
+                stepIndex: nil,
+                taskOrdinal: nil
+            )
+            streamController.finish()
+            return .cancelled(output: output, checkpointID: state.latestCheckpointID)
+        } catch {
+            streamController.finish(throwing: error)
+            throw error
+        }
+    }
+
+    /// Internal sentinel used to represent runtime-observed cancellation without treating arbitrary user-thrown
+    /// `CancellationError` values as cancellation.
+    private enum RuntimeCancellation: Error, Sendable {
+        case checkpointPersistenceRace
+        case executionObserved
+
+        var eventCause: HiveRunCancellationCause {
+            switch self {
+            case .checkpointPersistenceRace:
+                return .checkpointPersistenceRace
+            case .executionObserved:
+                return .executionObserved
+            }
+        }
+    }
+
+    private func saveCheckpoint(
+        _ checkpoint: HiveCheckpoint<Schema>,
+        to store: AnyHiveCheckpointStore<Schema>
+    ) async throws {
+        do {
+            try await store.save(checkpoint)
+        } catch is CancellationError {
+            throw RuntimeCancellation.checkpointPersistenceRace
+        }
+    }
+
+    /// Ensures loaded checkpoint state uses the active run handle's run ID.
+    /// This keeps handle/event IDs and newly persisted checkpoints in sync on cold-start restores.
+    private func rebindLoadedStateRunIDIfNeeded(
+        state: inout ThreadState<Schema>,
+        to runID: HiveRunID,
+        threadID: HiveThreadID
+    ) {
+        guard state.runID != runID else { return }
+        state.runID = runID
+        threadStates[threadID] = state
+    }
+
+    public func validateRunOptions(_ options: HiveRunOptions) throws {
+        guard options.maxSteps >= 0 else {
+            throw HiveRunOptionsValidationError.invalidBounds(
+                option: "maxSteps",
+                reason: "must be >= 0"
+            )
+        }
+        guard options.maxConcurrentTasks >= 1 else {
+            throw HiveRunOptionsValidationError.invalidBounds(
+                option: "maxConcurrentTasks",
+                reason: "must be >= 1"
+            )
+        }
+        guard options.eventBufferCapacity >= 1 else {
+            throw HiveRunOptionsValidationError.invalidBounds(
+                option: "eventBufferCapacity",
+                reason: "must be >= 1"
+            )
+        }
+        if case let .every(steps) = options.checkpointPolicy, steps < 1 {
+            throw HiveRunOptionsValidationError.invalidBounds(
+                option: "checkpointPolicy.every(steps:)",
+                reason: "steps must be >= 1"
+            )
+        }
+        if options.deterministicStreamBuffering, options.streamingMode != .events {
+            throw HiveRunOptionsValidationError.unsupportedCombination(
+                reason: "deterministicStreamBuffering is only supported when streamingMode == .events"
+            )
+        }
+        switch options.checkpointPolicy {
+        case .disabled:
+            break
+        case .everyStep, .every, .onInterrupt:
+            if environment.checkpointStore == nil {
+                throw HiveRunOptionsValidationError.missingRequiredComponent(
+                    component: "checkpointStore",
+                    reason: "checkpointPolicy requires a configured checkpoint store"
+                )
+            }
+        }
+        if let override = options.outputProjectionOverride {
+            _ = try normalizedOutputProjection(override)
+        }
+    }
+
+    private func validateRetryPolicies() throws {
+        var invalid: HiveNodeID?
+        for (id, node) in graph.nodesByID {
+            if case let .exponentialBackoff(_, factor, maxAttempts, _) = node.retryPolicy {
+                let invalidPolicy = maxAttempts < 1 || !factor.isFinite || factor < 1.0
+                if invalidPolicy {
+                    if let current = invalid {
+                        if HiveOrdering.lexicographicallyPrecedes(id.rawValue, current.rawValue) {
+                            invalid = id
+                        }
+                    } else {
+                        invalid = id
+                    }
+                }
+            }
+        }
+        if let invalid {
+            throw HiveRunOptionsValidationError.unsupportedCombination(
+                reason: "invalid retry policy for node \(invalid.rawValue)"
+            )
+        }
+    }
+
+    private func validateRequiredCodecs() throws {
+        if let missing = registry.firstMissingRequiredCodecID() {
+            throw HiveRuntimeError.missingCodec(channelID: missing)
+        }
+    }
+
+    private func normalizedOutputProjection(_ projection: HiveOutputProjection) throws -> HiveOutputProjection {
+        let normalized = projection.normalized()
+        switch normalized {
+        case .fullStore:
+            return normalized
+        case .channels(let ids):
+            for id in ids {
+                guard let spec = registry.channelSpecsByID[id] else {
+                    throw HiveRunOptionsValidationError.unsupportedCombination(
+                        reason: "output projection includes unknown channel \(id.rawValue)"
+                    )
+                }
+                if spec.scope == .taskLocal {
+                    throw HiveRunOptionsValidationError.unsupportedCombination(
+                        reason: "output projection includes task-local channel \(id.rawValue)"
+                    )
+                }
+            }
+            return normalized
+        }
+    }
+
+    private func buildOutput(options: HiveRunOptions, state: ThreadState<Schema>) throws -> HiveRunOutput<Schema> {
+        let projection = try normalizedOutputProjection(
+            options.outputProjectionOverride ?? graph.outputProjection
+        )
+
+        switch projection {
+        case .fullStore:
+            return .fullStore(state.global)
+        case .channels(let ids):
+            var values: [HiveProjectedChannelValue] = []
+            values.reserveCapacity(ids.count)
+            for id in ids {
+                let value = try state.global.valueAny(for: id)
+                values.append(HiveProjectedChannelValue(id: id, value: value))
+            }
+            return .channels(values)
+        }
+    }
+
+    private func applyInputWrites(
+        _ writes: [AnyHiveWrite<Schema>],
+        to global: inout HiveGlobalStore<Schema>
+    ) throws -> [HiveChannelID] {
+        var globalWritesByChannel: [HiveChannelID: [AnyHiveWrite<Schema>]] = [:]
+        for write in writes {
+            guard let spec = registry.channelSpecsByID[write.channelID] else {
+                throw HiveRuntimeError.unknownChannelID(write.channelID)
+            }
+            if spec.scope != .global {
+                throw HiveRuntimeError.taskLocalWriteNotAllowed
+            }
+            try storeSupport.validateValueType(write.value, spec: spec)
+            globalWritesByChannel[write.channelID, default: []].append(write)
+        }
+
+        var written: [HiveChannelID] = []
+        for spec in registry.sortedChannelSpecs where spec.scope == .global {
+            let writesForChannel = globalWritesByChannel[spec.id] ?? []
+            if writesForChannel.isEmpty { continue }
+            if spec.updatePolicy == .single, writesForChannel.count > 1 {
+                throw HiveRuntimeError.updatePolicyViolation(
+                    channelID: spec.id,
+                    policy: .single,
+                    writeCount: writesForChannel.count
+                )
+            }
+            var current = try global.valueAny(for: spec.id)
+            for write in writesForChannel {
+                current = try spec._reduceBox(current, write.value)
+            }
+            try global.setAny(current, for: spec.id)
+            written.append(spec.id)
+        }
+
+        return written
+    }
+
+    private func selectInterrupt(
+        tasks: [HiveTask<Schema>],
+        outputs: [HiveNodeOutput<Schema>]
+    ) throws -> HiveInterrupt<Schema>? {
+        // Selection is by smallest taskOrdinal (i.e., earliest task in this step).
+        for (index, output) in outputs.enumerated() {
+            if let request = output.interrupt {
+                let winningTaskID = tasks[index].id
+                let interruptID = makeInterruptID(winningTaskID: winningTaskID)
+                return HiveInterrupt(id: interruptID, payload: request.payload)
+            }
+        }
+        return nil
+    }
+
+    private func makeInterruptID(winningTaskID: HiveTaskID) -> HiveInterruptID {
+        var bytes = Data()
+        bytes.append(contentsOf: "HINT1".utf8)
+        bytes.append(contentsOf: winningTaskID.rawValue.utf8)
+        let hash = HiveSHA256.hash(data: bytes)
+        let hex = hash.compactMap { String(format: "%02x", $0) }.joined()
+        return HiveInterruptID(hex)
+    }
+
+    private func applyExternalWrites(
+        _ writes: [AnyHiveWrite<Schema>],
+        to global: inout HiveGlobalStore<Schema>
+    ) throws -> [HiveChannelID] {
+        func validateValueType(_ value: any Sendable, spec: AnyHiveChannelSpec<Schema>) throws {
+            let expectedValueTypeID = spec.valueTypeID
+            let actualValueTypeID = String(reflecting: type(of: value))
+            guard expectedValueTypeID == actualValueTypeID else {
+                throw HiveExternalWriteError.payloadTypeMismatch(
+                    channelID: spec.id,
+                    expectedValueTypeID: expectedValueTypeID,
+                    actualValueTypeID: actualValueTypeID
+                )
+            }
+        }
+
+        var writesByChannel: [HiveChannelID: [AnyHiveWrite<Schema>]] = [:]
+        for write in writes {
+            guard let spec = registry.channelSpecsByID[write.channelID] else {
+                throw HiveExternalWriteError.unknownChannel(channelID: write.channelID)
+            }
+            if spec.scope != .global {
+                throw HiveExternalWriteError.scopeMismatch(
+                    channelID: write.channelID,
+                    expected: .global,
+                    actual: spec.scope
+                )
+            }
+            try validateValueType(write.value, spec: spec)
+            writesByChannel[write.channelID, default: []].append(write)
+        }
+
+        // Enforce `.single` using the provided external writes array grouping.
+        for spec in registry.sortedChannelSpecs where spec.scope == .global {
+            let channelWrites = writesByChannel[spec.id] ?? []
+            if spec.updatePolicy == .single, channelWrites.count > 1 {
+                throw HiveExternalWriteError.updatePolicyViolation(
+                    channelID: spec.id,
+                    policy: .single,
+                    writeCount: channelWrites.count
+                )
+            }
+        }
+
+        var written: [HiveChannelID] = []
+        for spec in registry.sortedChannelSpecs where spec.scope == .global {
+            let channelWrites = writesByChannel[spec.id] ?? []
+            if channelWrites.isEmpty { continue }
+            var current = try global.valueAny(for: spec.id)
+            for write in channelWrites {
+                current = try spec._reduceBox(current, write.value)
+            }
+            try global.setAny(current, for: spec.id)
+            written.append(spec.id)
+        }
+
+        return written
+    }
+
+    private func makeCheckpoint(
+        threadID: HiveThreadID,
+        state: ThreadState<Schema>,
+        debugPayloads: Bool,
+        lineage: HiveCheckpointLineage? = nil
+    ) throws -> HiveCheckpoint<Schema> {
+        let checkpointID = try makeCheckpointID(runID: state.runID, stepIndex: state.stepIndex)
+
+        var globalDataByChannelID: [String: Data] = [:]
+        for spec in registry.sortedChannelSpecs where spec.scope == .global && spec.persistence == .checkpointed {
+            guard let encode = spec._encodeBox else {
+                throw HiveRuntimeError.missingCodec(channelID: spec.id)
+            }
+            let value = try state.global.valueAny(for: spec.id)
+            do {
+                globalDataByChannelID[spec.id.rawValue] = try encode(value)
+            } catch {
+                throw HiveRuntimeError.checkpointEncodeFailed(
+                    channelID: spec.id,
+                    errorDescription: HiveErrorDescription.describe(error, debugPayloads: debugPayloads)
+                )
+            }
+        }
+
+        let taskLocalSpecs = registry.sortedChannelSpecs.filter { $0.scope == .taskLocal }
+        func encodeFrontier(_ entries: [HiveFrontierTask<Schema>]) throws -> [HiveCheckpointTask] {
+            var encoded: [HiveCheckpointTask] = []
+            encoded.reserveCapacity(entries.count)
+
+            for entry in entries {
+                let fingerprint = try HiveTaskLocalFingerprint.digest(
+                    registry: registry,
+                    initialCache: initialCache,
+                    overlay: entry.seed.local,
+                    debugPayloads: debugPayloads
+                )
+
+                var localDataByChannelID: [String: Data] = [:]
+                for spec in taskLocalSpecs where spec.persistence == .checkpointed {
+                    guard let value = entry.seed.local.valueAny(for: spec.id) else { continue }
+                    guard let encode = spec._encodeBox else {
+                        throw HiveRuntimeError.missingCodec(channelID: spec.id)
+                    }
+                    do {
+                        localDataByChannelID[spec.id.rawValue] = try encode(value)
+                    } catch {
+                        throw HiveRuntimeError.checkpointEncodeFailed(
+                            channelID: spec.id,
+                            errorDescription: HiveErrorDescription.describe(error, debugPayloads: debugPayloads)
+                        )
+                    }
+                }
+
+                encoded.append(
+                    HiveCheckpointTask(
+                        provenance: entry.provenance,
+                        nodeID: entry.seed.nodeID,
+                        localFingerprint: fingerprint,
+                        localDataByChannelID: localDataByChannelID
+                    )
+                )
+            }
+
+            return encoded
+        }
+
+        let checkpointFrontier = try encodeFrontier(state.frontier)
+        let checkpointDeferredFrontier = try encodeFrontier(state.deferredFrontier)
+
+        var joinBarrierSeenByJoinID: [String: [String]] = [:]
+        joinBarrierSeenByJoinID.reserveCapacity(graph.joinEdges.count)
+        for edge in graph.joinEdges {
+            let seenMask = state.joinSeenParents[edge.id] ?? HiveBitset(wordCount: graph.joinBitsetWordCount)
+            var sortedParents: [String] = []
+            sortedParents.reserveCapacity(edge.parents.count)
+            for parent in edge.parents {
+                guard let ordinal = graph.nodeOrdinalByID[parent] else { continue }
+                if seenMask.contains(ordinal) {
+                    sortedParents.append(parent.rawValue)
+                }
+            }
+            joinBarrierSeenByJoinID[edge.id] = sortedParents
+        }
+
+        var channelVersionsByChannelID: [String: UInt64] = [:]
+        channelVersionsByChannelID.reserveCapacity(state.channelVersionsByChannelID.count)
+        for (channelID, version) in state.channelVersionsByChannelID where version > 0 {
+            channelVersionsByChannelID[channelID.rawValue] = version
+        }
+
+        var versionsSeenByNodeID: [String: [String: UInt64]] = [:]
+        versionsSeenByNodeID.reserveCapacity(state.versionsSeenByNodeID.count)
+        for (nodeID, perChannel) in state.versionsSeenByNodeID {
+            var rawPerChannel: [String: UInt64] = [:]
+            rawPerChannel.reserveCapacity(perChannel.count)
+            for (channelID, seenVersion) in perChannel {
+                rawPerChannel[channelID.rawValue] = seenVersion
+            }
+            versionsSeenByNodeID[nodeID.rawValue] = rawPerChannel
+        }
+
+        return HiveCheckpoint(
+            id: checkpointID,
+            threadID: threadID,
+            runID: state.runID,
+            stepIndex: state.stepIndex,
+            schemaVersion: graph.schemaVersion,
+            graphVersion: graph.graphVersion,
+            checkpointFormatVersion: lineage == nil ? "HCP2" : "HCP3",
+            channelVersionsByChannelID: channelVersionsByChannelID,
+            versionsSeenByNodeID: versionsSeenByNodeID,
+            updatedChannelsLastCommit: state.updatedChannelsLastCommit.map(\.rawValue),
+            globalDataByChannelID: globalDataByChannelID,
+            frontier: checkpointFrontier,
+            deferredFrontier: checkpointDeferredFrontier,
+            joinBarrierSeenByJoinID: joinBarrierSeenByJoinID,
+            interruption: state.interruption,
+            lineage: lineage
+        )
+    }
+
+    private func makeCheckpointID(runID: HiveRunID, stepIndex: Int) throws -> HiveCheckpointID {
+        guard let stepValue = UInt32(exactly: stepIndex) else {
+            throw HiveRuntimeError.stepIndexOutOfRange(stepIndex: stepIndex)
+        }
+
+        var bytes = Data()
+        bytes.append(contentsOf: "HCP1".utf8)
+        var uuid = runID.rawValue.uuid
+        withUnsafeBytes(of: &uuid) { bytes.append(contentsOf: $0) }
+        appendUInt32BE(stepValue, to: &bytes)
+
+        let hash = HiveSHA256.hash(data: bytes)
+        let hex = hash.compactMap { String(format: "%02x", $0) }.joined()
+        return HiveCheckpointID(hex)
+    }
+
+    private func executeStep(
+        state: ThreadState<Schema>,
+        threadID: HiveThreadID,
+        attemptID: HiveRunAttemptID,
+        options: HiveRunOptions,
+        emitter: HiveEventEmitter,
+        resume: HiveResume<Schema>?
+    ) async throws -> StepOutcome<Schema> {
+        var state = state
+        let stepIndex = state.stepIndex
+        guard UInt32(exactly: stepIndex) != nil else {
+            throw HiveRuntimeError.stepIndexOutOfRange(stepIndex: stepIndex)
+        }
+
+        let frontier = state.frontier
+        let tasks = try buildTasks(
+            frontier: frontier,
+            runID: state.runID,
+            stepIndex: stepIndex,
+            debugPayloads: options.debugPayloads
+        )
+
+        snapshotVersionsSeenForStepStart(tasks: tasks, state: &state)
+
+        emitter.emit(
+            kind: .stepStarted(stepIndex: stepIndex, frontierCount: tasks.count),
+            stepIndex: stepIndex,
+            taskOrdinal: nil
+        )
+
+        for task in tasks {
+            emitter.emit(
+                kind: .taskStarted(node: task.nodeID, taskID: task.id),
+                stepIndex: stepIndex,
+                taskOrdinal: task.ordinal
+            )
+        }
+
+        if Task.isCancelled {
+            for task in tasks {
+                emitter.emit(
+                    kind: .taskFailed(
+                        node: task.nodeID,
+                        taskID: task.id,
+                        errorDescription: HiveErrorDescription.describe(CancellationError(), debugPayloads: options.debugPayloads)
+                    ),
+                    stepIndex: stepIndex,
+                    taskOrdinal: task.ordinal
+                )
+            }
+            throw RuntimeCancellation.executionObserved
+        }
+
+        let droppedCounter = HiveDroppedEventCounter()
+
+        // Cache lookup: skip execution for tasks with a cache hit.
+        let cacheNowNs = DispatchTime.now().uptimeNanoseconds
+        let cachePreStoreView = HiveStoreView(
+            global: state.global,
+            taskLocal: HiveTaskLocalStore(registry: registry),
+            initialCache: initialCache,
+            registry: registry
+        )
+        var cachedResultsByTaskIndex: [Int: HiveNodeOutput<Schema>] = [:]
+        for (index, task) in tasks.enumerated() {
+            guard let node = graph.nodesByID[task.nodeID],
+                  let cachePolicy = node.cachePolicy
+            else { continue }
+            // Compute cache key — log failures instead of silently disabling caching.
+            let cacheKey: String
+            do {
+                cacheKey = try cachePolicy.keyProvider.cacheKey(forNode: task.nodeID, store: cachePreStoreView)
+            } catch {
+                environment.logger.debug(
+                    "Cache key computation failed for node \(task.nodeID.rawValue): \(error)",
+                    metadata: [:]
+                )
+                continue
+            }
+            guard var nodeCache = state.nodeCaches[task.nodeID] else { continue }
+            let cachedOutput = nodeCache.lookup(key: cacheKey, policy: cachePolicy, nowNanoseconds: cacheNowNs)
+            // Always write back: persists LRU order update AND expired-entry removal to state.
+            // Without this writeback, HiveNodeCache is a value type whose mutations inside
+            // lookup() are silently discarded, breaking LRU eviction ordering.
+            state.nodeCaches[task.nodeID] = nodeCache
+            guard let cachedOutput else { continue }
+            cachedResultsByTaskIndex[index] = cachedOutput
+        }
+
+        // Only execute tasks that were not cache hits.
+        let uncachedIndices = tasks.indices.filter { cachedResultsByTaskIndex[$0] == nil }
+        let uncachedTasks = uncachedIndices.map { tasks[$0] }
+
+        let executionResults = await Self.executeTasks(
+            tasks: uncachedTasks,
+            options: options,
+            stepIndex: stepIndex,
+            threadID: threadID,
+            attemptID: attemptID,
+            runID: state.runID,
+            graph: graph,
+            environment: environment,
+            registry: registry,
+            initialCache: initialCache,
+            preStepGlobal: state.global,
+            resume: resume,
+            emitter: emitter,
+            droppedCounter: droppedCounter
+        )
+
+        // Merge cached and fresh results back into a full-sized array.
+        var results = Array(repeating: TaskExecutionResult<Schema>.empty, count: tasks.count)
+        for (resultIndex, taskIndex) in uncachedIndices.enumerated() {
+            results[taskIndex] = executionResults[resultIndex]
+        }
+        for (taskIndex, cachedOutput) in cachedResultsByTaskIndex {
+            results[taskIndex] = TaskExecutionResult(
+                output: cachedOutput,
+                error: nil,
+                streamEvents: nil,
+                streamDrops: HiveDroppedEventCounts()
+            )
+        }
+
+        if Task.isCancelled || results.contains(where: { $0.error is RuntimeCancellation }) {
+            if options.deterministicStreamBuffering == false {
+                // Live stream events already emitted (if any). Ensure determinism for task failure surface.
+            }
+
+            for task in tasks {
+                emitter.emit(
+                    kind: .taskFailed(
+                        node: task.nodeID,
+                        taskID: task.id,
+                        errorDescription: HiveErrorDescription.describe(CancellationError(), debugPayloads: options.debugPayloads)
+                    ),
+                    stepIndex: stepIndex,
+                    taskOrdinal: task.ordinal
+                )
+            }
+            throw RuntimeCancellation.executionObserved
+        }
+
+        var dropped = droppedCounter.snapshot()
+        if options.deterministicStreamBuffering {
+            for result in results {
+                dropped.droppedDebugEvents += result.streamDrops.droppedDebugEvents
+            }
+
+            for result in results {
+                guard let events = result.streamEvents else { continue }
+                for event in events {
+                    let enqueueResult = emitter.emit(
+                        kind: event.kind,
+                        stepIndex: stepIndex,
+                        taskOrdinal: event.taskOrdinal,
+                        metadata: event.metadata,
+                        treatAsNonDroppable: true
+                    )
+                    dropped.record(enqueueResult)
+                }
+            }
+        }
+
+        var firstError: Error?
+        for (index, result) in results.enumerated() {
+            let task = tasks[index]
+            if let error = result.error {
+                if firstError == nil {
+                    firstError = error
+                }
+                emitter.emit(
+                    kind: .taskFailed(
+                        node: task.nodeID,
+                        taskID: task.id,
+                        errorDescription: HiveErrorDescription.describe(error, debugPayloads: options.debugPayloads)
+                    ),
+                    stepIndex: stepIndex,
+                    taskOrdinal: task.ordinal
+                )
+            } else {
+                emitter.emit(
+                    kind: .taskFinished(node: task.nodeID, taskID: task.id),
+                    stepIndex: stepIndex,
+                    taskOrdinal: task.ordinal
+                )
+            }
+        }
+
+        if let firstError {
+            throw firstError
+        }
+
+        var outputs: [HiveNodeOutput<Schema>] = []
+        outputs.reserveCapacity(results.count)
+        for result in results {
+            guard let output = result.output else {
+                throw HiveRuntimeError.internalInvariantViolation(
+                    "Task result missing output without error."
+                )
+            }
+            outputs.append(output)
+        }
+
+        // Cache: store new outputs for nodes with a cache policy.
+        var updatedNodeCaches = state.nodeCaches
+        let storeNowNs = DispatchTime.now().uptimeNanoseconds
+        for (index, output) in outputs.enumerated() {
+            let task = tasks[index]
+            guard let node = graph.nodesByID[task.nodeID],
+                  let cachePolicy = node.cachePolicy,
+                  let cacheKey = try? cachePolicy.keyProvider.cacheKey(forNode: task.nodeID, store: cachePreStoreView)
+            else { continue }
+            var nodeCache = updatedNodeCaches[task.nodeID] ?? HiveNodeCache()
+            nodeCache.store(key: cacheKey, output: output, policy: cachePolicy, nowNanoseconds: storeNowNs)
+            updatedNodeCaches[task.nodeID] = nodeCache
+        }
+
+        let commitResult = try commitStep(
+            state: state,
+            tasks: tasks,
+            outputs: outputs,
+            options: options
+        )
+
+        var nextState = state
+        nextState.stepIndex += 1
+        nextState.global = commitResult.global
+        nextState.joinSeenParents = commitResult.joinSeenParents
+        nextState.updatedChannelsLastCommit = commitResult.writtenGlobalChannels
+        nextState.nodeCaches = updatedNodeCaches
+        if !commitResult.writtenGlobalChannels.isEmpty {
+            for channelID in commitResult.writtenGlobalChannels {
+                let current = nextState.channelVersionsByChannelID[channelID] ?? 0
+                nextState.channelVersionsByChannelID[channelID] = current &+ 1
+            }
+        }
+        nextState.frontier = filterFrontierForTriggers(
+            commitResult.frontier,
+            channelVersionsByChannelID: nextState.channelVersionsByChannelID,
+            versionsSeenByNodeID: nextState.versionsSeenByNodeID
+        )
+        nextState.deferredFrontier = state.deferredFrontier + commitResult.deferredFrontier
+
+        let selectedInterrupt = try selectInterrupt(tasks: tasks, outputs: outputs)
+        var checkpointToSave: HiveCheckpoint<Schema>?
+        let shouldSaveForPolicy: Bool
+        switch options.checkpointPolicy {
+        case .disabled:
+            shouldSaveForPolicy = false
+        case .everyStep:
+            shouldSaveForPolicy = true
+        case .every(let steps):
+            shouldSaveForPolicy = steps > 0 && (nextState.stepIndex % steps == 0)
+        case .onInterrupt:
+            shouldSaveForPolicy = selectedInterrupt != nil
+        }
+
+        let shouldSave = shouldSaveForPolicy || selectedInterrupt != nil
+        if shouldSave {
+            // Commit-time enforcement: checkpoint boundaries require checkpoint store.
+            guard environment.checkpointStore != nil else {
+                throw HiveRuntimeError.checkpointStoreMissing
+            }
+            if let selectedInterrupt {
+                nextState.interruption = selectedInterrupt
+            }
+            checkpointToSave = try makeCheckpoint(
+                threadID: threadID,
+                state: nextState,
+                debugPayloads: options.debugPayloads
+            )
+        }
+
+        return StepOutcome(
+            nextState: nextState,
+            writtenGlobalChannels: commitResult.writtenGlobalChannels,
+            dropped: dropped,
+            selectedInterrupt: selectedInterrupt,
+            checkpointToSave: checkpointToSave
+        )
+    }
+
+    private func buildTasks(
+        frontier: [HiveFrontierTask<Schema>],
+        runID: HiveRunID,
+        stepIndex: Int,
+        debugPayloads: Bool
+    ) throws -> [HiveTask<Schema>] {
+        var tasks: [HiveTask<Schema>] = []
+        tasks.reserveCapacity(frontier.count)
+
+        for (ordinal, entry) in frontier.enumerated() {
+            guard UInt32(exactly: ordinal) != nil else {
+                throw HiveRuntimeError.taskOrdinalOutOfRange(ordinal: ordinal)
+            }
+            let fingerprint = try HiveTaskLocalFingerprint.digest(
+                registry: registry,
+                initialCache: initialCache,
+                overlay: entry.seed.local,
+                debugPayloads: debugPayloads
+            )
+            let taskID = try makeTaskID(
+                runID: runID,
+                stepIndex: stepIndex,
+                nodeID: entry.seed.nodeID,
+                ordinal: ordinal,
+                localFingerprint: fingerprint
+            )
+            tasks.append(
+                HiveTask(
+                    id: taskID,
+                    ordinal: ordinal,
+                    provenance: entry.provenance,
+                    nodeID: entry.seed.nodeID,
+                    local: entry.seed.local
+                )
+            )
+        }
+        return tasks
+    }
+
+    private func snapshotVersionsSeenForStepStart(
+        tasks: [HiveTask<Schema>],
+        state: inout ThreadState<Schema>
+    ) {
+        if tasks.isEmpty { return }
+
+        for task in tasks {
+            guard let node = graph.nodesByID[task.nodeID] else { continue }
+            let channels = node.runWhen.triggerChannels
+            if channels.isEmpty { continue }
+
+            var perChannel = state.versionsSeenByNodeID[task.nodeID] ?? [:]
+            perChannel.reserveCapacity(max(perChannel.count, channels.count))
+            for channelID in channels {
+                perChannel[channelID] = state.channelVersionsByChannelID[channelID] ?? 0
+            }
+            state.versionsSeenByNodeID[task.nodeID] = perChannel
+        }
+    }
+
+    private func filterFrontierForTriggers(
+        _ frontier: [HiveFrontierTask<Schema>],
+        channelVersionsByChannelID: [HiveChannelID: UInt64],
+        versionsSeenByNodeID: [HiveNodeID: [HiveChannelID: UInt64]]
+    ) -> [HiveFrontierTask<Schema>] {
+        if frontier.isEmpty { return [] }
+
+        func channelChanged(
+            channelID: HiveChannelID,
+            seen: [HiveChannelID: UInt64]?
+        ) -> Bool {
+            let current = channelVersionsByChannelID[channelID] ?? 0
+            guard let seenValue = seen?[channelID] else { return true }
+            return current > seenValue
+        }
+
+        var filtered: [HiveFrontierTask<Schema>] = []
+        filtered.reserveCapacity(frontier.count)
+
+        for entry in frontier {
+            if entry.isJoinSeed {
+                filtered.append(entry)
+                continue
+            }
+
+            guard let node = graph.nodesByID[entry.seed.nodeID] else {
+                filtered.append(entry)
+                continue
+            }
+
+            switch node.runWhen.normalized {
+            case .always:
+                filtered.append(entry)
+            case .anyOf(let channels):
+                if channels.isEmpty {
+                    filtered.append(entry)
+                    continue
+                }
+                let seen = versionsSeenByNodeID[entry.seed.nodeID]
+                if channels.contains(where: { channelChanged(channelID: $0, seen: seen) }) {
+                    filtered.append(entry)
+                }
+            case .allOf(let channels):
+                if channels.isEmpty {
+                    filtered.append(entry)
+                    continue
+                }
+                let seen = versionsSeenByNodeID[entry.seed.nodeID]
+                if channels.allSatisfy({ channelChanged(channelID: $0, seen: seen) }) {
+                    filtered.append(entry)
+                }
+            }
+        }
+
+        return filtered
+    }
+
+    private static func executeTasks(
+        tasks: [HiveTask<Schema>],
+        options: HiveRunOptions,
+        stepIndex: Int,
+        threadID: HiveThreadID,
+        attemptID: HiveRunAttemptID,
+        runID: HiveRunID,
+        graph: CompiledHiveGraph<Schema>,
+        environment: HiveEnvironment<Schema>,
+        registry: HiveSchemaRegistry<Schema>,
+        initialCache: HiveInitialCache<Schema>,
+        preStepGlobal: HiveGlobalStore<Schema>,
+        resume: HiveResume<Schema>?,
+        emitter: HiveEventEmitter,
+        droppedCounter: HiveDroppedEventCounter
+    ) async -> [TaskExecutionResult<Schema>] {
+        if tasks.isEmpty { return [] }
+        let concurrency = max(1, min(options.maxConcurrentTasks, tasks.count))
+        var results = Array(repeating: TaskExecutionResult<Schema>.empty, count: tasks.count)
+
+        await withTaskGroup(of: (Int, TaskExecutionResult<Schema>).self) { group in
+            var nextIndex = 0
+            var cancellationObserved = false
+            func addTask(_ index: Int) {
+                let task = tasks[index]
+                group.addTask {
+                    let result = await Self.executeTask(
+                        task: task,
+                        stepIndex: stepIndex,
+                        threadID: threadID,
+                        attemptID: attemptID,
+                        runID: runID,
+                        options: options,
+                        graph: graph,
+                        environment: environment,
+                        registry: registry,
+                        initialCache: initialCache,
+                        preStepGlobal: preStepGlobal,
+                        resume: resume,
+                        emitter: emitter,
+                        droppedCounter: droppedCounter
+                    )
+                    return (index, result)
+                }
+            }
+
+            while nextIndex < concurrency {
+                addTask(nextIndex)
+                nextIndex += 1
+            }
+
+            while let (index, result) = await group.next() {
+                results[index] = result
+
+                if cancellationObserved == false {
+                    // If any task reports cancellation (including CancellationError during retry-backoff sleep),
+                    // treat the step as cancelled and cancel remaining in-flight tasks.
+                    if Task.isCancelled || (result.error is RuntimeCancellation) {
+                        cancellationObserved = true
+                        group.cancelAll()
+                    }
+                }
+
+                if cancellationObserved == false, nextIndex < tasks.count {
+                    addTask(nextIndex)
+                    nextIndex += 1
+                }
+            }
+        }
+
+        return results
+    }
+
+    private static func executeTask(
+        task: HiveTask<Schema>,
+        stepIndex: Int,
+        threadID: HiveThreadID,
+        attemptID: HiveRunAttemptID,
+        runID: HiveRunID,
+        options: HiveRunOptions,
+        graph: CompiledHiveGraph<Schema>,
+        environment: HiveEnvironment<Schema>,
+        registry: HiveSchemaRegistry<Schema>,
+        initialCache: HiveInitialCache<Schema>,
+        preStepGlobal: HiveGlobalStore<Schema>,
+        resume: HiveResume<Schema>?,
+        emitter: HiveEventEmitter,
+        droppedCounter: HiveDroppedEventCounter
+    ) async -> TaskExecutionResult<Schema> {
+        guard let node = graph.nodesByID[task.nodeID] else {
+            return TaskExecutionResult(error: HiveRuntimeError.unknownNodeID(task.nodeID))
+        }
+
+        switch node.retryPolicy {
+        case .none:
+            return await runNodeAttempt(
+                node: node,
+                task: task,
+                stepIndex: stepIndex,
+                threadID: threadID,
+                attemptID: attemptID,
+                runID: runID,
+                options: options,
+                environment: environment,
+                registry: registry,
+                initialCache: initialCache,
+                preStepGlobal: preStepGlobal,
+                resume: resume,
+                emitter: emitter,
+                droppedCounter: droppedCounter
+            )
+        case let .exponentialBackoff(initialNanoseconds, factor, maxAttempts, maxNanoseconds):
+            var attempt = 1
+            while attempt <= maxAttempts {
+                let result = await runNodeAttempt(
+                    node: node,
+                    task: task,
+                    stepIndex: stepIndex,
+                    threadID: threadID,
+                    attemptID: attemptID,
+                    runID: runID,
+                    options: options,
+                    environment: environment,
+                    registry: registry,
+                    initialCache: initialCache,
+                    preStepGlobal: preStepGlobal,
+                    resume: resume,
+                    emitter: emitter,
+                    droppedCounter: droppedCounter
+                )
+                if result.error == nil {
+                    return result
+                }
+                if attempt == maxAttempts {
+                    return result
+                }
+                if Task.isCancelled {
+                    return TaskExecutionResult(error: RuntimeCancellation.executionObserved)
+                }
+
+                let delay = Self.retryDelayNanoseconds(
+                    initialNanoseconds: initialNanoseconds,
+                    factor: factor,
+                    attempt: attempt,
+                    maxNanoseconds: maxNanoseconds
+                )
+                do {
+                    try await environment.clock.sleep(nanoseconds: delay)
+                } catch is CancellationError {
+                    return TaskExecutionResult(error: RuntimeCancellation.executionObserved)
+                } catch {
+                    return TaskExecutionResult(error: error)
+                }
+                attempt += 1
+            }
+            return TaskExecutionResult(error: HiveRuntimeError.invalidRunOptions("retry attempts exhausted"))
+        }
+    }
+
+    private static func retryDelayNanoseconds(
+        initialNanoseconds: UInt64,
+        factor: Double,
+        attempt: Int,
+        maxNanoseconds: UInt64
+    ) -> UInt64 {
+        // Spec: attempts are 1-based, and the delay for a failure before attempt+1 is:
+        // min(maxNanoseconds, floor(initialNanoseconds * pow(factor, attempt-1))).
+        let exponent = Double(max(0, attempt - 1))
+        let raw = Double(initialNanoseconds) * pow(factor, exponent)
+        let floored = raw.rounded(.down)
+        let capped = min(Double(maxNanoseconds), floored)
+        if capped <= 0 { return 0 }
+        return UInt64(capped)
+    }
+
+    private static func runNodeAttempt(
+        node: HiveCompiledNode<Schema>,
+        task: HiveTask<Schema>,
+        stepIndex: Int,
+        threadID: HiveThreadID,
+        attemptID: HiveRunAttemptID,
+        runID: HiveRunID,
+        options: HiveRunOptions,
+        environment: HiveEnvironment<Schema>,
+        registry: HiveSchemaRegistry<Schema>,
+        initialCache: HiveInitialCache<Schema>,
+        preStepGlobal: HiveGlobalStore<Schema>,
+        resume: HiveResume<Schema>?,
+        emitter: HiveEventEmitter,
+        droppedCounter: HiveDroppedEventCounter
+    ) async -> TaskExecutionResult<Schema> {
+        let bufferingCapacity = max(1, options.eventBufferCapacity)
+        let streamBuffer: HivePerAttemptStreamBuffer? = options.deterministicStreamBuffering
+            ? HivePerAttemptStreamBuffer(capacity: bufferingCapacity, stepIndex: stepIndex, taskOrdinal: task.ordinal)
+            : nil
+
+        let storeView = HiveStoreView(
+            global: preStepGlobal,
+            taskLocal: task.local,
+            initialCache: initialCache,
+            registry: registry
+        )
+
+        let runContext = HiveRunContext<Schema>(
+            runID: runID,
+            threadID: threadID,
+            attemptID: attemptID,
+            stepIndex: stepIndex,
+            taskID: task.id,
+            options: options,
+            resume: resume
+        )
+
+        let input = HiveNodeInput(
+            store: storeView,
+            run: runContext,
+            context: environment.context,
+            environment: environment,
+            emitStream: { kind, metadata in
+                if let streamBuffer {
+                    streamBuffer.record(kind: mapStream(kind), metadata: metadata)
+                    return
+                }
+                let enqueueResult = emitter.emit(
+                    kind: mapStream(kind),
+                    stepIndex: stepIndex,
+                    taskOrdinal: task.ordinal,
+                    metadata: metadata
+                )
+                droppedCounter.record(enqueueResult)
+            },
+            emitDebug: { name, metadata in
+                if let streamBuffer {
+                    streamBuffer.record(kind: .customDebug(name: name), metadata: metadata)
+                    return
+                }
+                let enqueueResult = emitter.emit(
+                    kind: .customDebug(name: name),
+                    stepIndex: stepIndex,
+                    taskOrdinal: task.ordinal,
+                    metadata: metadata
+                )
+                droppedCounter.record(enqueueResult)
+            }
+        )
+
+        do {
+            let output = try await node.run(input)
+            if let streamBuffer {
+                let snapshot = streamBuffer.snapshot()
+                if let overflowError = snapshot.overflowError {
+                    return TaskExecutionResult(error: overflowError)
+                }
+                return TaskExecutionResult(output: output, streamEvents: snapshot.events, streamDrops: snapshot.dropped)
+            }
+            return TaskExecutionResult(output: output, error: nil, streamEvents: nil, streamDrops: .init())
+        } catch {
+            if options.deterministicStreamBuffering {
+                // Failed-attempt stream events are discarded in this mode.
+                return TaskExecutionResult(error: error)
+            }
+            return TaskExecutionResult(error: error)
+        }
+    }
+
+    private func commitStep(
+        state: ThreadState<Schema>,
+        tasks: [HiveTask<Schema>],
+        outputs: [HiveNodeOutput<Schema>],
+        options: HiveRunOptions
+    ) throws -> CommitResult<Schema> {
+        let (perTaskWrites, globalWritesByChannel) = try collectWrites(tasks: tasks, outputs: outputs)
+
+        var postGlobal = state.global
+
+        for spec in registry.sortedChannelSpecs where spec.scope == .global {
+            let writes = globalWritesByChannel[spec.id] ?? []
+            if writes.isEmpty { continue }
+            if spec.updatePolicy == .single, writes.count > 1 {
+                throw HiveRuntimeError.updatePolicyViolation(
+                    channelID: spec.id,
+                    policy: .single,
+                    writeCount: writes.count
+                )
+            }
+        }
+
+        var writtenGlobalChannels: [HiveChannelID] = []
+        for spec in registry.sortedChannelSpecs where spec.scope == .global {
+            guard let writes = globalWritesByChannel[spec.id], !writes.isEmpty else { continue }
+            let ordered = writes.sorted { lhs, rhs in
+                if lhs.taskOrdinal == rhs.taskOrdinal {
+                    return lhs.emissionIndex < rhs.emissionIndex
+                }
+                return lhs.taskOrdinal < rhs.taskOrdinal
+            }
+            var current = try postGlobal.valueAny(for: spec.id)
+            for write in ordered {
+                current = try spec._reduceBox(current, write.value)
+            }
+            try postGlobal.setAny(current, for: spec.id)
+            writtenGlobalChannels.append(spec.id)
+        }
+
+        // Reset ephemeral channels to initial value after each superstep commit.
+        for spec in registry.sortedChannelSpecs where spec.scope == .global && spec.persistence.resetsAfterStep {
+            let initialValue = spec._initialBox()
+            try postGlobal.setAny(initialValue, for: spec.id)
+        }
+
+        var postTaskLocal: [HiveTaskLocalStore<Schema>] = []
+        postTaskLocal.reserveCapacity(tasks.count)
+
+        for (index, task) in tasks.enumerated() {
+            var overlay = task.local
+            let writes = perTaskWrites[index].taskLocal
+
+            var writesByChannel: [HiveChannelID: [WriteRecord<Schema>]] = [:]
+            for write in writes {
+                writesByChannel[write.channelID, default: []].append(write)
+            }
+
+            for spec in registry.sortedChannelSpecs where spec.scope == .taskLocal {
+                let channelWrites = writesByChannel[spec.id] ?? []
+                if channelWrites.isEmpty { continue }
+                if spec.updatePolicy == .single, channelWrites.count > 1 {
+                    throw HiveRuntimeError.updatePolicyViolation(
+                        channelID: spec.id,
+                        policy: .single,
+                        writeCount: channelWrites.count
+                    )
+                }
+                let ordered = channelWrites.sorted { $0.emissionIndex < $1.emissionIndex }
+                var current = try (overlay.valueAny(for: spec.id) ?? initialCache.valueAny(for: spec.id))
+                for write in ordered {
+                    current = try spec._reduceBox(current, write.value)
+                }
+                try overlay.setAny(current, for: spec.id)
+            }
+            postTaskLocal.append(overlay)
+        }
+
+        var nextGraphSeeds: [HiveTaskSeed<Schema>] = []
+        var nextSpawnSeeds: [HiveTaskSeed<Schema>] = []
+
+        for (index, task) in tasks.enumerated() {
+            let output = outputs[index]
+            if !output.spawn.isEmpty {
+                nextSpawnSeeds.append(contentsOf: output.spawn)
+            }
+
+            let normalizedNext = output.next.normalized
+            switch normalizedNext {
+            case .useGraphEdges:
+                break
+            case .end:
+                continue
+            case .to(let nodes):
+                for node in nodes {
+                    nextGraphSeeds.append(HiveTaskSeed(nodeID: node))
+                }
+                continue
+            }
+
+            if let router = graph.routersByFrom[task.nodeID] {
+                let routerGlobal = try applyGlobalWritesForTask(
+                    taskIndex: index,
+                    preStepGlobal: state.global,
+                    perTaskWrites: perTaskWrites
+                )
+                let routerView = HiveStoreView(
+                    global: routerGlobal,
+                    taskLocal: postTaskLocal[index],
+                    initialCache: initialCache,
+                    registry: registry
+                )
+                let routed = router(routerView).normalized
+                switch routed {
+                case .useGraphEdges:
+                    let staticEdges = graph.staticEdgesByFrom[task.nodeID] ?? []
+                    for node in staticEdges {
+                        nextGraphSeeds.append(HiveTaskSeed(nodeID: node))
+                    }
+                case .end:
+                    break
+                case .to(let nodes):
+                    for node in nodes {
+                        nextGraphSeeds.append(HiveTaskSeed(nodeID: node))
+                    }
+                }
+            } else {
+                let staticEdges = graph.staticEdgesByFrom[task.nodeID] ?? []
+                for node in staticEdges {
+                    nextGraphSeeds.append(HiveTaskSeed(nodeID: node))
+                }
+            }
+        }
+
+        var joinSeen = state.joinSeenParents
+        var joinSeedKeys: Set<SeedKey> = []
+        var completedNodesMask = HiveBitset(wordCount: graph.joinBitsetWordCount)
+        for task in tasks {
+            if let ordinal = graph.nodeOrdinalByID[task.nodeID] {
+                completedNodesMask.insert(ordinal)
+            }
+        }
+
+        for task in tasks {
+            for edge in graph.joinEdgesByTarget[task.nodeID] ?? [] {
+                guard let parentMask = graph.joinParentMaskByJoinID[edge.id] else { continue }
+                if joinSeen[edge.id] == parentMask {
+                    joinSeen[edge.id] = HiveBitset(wordCount: graph.joinBitsetWordCount)
+                }
+            }
+        }
+
+        var affectedJoinIDs: Set<String> = []
+        affectedJoinIDs.reserveCapacity(tasks.count)
+        for task in tasks {
+            for edge in graph.joinEdgesByParent[task.nodeID] ?? [] {
+                affectedJoinIDs.insert(edge.id)
+            }
+        }
+
+        var affectedEdges: [HiveJoinEdge] = []
+        affectedEdges.reserveCapacity(affectedJoinIDs.count)
+        for joinID in affectedJoinIDs {
+            guard let edge = graph.joinEdgeByID[joinID] else { continue }
+            affectedEdges.append(edge)
+        }
+        affectedEdges.sort { lhs, rhs in
+            let left = graph.joinEdgeOrderByID[lhs.id] ?? 0
+            let right = graph.joinEdgeOrderByID[rhs.id] ?? 0
+            return left < right
+        }
+
+        for edge in affectedEdges {
+            guard let parentMask = graph.joinParentMaskByJoinID[edge.id] else { continue }
+            let wasAvailable = (joinSeen[edge.id] == parentMask)
+            var seen = joinSeen[edge.id] ?? HiveBitset(wordCount: graph.joinBitsetWordCount)
+            for parent in edge.parents {
+                guard let ordinal = graph.nodeOrdinalByID[parent] else { continue }
+                if completedNodesMask.contains(ordinal) {
+                    seen.insert(ordinal)
+                }
+            }
+            joinSeen[edge.id] = seen
+            let isAvailable = (seen == parentMask)
+            if !wasAvailable && isAvailable {
+                let seed = HiveTaskSeed<Schema>(nodeID: edge.target)
+                nextGraphSeeds.append(seed)
+                let fingerprint = try HiveTaskLocalFingerprint.digest(
+                    registry: registry,
+                    initialCache: initialCache,
+                    overlay: seed.local,
+                    debugPayloads: options.debugPayloads
+                )
+                joinSeedKeys.insert(SeedKey(nodeID: seed.nodeID, fingerprint: fingerprint))
+            }
+        }
+
+        let dedupedGraphSeeds = try dedupeGraphSeeds(nextGraphSeeds, options: options)
+
+        try validateSeedNodes(dedupedGraphSeeds.map(\.seed), spawnSeeds: nextSpawnSeeds)
+
+        var nextFrontier: [HiveFrontierTask<Schema>] = []
+        nextFrontier.reserveCapacity(dedupedGraphSeeds.count + nextSpawnSeeds.count)
+        for entry in dedupedGraphSeeds {
+            nextFrontier.append(
+                HiveFrontierTask(
+                    seed: entry.seed,
+                    provenance: .graph,
+                    isJoinSeed: joinSeedKeys.contains(entry.key)
+                )
+            )
+        }
+        for seed in nextSpawnSeeds {
+            nextFrontier.append(HiveFrontierTask(seed: seed, provenance: .spawn, isJoinSeed: false))
+        }
+
+        var normalFrontier: [HiveFrontierTask<Schema>] = []
+        var deferredNextFrontier: [HiveFrontierTask<Schema>] = []
+        for task in nextFrontier {
+            if graph.nodesByID[task.seed.nodeID]?.options.contains(.deferred) == true {
+                deferredNextFrontier.append(task)
+            } else {
+                normalFrontier.append(task)
+            }
+        }
+
+        return CommitResult(
+            global: postGlobal,
+            frontier: normalFrontier,
+            deferredFrontier: deferredNextFrontier,
+            joinSeenParents: joinSeen,
+            writtenGlobalChannels: writtenGlobalChannels
+        )
+    }
+
+    private func collectWrites(
+        tasks: [HiveTask<Schema>],
+        outputs: [HiveNodeOutput<Schema>]
+    ) throws -> ([TaskWrites<Schema>], [HiveChannelID: [WriteRecord<Schema>]]) {
+        var perTaskWrites: [TaskWrites<Schema>] = Array(repeating: TaskWrites(), count: tasks.count)
+        var globalWritesByChannel: [HiveChannelID: [WriteRecord<Schema>]] = [:]
+
+        for (taskIndex, output) in outputs.enumerated() {
+            for (emissionIndex, write) in output.writes.enumerated() {
+                guard let spec = registry.channelSpecsByID[write.channelID] else {
+                    throw HiveRuntimeError.unknownChannelID(write.channelID)
+                }
+                try storeSupport.validateValueType(write.value, spec: spec)
+                let record = WriteRecord(
+                    channelID: write.channelID,
+                    value: write.value,
+                    emissionIndex: emissionIndex,
+                    taskOrdinal: taskIndex,
+                    spec: spec
+                )
+                switch spec.scope {
+                case .global:
+                    perTaskWrites[taskIndex].global.append(record)
+                    globalWritesByChannel[write.channelID, default: []].append(record)
+                case .taskLocal:
+                    perTaskWrites[taskIndex].taskLocal.append(record)
+                }
+            }
+        }
+
+        return (perTaskWrites, globalWritesByChannel)
+    }
+
+    private func applyGlobalWritesForTask(
+        taskIndex: Int,
+        preStepGlobal: HiveGlobalStore<Schema>,
+        perTaskWrites: [TaskWrites<Schema>]
+    ) throws -> HiveGlobalStore<Schema> {
+        var global = preStepGlobal
+        let writes = perTaskWrites[taskIndex].global.sorted { $0.emissionIndex < $1.emissionIndex }
+        if writes.isEmpty {
+            return global
+        }
+        // Router "fresh read" requires applying this task's global writes in ascending emission order.
+        // Channels are independent, but error precedence (e.g., reducer throws) must follow emission order.
+        for write in writes {
+            let current = try global.valueAny(for: write.channelID)
+            let reduced = try write.spec._reduceBox(current, write.value)
+            try global.setAny(reduced, for: write.channelID)
+        }
+
+        return global
+    }
+
+    private func dedupeGraphSeeds(
+        _ seeds: [HiveTaskSeed<Schema>],
+        options: HiveRunOptions
+    ) throws -> [(seed: HiveTaskSeed<Schema>, key: SeedKey)] {
+        var seen: Set<SeedKey> = []
+        var deduped: [(seed: HiveTaskSeed<Schema>, key: SeedKey)] = []
+        deduped.reserveCapacity(seeds.count)
+
+        for seed in seeds {
+            let fingerprint = try HiveTaskLocalFingerprint.digest(
+                registry: registry,
+                initialCache: initialCache,
+                overlay: seed.local,
+                debugPayloads: options.debugPayloads
+            )
+            let key = SeedKey(nodeID: seed.nodeID, fingerprint: fingerprint)
+            if seen.insert(key).inserted {
+                deduped.append((seed: seed, key: key))
+            }
+        }
+
+        return deduped
+    }
+
+    private func validateSeedNodes(
+        _ graphSeeds: [HiveTaskSeed<Schema>],
+        spawnSeeds: [HiveTaskSeed<Schema>]
+    ) throws {
+        for seed in graphSeeds {
+            guard graph.nodesByID[seed.nodeID] != nil else {
+                throw HiveRuntimeError.unknownNodeID(seed.nodeID)
+            }
+        }
+        for seed in spawnSeeds {
+            guard graph.nodesByID[seed.nodeID] != nil else {
+                throw HiveRuntimeError.unknownNodeID(seed.nodeID)
+            }
+        }
+    }
+
+    private func makeTaskID(
+        runID: HiveRunID,
+        stepIndex: Int,
+        nodeID: HiveNodeID,
+        ordinal: Int,
+        localFingerprint: Data
+    ) throws -> HiveTaskID {
+        guard let stepValue = UInt32(exactly: stepIndex) else {
+            throw HiveRuntimeError.stepIndexOutOfRange(stepIndex: stepIndex)
+        }
+        guard let ordinalValue = UInt32(exactly: ordinal) else {
+            throw HiveRuntimeError.taskOrdinalOutOfRange(ordinal: ordinal)
+        }
+        guard localFingerprint.count == 32 else {
+            throw HiveRuntimeError.invalidTaskLocalFingerprintLength(
+                expected: 32,
+                actual: localFingerprint.count
+            )
+        }
+
+        var bytes = Data()
+        var uuid = runID.rawValue.uuid
+        withUnsafeBytes(of: &uuid) { bytes.append(contentsOf: $0) }
+
+        appendUInt32BE(stepValue, to: &bytes)
+        bytes.append(0)
+        bytes.append(contentsOf: nodeID.rawValue.utf8)
+        bytes.append(0)
+        appendUInt32BE(ordinalValue, to: &bytes)
+        bytes.append(localFingerprint)
+
+        let hash = HiveSHA256.hash(data: bytes)
+        let hex = hash.compactMap { String(format: "%02x", $0) }.joined()
+        return HiveTaskID(hex)
+    }
+
+    private func payloadHash(for channelID: HiveChannelID, in global: HiveGlobalStore<Schema>) throws -> String {
+        let spec = try storeSupport.requireSpec(for: channelID)
+        let value = try global.valueAny(for: channelID)
+        let bytes = try canonicalBytes(for: value, spec: spec)
+        let hash = HiveSHA256.hash(data: bytes)
+        return hash.compactMap { String(format: "%02x", $0) }.joined()
+    }
+
+    private func makeGlobalChannelPayloadHashes(
+        from global: HiveGlobalStore<Schema>
+    ) throws -> [HiveChannelID: String] {
+        var hashes: [HiveChannelID: String] = [:]
+        hashes.reserveCapacity(registry.sortedChannelSpecs.count)
+        for spec in registry.sortedChannelSpecs where spec.scope == .global {
+            hashes[spec.id] = try payloadHash(for: spec.id, in: global)
+        }
+        return hashes
+    }
+
+    private func makeInterruptionSnapshot(
+        from interruption: HiveInterrupt<Schema>?
+    ) throws -> HiveRuntimeInterruptionSnapshot? {
+        guard let interruption else { return nil }
+        let payloadBytes: Data
+        if let stableJSON = try stableJSONDataIfEncodable(interruption.payload) {
+            payloadBytes = stableJSON
+        } else {
+            payloadBytes = Data(String(reflecting: type(of: interruption.payload)).utf8)
+        }
+        let digest = HiveSHA256.hash(data: payloadBytes)
+        let payloadHash = digest.compactMap { String(format: "%02x", $0) }.joined()
+        return HiveRuntimeInterruptionSnapshot(
+            interruptID: interruption.id,
+            payloadHash: payloadHash
+        )
+    }
+
+    private func makeFrontierSummary(
+        from frontier: [HiveFrontierTask<Schema>]
+    ) throws -> [HiveRuntimeFrontierSummary] {
+        var summary: [HiveRuntimeFrontierSummary] = []
+        summary.reserveCapacity(frontier.count)
+        for entry in frontier {
+            let fingerprint = try HiveTaskLocalFingerprint.digest(
+                registry: registry,
+                initialCache: initialCache,
+                overlay: entry.seed.local,
+                debugPayloads: false
+            )
+            let digest = HiveSHA256.hash(data: fingerprint)
+            let fingerprintHash = digest.compactMap { String(format: "%02x", $0) }.joined()
+            summary.append(
+                HiveRuntimeFrontierSummary(
+                    nodeID: entry.seed.nodeID,
+                    provenance: entry.provenance,
+                    taskLocalFingerprintHash: fingerprintHash
+                )
+            )
+        }
+        summary.sort { lhs, rhs in
+            if lhs.nodeID != rhs.nodeID {
+                return HiveOrdering.lexicographicallyPrecedes(lhs.nodeID.rawValue, rhs.nodeID.rawValue)
+            }
+            if lhs.provenance != rhs.provenance {
+                return HiveOrdering.lexicographicallyPrecedes(lhs.provenance.rawValue, rhs.provenance.rawValue)
+            }
+            return HiveOrdering.lexicographicallyPrecedes(lhs.taskLocalFingerprintHash, rhs.taskLocalFingerprintHash)
+        }
+        return summary
+    }
+
+    private func writeAppliedMetadata(
+        for channelID: HiveChannelID,
+        in global: HiveGlobalStore<Schema>,
+        debugPayloads: Bool
+    ) throws -> [String: String] {
+        guard debugPayloads else { return [:] }
+        let spec = try storeSupport.requireSpec(for: channelID)
+        let value = try global.valueAny(for: channelID)
+
+        var encoding: String = "unhashable"
+        var payload: String = ""
+
+        if let encode = spec._encodeBox {
+            do {
+                let data = try encode(value)
+                encoding = "codec.base64"
+                payload = data.base64EncodedString()
+            } catch {
+                if let json = try stableJSONDataIfEncodable(value) {
+                    encoding = "json.utf8"
+                    payload = String(decoding: json, as: UTF8.self)
+                }
+            }
+        } else if let json = try stableJSONDataIfEncodable(value) {
+            encoding = "json.utf8"
+            payload = String(decoding: json, as: UTF8.self)
+        }
+
+        return [
+            "valueTypeID": spec.valueTypeID,
+            "codecID": spec.codecID ?? "",
+            "payloadEncoding": encoding,
+            "payload": payload
+        ]
+    }
+
+    private func appendUInt32BE(_ value: UInt32, to data: inout Data) {
+        var bigEndian = value.bigEndian
+        withUnsafeBytes(of: &bigEndian) { data.append(contentsOf: $0) }
+    }
+
+    private func canonicalBytes(for value: any Sendable, spec: AnyHiveChannelSpec<Schema>) throws -> Data {
+        if let encode = spec._encodeBox {
+            do {
+                return try encode(value)
+            } catch {
+                if let json = try stableJSONDataIfEncodable(value) {
+                    return json
+                }
+                return Data(("unhashable:" + spec.valueTypeID).utf8)
+            }
+        }
+
+        if let json = try stableJSONDataIfEncodable(value) {
+            return json
+        }
+
+        return Data(("unhashable:" + spec.valueTypeID).utf8)
+    }
+
+    private func stableJSONDataIfEncodable(_ value: any Sendable) throws -> Data? {
+        guard let encodable = value as? any Encodable else { return nil }
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.dataEncodingStrategy = .base64
+        return try encoder.encode(HiveAnyEncodable(encodable))
+    }
+
+    private struct HiveAnyEncodable: Encodable {
+        let encodable: any Encodable
+
+        init(_ encodable: any Encodable) {
+            self.encodable = encodable
+        }
+
+        func encode(to encoder: Encoder) throws {
+            try encodable.encode(to: encoder)
+        }
+    }
+
+    private static func mapStream(_ kind: HiveStreamEventKind) -> HiveEventKind {
+        switch kind {
+        case .customDebug(let name):
+            return .customDebug(name: name)
+        }
+    }
+}
+
+private struct HiveFrontierTask<Schema: HiveSchema>: Sendable {
+    let seed: HiveTaskSeed<Schema>
+    let provenance: HiveTaskProvenance
+    let isJoinSeed: Bool
+}
+
+private struct ThreadState<Schema: HiveSchema>: Sendable {
+    var runID: HiveRunID
+    var stepIndex: Int
+    var global: HiveGlobalStore<Schema>
+    var frontier: [HiveFrontierTask<Schema>]
+    var deferredFrontier: [HiveFrontierTask<Schema>]
+    var joinSeenParents: [String: HiveBitset]
+    var interruption: HiveInterrupt<Schema>?
+    var latestCheckpointID: HiveCheckpointID?
+    var channelVersionsByChannelID: [HiveChannelID: UInt64]
+    var versionsSeenByNodeID: [HiveNodeID: [HiveChannelID: UInt64]]
+    var updatedChannelsLastCommit: [HiveChannelID]
+    var nodeCaches: [HiveNodeID: HiveNodeCache<Schema>]
+}
+
+private struct WriteRecord<Schema: HiveSchema>: Sendable {
+    let channelID: HiveChannelID
+    let value: any Sendable
+    let emissionIndex: Int
+    let taskOrdinal: Int
+    let spec: AnyHiveChannelSpec<Schema>
+}
+
+private struct TaskWrites<Schema: HiveSchema>: Sendable {
+    var global: [WriteRecord<Schema>] = []
+    var taskLocal: [WriteRecord<Schema>] = []
+}
+
+private struct CommitResult<Schema: HiveSchema>: Sendable {
+    let global: HiveGlobalStore<Schema>
+    let frontier: [HiveFrontierTask<Schema>]
+    let deferredFrontier: [HiveFrontierTask<Schema>]
+    let joinSeenParents: [String: HiveBitset]
+    let writtenGlobalChannels: [HiveChannelID]
+}
+
+private struct StepOutcome<Schema: HiveSchema>: Sendable {
+    let nextState: ThreadState<Schema>
+    let writtenGlobalChannels: [HiveChannelID]
+    let dropped: HiveDroppedEventCounts
+    let selectedInterrupt: HiveInterrupt<Schema>?
+    let checkpointToSave: HiveCheckpoint<Schema>?
+}
+
+private struct HiveDroppedEventCounts: Sendable {
+    var droppedDebugEvents: Int = 0
+
+    mutating func record(_ enqueueResult: HiveEventEnqueueResult) {
+        switch enqueueResult {
+        case .droppedDebug:
+            droppedDebugEvents += 1
+        case .enqueued, .terminated:
+            break
+        }
+    }
+}
+
+private final class HiveDroppedEventCounter: Sendable {
+    private let counts = Mutex(HiveDroppedEventCounts())
+
+    func record(_ enqueueResult: HiveEventEnqueueResult) {
+        counts.withLock { $0.record(enqueueResult) }
+    }
+
+    func snapshot() -> HiveDroppedEventCounts {
+        counts.withLock { $0 }
+    }
+}
+
+private struct BufferedStreamEvent: Sendable {
+    let kind: HiveEventKind
+    let metadata: [String: String]
+    let taskOrdinal: Int
+}
+
+private final class HivePerAttemptStreamBuffer: Sendable {
+    private struct State {
+        var events: [BufferedStreamEvent]
+        var dropped: HiveDroppedEventCounts
+        var overflowError: Error?
+    }
+
+    private let capacity: Int
+    private let stepIndex: Int
+    private let taskOrdinal: Int
+    private let state: Mutex<State>
+
+    init(capacity: Int, stepIndex: Int, taskOrdinal: Int) {
+        self.capacity = max(1, capacity)
+        self.stepIndex = stepIndex
+        self.taskOrdinal = taskOrdinal
+        var initialEvents: [BufferedStreamEvent] = []
+        initialEvents.reserveCapacity(min(8, self.capacity))
+        self.state = Mutex(State(events: initialEvents, dropped: HiveDroppedEventCounts(), overflowError: nil))
+    }
+
+    func record(kind: HiveEventKind, metadata: [String: String]) {
+        state.withLock { state in
+            guard state.overflowError == nil else { return }
+
+            if state.events.count < capacity {
+                state.events.append(BufferedStreamEvent(kind: kind, metadata: metadata, taskOrdinal: taskOrdinal))
+                return
+            }
+
+            switch kind {
+            case .customDebug:
+                state.dropped.droppedDebugEvents += 1
+            default:
+                state.overflowError = HiveRuntimeError.internalInvariantViolation(
+                    "Non-droppable stream event buffer overflow (stepIndex=\(stepIndex), taskOrdinal=\(taskOrdinal), perTaskCapacity=\(capacity))"
+                )
+            }
+        }
+    }
+
+    func snapshot() -> (events: [BufferedStreamEvent], dropped: HiveDroppedEventCounts, overflowError: Error?) {
+        state.withLock { (events: $0.events, dropped: $0.dropped, overflowError: $0.overflowError) }
+    }
+}
+
+private struct TaskExecutionResult<Schema: HiveSchema>: Sendable {
+    let output: HiveNodeOutput<Schema>?
+    let error: Error?
+    let streamEvents: [BufferedStreamEvent]?
+    let streamDrops: HiveDroppedEventCounts
+
+    static var empty: TaskExecutionResult<Schema> {
+        TaskExecutionResult(output: nil, error: nil, streamEvents: nil, streamDrops: .init())
+    }
+
+    init(
+        output: HiveNodeOutput<Schema>?,
+        error: Error?,
+        streamEvents: [BufferedStreamEvent]?,
+        streamDrops: HiveDroppedEventCounts
+    ) {
+        self.output = output
+        self.error = error
+        self.streamEvents = streamEvents
+        self.streamDrops = streamDrops
+    }
+
+    init(output: HiveNodeOutput<Schema>, streamEvents: [BufferedStreamEvent], streamDrops: HiveDroppedEventCounts) {
+        self.output = output
+        self.error = nil
+        self.streamEvents = streamEvents
+        self.streamDrops = streamDrops
+    }
+
+    init(error: Error) {
+        self.output = nil
+        self.error = error
+        self.streamEvents = nil
+        self.streamDrops = .init()
+    }
+}
+
+private struct SeedKey: Hashable, Sendable {
+    let nodeID: HiveNodeID
+    let fingerprint: Data
+}
+
+private final class HiveEventEmitter: Sendable {
+    private struct State {
+        var eventIndex: UInt64 = 0
+    }
+
+    private let runID: HiveRunID
+    private let attemptID: HiveRunAttemptID
+    private let streamController: HiveEventStreamController
+    private let state = Mutex(State())
+
+    init(
+        runID: HiveRunID,
+        attemptID: HiveRunAttemptID,
+        streamController: HiveEventStreamController
+    ) {
+        self.runID = runID
+        self.attemptID = attemptID
+        self.streamController = streamController
+    }
+
+    @discardableResult
+    func emit(
+        kind: HiveEventKind,
+        stepIndex: Int?,
+        taskOrdinal: Int?,
+        metadata: [String: String] = [:],
+        treatAsNonDroppable: Bool = false
+    ) -> HiveEventEnqueueResult {
+        state.withLock { state in
+            let nextIndex = state.eventIndex
+            let result = streamController.enqueue(
+                eventIndex: nextIndex,
+                runID: runID,
+                attemptID: attemptID,
+                kind: kind,
+                stepIndex: stepIndex,
+                taskOrdinal: taskOrdinal,
+                metadata: metadata,
+                treatAsNonDroppable: treatAsNonDroppable
+            )
+            if case .enqueued = result {
+                state.eventIndex += 1
+            }
+            return result
+        }
+    }
+}

--- a/Sources/HiveCore/Runtime/HiveRuntimeStateSnapshot.swift
+++ b/Sources/HiveCore/Runtime/HiveRuntimeStateSnapshot.swift
@@ -1,0 +1,133 @@
+import Foundation
+
+/// Stable interruption metadata included in runtime state snapshots.
+public struct HiveRuntimeInterruptionSnapshot: Sendable, Equatable, Codable {
+    public let interruptID: HiveInterruptID
+    public let payloadHash: String
+
+    public init(interruptID: HiveInterruptID, payloadHash: String) {
+        self.interruptID = interruptID
+        self.payloadHash = payloadHash
+    }
+}
+
+/// Stable, deterministic projection of a frontier task.
+public struct HiveRuntimeFrontierSummary: Sendable, Equatable, Codable {
+    public let nodeID: HiveNodeID
+    public let provenance: HiveTaskProvenance
+    public let taskLocalFingerprintHash: String
+
+    public init(
+        nodeID: HiveNodeID,
+        provenance: HiveTaskProvenance,
+        taskLocalFingerprintHash: String
+    ) {
+        self.nodeID = nodeID
+        self.provenance = provenance
+        self.taskLocalFingerprintHash = taskLocalFingerprintHash
+    }
+}
+
+/// Point-in-time deterministic runtime state snapshot for one thread.
+public struct HiveRuntimeStateSnapshot<Schema: HiveSchema>: Sendable {
+    public let threadID: HiveThreadID
+    public let runID: HiveRunID
+    public let stepIndex: Int
+    public let interruption: HiveRuntimeInterruptionSnapshot?
+    public let checkpointID: HiveCheckpointID?
+
+    /// Checkpoint summary retained for compatibility with existing state-inspection call sites.
+    public let checkpoint: HiveCheckpointSummary?
+
+    /// Canonical payload hash for each global channel.
+    public let globalChannelPayloadHashesByID: [HiveChannelID: String]
+
+    /// Stable frontier representation for deterministic comparisons.
+    public let frontierSummary: [HiveRuntimeFrontierSummary]
+
+    /// Typed projection of global values.
+    /// This is intentionally schema-bound (no untyped Any surface).
+    public let store: HiveGlobalStore<Schema>
+
+    public init(
+        threadID: HiveThreadID,
+        runID: HiveRunID,
+        stepIndex: Int,
+        interruption: HiveRuntimeInterruptionSnapshot?,
+        checkpointID: HiveCheckpointID?,
+        checkpoint: HiveCheckpointSummary?,
+        globalChannelPayloadHashesByID: [HiveChannelID: String],
+        frontierSummary: [HiveRuntimeFrontierSummary],
+        store: HiveGlobalStore<Schema>
+    ) {
+        self.threadID = threadID
+        self.runID = runID
+        self.stepIndex = stepIndex
+        self.interruption = interruption
+        self.checkpointID = checkpointID
+        self.checkpoint = checkpoint
+        self.globalChannelPayloadHashesByID = globalChannelPayloadHashesByID
+        self.frontierSummary = frontierSummary
+        self.store = store
+    }
+
+    /// Compatibility convenience for callers that only need next frontier nodes.
+    public var nextNodes: [HiveNodeID] {
+        var seen: Set<String> = []
+        var nodes: [HiveNodeID] = []
+        nodes.reserveCapacity(frontierSummary.count)
+        for entry in frontierSummary {
+            if seen.insert(entry.nodeID.rawValue).inserted {
+                nodes.append(entry.nodeID)
+            }
+        }
+        nodes.sort { HiveOrdering.lexicographicallyPrecedes($0.rawValue, $1.rawValue) }
+        return nodes
+    }
+
+    /// Returns a typed value projection when `store` is available.
+    public func value<Value: Sendable>(for key: HiveChannelKey<Schema, Value>) throws -> Value? {
+        try store.get(key)
+    }
+
+    /// Deterministic hash for snapshot comparison in tests and replay tooling.
+    public var deterministicRepresentationHash: String {
+        var data = Data("HSS2".utf8)
+        data.append(contentsOf: threadID.rawValue.utf8)
+        data.append(0)
+        data.append(contentsOf: runID.rawValue.uuidString.utf8)
+        data.append(0)
+        data.append(contentsOf: String(stepIndex).utf8)
+        data.append(0)
+        if let interruption {
+            data.append(contentsOf: interruption.interruptID.rawValue.utf8)
+            data.append(0)
+            data.append(contentsOf: interruption.payloadHash.utf8)
+        }
+        data.append(0)
+        if let checkpointID {
+            data.append(contentsOf: checkpointID.rawValue.utf8)
+        }
+        data.append(0)
+
+        for (channelID, payloadHash) in globalChannelPayloadHashesByID
+            .sorted(by: { HiveOrdering.lexicographicallyPrecedes($0.key.rawValue, $1.key.rawValue) }) {
+            data.append(contentsOf: channelID.rawValue.utf8)
+            data.append(0)
+            data.append(contentsOf: payloadHash.utf8)
+            data.append(0)
+        }
+
+        for entry in frontierSummary {
+            data.append(contentsOf: entry.nodeID.rawValue.utf8)
+            data.append(0)
+            data.append(contentsOf: entry.provenance.rawValue.utf8)
+            data.append(0)
+            data.append(contentsOf: entry.taskLocalFingerprintHash.utf8)
+            data.append(0)
+        }
+
+        let digest = HiveSHA256.hash(data: data)
+        return digest.compactMap { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Sources/HiveCore/Runtime/HiveTaskTypes.swift
+++ b/Sources/HiveCore/Runtime/HiveTaskTypes.swift
@@ -1,0 +1,123 @@
+/// Seed used to schedule a task in the next frontier.
+public struct HiveTaskSeed<Schema: HiveSchema>: Sendable {
+    public let nodeID: HiveNodeID
+    public let local: HiveTaskLocalStore<Schema>
+
+    public init(nodeID: HiveNodeID, local: HiveTaskLocalStore<Schema> = .empty) {
+        self.nodeID = nodeID
+        self.local = local
+    }
+}
+
+/// Origin of a scheduled task.
+public enum HiveTaskProvenance: String, Codable, Sendable {
+    case graph
+    case spawn
+}
+
+/// Executable task derived from the frontier.
+public struct HiveTask<Schema: HiveSchema>: Sendable {
+    public let id: HiveTaskID
+    public let ordinal: Int
+    public let provenance: HiveTaskProvenance
+    public let nodeID: HiveNodeID
+    public let local: HiveTaskLocalStore<Schema>
+
+    public init(
+        id: HiveTaskID,
+        ordinal: Int,
+        provenance: HiveTaskProvenance,
+        nodeID: HiveNodeID,
+        local: HiveTaskLocalStore<Schema>
+    ) {
+        self.id = id
+        self.ordinal = ordinal
+        self.provenance = provenance
+        self.nodeID = nodeID
+        self.local = local
+    }
+}
+
+/// Run-scoped context provided to each node.
+public struct HiveRunContext<Schema: HiveSchema>: Sendable {
+    public let runID: HiveRunID
+    public let threadID: HiveThreadID
+    public let attemptID: HiveRunAttemptID
+    public let stepIndex: Int
+    public let taskID: HiveTaskID
+    public let options: HiveRunOptions
+    public let resume: HiveResume<Schema>?
+
+    public init(
+        runID: HiveRunID,
+        threadID: HiveThreadID,
+        attemptID: HiveRunAttemptID,
+        stepIndex: Int,
+        taskID: HiveTaskID,
+        options: HiveRunOptions = HiveRunOptions(),
+        resume: HiveResume<Schema>?
+    ) {
+        self.runID = runID
+        self.threadID = threadID
+        self.attemptID = attemptID
+        self.stepIndex = stepIndex
+        self.taskID = taskID
+        self.options = options
+        self.resume = resume
+    }
+}
+
+/// Node execution closure.
+public typealias NodeAction<Schema: HiveSchema> =
+    @Sendable (HiveNodeInput<Schema>) async throws -> HiveNodeOutput<Schema>
+
+/// Inputs passed to a node execution.
+public struct HiveNodeInput<Schema: HiveSchema>: Sendable {
+    public let store: HiveStoreView<Schema>
+    public let run: HiveRunContext<Schema>
+    public let context: Schema.Context
+    public let environment: HiveEnvironment<Schema>
+    public let emitStream: @Sendable (_ kind: HiveStreamEventKind, _ metadata: [String: String]) -> Void
+    public let emitDebug: @Sendable (_ name: String, _ metadata: [String: String]) -> Void
+
+    public init(
+        store: HiveStoreView<Schema>,
+        run: HiveRunContext<Schema>,
+        context: Schema.Context,
+        environment: HiveEnvironment<Schema>,
+        emitStream: @escaping @Sendable (_ kind: HiveStreamEventKind, _ metadata: [String: String]) -> Void,
+        emitDebug: @escaping @Sendable (_ name: String, _ metadata: [String: String]) -> Void
+    ) {
+        self.store = store
+        self.run = run
+        self.context = context
+        self.environment = environment
+        self.emitStream = emitStream
+        self.emitDebug = emitDebug
+    }
+}
+
+/// Stream-only event kinds emitted by nodes.
+public enum HiveStreamEventKind: Sendable {
+    case customDebug(name: String)
+}
+
+/// Output of a node execution.
+public struct HiveNodeOutput<Schema: HiveSchema>: Sendable {
+    public var writes: [AnyHiveWrite<Schema>]
+    public var spawn: [HiveTaskSeed<Schema>]
+    public var next: Route
+    public var interrupt: HiveInterruptRequest<Schema>?
+
+    public init(
+        writes: [AnyHiveWrite<Schema>] = [],
+        spawn: [HiveTaskSeed<Schema>] = [],
+        next: Route = .useGraphEdges,
+        interrupt: HiveInterruptRequest<Schema>? = nil
+    ) {
+        self.writes = writes
+        self.spawn = spawn
+        self.next = next
+        self.interrupt = interrupt
+    }
+}

--- a/Sources/HiveCore/Runtime/HiveTranscript.swift
+++ b/Sources/HiveCore/Runtime/HiveTranscript.swift
@@ -1,0 +1,410 @@
+import Foundation
+
+public struct HiveTranscriptNormalizationOptions: Sendable, Equatable {
+    public var normalizeRunIdentifiers: Bool
+    public var normalizeEventIndices: Bool
+    public var stripMetadataKeys: Set<String>
+
+    public init(
+        normalizeRunIdentifiers: Bool = true,
+        normalizeEventIndices: Bool = true,
+        stripMetadataKeys: Set<String> = ["timestamp", "time", "now", "wallClock", "clock"]
+    ) {
+        self.normalizeRunIdentifiers = normalizeRunIdentifiers
+        self.normalizeEventIndices = normalizeEventIndices
+        self.stripMetadataKeys = stripMetadataKeys
+    }
+
+    public static let swarmDeterministicDefault = HiveTranscriptNormalizationOptions()
+}
+
+public struct HiveTranscriptEventID: Codable, Sendable, Equatable {
+    public let runID: String
+    public let attemptID: String
+    public let eventIndex: UInt64
+    public let stepIndex: Int?
+    public let taskOrdinal: Int?
+
+    public init(
+        runID: String,
+        attemptID: String,
+        eventIndex: UInt64,
+        stepIndex: Int?,
+        taskOrdinal: Int?
+    ) {
+        self.runID = runID
+        self.attemptID = attemptID
+        self.eventIndex = eventIndex
+        self.stepIndex = stepIndex
+        self.taskOrdinal = taskOrdinal
+    }
+}
+
+public struct HiveTranscriptEvent: Codable, Sendable, Equatable {
+    public let id: HiveTranscriptEventID
+    public let kind: String
+    public let fields: [String: String]
+    public let metadata: [String: String]
+
+    public init(
+        id: HiveTranscriptEventID,
+        kind: String,
+        fields: [String: String],
+        metadata: [String: String]
+    ) {
+        self.id = id
+        self.kind = kind
+        self.fields = fields
+        self.metadata = metadata
+    }
+}
+
+public struct HiveEventTranscript: Codable, Sendable, Equatable {
+    public let schemaVersion: HiveEventSchemaVersion
+    public let events: [HiveTranscriptEvent]
+
+    public init(schemaVersion: HiveEventSchemaVersion, events: [HiveTranscriptEvent]) {
+        self.schemaVersion = schemaVersion
+        self.events = events
+    }
+
+    public init(
+        events sourceEvents: [HiveEvent],
+        normalization: HiveTranscriptNormalizationOptions = .swarmDeterministicDefault
+    ) {
+        let schemaVersion = sourceEvents.first?.schemaVersion ?? .current
+        self.schemaVersion = schemaVersion
+        self.events = sourceEvents.enumerated().map { offset, event in
+            let normalizedID = HiveTranscriptEventID(
+                runID: normalization.normalizeRunIdentifiers
+                    ? "normalized-run"
+                    : event.id.runID.rawValue.uuidString.lowercased(),
+                attemptID: normalization.normalizeRunIdentifiers
+                    ? "normalized-attempt"
+                    : event.id.attemptID.rawValue.uuidString.lowercased(),
+                eventIndex: normalization.normalizeEventIndices ? UInt64(offset) : event.id.eventIndex,
+                stepIndex: event.id.stepIndex,
+                taskOrdinal: event.id.taskOrdinal
+            )
+            let stableFields = normalization.normalizeRunIdentifiers
+                ? Self.normalizedFields(
+                    event.kind.stableFields,
+                    for: event.kind,
+                    eventOrdinal: offset,
+                    stepIndex: event.id.stepIndex,
+                    taskOrdinal: event.id.taskOrdinal
+                )
+                : event.kind.stableFields
+            return HiveTranscriptEvent(
+                id: normalizedID,
+                kind: event.kind.stableName,
+                fields: stableFields,
+                metadata: event.metadata.filter { normalization.stripMetadataKeys.contains($0.key) == false }
+            )
+        }
+    }
+
+    public func validateReplayCompatibility(
+        expected: HiveEventSchemaVersion = .current
+    ) throws {
+        guard schemaVersion == expected else {
+            throw HiveEventReplayCompatibilityError.incompatibleSchemaVersion(
+                expected: expected,
+                found: schemaVersion
+            )
+        }
+    }
+
+    public func stableData() throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        return try encoder.encode(self)
+    }
+
+    public func transcriptHash() throws -> String {
+        let data = try stableData()
+        let digest = HiveSHA256.hash(data: data)
+        return digest.compactMap { String(format: "%02x", $0) }.joined()
+    }
+
+    public func firstDiff(comparedTo other: HiveEventTranscript) -> HiveTranscriptDiff? {
+        if schemaVersion != other.schemaVersion {
+            return HiveTranscriptDiff(
+                eventIndex: 0,
+                keyPath: "schemaVersion",
+                lhs: schemaVersion.rawValue,
+                rhs: other.schemaVersion.rawValue
+            )
+        }
+
+        let sharedCount = min(events.count, other.events.count)
+        for index in 0..<sharedCount {
+            let lhs = events[index]
+            let rhs = other.events[index]
+            if lhs.id != rhs.id {
+                if lhs.id.runID != rhs.id.runID {
+                    return HiveTranscriptDiff(eventIndex: index, keyPath: "events[\(index)].id.runID", lhs: lhs.id.runID, rhs: rhs.id.runID)
+                }
+                if lhs.id.attemptID != rhs.id.attemptID {
+                    return HiveTranscriptDiff(eventIndex: index, keyPath: "events[\(index)].id.attemptID", lhs: lhs.id.attemptID, rhs: rhs.id.attemptID)
+                }
+                if lhs.id.eventIndex != rhs.id.eventIndex {
+                    return HiveTranscriptDiff(
+                        eventIndex: index,
+                        keyPath: "events[\(index)].id.eventIndex",
+                        lhs: String(lhs.id.eventIndex),
+                        rhs: String(rhs.id.eventIndex)
+                    )
+                }
+                if lhs.id.stepIndex != rhs.id.stepIndex {
+                    return HiveTranscriptDiff(
+                        eventIndex: index,
+                        keyPath: "events[\(index)].id.stepIndex",
+                        lhs: lhs.id.stepIndex.map(String.init) ?? "nil",
+                        rhs: rhs.id.stepIndex.map(String.init) ?? "nil"
+                    )
+                }
+                if lhs.id.taskOrdinal != rhs.id.taskOrdinal {
+                    return HiveTranscriptDiff(
+                        eventIndex: index,
+                        keyPath: "events[\(index)].id.taskOrdinal",
+                        lhs: lhs.id.taskOrdinal.map(String.init) ?? "nil",
+                        rhs: rhs.id.taskOrdinal.map(String.init) ?? "nil"
+                    )
+                }
+            }
+
+            if lhs.kind != rhs.kind {
+                return HiveTranscriptDiff(
+                    eventIndex: index,
+                    keyPath: "events[\(index)].kind",
+                    lhs: lhs.kind,
+                    rhs: rhs.kind
+                )
+            }
+
+            if lhs.fields != rhs.fields {
+                let differingKey = Set(lhs.fields.keys)
+                    .union(rhs.fields.keys)
+                    .sorted(by: HiveOrdering.lexicographicallyPrecedes)
+                    .first { lhs.fields[$0] != rhs.fields[$0] }
+                    ?? "unknown"
+                return HiveTranscriptDiff(
+                    eventIndex: index,
+                    keyPath: "events[\(index)].fields.\(differingKey)",
+                    lhs: lhs.fields[differingKey] ?? "nil",
+                    rhs: rhs.fields[differingKey] ?? "nil"
+                )
+            }
+
+            if lhs.metadata != rhs.metadata {
+                let differingKey = Set(lhs.metadata.keys)
+                    .union(rhs.metadata.keys)
+                    .sorted(by: HiveOrdering.lexicographicallyPrecedes)
+                    .first { lhs.metadata[$0] != rhs.metadata[$0] }
+                    ?? "unknown"
+                return HiveTranscriptDiff(
+                    eventIndex: index,
+                    keyPath: "events[\(index)].metadata.\(differingKey)",
+                    lhs: lhs.metadata[differingKey] ?? "nil",
+                    rhs: rhs.metadata[differingKey] ?? "nil"
+                )
+            }
+        }
+
+        if events.count != other.events.count {
+            return HiveTranscriptDiff(
+                eventIndex: sharedCount,
+                keyPath: "events.count",
+                lhs: String(events.count),
+                rhs: String(other.events.count)
+            )
+        }
+
+        return nil
+    }
+}
+
+public struct HiveTranscriptDiff: Sendable, Equatable {
+    public let eventIndex: Int
+    public let keyPath: String
+    public let lhs: String
+    public let rhs: String
+
+    public init(eventIndex: Int, keyPath: String, lhs: String, rhs: String) {
+        self.eventIndex = eventIndex
+        self.keyPath = keyPath
+        self.lhs = lhs
+        self.rhs = rhs
+    }
+}
+
+    public enum HiveTranscriptHasher {
+    public static func transcriptHash(
+        events: [HiveEvent],
+        normalization: HiveTranscriptNormalizationOptions = .swarmDeterministicDefault
+    ) throws -> String {
+        try HiveEventTranscript(events: events, normalization: normalization).transcriptHash()
+    }
+
+    public static func finalStateHash<Schema: HiveSchema>(
+        stateSnapshot: HiveRuntimeStateSnapshot<Schema>
+    ) -> String {
+        var data = Data("HFS1".utf8)
+        data.append(contentsOf: stateSnapshot.threadID.rawValue.utf8)
+        data.append(0)
+        data.append(contentsOf: String(stateSnapshot.stepIndex).utf8)
+        data.append(0)
+
+        for (channelID, payloadHash) in stateSnapshot.globalChannelPayloadHashesByID
+            .sorted(by: { HiveOrdering.lexicographicallyPrecedes($0.key.rawValue, $1.key.rawValue) }) {
+            data.append(contentsOf: channelID.rawValue.utf8)
+            data.append(0)
+            data.append(contentsOf: payloadHash.utf8)
+            data.append(0)
+        }
+
+        for entry in stateSnapshot.frontierSummary {
+            data.append(contentsOf: entry.nodeID.rawValue.utf8)
+            data.append(0)
+            data.append(contentsOf: entry.provenance.rawValue.utf8)
+            data.append(0)
+            data.append(contentsOf: entry.taskLocalFingerprintHash.utf8)
+            data.append(0)
+        }
+
+        if let interruption = stateSnapshot.interruption {
+            data.append(contentsOf: interruption.payloadHash.utf8)
+            data.append(0)
+        }
+
+        let digest = HiveSHA256.hash(data: data)
+        return digest.compactMap { String(format: "%02x", $0) }.joined()
+    }
+
+    public static func firstDiff(
+        lhs: HiveEventTranscript,
+        rhs: HiveEventTranscript
+    ) -> HiveTranscriptDiff? {
+        lhs.firstDiff(comparedTo: rhs)
+    }
+}
+
+private extension HiveEventTranscript {
+    static func normalizedFields(
+        _ fields: [String: String],
+        for kind: HiveEventKind,
+        eventOrdinal: Int,
+        stepIndex: Int?,
+        taskOrdinal: Int?
+    ) -> [String: String] {
+        var normalized = fields
+        switch kind {
+        case .taskStarted, .taskFinished, .taskFailed:
+            let stepToken = stepIndex.map(String.init) ?? "none"
+            let taskToken = taskOrdinal.map(String.init) ?? String(eventOrdinal)
+            normalized["taskID"] = "normalized-task-\(stepToken)-\(taskToken)"
+        case .checkpointSaved, .checkpointLoaded:
+            let stepToken = stepIndex.map(String.init) ?? "none"
+            normalized["checkpointID"] = "normalized-checkpoint-\(stepToken)"
+        case .runInterrupted, .runResumed:
+            normalized["interruptID"] = "normalized-interrupt"
+        case .forkStarted, .forkCompleted, .forkFailed:
+            if normalized["sourceCheckpointID"] != nil {
+                normalized["sourceCheckpointID"] = "normalized-source-checkpoint"
+            }
+            if normalized["targetCheckpointID"] != nil {
+                normalized["targetCheckpointID"] = "normalized-target-checkpoint"
+            }
+        default:
+            break
+        }
+        return normalized
+    }
+}
+
+private extension HiveEventKind {
+    var stableName: String {
+        switch self {
+        case .runStarted: return "run.started"
+        case .runFinished: return "run.finished"
+        case .runInterrupted: return "run.interrupted"
+        case .runResumed: return "run.resumed"
+        case .runCancelled: return "run.cancelled"
+        case .forkStarted: return "fork.started"
+        case .forkCompleted: return "fork.completed"
+        case .forkFailed: return "fork.failed"
+        case .stepStarted: return "step.started"
+        case .stepFinished: return "step.finished"
+        case .taskStarted: return "task.started"
+        case .taskFinished: return "task.finished"
+        case .taskFailed: return "task.failed"
+        case .writeApplied: return "write.applied"
+        case .checkpointSaved: return "checkpoint.saved"
+        case .checkpointLoaded: return "checkpoint.loaded"
+        case .storeSnapshot: return "store.snapshot"
+        case .channelUpdates: return "channel.updates"
+        case .streamBackpressure: return "stream.backpressure"
+        case .customDebug: return "debug.custom"
+        }
+    }
+
+    var stableFields: [String: String] {
+        switch self {
+        case .runStarted(let threadID):
+            return ["threadID": threadID.rawValue]
+        case .runFinished:
+            return [:]
+        case .runInterrupted(let interruptID):
+            return ["interruptID": interruptID.rawValue]
+        case .runResumed(let interruptID):
+            return ["interruptID": interruptID.rawValue]
+        case .runCancelled(let cause):
+            return ["cause": cause.rawValue]
+        case .forkStarted(let sourceThreadID, let targetThreadID, let sourceCheckpointID):
+            return [
+                "sourceThreadID": sourceThreadID.rawValue,
+                "targetThreadID": targetThreadID.rawValue,
+                "sourceCheckpointID": sourceCheckpointID?.rawValue ?? "nil"
+            ]
+        case .forkCompleted(let sourceThreadID, let targetThreadID, let sourceCheckpointID, let targetCheckpointID):
+            return [
+                "sourceThreadID": sourceThreadID.rawValue,
+                "targetThreadID": targetThreadID.rawValue,
+                "sourceCheckpointID": sourceCheckpointID.rawValue,
+                "targetCheckpointID": targetCheckpointID?.rawValue ?? "nil"
+            ]
+        case .forkFailed(let sourceThreadID, let targetThreadID, let sourceCheckpointID, let errorCode):
+            return [
+                "sourceThreadID": sourceThreadID.rawValue,
+                "targetThreadID": targetThreadID.rawValue,
+                "sourceCheckpointID": sourceCheckpointID?.rawValue ?? "nil",
+                "errorCode": errorCode
+            ]
+        case .stepStarted(let stepIndex, let frontierCount):
+            return ["stepIndex": String(stepIndex), "frontierCount": String(frontierCount)]
+        case .stepFinished(let stepIndex, let nextFrontierCount):
+            return ["stepIndex": String(stepIndex), "nextFrontierCount": String(nextFrontierCount)]
+        case .taskStarted(let node, let taskID):
+            return ["node": node.rawValue, "taskID": taskID.rawValue]
+        case .taskFinished(let node, let taskID):
+            return ["node": node.rawValue, "taskID": taskID.rawValue]
+        case .taskFailed(let node, let taskID, let errorDescription):
+            return ["node": node.rawValue, "taskID": taskID.rawValue, "error": errorDescription]
+        case .writeApplied(let channelID, let payloadHash):
+            return ["channelID": channelID.rawValue, "payloadHash": payloadHash]
+        case .checkpointSaved(let checkpointID):
+            return ["checkpointID": checkpointID.rawValue]
+        case .checkpointLoaded(let checkpointID):
+            return ["checkpointID": checkpointID.rawValue]
+        case .storeSnapshot(let channelValues):
+            return ["channels": channelValues.map(\.channelID.rawValue).joined(separator: ",")]
+        case .channelUpdates(let channelValues):
+            return ["channels": channelValues.map(\.channelID.rawValue).joined(separator: ",")]
+        case .streamBackpressure(let droppedDebugEvents):
+            return ["droppedDebugEvents": String(droppedDebugEvents)]
+        case .customDebug(let name):
+            return ["name": name]
+        }
+    }
+}

--- a/Sources/HiveCore/Schema/AnyHiveChannelSpec.swift
+++ b/Sources/HiveCore/Schema/AnyHiveChannelSpec.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+public struct AnyHiveChannelSpec<Schema: HiveSchema>: Sendable {
+    public let id: HiveChannelID
+    public let scope: HiveChannelScope
+    public let persistence: HiveChannelPersistence
+    public let updatePolicy: HiveUpdatePolicy
+
+    /// Diagnostic only; typically String(reflecting: Value.self).
+    public let valueTypeID: String
+
+    /// Equal to `codec?.id`, else nil.
+    public let codecID: String?
+
+    internal let _initialBox: @Sendable () -> any Sendable
+    internal let _reduceBox: @Sendable (any Sendable, any Sendable) throws -> any Sendable
+    internal let _encodeBox: (@Sendable (any Sendable) throws -> Data)?
+    internal let _decodeBox: (@Sendable (Data) throws -> any Sendable)?
+
+    public init<Value: Sendable>(
+        _ spec: HiveChannelSpec<Schema, Value>,
+        valueTypeID: String = String(reflecting: Value.self)
+    ) {
+        self.id = spec.key.id
+        self.scope = spec.scope
+        self.persistence = spec.persistence
+        self.updatePolicy = spec.updatePolicy
+        self.valueTypeID = valueTypeID
+        self.codecID = spec.codec?.id
+
+        self._initialBox = { spec.initial() }
+        self._reduceBox = { current, update in
+            guard let typedCurrent = current as? Value else {
+                throw HiveChannelSpecTypeMismatchError.expected(Value.self, actual: type(of: current))
+            }
+            guard let typedUpdate = update as? Value else {
+                throw HiveChannelSpecTypeMismatchError.expected(Value.self, actual: type(of: update))
+            }
+            return try spec.reducer.reduce(current: typedCurrent, update: typedUpdate)
+        }
+
+        if let codec = spec.codec {
+            self._encodeBox = { value in
+                guard let typedValue = value as? Value else {
+                    throw HiveChannelSpecTypeMismatchError.expected(Value.self, actual: type(of: value))
+                }
+                return try codec.encode(typedValue)
+            }
+            self._decodeBox = { data in
+                try codec.decode(data)
+            }
+        } else {
+            self._encodeBox = nil
+            self._decodeBox = nil
+        }
+    }
+}
+
+internal enum HiveChannelSpecTypeMismatchError: Error {
+    case expected(Any.Type, actual: Any.Type)
+}

--- a/Sources/HiveCore/Schema/AnyHiveWrite.swift
+++ b/Sources/HiveCore/Schema/AnyHiveWrite.swift
@@ -1,0 +1,13 @@
+/// Type-erased write to a channel.
+public struct AnyHiveWrite<Schema: HiveSchema>: Sendable {
+    public let channelID: HiveChannelID
+    public let value: any Sendable
+
+    public init<Value: Sendable>(_ key: HiveChannelKey<Schema, Value>, _ value: Value) {
+        self.channelID = key.id
+        self.value = value
+    }
+}
+
+/// Deterministic ordering key inside a task output writes array.
+public typealias HiveWriteEmissionIndex = Int

--- a/Sources/HiveCore/Schema/HiveBarrierTopicChannels.swift
+++ b/Sources/HiveCore/Schema/HiveBarrierTopicChannels.swift
@@ -1,0 +1,205 @@
+/// Stable identifier for a barrier instance within barrier channel state.
+public struct HiveBarrierKey: Hashable, Sendable, Codable {
+    public let rawValue: String
+
+    public init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+}
+
+/// Stable token value recorded for a producer within a barrier.
+public struct HiveBarrierToken: Hashable, Sendable, Codable {
+    public let rawValue: String
+
+    public init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+}
+
+/// Barrier channel update operations.
+public enum HiveBarrierUpdate: Sendable, Hashable, Codable {
+    case markSeen(barrier: HiveBarrierKey, producer: HiveNodeID, token: HiveBarrierToken)
+    case consume(barrier: HiveBarrierKey, expectedProducers: [HiveNodeID])
+}
+
+/// Deterministic barrier channel state.
+///
+/// The internal representation uses string keys to avoid non-canonical encoding pitfalls.
+public struct HiveBarrierState: Sendable, Hashable, Codable {
+    private var tokensByBarrierID: [String: [String: HiveBarrierToken]]
+
+    public init(tokensByBarrierID: [String: [String: HiveBarrierToken]] = [:]) {
+        self.tokensByBarrierID = tokensByBarrierID
+    }
+
+    public static var empty: Self { Self() }
+
+    public func token(for barrier: HiveBarrierKey, producer: HiveNodeID) -> HiveBarrierToken? {
+        tokensByBarrierID[barrier.rawValue]?[producer.rawValue]
+    }
+
+    public func tokens(for barrier: HiveBarrierKey) -> [HiveNodeID: HiveBarrierToken] {
+        guard let raw = tokensByBarrierID[barrier.rawValue] else { return [:] }
+        var result: [HiveNodeID: HiveBarrierToken] = [:]
+        result.reserveCapacity(raw.count)
+        for (producerRaw, token) in raw {
+            result[HiveNodeID(producerRaw)] = token
+        }
+        return result
+    }
+
+    public func isAvailable(barrier: HiveBarrierKey, expectedProducers: [HiveNodeID]) -> Bool {
+        guard let tokens = tokensByBarrierID[barrier.rawValue] else { return false }
+        for producer in expectedProducers {
+            if tokens[producer.rawValue] == nil {
+                return false
+            }
+        }
+        return true
+    }
+
+    mutating func apply(_ update: HiveBarrierUpdate) {
+        switch update {
+        case .markSeen(let barrier, let producer, let token):
+            var perProducer = tokensByBarrierID[barrier.rawValue] ?? [:]
+            perProducer[producer.rawValue] = token
+            tokensByBarrierID[barrier.rawValue] = perProducer
+        case .consume(let barrier, let expectedProducers):
+            guard isAvailable(barrier: barrier, expectedProducers: expectedProducers) else { return }
+            tokensByBarrierID[barrier.rawValue] = nil
+        }
+    }
+}
+
+/// Channel value wrapper for barrier channels.
+///
+/// The reducer for this value type must normalize to `.state`.
+public enum HiveBarrierChannelValue: Sendable, Hashable, Codable {
+    case state(HiveBarrierState)
+    case update(HiveBarrierUpdate)
+
+    public var stateValue: HiveBarrierState? {
+        if case .state(let state) = self { return state }
+        return nil
+    }
+}
+
+public extension HiveReducer where Value == HiveBarrierChannelValue {
+    static func barrier() -> HiveReducer<Value> {
+        HiveReducer { current, update in
+            func extractState(_ value: HiveBarrierChannelValue) -> HiveBarrierState {
+                switch value {
+                case .state(let state):
+                    return state
+                case .update(let update):
+                    var state = HiveBarrierState.empty
+                    state.apply(update)
+                    return state
+                }
+            }
+
+            var state = extractState(current)
+            switch update {
+            case .state(let newState):
+                state = newState
+            case .update(let update):
+                state.apply(update)
+            }
+            return .state(state)
+        }
+    }
+}
+
+/// Stable identifier for a topic instance within topic channel state.
+public struct HiveTopicKey: Hashable, Sendable, Codable {
+    public let rawValue: String
+
+    public init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+}
+
+/// Topic channel update operations.
+public enum HiveTopicUpdate<Value: Sendable & Codable>: Sendable, Codable {
+    case publish(topic: HiveTopicKey, value: Value)
+    case clear(topic: HiveTopicKey)
+}
+
+/// Deterministic topic channel state.
+public struct HiveTopicState<Value: Sendable & Codable>: Sendable, Codable {
+    private var valuesByTopicID: [String: [Value]]
+
+    public init(valuesByTopicID: [String: [Value]] = [:]) {
+        self.valuesByTopicID = valuesByTopicID
+    }
+
+    public static var empty: Self { Self() }
+
+    public func values(for topic: HiveTopicKey) -> [Value] {
+        valuesByTopicID[topic.rawValue] ?? []
+    }
+
+    mutating func apply(_ update: HiveTopicUpdate<Value>, maxValuesPerTopic: Int) {
+        switch update {
+        case .publish(let topic, let value):
+            let maxValues = max(0, maxValuesPerTopic)
+            guard maxValues != 0 else {
+                valuesByTopicID[topic.rawValue] = []
+                return
+            }
+
+            var values = valuesByTopicID[topic.rawValue] ?? []
+            values.append(value)
+            if values.count > maxValues {
+                values.removeFirst(values.count - maxValues)
+            }
+            valuesByTopicID[topic.rawValue] = values
+        case .clear(let topic):
+            valuesByTopicID[topic.rawValue] = nil
+        }
+    }
+}
+
+/// Channel value wrapper for topic channels.
+///
+/// The reducer for this value type must normalize to `.state`.
+public enum HiveTopicChannelValue<Value: Sendable & Codable>: Sendable, Codable {
+    case state(HiveTopicState<Value>)
+    case update(HiveTopicUpdate<Value>)
+
+    public var stateValue: HiveTopicState<Value>? {
+        if case .state(let state) = self { return state }
+        return nil
+    }
+}
+
+public extension HiveReducer {
+    static func topicAppendOnly<TopicValue>(
+        maxValuesPerTopic: Int
+    ) -> HiveReducer<HiveTopicChannelValue<TopicValue>>
+    where Value == HiveTopicChannelValue<TopicValue>, TopicValue: Sendable & Codable {
+        // Defensive normalization: invalid configuration should not crash the process.
+        let normalizedMaxValuesPerTopic = Swift.max(1, maxValuesPerTopic)
+        return HiveReducer<HiveTopicChannelValue<TopicValue>> { current, update in
+            func extractState(_ value: HiveTopicChannelValue<TopicValue>) -> HiveTopicState<TopicValue> {
+                switch value {
+                case .state(let state):
+                    return state
+                case .update(let update):
+                    var state = HiveTopicState<TopicValue>.empty
+                    state.apply(update, maxValuesPerTopic: normalizedMaxValuesPerTopic)
+                    return state
+                }
+            }
+
+            var state = extractState(current)
+            switch update {
+            case .state(let newState):
+                state = newState
+            case .update(let update):
+                state.apply(update, maxValuesPerTopic: normalizedMaxValuesPerTopic)
+            }
+            return .state(state)
+        }
+    }
+}

--- a/Sources/HiveCore/Schema/HiveChannelID.swift
+++ b/Sources/HiveCore/Schema/HiveChannelID.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Stable identifier for a channel within a schema.
+public struct HiveChannelID: Hashable, Sendable {
+    public let rawValue: String
+
+    public init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+}

--- a/Sources/HiveCore/Schema/HiveChannelKey.swift
+++ b/Sources/HiveCore/Schema/HiveChannelKey.swift
@@ -1,0 +1,8 @@
+/// Typed key for reading and writing channel values.
+public struct HiveChannelKey<Schema: HiveSchema, Value: Sendable>: Hashable, Sendable {
+    public let id: HiveChannelID
+
+    public init(_ id: HiveChannelID) {
+        self.id = id
+    }
+}

--- a/Sources/HiveCore/Schema/HiveChannelSpec.swift
+++ b/Sources/HiveCore/Schema/HiveChannelSpec.swift
@@ -1,0 +1,57 @@
+/// Defines where a channel is stored.
+public enum HiveChannelScope: Sendable {
+    case global
+    case taskLocal
+}
+
+/// Defines whether a channel participates in checkpointing.
+public enum HiveChannelPersistence: Sendable {
+    case checkpointed
+    case untracked
+    /// Value resets to `initial()` at the start of each superstep.
+    /// Distinct from `.untracked` (which skips checkpointing but keeps the value).
+    case ephemeral
+}
+
+extension HiveChannelPersistence {
+    /// `true` for channels whose value is reset to `initial()` at the start of the next superstep.
+    public var resetsAfterStep: Bool {
+        if case .ephemeral = self { return true }
+        return false
+    }
+}
+
+/// Defines how multiple writes to the same channel are handled.
+public enum HiveUpdatePolicy: Sendable {
+    case single
+    case multi
+}
+
+/// Schema-declared channel metadata and behavior.
+public struct HiveChannelSpec<Schema: HiveSchema, Value: Sendable>: Sendable {
+    public let key: HiveChannelKey<Schema, Value>
+    public let scope: HiveChannelScope
+    public let reducer: HiveReducer<Value>
+    public let updatePolicy: HiveUpdatePolicy
+    public let initial: @Sendable () -> Value
+    public let codec: HiveAnyCodec<Value>?
+    public let persistence: HiveChannelPersistence
+
+    public init(
+        key: HiveChannelKey<Schema, Value>,
+        scope: HiveChannelScope,
+        reducer: HiveReducer<Value>,
+        updatePolicy: HiveUpdatePolicy = .single,
+        initial: @escaping @Sendable () -> Value,
+        codec: HiveAnyCodec<Value>? = nil,
+        persistence: HiveChannelPersistence
+    ) {
+        self.key = key
+        self.scope = scope
+        self.reducer = reducer
+        self.updatePolicy = updatePolicy
+        self.initial = initial
+        self.codec = codec
+        self.persistence = persistence
+    }
+}

--- a/Sources/HiveCore/Schema/HiveChannelTypeRegistry.swift
+++ b/Sources/HiveCore/Schema/HiveChannelTypeRegistry.swift
@@ -1,0 +1,55 @@
+/// Type registry keyed by channel ID for runtime type validation.
+struct HiveChannelTypeRegistry<Schema: HiveSchema>: Sendable {
+    private let valueTypeIDsByID: [HiveChannelID: String]
+
+    init(_ registry: HiveSchemaRegistry<Schema>) {
+        var ids: [HiveChannelID: String] = [:]
+        ids.reserveCapacity(registry.channelSpecs.count)
+        for spec in registry.channelSpecs {
+            ids[spec.id] = spec.valueTypeID
+        }
+        self.valueTypeIDsByID = ids
+    }
+
+    func cast<Value: Sendable>(
+        _ value: any Sendable,
+        for key: HiveChannelKey<Schema, Value>
+    ) throws -> Value {
+        let expectedValueTypeID = String(reflecting: Value.self)
+        guard let registered = valueTypeIDsByID[key.id] else {
+            return try HiveChannelTypeRegistry.failUnknown(channelID: key.id)
+        }
+        if registered != expectedValueTypeID {
+            return try HiveChannelTypeRegistry.fail(
+                channelID: key.id,
+                expected: registered,
+                actual: expectedValueTypeID
+            )
+        }
+        guard let typed = value as? Value else {
+            let actualValueTypeID = String(reflecting: type(of: value))
+            return try HiveChannelTypeRegistry.fail(
+                channelID: key.id,
+                expected: expectedValueTypeID,
+                actual: actualValueTypeID
+            )
+        }
+        return typed
+    }
+
+    private static func failUnknown<T>(channelID: HiveChannelID) throws -> T {
+        throw HiveRuntimeError.unknownChannelID(channelID)
+    }
+
+    private static func fail<T>(
+        channelID: HiveChannelID,
+        expected: String,
+        actual: String
+    ) throws -> T {
+        throw HiveRuntimeError.channelTypeMismatch(
+            channelID: channelID,
+            expectedValueTypeID: expected,
+            actualValueTypeID: actual
+        )
+    }
+}

--- a/Sources/HiveCore/Schema/HiveCodec.swift
+++ b/Sources/HiveCore/Schema/HiveCodec.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Deterministic encoder/decoder for checkpointing and hashing.
+public protocol HiveCodec: Sendable {
+    associatedtype Value: Sendable
+
+    /// Stable identifier included in schema versioning.
+    var id: String { get }
+
+    /// Returns canonical bytes for the provided value.
+    func encode(_ value: Value) throws -> Data
+    /// Decodes a value from canonical bytes.
+    func decode(_ data: Data) throws -> Value
+}
+
+/// Type-erased codec wrapper.
+public struct HiveAnyCodec<Value: Sendable>: Sendable {
+    public let id: String
+    private let _encode: @Sendable (Value) throws -> Data
+    private let _decode: @Sendable (Data) throws -> Value
+
+    public init<C: HiveCodec>(_ codec: C) where C.Value == Value {
+        self.id = codec.id
+        self._encode = codec.encode
+        self._decode = codec.decode
+    }
+
+    public func encode(_ value: Value) throws -> Data {
+        try _encode(value)
+    }
+
+    public func decode(_ data: Data) throws -> Value {
+        try _decode(data)
+    }
+}

--- a/Sources/HiveCore/Schema/HiveCompilationError.swift
+++ b/Sources/HiveCore/Schema/HiveCompilationError.swift
@@ -1,0 +1,27 @@
+/// Compilation-time schema validation errors.
+public enum HiveCompilationError: Error, Sendable {
+    /// Multiple channel specs declare the same `HiveChannelID`.
+    case duplicateChannelID(HiveChannelID)
+    /// v1 restriction: `.taskLocal` channels must be `.checkpointed`.
+    case invalidTaskLocalUntracked(channelID: HiveChannelID)
+    case startEmpty
+    case duplicateStartNode(HiveNodeID)
+    case duplicateNodeID(HiveNodeID)
+    case invalidNodeIDContainsReservedJoinCharacters(nodeID: HiveNodeID)
+    case unknownStartNode(HiveNodeID)
+    case unknownEdgeEndpoint(from: HiveNodeID, to: HiveNodeID, unknown: HiveNodeID)
+    case duplicateRouter(from: HiveNodeID)
+    case unknownRouterFrom(HiveNodeID)
+    case invalidJoinEdgeParentsEmpty(target: HiveNodeID)
+    case invalidJoinEdgeParentsContainsDuplicate(parent: HiveNodeID, target: HiveNodeID)
+    case invalidJoinEdgeParentsContainsTarget(target: HiveNodeID)
+    case unknownJoinParent(parent: HiveNodeID, target: HiveNodeID)
+    case unknownJoinTarget(target: HiveNodeID)
+    case duplicateJoinEdge(joinID: String)
+    case staticGraphCycleDetected(nodes: [HiveNodeID])
+    case outputProjectionUnknownChannel(HiveChannelID)
+    case outputProjectionIncludesTaskLocal(HiveChannelID)
+    case invalidNodeRunWhenChannelsEmpty(nodeID: HiveNodeID)
+    case invalidNodeRunWhenUnknownChannel(nodeID: HiveNodeID, channelID: HiveChannelID)
+    case invalidNodeRunWhenIncludesTaskLocalChannel(nodeID: HiveNodeID, channelID: HiveChannelID)
+}

--- a/Sources/HiveCore/Schema/HiveIdentifiers.swift
+++ b/Sources/HiveCore/Schema/HiveIdentifiers.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+public struct HiveRunID: Hashable, Codable, Sendable {
+    public let rawValue: UUID
+
+    public init(_ rawValue: UUID) {
+        self.rawValue = rawValue
+    }
+}
+
+public struct HiveRunAttemptID: Hashable, Codable, Sendable {
+    public let rawValue: UUID
+
+    public init(_ rawValue: UUID) {
+        self.rawValue = rawValue
+    }
+}
+
+public struct HiveThreadID: Hashable, Codable, Sendable {
+    public let rawValue: String
+
+    public init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+}
+
+/// Lowercase hex of a 32-byte SHA-256 digest.
+public struct HiveTaskID: Hashable, Codable, Sendable {
+    public let rawValue: String
+
+    public init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+}

--- a/Sources/HiveCore/Schema/HiveInputContext.swift
+++ b/Sources/HiveCore/Schema/HiveInputContext.swift
@@ -1,0 +1,12 @@
+/// Context used to derive input writes for an attempt.
+public struct HiveInputContext: Sendable {
+    public let threadID: HiveThreadID
+    public let runID: HiveRunID
+    public let stepIndex: Int
+
+    public init(threadID: HiveThreadID, runID: HiveRunID, stepIndex: Int) {
+        self.threadID = threadID
+        self.runID = runID
+        self.stepIndex = stepIndex
+    }
+}

--- a/Sources/HiveCore/Schema/HiveJSONCodec.swift
+++ b/Sources/HiveCore/Schema/HiveJSONCodec.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// JSON-based codec for Codable values with deterministic key ordering.
+public struct HiveJSONCodec<Value: Codable & Sendable>: HiveCodec {
+    public let id: String
+
+    public init(id: String? = nil) {
+        self.id = id ?? "hive.json.v1:\(String(reflecting: Value.self))"
+    }
+
+    public func encode(_ value: Value) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        return try encoder.encode(value)
+    }
+
+    public func decode(_ data: Data) throws -> Value {
+        let decoder = JSONDecoder()
+        return try decoder.decode(Value.self, from: data)
+    }
+}

--- a/Sources/HiveCore/Schema/HiveReducer+Standard.swift
+++ b/Sources/HiveCore/Schema/HiveReducer+Standard.swift
@@ -1,0 +1,92 @@
+public extension HiveReducer {
+    /// Always selects the update value, ignoring the current value.
+    static func lastWriteWins() -> HiveReducer<Value> {
+        HiveReducer { _, update in update }
+    }
+
+    /// Combines current and update using a caller-supplied binary operator.
+    /// Folds all updates into the current value using the supplied binary operation.
+    static func binaryOp(
+        _ op: @escaping @Sendable (Value, Value) -> Value
+    ) -> HiveReducer<Value> {
+        HiveReducer { current, update in op(current, update) }
+    }
+}
+
+public extension HiveReducer where Value: Numeric & Sendable {
+    /// Accumulates updates by addition. Common for counters and running totals.
+    static func sum() -> HiveReducer<Value> {
+        HiveReducer { current, update in current + update }
+    }
+}
+
+public extension HiveReducer where Value: Comparable & Sendable {
+    /// Retains the lesser of current and update.
+    static func min() -> HiveReducer<Value> {
+        HiveReducer { current, update in Swift.min(current, update) }
+    }
+
+    /// Retains the greater of current and update.
+    static func max() -> HiveReducer<Value> {
+        HiveReducer { current, update in Swift.max(current, update) }
+    }
+}
+
+public extension HiveReducer where Value: RangeReplaceableCollection {
+    /// Appends update elements to the current collection, preserving order.
+    static func append() -> HiveReducer<Value> {
+        HiveReducer { current, update in
+            var combined = current
+            combined.append(contentsOf: update)
+            return combined
+        }
+    }
+}
+
+public extension HiveReducer {
+    /// Appends update elements for optional collections, treating nil as empty.
+    /// Returns nil only when both current and update are nil.
+    static func appendNonNil<C>() -> HiveReducer<C?> where C: RangeReplaceableCollection, C: Sendable {
+        HiveReducer<C?> { current, update in
+            switch (current, update) {
+            case (nil, nil):
+                return nil
+            case (nil, let update?):
+                return update
+            case (let current?, nil):
+                return current
+            case (let current?, let update?):
+                var combined = current
+                combined.append(contentsOf: update)
+                return combined
+            }
+        }
+    }
+
+    /// Merges two sets using union semantics.
+    static func setUnion<Element>() -> HiveReducer<Set<Element>> where Element: Hashable, Element: Sendable {
+        HiveReducer<Set<Element>> { current, update in
+            current.union(update)
+        }
+    }
+
+    /// Merges update entries into current, resolving conflicts via `valueReducer`.
+    /// Update keys are processed in ascending UTF-8 lexicographic order.
+    static func dictionaryMerge<V>(valueReducer: HiveReducer<V>) -> HiveReducer<[String: V]> where V: Sendable {
+        HiveReducer<[String: V]> { current, update in
+            var merged = current
+            let sortedKeys = update.keys.sorted { lhs, rhs in
+                lhs.utf8.lexicographicallyPrecedes(rhs.utf8)
+            }
+            for key in sortedKeys {
+                guard let updateValue = update[key] else { continue }
+                if let currentValue = merged[key] {
+                    merged[key] = try valueReducer.reduce(current: currentValue, update: updateValue)
+                } else {
+                    merged[key] = updateValue
+                }
+            }
+            return merged
+        }
+    }
+}

--- a/Sources/HiveCore/Schema/HiveReducer.swift
+++ b/Sources/HiveCore/Schema/HiveReducer.swift
@@ -1,0 +1,12 @@
+/// Combines multiple writes targeting the same channel.
+public struct HiveReducer<Value: Sendable>: Sendable {
+    private let _reduce: @Sendable (Value, Value) throws -> Value
+
+    public init(_ reduce: @escaping @Sendable (Value, Value) throws -> Value) {
+        self._reduce = reduce
+    }
+
+    public func reduce(current: Value, update: Value) throws -> Value {
+        try _reduce(current, update)
+    }
+}

--- a/Sources/HiveCore/Schema/HiveSchema.swift
+++ b/Sources/HiveCore/Schema/HiveSchema.swift
@@ -1,0 +1,16 @@
+/// Defines the channels and input mapping for a Hive graph.
+public protocol HiveSchema: Sendable {
+    associatedtype Context: Sendable = Void
+    associatedtype Input: Sendable = Void
+    associatedtype InterruptPayload: Codable & Sendable = String
+    associatedtype ResumePayload: Codable & Sendable = String
+
+    static var channelSpecs: [AnyHiveChannelSpec<Self>] { get }
+
+    /// Converts a typed run input into synthetic writes applied before step 0.
+    static func inputWrites(_ input: Input, inputContext: HiveInputContext) throws -> [AnyHiveWrite<Self>]
+}
+
+public extension HiveSchema where Input == Void {
+    static func inputWrites(_ input: Void, inputContext: HiveInputContext) throws -> [AnyHiveWrite<Self>] { [] }
+}

--- a/Sources/HiveCore/Schema/HiveSchemaRegistry.swift
+++ b/Sources/HiveCore/Schema/HiveSchemaRegistry.swift
@@ -1,0 +1,106 @@
+/// Validated schema registry used by compilation and runtime.
+public struct HiveSchemaRegistry<Schema: HiveSchema>: Sendable {
+    /// Original order as declared by the schema.
+    public let channelSpecs: [AnyHiveChannelSpec<Schema>]
+    /// Lookup by channel ID.
+    public let channelSpecsByID: [HiveChannelID: AnyHiveChannelSpec<Schema>]
+    /// Deterministic iteration by `HiveChannelID.rawValue` (lexicographic by UTF-8).
+    public let sortedChannelSpecs: [AnyHiveChannelSpec<Schema>]
+
+    public init(_ schemaType: Schema.Type = Schema.self) throws {
+        try self.init(channelSpecs: schemaType.channelSpecs)
+    }
+
+    public init(channelSpecs: [AnyHiveChannelSpec<Schema>]) throws {
+        self.channelSpecs = channelSpecs
+
+        if let duplicateID = HiveSchemaRegistry.firstDuplicateID(in: channelSpecs) {
+            throw HiveCompilationError.duplicateChannelID(duplicateID)
+        }
+        if let invalidID = HiveSchemaRegistry.firstInvalidTaskLocalUntrackedID(in: channelSpecs) {
+            throw HiveCompilationError.invalidTaskLocalUntracked(channelID: invalidID)
+        }
+
+        var byID: [HiveChannelID: AnyHiveChannelSpec<Schema>] = [:]
+        byID.reserveCapacity(channelSpecs.count)
+        for spec in channelSpecs {
+            byID[spec.id] = spec
+        }
+        self.channelSpecsByID = byID
+
+        self.sortedChannelSpecs = channelSpecs.sorted { lhs, rhs in
+            HiveSchemaRegistry.lexicographicallyPrecedes(lhs.id.rawValue, rhs.id.rawValue)
+        }
+    }
+
+    /// Returns the smallest channel ID with a missing required codec, if any.
+    public func firstMissingRequiredCodecID() -> HiveChannelID? {
+        HiveSchemaRegistry.firstMissingRequiredCodecID(in: channelSpecs)
+    }
+
+    private static func firstDuplicateID(in specs: [AnyHiveChannelSpec<Schema>]) -> HiveChannelID? {
+        var counts: [String: Int] = [:]
+        counts.reserveCapacity(specs.count)
+        for spec in specs {
+            counts[spec.id.rawValue, default: 0] += 1
+        }
+
+        var smallestDuplicate: String?
+        for (id, count) in counts where count > 1 {
+            if let currentSmallest = smallestDuplicate {
+                if lexicographicallyPrecedes(id, currentSmallest) {
+                    smallestDuplicate = id
+                }
+            } else {
+                smallestDuplicate = id
+            }
+        }
+
+        if let smallestDuplicate {
+            return HiveChannelID(smallestDuplicate)
+        }
+        return nil
+    }
+
+    private static func firstInvalidTaskLocalUntrackedID(in specs: [AnyHiveChannelSpec<Schema>]) -> HiveChannelID? {
+        var smallest: String?
+        for spec in specs where spec.scope == .taskLocal && spec.persistence == .untracked {
+            let id = spec.id.rawValue
+            if let currentSmallest = smallest {
+                if lexicographicallyPrecedes(id, currentSmallest) {
+                    smallest = id
+                }
+            } else {
+                smallest = id
+            }
+        }
+        if let smallest {
+            return HiveChannelID(smallest)
+        }
+        return nil
+    }
+
+    private static func firstMissingRequiredCodecID(in specs: [AnyHiveChannelSpec<Schema>]) -> HiveChannelID? {
+        var smallest: String?
+        for spec in specs {
+            let requiresCodec = (spec.scope == .taskLocal) || (spec.scope == .global && spec.persistence == .checkpointed)
+            guard requiresCodec, spec.codecID == nil else { continue }
+            let id = spec.id.rawValue
+            if let currentSmallest = smallest {
+                if lexicographicallyPrecedes(id, currentSmallest) {
+                    smallest = id
+                }
+            } else {
+                smallest = id
+            }
+        }
+        if let smallest {
+            return HiveChannelID(smallest)
+        }
+        return nil
+    }
+
+    private static func lexicographicallyPrecedes(_ lhs: String, _ rhs: String) -> Bool {
+        lhs.utf8.lexicographicallyPrecedes(rhs.utf8)
+    }
+}

--- a/Sources/HiveCore/Store/HiveGlobalStore.swift
+++ b/Sources/HiveCore/Store/HiveGlobalStore.swift
@@ -1,0 +1,70 @@
+/// Snapshot store for global-scoped channels.
+public struct HiveGlobalStore<Schema: HiveSchema>: Sendable {
+    private let access: HiveStoreSupport<Schema>
+    private var valuesByID: [HiveChannelID: any Sendable]
+
+    public init() throws {
+        let registry = try HiveSchemaRegistry<Schema>()
+        let initialCache = HiveInitialCache(registry: registry)
+        try self.init(registry: registry, initialCache: initialCache)
+    }
+
+    init(registry: HiveSchemaRegistry<Schema>, initialCache: HiveInitialCache<Schema>) throws {
+        self.access = HiveStoreSupport(registry: registry)
+        var values: [HiveChannelID: any Sendable] = [:]
+        values.reserveCapacity(registry.channelSpecs.count)
+        for spec in registry.channelSpecs where spec.scope == .global {
+            values[spec.id] = try initialCache.valueAny(for: spec.id)
+        }
+        self.valuesByID = values
+    }
+
+    init(
+        registry: HiveSchemaRegistry<Schema>,
+        initialCache: HiveInitialCache<Schema>,
+        checkpointedValuesByID: [HiveChannelID: any Sendable]
+    ) throws {
+        self.access = HiveStoreSupport(registry: registry)
+        var values: [HiveChannelID: any Sendable] = [:]
+        values.reserveCapacity(registry.channelSpecs.count)
+        for spec in registry.channelSpecs where spec.scope == .global {
+            values[spec.id] = try initialCache.valueAny(for: spec.id)
+        }
+
+        for (id, value) in checkpointedValuesByID {
+            let spec = try access.requireScope(.global, for: id)
+            guard spec.persistence == .checkpointed else {
+                throw HiveRuntimeError.checkpointOverrideNotCheckpointed(channelID: id)
+            }
+            try access.validateValueType(value, spec: spec)
+            values[id] = value
+        }
+
+        self.valuesByID = values
+    }
+
+    public func get<Value: Sendable>(_ key: HiveChannelKey<Schema, Value>) throws -> Value {
+        let spec = try access.requireScope(.global, for: key.id)
+        let value = try valueAny(for: key.id)
+        return try access.cast(value, for: key, spec: spec)
+    }
+
+    mutating func set<Value: Sendable>(_ key: HiveChannelKey<Schema, Value>, _ value: Value) throws {
+        let spec = try access.requireScope(.global, for: key.id)
+        try access.validateKeyType(key, spec: spec)
+        valuesByID[key.id] = value
+    }
+
+    mutating func setAny(_ value: any Sendable, for id: HiveChannelID) throws {
+        let spec = try access.requireScope(.global, for: id)
+        try access.validateValueType(value, spec: spec)
+        valuesByID[id] = value
+    }
+
+    func valueAny(for id: HiveChannelID) throws -> any Sendable {
+        guard let value = valuesByID[id] else {
+            throw HiveRuntimeError.storeValueMissing(channelID: id)
+        }
+        return value
+    }
+}

--- a/Sources/HiveCore/Store/HiveInitialCache.swift
+++ b/Sources/HiveCore/Store/HiveInitialCache.swift
@@ -1,0 +1,29 @@
+/// Deterministic cache of channel initial values.
+struct HiveInitialCache<Schema: HiveSchema>: Sendable {
+    private let access: HiveStoreSupport<Schema>
+    private let valuesByID: [HiveChannelID: any Sendable]
+
+    init(registry: HiveSchemaRegistry<Schema>) {
+        self.access = HiveStoreSupport(registry: registry)
+        var values: [HiveChannelID: any Sendable] = [:]
+        values.reserveCapacity(registry.channelSpecs.count)
+        for spec in registry.sortedChannelSpecs {
+            values[spec.id] = spec._initialBox()
+        }
+        self.valuesByID = values
+    }
+
+    func get<Value: Sendable>(_ key: HiveChannelKey<Schema, Value>) throws -> Value {
+        let spec = try access.requireSpec(for: key.id)
+        let value = try valueAny(for: key.id)
+        return try access.cast(value, for: key, spec: spec)
+    }
+
+    func valueAny(for id: HiveChannelID) throws -> any Sendable {
+        _ = try access.requireSpec(for: id)
+        guard let value = valuesByID[id] else {
+            throw HiveRuntimeError.storeValueMissing(channelID: id)
+        }
+        return value
+    }
+}

--- a/Sources/HiveCore/Store/HiveStoreSupport.swift
+++ b/Sources/HiveCore/Store/HiveStoreSupport.swift
@@ -1,0 +1,69 @@
+/// Internal helper for scope/type validation in store access.
+internal struct HiveStoreSupport<Schema: HiveSchema>: Sendable {
+    let registry: HiveSchemaRegistry<Schema>
+
+    init(registry: HiveSchemaRegistry<Schema>) {
+        self.registry = registry
+    }
+
+    func requireSpec(for id: HiveChannelID) throws -> AnyHiveChannelSpec<Schema> {
+        guard let spec = registry.channelSpecsByID[id] else {
+            throw HiveRuntimeError.unknownChannelID(id)
+        }
+        return spec
+    }
+
+    func requireScope(_ expected: HiveChannelScope, for id: HiveChannelID) throws -> AnyHiveChannelSpec<Schema> {
+        let spec = try requireSpec(for: id)
+        guard spec.scope == expected else {
+            throw HiveRuntimeError.scopeMismatch(channelID: id, expected: expected, actual: spec.scope)
+        }
+        return spec
+    }
+
+    func validateKeyType<Value: Sendable>(
+        _ key: HiveChannelKey<Schema, Value>,
+        spec: AnyHiveChannelSpec<Schema>
+    ) throws {
+        let expectedValueTypeID = spec.valueTypeID
+        let actualValueTypeID = String(reflecting: Value.self)
+        guard expectedValueTypeID == actualValueTypeID else {
+            throw HiveRuntimeError.channelTypeMismatch(
+                channelID: key.id,
+                expectedValueTypeID: expectedValueTypeID,
+                actualValueTypeID: actualValueTypeID
+            )
+        }
+    }
+
+    func validateValueType(
+        _ value: any Sendable,
+        spec: AnyHiveChannelSpec<Schema>
+    ) throws {
+        let expectedValueTypeID = spec.valueTypeID
+        let actualValueTypeID = String(reflecting: type(of: value))
+        guard expectedValueTypeID == actualValueTypeID else {
+            throw HiveRuntimeError.channelTypeMismatch(
+                channelID: spec.id,
+                expectedValueTypeID: expectedValueTypeID,
+                actualValueTypeID: actualValueTypeID
+            )
+        }
+    }
+
+    func cast<Value: Sendable>(
+        _ value: any Sendable,
+        for key: HiveChannelKey<Schema, Value>,
+        spec: AnyHiveChannelSpec<Schema>
+    ) throws -> Value {
+        try validateKeyType(key, spec: spec)
+        guard let typed = value as? Value else {
+            throw HiveRuntimeError.channelTypeMismatch(
+                channelID: key.id,
+                expectedValueTypeID: spec.valueTypeID,
+                actualValueTypeID: String(reflecting: type(of: value))
+            )
+        }
+        return typed
+    }
+}

--- a/Sources/HiveCore/Store/HiveStoreView.swift
+++ b/Sources/HiveCore/Store/HiveStoreView.swift
@@ -1,0 +1,48 @@
+/// Read-only composed view of global store, task-local overlay, and initial cache.
+public struct HiveStoreView<Schema: HiveSchema>: Sendable {
+    private let access: HiveStoreSupport<Schema>
+    private let global: HiveGlobalStore<Schema>
+    private let taskLocal: HiveTaskLocalStore<Schema>
+    private let initialCache: HiveInitialCache<Schema>
+
+    init(
+        global: HiveGlobalStore<Schema>,
+        taskLocal: HiveTaskLocalStore<Schema>,
+        initialCache: HiveInitialCache<Schema>,
+        registry: HiveSchemaRegistry<Schema>
+    ) {
+        self.access = HiveStoreSupport(registry: registry)
+        self.global = global
+        self.taskLocal = taskLocal
+        self.initialCache = initialCache
+    }
+
+    public func get<Value: Sendable>(_ key: HiveChannelKey<Schema, Value>) throws -> Value {
+        let spec = try access.requireSpec(for: key.id)
+        switch spec.scope {
+        case .global:
+            return try global.get(key)
+        case .taskLocal:
+            if let overlay = taskLocal.valueAny(for: key.id) {
+                return try access.cast(overlay, for: key, spec: spec)
+            }
+            let initialValue = try initialCache.valueAny(for: key.id)
+            return try access.cast(initialValue, for: key, spec: spec)
+        }
+    }
+
+    /// Type-erased read for a channel by ID. Returns the global value for global-scoped channels
+    /// or the task-local overlay (falling back to the initial value) for task-local channels.
+    func valueAny(for id: HiveChannelID) throws -> any Sendable {
+        let spec = try access.requireSpec(for: id)
+        switch spec.scope {
+        case .global:
+            return try global.valueAny(for: id)
+        case .taskLocal:
+            if let overlay = taskLocal.valueAny(for: id) {
+                return overlay
+            }
+            return try initialCache.valueAny(for: id)
+        }
+    }
+}

--- a/Sources/HiveCore/Store/HiveTaskLocalFingerprint.swift
+++ b/Sources/HiveCore/Store/HiveTaskLocalFingerprint.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// Task-local fingerprint computation and hashing.
+enum HiveTaskLocalFingerprint {
+    static func digest<Schema: HiveSchema>(
+        registry: HiveSchemaRegistry<Schema>,
+        initialCache: HiveInitialCache<Schema>,
+        overlay: HiveTaskLocalStore<Schema>,
+        debugPayloads: Bool = false
+    ) throws -> Data {
+        let canonical = try canonicalBytes(
+            registry: registry,
+            initialCache: initialCache,
+            overlay: overlay,
+            debugPayloads: debugPayloads
+        )
+        let hash = HiveSHA256.hash(data: canonical)
+        return Data(hash)
+    }
+
+    static func canonicalBytes<Schema: HiveSchema>(
+        registry: HiveSchemaRegistry<Schema>,
+        initialCache: HiveInitialCache<Schema>,
+        overlay: HiveTaskLocalStore<Schema>,
+        debugPayloads: Bool
+    ) throws -> Data {
+        let taskLocalSpecs = registry.sortedChannelSpecs.filter { $0.scope == .taskLocal }
+
+        var entries: [(idData: Data, valueData: Data)] = []
+        entries.reserveCapacity(taskLocalSpecs.count)
+
+        for spec in taskLocalSpecs {
+            guard let encode = spec._encodeBox else {
+                throw HiveRuntimeError.missingCodec(channelID: spec.id)
+            }
+
+            let effectiveValue = try (overlay.valueAny(for: spec.id) ?? initialCache.valueAny(for: spec.id))
+
+            do {
+                let valueData = try encode(effectiveValue)
+                let idData = Data(spec.id.rawValue.utf8)
+                entries.append((idData: idData, valueData: valueData))
+            } catch {
+                throw HiveRuntimeError.taskLocalFingerprintEncodeFailed(
+                    channelID: spec.id,
+                    errorDescription: HiveErrorDescription.describe(
+                        error,
+                        debugPayloads: debugPayloads
+                    )
+                )
+            }
+        }
+
+        var bytes = Data()
+        bytes.append(contentsOf: [0x48, 0x4C, 0x46, 0x31])
+        appendUInt32BE(try lengthAsUInt32(entries.count), to: &bytes)
+        for entry in entries {
+            appendUInt32BE(try lengthAsUInt32(entry.idData.count), to: &bytes)
+            bytes.append(entry.idData)
+            appendUInt32BE(try lengthAsUInt32(entry.valueData.count), to: &bytes)
+            bytes.append(entry.valueData)
+        }
+        return bytes
+    }
+
+    private static func appendUInt32BE(_ value: UInt32, to data: inout Data) {
+        var bigEndian = value.bigEndian
+        withUnsafeBytes(of: &bigEndian) { data.append(contentsOf: $0) }
+    }
+
+    private static func lengthAsUInt32(_ length: Int) throws -> UInt32 {
+        guard let value = UInt32(exactly: length) else {
+            throw HiveRuntimeError.internalInvariantViolation(
+                "Task-local fingerprint value length is out of UInt32 range: \(length)"
+            )
+        }
+        return value
+    }
+
+    // error description formatting is centralized in HiveErrorDescription
+}

--- a/Sources/HiveCore/Store/HiveTaskLocalStore.swift
+++ b/Sources/HiveCore/Store/HiveTaskLocalStore.swift
@@ -1,0 +1,66 @@
+/// Overlay-only store for task-local channels.
+public struct HiveTaskLocalStore<Schema: HiveSchema>: Sendable {
+    public static var empty: HiveTaskLocalStore<Schema> {
+        do {
+            let registry = try HiveSchemaRegistry<Schema>()
+            return HiveTaskLocalStore(registry: registry)
+        } catch {
+            return HiveTaskLocalStore(initializationError: error)
+        }
+    }
+
+    private let access: HiveStoreSupport<Schema>?
+    private let initializationError: Error?
+    private var valuesByID: [HiveChannelID: any Sendable]
+
+    init(
+        registry: HiveSchemaRegistry<Schema>,
+        valuesByID: [HiveChannelID: any Sendable] = [:]
+    ) {
+        self.access = HiveStoreSupport(registry: registry)
+        self.initializationError = nil
+        self.valuesByID = valuesByID
+    }
+
+    private init(initializationError: Error) {
+        self.access = nil
+        self.initializationError = initializationError
+        self.valuesByID = [:]
+    }
+
+    private func requireAccess() throws -> HiveStoreSupport<Schema> {
+        guard let access else {
+            throw initializationError ?? HiveRuntimeError.internalInvariantViolation(
+                "HiveTaskLocalStore was not initialized with a schema registry."
+            )
+        }
+        return access
+    }
+
+    public func get<Value: Sendable>(_ key: HiveChannelKey<Schema, Value>) throws -> Value? {
+        let access = try requireAccess()
+        let spec = try access.requireScope(.taskLocal, for: key.id)
+        guard let value = valuesByID[key.id] else {
+            return nil
+        }
+        return try access.cast(value, for: key, spec: spec)
+    }
+
+    public mutating func set<Value: Sendable>(_ key: HiveChannelKey<Schema, Value>, _ value: Value) throws {
+        let access = try requireAccess()
+        let spec = try access.requireScope(.taskLocal, for: key.id)
+        try access.validateKeyType(key, spec: spec)
+        valuesByID[key.id] = value
+    }
+
+    mutating func setAny(_ value: any Sendable, for id: HiveChannelID) throws {
+        let access = try requireAccess()
+        let spec = try access.requireScope(.taskLocal, for: id)
+        try access.validateValueType(value, spec: spec)
+        valuesByID[id] = value
+    }
+
+    func valueAny(for id: HiveChannelID) -> (any Sendable)? {
+        valuesByID[id]
+    }
+}

--- a/Sources/HiveCore/Support/HiveSHA256.swift
+++ b/Sources/HiveCore/Support/HiveSHA256.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+#if canImport(CryptoKit)
+import CryptoKit
+#else
+import Crypto
+#endif
+
+enum HiveSHA256 {
+    struct Hasher {
+        private var hasher = SHA256()
+
+        mutating func update(data: Data) {
+            hasher.update(data: data)
+        }
+
+        mutating func finalize() -> [UInt8] {
+            Array(hasher.finalize())
+        }
+    }
+
+    static func hash(data: Data) -> [UInt8] {
+        Array(SHA256.hash(data: data))
+    }
+
+    static func digest(data: Data) -> Data {
+        Data(hash(data: data))
+    }
+
+    static func hex(data: Data) -> String {
+        hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Sources/Membrane/Membrane.swift
+++ b/Sources/Membrane/Membrane.swift
@@ -1,0 +1,2 @@
+// Membrane — 5-stage context management pipeline implementation.
+@_exported import MembraneCore

--- a/Sources/Membrane/MembraneSession.swift
+++ b/Sources/Membrane/MembraneSession.swift
@@ -1,0 +1,387 @@
+import Foundation
+import MembraneContextCore
+import MembraneCore
+
+public struct MembraneFeatureConfiguration: Sendable, Equatable {
+    public static let `default` = MembraneFeatureConfiguration()
+
+    public var jitMinToolCount: Int
+    public var defaultJITLoadCount: Int
+    public var pointerThresholdBytes: Int
+    public var pointerSummaryMaxChars: Int
+    public var runtimeFeatureFlags: [String: Bool]
+    public var runtimeModelAllowlist: [String]
+
+    public init(
+        jitMinToolCount: Int = 12,
+        defaultJITLoadCount: Int = 6,
+        pointerThresholdBytes: Int = 1024,
+        pointerSummaryMaxChars: Int = 240,
+        runtimeFeatureFlags: [String: Bool] = [:],
+        runtimeModelAllowlist: [String] = []
+    ) {
+        self.jitMinToolCount = max(1, jitMinToolCount)
+        self.defaultJITLoadCount = max(1, defaultJITLoadCount)
+        self.pointerThresholdBytes = max(1, pointerThresholdBytes)
+        self.pointerSummaryMaxChars = max(0, pointerSummaryMaxChars)
+        self.runtimeFeatureFlags = runtimeFeatureFlags
+        self.runtimeModelAllowlist = runtimeModelAllowlist.sorted()
+    }
+}
+
+public struct MembranePreparedContext: Sendable {
+    public let plan: ContextPlan
+    public let selectedToolNames: [String]
+    public let mode: String
+    public let snapshot: ContextSnapshot?
+    public let recalledMemories: [ContextRecallCandidate]
+
+    public init(
+        plan: ContextPlan,
+        selectedToolNames: [String],
+        mode: String,
+        snapshot: ContextSnapshot?,
+        recalledMemories: [ContextRecallCandidate] = []
+    ) {
+        self.plan = plan
+        self.selectedToolNames = selectedToolNames
+        self.mode = mode
+        self.snapshot = snapshot
+        self.recalledMemories = recalledMemories
+    }
+}
+
+public actor MembraneSession {
+    private let configuration: MembraneFeatureConfiguration
+    private let baseBudget: ContextBudget
+    private let backend: any MembraneContextBackend
+    private let recallStore: (any ContextRecallStore)?
+    private let pointerStore: any PointerStore
+    private let pointerResolver: PointerResolver
+    private let jitLoader: JITToolLoader
+
+    private var loadedToolNames: [String]
+    private var allowListToolNames: [String]
+    private var pointerIDs: [String]
+    private var usageCounts: [String: Int]
+    private var snapshotState: ContextSnapshot?
+
+    public init(
+        configuration: MembraneFeatureConfiguration = .default,
+        budget: ContextBudget = ContextBudget(totalTokens: 4096, profile: .foundationModels4K),
+        backend: (any MembraneContextBackend)? = nil,
+        recallStore: (any ContextRecallStore)? = nil,
+        pointerStore: (any PointerStore)? = nil,
+        initialSnapshot: ContextSnapshot? = nil
+    ) {
+        self.configuration = configuration
+        self.baseBudget = budget
+        self.backend = backend ?? MembraneContextCoreBackend()
+        self.recallStore = recallStore
+
+        let resolvedPointerStore = pointerStore ?? InMemoryPointerStore()
+        self.pointerStore = resolvedPointerStore
+        self.pointerResolver = PointerResolver(
+            store: resolvedPointerStore,
+            config: PointerResolverConfig(
+                pointerThresholdBytes: configuration.pointerThresholdBytes,
+                summaryMaxChars: configuration.pointerSummaryMaxChars
+            )
+        )
+        self.jitLoader = JITToolLoader(jitMinToolCount: configuration.jitMinToolCount)
+
+        let normalized = initialSnapshot?.normalized()
+        self.loadedToolNames = normalized?.toolState.loadedToolNames ?? []
+        self.allowListToolNames = normalized?.toolState.allowListToolNames ?? []
+        self.pointerIDs = normalized?.pointerIDs ?? []
+        self.usageCounts = Dictionary(
+            uniqueKeysWithValues: (normalized?.toolState.usageCounts ?? []).map { ($0.toolName, $0.count) }
+        )
+        self.snapshotState = normalized
+    }
+
+    public func prepare(_ request: ContextRequest) async throws -> MembranePreparedContext {
+        let recalledMemories = try await recalledMemories(for: request)
+        let requestWithRecall = merge(recalledMemories: recalledMemories, into: request)
+
+        let sortedTools = requestWithRecall.tools.sorted { lhs, rhs in
+            if lhs.name != rhs.name {
+                return lhs.name < rhs.name
+            }
+            return lhs.description < rhs.description
+        }
+
+        var selectedToolNames = sortedTools.map(\.name)
+        var toolMode = ContextSnapshot.ToolState.Mode.allowAll
+        let nextPlan = jitLoader.plan(
+            tools: sortedTools,
+            existingPlan: currentToolPlan(fallback: requestWithRecall.toolPlan)
+        )
+
+        switch nextPlan {
+        case .allowAll:
+            allowListToolNames = []
+            toolMode = .allowAll
+
+        case let .allowList(toolNames):
+            let allowSet = Set(toolNames)
+            allowListToolNames = Array(allowSet).sorted()
+            selectedToolNames = sortedTools.compactMap { allowSet.contains($0.name) ? $0.name : nil }
+            toolMode = .allowList
+
+        case let .jit(index, _):
+            var loadedSet = Set(loadedToolNames)
+            if loadedSet.isEmpty {
+                loadedSet.formUnion(index.map(\.name).sorted().prefix(configuration.defaultJITLoadCount))
+            }
+            loadedToolNames = Array(loadedSet).sorted()
+            selectedToolNames = sortedTools.compactMap { loadedSet.contains($0.name) ? $0.name : nil }
+            toolMode = .jit
+        }
+
+        let budget = snapshotBudget(from: snapshotState) ?? baseBudget
+        let preparation = try await backend.prepare(
+            request: ContextRequest(
+                systemPrompt: requestWithRecall.systemPrompt,
+                basePrompt: requestWithRecall.basePrompt,
+                userInput: requestWithRecall.userInput,
+                tools: sortedTools,
+                toolPlan: nextPlan,
+                history: requestWithRecall.history,
+                memories: requestWithRecall.memories,
+                retrieval: requestWithRecall.retrieval,
+                pointers: requestWithRecall.pointers,
+                metadata: requestWithRecall.metadata,
+                recallQuery: requestWithRecall.recallQuery,
+                recallLimit: requestWithRecall.recallLimit
+            ),
+            budget: budget,
+            snapshot: snapshotState
+        )
+
+        let mergedSnapshot = makeSnapshot(
+            from: preparation.snapshot,
+            budget: preparation.plan.budget,
+            toolMode: toolMode
+        )
+        snapshotState = mergedSnapshot
+
+        return MembranePreparedContext(
+            plan: preparation.plan,
+            selectedToolNames: selectedToolNames.sorted(),
+            mode: modeString(toolMode),
+            snapshot: mergedSnapshot,
+            recalledMemories: recalledMemories
+        )
+    }
+
+    public func transformToolResult(toolName: String, output: String) async throws -> PointerizationDecision {
+        usageCounts[toolName, default: 0] += 1
+        let decision = try await pointerResolver.pointerizeIfNeeded(toolName: toolName, output: output)
+        if case let .pointer(pointer, _) = decision {
+            pointerIDs = Array(Set(pointerIDs + [pointer.id])).sorted()
+        }
+        snapshotState = makeSnapshot(from: try await backend.snapshot(), budget: snapshotBudget(from: snapshotState) ?? baseBudget, toolMode: currentToolMode())
+        return decision
+    }
+
+    public func handleInternalToolCall(
+        name: String,
+        arguments: [String: String]
+    ) async throws -> String? {
+        switch name {
+        case "membrane_load_tool_schema":
+            guard let toolName = arguments["tool_name"], toolName.isEmpty == false else {
+                return nil
+            }
+            loadedToolNames = Array(Set(loadedToolNames + [toolName])).sorted()
+            snapshotState = makeSnapshot(from: try await backend.snapshot(), budget: snapshotBudget(from: snapshotState) ?? baseBudget, toolMode: .jit)
+            return "Loaded tool schema: \(toolName)"
+
+        case "Add_Tools":
+            let names = parseToolNames(arguments["tool_names"])
+            guard names.isEmpty == false else { return nil }
+            loadedToolNames = Array(Set(loadedToolNames + names)).sorted()
+            snapshotState = makeSnapshot(from: try await backend.snapshot(), budget: snapshotBudget(from: snapshotState) ?? baseBudget, toolMode: .jit)
+            return "Added tools: \(names.sorted().joined(separator: ", "))"
+
+        case "Remove_Tools":
+            let names = Set(parseToolNames(arguments["tool_names"]))
+            guard names.isEmpty == false else { return nil }
+            loadedToolNames.removeAll { names.contains($0) }
+            loadedToolNames.sort()
+            snapshotState = makeSnapshot(from: try await backend.snapshot(), budget: snapshotBudget(from: snapshotState) ?? baseBudget, toolMode: currentToolMode())
+            return "Removed tools: \(names.sorted().joined(separator: ", "))"
+
+        case "resolve_pointer":
+            guard let pointerID = arguments["pointer_id"], pointerID.isEmpty == false else {
+                return nil
+            }
+            let payload = try await pointerStore.resolve(pointerID: pointerID)
+            if let text = String(data: payload, encoding: .utf8) {
+                return text
+            }
+            return payload.base64EncodedString()
+
+        default:
+            return nil
+        }
+    }
+
+    public func restore(snapshot: ContextSnapshot?) async throws {
+        let normalized = snapshot?.normalized()
+        snapshotState = normalized
+        loadedToolNames = normalized?.toolState.loadedToolNames ?? []
+        allowListToolNames = normalized?.toolState.allowListToolNames ?? []
+        pointerIDs = normalized?.pointerIDs ?? []
+        usageCounts = Dictionary(
+            uniqueKeysWithValues: (normalized?.toolState.usageCounts ?? []).map { ($0.toolName, $0.count) }
+        )
+        try await backend.restore(snapshot: normalized)
+    }
+
+    public func snapshot() async throws -> ContextSnapshot? {
+        if let backendSnapshot = try await backend.snapshot() {
+            snapshotState = makeSnapshot(
+                from: backendSnapshot,
+                budget: snapshotBudget(from: snapshotState) ?? baseBudget,
+                toolMode: currentToolMode()
+            )
+        }
+        return snapshotState?.normalized()
+    }
+
+    private func recalledMemories(for request: ContextRequest) async throws -> [ContextRecallCandidate] {
+        guard let recallStore else { return [] }
+        let query = (request.recallQuery ?? request.userInput).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard query.isEmpty == false else { return [] }
+        return try await recallStore.recall(query: query, limit: request.recallLimit)
+    }
+
+    private func merge(
+        recalledMemories: [ContextRecallCandidate],
+        into request: ContextRequest
+    ) -> ContextRequest {
+        guard recalledMemories.isEmpty == false else { return request }
+
+        let recalledSlices = recalledMemories.map { candidate in
+            ContextSlice(
+                content: candidate.content,
+                tokenCount: candidate.content.count,
+                importance: candidate.score ?? 1.0,
+                source: .retrieval,
+                tier: .full,
+                timestamp: .now
+            )
+        }
+
+        return ContextRequest(
+            systemPrompt: request.systemPrompt,
+            basePrompt: request.basePrompt,
+            userInput: request.userInput,
+            tools: request.tools,
+            toolPlan: request.toolPlan,
+            history: request.history,
+            memories: request.memories,
+            retrieval: request.retrieval + recalledSlices,
+            pointers: request.pointers,
+            metadata: request.metadata,
+            recallQuery: request.recallQuery,
+            recallLimit: request.recallLimit
+        )
+    }
+
+    private func currentToolPlan(fallback: ToolPlan) -> ToolPlan {
+        switch currentToolMode() {
+        case .allowAll:
+            return fallback
+        case .allowList:
+            return .allowList(normalized: allowListToolNames)
+        case .jit:
+            let index = loadedToolNames.map { ToolIndexEntry(name: $0, description: "") }
+            return .jit(normalized: index, loaded: loadedToolNames)
+        }
+    }
+
+    private func currentToolMode() -> ContextSnapshot.ToolState.Mode {
+        if loadedToolNames.isEmpty == false {
+            return .jit
+        }
+        if allowListToolNames.isEmpty == false {
+            return .allowList
+        }
+        return .allowAll
+    }
+
+    private func makeSnapshot(
+        from backendSnapshot: ContextSnapshot?,
+        budget: ContextBudget,
+        toolMode: ContextSnapshot.ToolState.Mode
+    ) -> ContextSnapshot {
+        let usageEntries = usageCounts
+            .map { ContextSnapshot.ToolState.UsageCount(toolName: $0.key, count: $0.value) }
+            .sorted { lhs, rhs in
+                if lhs.toolName != rhs.toolName {
+                    return lhs.toolName < rhs.toolName
+                }
+                return lhs.count < rhs.count
+            }
+
+        return ContextSnapshot(
+            budget: ContextSnapshot.BudgetSnapshot(
+                totalTokens: budget.totalTokens,
+                allocations: budget.bucketAllocations.map {
+                    .init(bucketID: $0.key.rawValue, allocatedTokens: $0.value)
+                }.sorted { $0.bucketID < $1.bucketID },
+                kvBytesPerToken: budget.kvBytesPerToken,
+                kvMemoryBudgetBytes: budget.kvMemoryBudgetBytes,
+                maxSequenceLength: budget.maxSequenceLength
+            ),
+            csoSummaries: backendSnapshot?.csoSummaries ?? snapshotState?.csoSummaries ?? [],
+            pagingCursor: backendSnapshot?.pagingCursor ?? snapshotState?.pagingCursor,
+            toolState: .init(
+                mode: toolMode,
+                loadedToolNames: loadedToolNames,
+                allowListToolNames: allowListToolNames,
+                usageCounts: usageEntries
+            ),
+            pointerIDs: pointerIDs,
+            backendID: backendSnapshot?.backendID,
+            backendState: backendSnapshot?.backendState
+        ).normalized()
+    }
+
+    private func snapshotBudget(from snapshot: ContextSnapshot?) -> ContextBudget? {
+        guard let snapshot else { return nil }
+        var budget = ContextBudget(
+            totalTokens: snapshot.budget.totalTokens,
+            profile: .foundationModels4K,
+            kvBytesPerToken: snapshot.budget.kvBytesPerToken,
+            kvMemoryBudgetBytes: snapshot.budget.kvMemoryBudgetBytes
+        )
+        for allocation in snapshot.budget.allocations {
+            guard let bucketID = BucketID(rawValue: allocation.bucketID) else { continue }
+            try? budget.allocate(allocation.allocatedTokens, to: bucketID)
+        }
+        return budget
+    }
+
+    private func parseToolNames(_ rawValue: String?) -> [String] {
+        guard let rawValue else { return [] }
+        return rawValue
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { $0.isEmpty == false }
+    }
+
+    private func modeString(_ mode: ContextSnapshot.ToolState.Mode) -> String {
+        switch mode {
+        case .allowAll:
+            "allowAll"
+        case .allowList:
+            "allowList"
+        case .jit:
+            "jit"
+        }
+    }
+}

--- a/Sources/Membrane/Pipeline/MembranePipeline.swift
+++ b/Sources/Membrane/Pipeline/MembranePipeline.swift
@@ -1,0 +1,147 @@
+import MembraneCore
+
+public enum PipelineMode: Sendable {
+    case full
+    case budgetOnly
+}
+
+public actor MembranePipeline {
+    private let baseBudget: ContextBudget
+    private let intakeStage: (any IntakeStage)?
+    private let allocatorStage: (any BudgetStage)?
+    private let compressStage: (any CompressStage)?
+    private let pageStage: (any PageStage)?
+    private let emitStage: (any EmitStage)?
+    private let mode: PipelineMode
+
+    public init(
+        budget: ContextBudget,
+        intake: (any IntakeStage)? = nil,
+        allocator: (any BudgetStage)? = nil,
+        compress: (any CompressStage)? = nil,
+        page: (any PageStage)? = nil,
+        emit: (any EmitStage)? = nil,
+        mode: PipelineMode = .full
+    ) {
+        self.baseBudget = budget
+        self.intakeStage = intake
+        self.allocatorStage = allocator
+        self.compressStage = compress
+        self.pageStage = page
+        self.emitStage = emit
+        self.mode = mode
+    }
+
+    public static func foundationModel(
+        budget: ContextBudget = ContextBudget(totalTokens: 4096, profile: .foundationModels4K),
+        intake: (any IntakeStage)? = nil,
+        allocator: (any BudgetStage)? = nil,
+        compress: (any CompressStage)? = nil,
+        page: (any PageStage)? = nil,
+        emit: (any EmitStage)? = nil
+    ) -> MembranePipeline {
+        MembranePipeline(
+            budget: budget,
+            intake: intake,
+            allocator: allocator,
+            compress: compress,
+            page: page,
+            emit: emit,
+            mode: .budgetOnly
+        )
+    }
+
+    public static func openModel(
+        budget: ContextBudget,
+        intake: (any IntakeStage)? = nil,
+        allocator: (any BudgetStage)? = nil,
+        compress: (any CompressStage)? = nil,
+        page: (any PageStage)? = nil,
+        emit: (any EmitStage)? = nil
+    ) -> MembranePipeline {
+        MembranePipeline(
+            budget: budget,
+            intake: intake,
+            allocator: allocator,
+            compress: compress,
+            page: page,
+            emit: emit,
+            mode: .full
+        )
+    }
+
+    public func prepare(_ request: ContextRequest) async throws -> ContextPlan {
+        var budget = baseBudget
+
+        var window = ContextWindow(
+            systemPrompt: ContextSlice(
+                content: request.systemPrompt,
+                tokenCount: request.systemPrompt.count,
+                importance: 1.0,
+                source: .system,
+                tier: .full,
+                timestamp: .now
+            ),
+            memory: request.memories,
+            tools: request.tools,
+            toolPlan: request.toolPlan,
+            history: request.history,
+            retrieval: request.retrieval,
+            pointers: request.pointers,
+            metadata: request.metadata
+        )
+
+        if let intakeStage {
+            window = try await intakeStage.process(request, budget: budget)
+        }
+
+        var budgeted = BudgetedContext(window: window, budget: budget)
+        if let allocatorStage {
+            budgeted = try await allocatorStage.process(budgeted.window, budget: budgeted.budget)
+        }
+        budget = budgeted.budget
+
+        var compressed = CompressedContext(
+            window: budgeted.window,
+            budget: budgeted.budget,
+            compressionReport: CompressionReport(
+                originalTokens: budgeted.window.totalTokenCount,
+                compressedTokens: budgeted.window.totalTokenCount,
+                techniquesApplied: []
+            )
+        )
+        if let compressStage {
+            compressed = try await compressStage.process(
+                BudgetedContext(window: compressed.window, budget: compressed.budget),
+                budget: compressed.budget
+            )
+        }
+        budget = compressed.budget
+
+        var paged = PagedContext(window: compressed.window, budget: compressed.budget, pagedOut: [])
+        if mode == .full, let pageStage {
+            paged = try await pageStage.process(
+                CompressedContext(
+                    window: paged.window,
+                    budget: paged.budget,
+                    compressionReport: compressed.compressionReport
+                ),
+                budget: paged.budget
+            )
+        }
+        budget = paged.budget
+
+        var plannedRequest = ContextPlan(
+            prompt: request.basePrompt.isEmpty ? request.userInput : request.basePrompt,
+            systemPrompt: paged.window.systemPrompt.content,
+            toolPlan: paged.window.toolPlan,
+            budget: budget,
+            metadata: paged.window.metadata
+        )
+        if mode == .full, let emitStage {
+            plannedRequest = try await emitStage.process(paged, budget: budget)
+        }
+
+        return plannedRequest
+    }
+}

--- a/Sources/Membrane/Stages/Budget/GQAMemoryEstimator.swift
+++ b/Sources/Membrane/Stages/Budget/GQAMemoryEstimator.swift
@@ -1,0 +1,31 @@
+import MembraneCore
+
+/// Stage 2 helper that annotates context budgets with architecture-aware
+/// KV memory sizing when architecture metadata is explicitly provided.
+public actor GQAMemoryEstimator: BudgetStage {
+    private let architecture: ModelArchitectureInfo?
+    private let kvMemoryBudgetBytes: Int?
+
+    public init(architecture: ModelArchitectureInfo?, kvMemoryBudgetBytes: Int?) {
+        self.architecture = architecture
+        self.kvMemoryBudgetBytes = kvMemoryBudgetBytes
+    }
+
+    public func process(_ input: ContextWindow, budget: ContextBudget) async throws -> BudgetedContext {
+        guard let architecture else {
+            return BudgetedContext(window: input, budget: budget)
+        }
+
+        let kvBytesPerToken = architecture.kvBytesPerToken
+        guard kvBytesPerToken > 0 else {
+            return BudgetedContext(window: input, budget: budget)
+        }
+
+        let updatedBudget = budget.withKVSizing(
+            kvBytesPerToken: kvBytesPerToken,
+            kvMemoryBudgetBytes: kvMemoryBudgetBytes
+        )
+
+        return BudgetedContext(window: input, budget: updatedBudget)
+    }
+}

--- a/Sources/Membrane/Stages/Budget/UnifiedBudgetAllocator.swift
+++ b/Sources/Membrane/Stages/Budget/UnifiedBudgetAllocator.swift
@@ -1,0 +1,43 @@
+import MembraneCore
+
+/// Stage 2 budget allocator that consolidates context demands into deterministic
+/// bucket allocations.
+public actor UnifiedBudgetAllocator: BudgetStage {
+    private let allocationPriority: [BucketID] = [
+        .system,
+        .history,
+        .memory,
+        .tools,
+        .retrieval,
+        .toolIO,
+    ]
+
+    public init() {}
+
+    public func process(_ input: ContextWindow, budget: ContextBudget) async throws -> BudgetedContext {
+        var mutableBudget = budget
+
+        let demand: [BucketID: Int] = [
+            .system: input.systemPrompt.tokenCount,
+            .history: input.history.reduce(0) { $0 + $1.tokenCount },
+            .memory: input.memory.reduce(0) { $0 + $1.tokenCount },
+            .tools: input.tools.reduce(0) { $0 + $1.estimatedTokens },
+            .retrieval: input.retrieval.reduce(0) { $0 + $1.tokenCount },
+            .toolIO: 0,
+        ]
+
+        for bucket in allocationPriority {
+            let requested = max(demand[bucket] ?? 0, 0)
+            guard requested > 0 else {
+                continue
+            }
+
+            let toAllocate = min(requested, mutableBudget.remaining(for: bucket), mutableBudget.totalRemaining)
+            if toAllocate > 0 {
+                try mutableBudget.allocate(toAllocate, to: bucket)
+            }
+        }
+
+        return BudgetedContext(window: input, budget: mutableBudget)
+    }
+}

--- a/Sources/Membrane/Stages/Compress/CSODistiller.swift
+++ b/Sources/Membrane/Stages/Compress/CSODistiller.swift
@@ -1,0 +1,135 @@
+import Foundation
+import MembraneCore
+
+/// Stage 3 compressor: distills older conversation turns into a bounded
+/// Context State Object (CSO) while keeping recent turns verbatim.
+public actor CSODistiller: CompressStage {
+    private var currentCSO: ContextStateObject
+    private let keepRecentTurns: Int
+
+    public init(keepRecentTurns: Int = 3) {
+        self.keepRecentTurns = max(keepRecentTurns, 0)
+        self.currentCSO = ContextStateObject()
+    }
+
+    public func process(_ input: BudgetedContext, budget: ContextBudget) async throws -> CompressedContext {
+        let history = input.window.history
+        let originalTokens = history.reduce(0) { $0 + $1.tokenCount }
+
+        guard history.count > keepRecentTurns else {
+            return CompressedContext(
+                window: input.window,
+                budget: budget,
+                compressionReport: CompressionReport(
+                    originalTokens: originalTokens,
+                    compressedTokens: originalTokens,
+                    techniquesApplied: []
+                )
+            )
+        }
+
+        let olderTurns = Array(history.dropLast(keepRecentTurns))
+        let recentTurns = Array(history.suffix(keepRecentTurns))
+
+        let distilled = distill(turns: olderTurns.map(\.content), existing: currentCSO)
+        currentCSO = distilled
+
+        let csoSlice = ContextSlice(
+            content: distilled.formatted(),
+            tokenCount: distilled.estimatedTokenCount,
+            importance: 0.9,
+            source: .history,
+            tier: .gist,
+            timestamp: .now
+        )
+
+        var window = input.window
+        window.history = [csoSlice] + recentTurns
+
+        let compressedTokens = window.history.reduce(0) { $0 + $1.tokenCount }
+        return CompressedContext(
+            window: window,
+            budget: budget,
+            compressionReport: CompressionReport(
+                originalTokens: originalTokens,
+                compressedTokens: compressedTokens,
+                techniquesApplied: ["CSO"]
+            )
+        )
+    }
+
+    func distill(turns: [String], existing: ContextStateObject? = nil) -> ContextStateObject {
+        var cso = existing ?? ContextStateObject()
+
+        for rawTurn in turns {
+            let turn = rawTurn.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !turn.isEmpty else {
+                continue
+            }
+
+            extractEntities(from: turn, into: &cso)
+            extractDecisions(from: turn, into: &cso)
+            extractQuestions(from: turn, into: &cso)
+            extractFacts(from: turn, into: &cso)
+        }
+
+        cso.turnCount += turns.count
+        cso.trimBounds()
+        return cso
+    }
+
+    private func extractEntities(from turn: String, into cso: inout ContextStateObject) {
+        let ignored = Set(["User", "Assistant", "The", "This", "That", "When", "Where", "What", "Why", "How", "Turn"])
+
+        for part in turn.split(separator: " ") {
+            let token = part.trimmingCharacters(in: .punctuationCharacters)
+            guard token.count >= 2,
+                  token.first?.isUppercase == true,
+                  !ignored.contains(token),
+                  !token.allSatisfy({ $0.isNumber }) else {
+                continue
+            }
+            cso.addEntity(token)
+        }
+    }
+
+    private func extractDecisions(from turn: String, into cso: inout ContextStateObject) {
+        let lower = turn.lowercased()
+        let markers = ["decided", "chose", "selected", "will use", "going with", "picked", "using"]
+        guard markers.contains(where: { lower.contains($0) }) else {
+            return
+        }
+
+        if !cso.decisions.contains(turn) {
+            cso.decisions.append(turn)
+        }
+    }
+
+    private func extractQuestions(from turn: String, into cso: inout ContextStateObject) {
+        guard turn.contains("?") else {
+            return
+        }
+
+        let fragments = turn
+            .split(separator: "?")
+            .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+
+        for fragment in fragments {
+            if !cso.openQuestions.contains(fragment) {
+                cso.openQuestions.append(fragment)
+            }
+        }
+    }
+
+    private func extractFacts(from turn: String, into cso: inout ContextStateObject) {
+        let markers = [" is ", " are ", " contains ", " includes "]
+        guard markers.contains(where: { turn.localizedCaseInsensitiveContains($0) }) else {
+            return
+        }
+
+        if !cso.keyFacts.contains(turn) {
+            cso.keyFacts.append(turn)
+        }
+    }
+}

--- a/Sources/Membrane/Stages/Compress/SurrogateTierSelector.swift
+++ b/Sources/Membrane/Stages/Compress/SurrogateTierSelector.swift
@@ -1,0 +1,76 @@
+import MembraneCore
+
+public struct SurrogateCandidate: Sendable, Equatable {
+    public let id: String
+    public let accessFrequency: Int
+    public let recencyScore: Double
+    public let relevanceScore: Double
+    public let full: ContextSlice
+    public let gist: ContextSlice
+    public let micro: ContextSlice
+
+    public init(
+        id: String,
+        accessFrequency: Int,
+        recencyScore: Double,
+        relevanceScore: Double,
+        full: ContextSlice,
+        gist: ContextSlice,
+        micro: ContextSlice
+    ) {
+        self.id = id
+        self.accessFrequency = accessFrequency
+        self.recencyScore = recencyScore
+        self.relevanceScore = relevanceScore
+        self.full = full
+        self.gist = gist
+        self.micro = micro
+    }
+}
+
+public struct SurrogateTierSelector: Sendable {
+    public init() {}
+
+    public func select(
+        candidates: [SurrogateCandidate],
+        retrievalTokenBudget: Int,
+        querySpecificity: Double
+    ) -> [ContextSlice] {
+        let specificity = min(max(querySpecificity, 0.0), 1.0)
+        let preferFullTier = specificity >= 0.7
+
+        let ranked = candidates.sorted { lhs, rhs in
+            let lhsScore = score(lhs)
+            let rhsScore = score(rhs)
+
+            if lhsScore != rhsScore {
+                return lhsScore > rhsScore
+            }
+
+            return lhs.id < rhs.id
+        }
+
+        var remaining = max(0, retrievalTokenBudget)
+        var selected: [ContextSlice] = []
+
+        for candidate in ranked where remaining > 0 {
+            let preferredTier = preferFullTier ? candidate.full : candidate.gist
+            let secondaryTier = preferFullTier ? candidate.gist : candidate.full
+            let tiers = [preferredTier, secondaryTier, candidate.micro]
+            guard let chosen = tiers.first(where: { $0.tokenCount <= remaining }) else {
+                continue
+            }
+
+            selected.append(chosen)
+            remaining -= chosen.tokenCount
+        }
+
+        return selected
+    }
+
+    private func score(_ candidate: SurrogateCandidate) -> Double {
+        Double(candidate.accessFrequency) * 0.4
+        + candidate.recencyScore * 0.2
+        + candidate.relevanceScore * 0.4
+    }
+}

--- a/Sources/Membrane/Stages/Compress/ToolPruner.swift
+++ b/Sources/Membrane/Stages/Compress/ToolPruner.swift
@@ -1,0 +1,41 @@
+import MembraneCore
+
+public struct ToolPruner: Sendable {
+    public let pruneAfterTurn: Int
+    public let keepTopK: Int
+
+    public init(pruneAfterTurn: Int = 8, keepTopK: Int = 12) {
+        self.pruneAfterTurn = pruneAfterTurn
+        self.keepTopK = keepTopK
+    }
+
+    public func prune(
+        availableTools: [ToolManifest],
+        existingPlan: ToolPlan,
+        usageCountByToolName: [String: Int],
+        currentTurn: Int
+    ) -> ToolPlan {
+        if case .jit = existingPlan {
+            return existingPlan
+        }
+
+        guard currentTurn >= pruneAfterTurn else {
+            return existingPlan
+        }
+
+        let kept = availableTools
+            .map { tool in
+                (name: tool.name, usage: usageCountByToolName[tool.name] ?? 0)
+            }
+            .sorted { lhs, rhs in
+                if lhs.usage != rhs.usage {
+                    return lhs.usage > rhs.usage
+                }
+                return lhs.name < rhs.name
+            }
+            .prefix(max(0, keepTopK))
+            .map(\.name)
+
+        return ToolPlan.allowList(normalized: Array(kept))
+    }
+}

--- a/Sources/Membrane/Stages/Intake/JITToolLoader.swift
+++ b/Sources/Membrane/Stages/Intake/JITToolLoader.swift
@@ -1,0 +1,31 @@
+import MembraneCore
+
+public struct JITToolLoader: Sendable {
+    public let jitMinToolCount: Int
+
+    public init(jitMinToolCount: Int = 10) {
+        self.jitMinToolCount = jitMinToolCount
+    }
+
+    public func plan(tools: [ToolManifest], existingPlan: ToolPlan) -> ToolPlan {
+        let loadedToolNames: [String]
+        switch existingPlan {
+        case let .jit(_, loaded):
+            loadedToolNames = loaded
+        default:
+            loadedToolNames = []
+        }
+
+        // Sticky JIT: once tools are actively loaded, keep JIT mode for deterministic continuity.
+        let shouldUseJIT = tools.count >= jitMinToolCount || !loadedToolNames.isEmpty
+        guard shouldUseJIT else {
+            return .allowAll
+        }
+
+        let index = tools.map { tool in
+            ToolIndexEntry(name: tool.name, description: tool.description)
+        }
+
+        return ToolPlan.jit(normalized: index, loaded: loadedToolNames)
+    }
+}

--- a/Sources/Membrane/Stages/Intake/PointerResolver.swift
+++ b/Sources/Membrane/Stages/Intake/PointerResolver.swift
@@ -1,0 +1,86 @@
+import CryptoKit
+import Foundation
+import MembraneCore
+
+public struct PointerResolverConfig: Sendable, Equatable {
+    public var pointerThresholdBytes: Int
+    public var summaryMaxChars: Int
+
+    public init(pointerThresholdBytes: Int = 1024, summaryMaxChars: Int = 200) {
+        self.pointerThresholdBytes = pointerThresholdBytes
+        self.summaryMaxChars = summaryMaxChars
+    }
+}
+
+public enum PointerizationDecision: Sendable, Equatable {
+    case inline(String)
+    case pointer(MemoryPointer, replacementText: String)
+}
+
+public actor PointerResolver: Sendable {
+    private let store: any PointerStore
+    private let config: PointerResolverConfig
+
+    public init(store: any PointerStore, config: PointerResolverConfig = .init()) {
+        self.store = store
+        self.config = config
+    }
+
+    public func pointerizeIfNeeded(toolName: String, output: String) async throws -> PointerizationDecision {
+        let payload = Data(output.utf8)
+        if payload.count <= config.pointerThresholdBytes {
+            return .inline(output)
+        }
+
+        let summary = Self.makeSummary(text: output, maxChars: config.summaryMaxChars)
+        let pointer = try await store.store(payload: payload, dataType: .document, summary: summary)
+
+        let replacement = """
+        [POINTER id=\(pointer.id) tool=\(toolName) bytes=\(pointer.byteSize)] \(pointer.summary)
+        Use resolve_pointer(pointer_id: "\(pointer.id)") to access the full payload.
+        """
+
+        return .pointer(pointer, replacementText: replacement)
+    }
+
+    static func makeSummary(text: String, maxChars: Int) -> String {
+        let maxChars = max(0, maxChars)
+        guard text.count > maxChars else {
+            return text
+        }
+
+        let end = text.index(text.startIndex, offsetBy: maxChars)
+        return String(text[..<end]) + "..."
+    }
+}
+
+public actor InMemoryPointerStore: PointerStore {
+    private var payloadByID: [String: Data]
+
+    public init() {
+        self.payloadByID = [:]
+    }
+
+    public func store(payload: Data, dataType: MemoryPointer.DataType, summary: String) async throws -> MemoryPointer {
+        let id = Self.pointerID(for: payload)
+        payloadByID[id] = payload
+        return MemoryPointer(id: id, dataType: dataType, byteSize: payload.count, summary: summary)
+    }
+
+    public func resolve(pointerID: String) async throws -> Data {
+        guard let payload = payloadByID[pointerID] else {
+            throw MembraneError.pointerResolutionFailed(pointerID: pointerID)
+        }
+        return payload
+    }
+
+    public func delete(pointerID: String) async {
+        payloadByID.removeValue(forKey: pointerID)
+    }
+
+    private static func pointerID(for payload: Data) -> String {
+        let digest = SHA256.hash(data: payload)
+        let hex = digest.map { String(format: "%02x", $0) }.joined()
+        return "ptr_\(hex.prefix(12))"
+    }
+}

--- a/Sources/Membrane/Stages/Intake/RAPTORRetriever.swift
+++ b/Sources/Membrane/Stages/Intake/RAPTORRetriever.swift
@@ -1,0 +1,62 @@
+import MembraneCore
+
+public protocol RAPTORIndex: Sendable {
+    func search(query: String, topK: Int) async throws -> [RAPTORNode]
+}
+
+public struct RAPTORRetriever: Sendable {
+    private let index: any RAPTORIndex
+    private let topK: Int
+    private let defaultImportance: Double
+    private let defaultTier: CompressionTier
+
+    public init(
+        index: any RAPTORIndex,
+        topK: Int = 8,
+        defaultImportance: Double = 0.6,
+        defaultTier: CompressionTier = .gist
+    ) {
+        self.index = index
+        self.topK = max(0, topK)
+        self.defaultImportance = defaultImportance
+        self.defaultTier = defaultTier
+    }
+
+    public func retrieve(query: String, budget: ContextBudget) async throws -> [ContextSlice] {
+        let candidates = try await index.search(query: query, topK: topK)
+        let ordered = candidates.sorted(by: Self.isOrderedBefore(lhs:rhs:))
+
+        var remaining = max(0, budget.ceiling(for: .retrieval))
+        var output: [ContextSlice] = []
+
+        for node in ordered {
+            if node.tokenCount > remaining {
+                break
+            }
+
+            output.append(
+                ContextSlice(
+                    content: node.text,
+                    tokenCount: node.tokenCount,
+                    importance: defaultImportance,
+                    source: .retrieval,
+                    tier: defaultTier,
+                    timestamp: .now
+                )
+            )
+            remaining -= node.tokenCount
+        }
+
+        return output
+    }
+
+    private static func isOrderedBefore(lhs: RAPTORNode, rhs: RAPTORNode) -> Bool {
+        if lhs.depth != rhs.depth {
+            return lhs.depth < rhs.depth
+        }
+        return lhs.id < rhs.id
+    }
+}
+
+// Task 21 integration note: MembraneWax will provide a RAPTORIndex implementation
+// backed by Wax persistence so retrieval uses durable tree nodes.

--- a/Sources/Membrane/Stages/Page/MemGPTPager.swift
+++ b/Sources/Membrane/Stages/Page/MemGPTPager.swift
@@ -1,0 +1,90 @@
+import MembraneCore
+
+/// Stage 4 pager for open-model pipelines. It evicts low-importance slices
+/// from retrieval/memory/history until token pressure is below threshold.
+public actor MemGPTPager: PageStage {
+    private let pressureThreshold: Double
+    private let keepRecentHistoryTurns: Int
+
+    public init(pressureThreshold: Double = 0.85, keepRecentHistoryTurns: Int = 3) {
+        self.pressureThreshold = min(max(pressureThreshold, 0.0), 1.0)
+        self.keepRecentHistoryTurns = max(keepRecentHistoryTurns, 0)
+    }
+
+    public func process(_ input: CompressedContext, budget: ContextBudget) async throws -> PagedContext {
+        var window = input.window
+        var pagedOut: [ContextSlice] = []
+
+        let thresholdTokens = Int(Double(budget.totalTokens) * pressureThreshold)
+        guard window.totalTokenCount > thresholdTokens else {
+            return PagedContext(window: window, budget: budget, pagedOut: [])
+        }
+
+        while window.totalTokenCount > thresholdTokens {
+            guard let candidate = nextEvictionCandidate(from: window) else {
+                throw MembraneError.contextWindowExceeded(totalTokens: window.totalTokenCount, limit: thresholdTokens)
+            }
+
+            switch candidate.source {
+            case .retrieval:
+                pagedOut.append(window.retrieval.remove(at: candidate.index))
+            case .memory:
+                pagedOut.append(window.memory.remove(at: candidate.index))
+            case .history:
+                pagedOut.append(window.history.remove(at: candidate.index))
+            default:
+                throw MembraneError.pagingStorageUnavailable(reason: "Unsupported source for paging: \(candidate.source.rawValue)")
+            }
+        }
+
+        return PagedContext(window: window, budget: budget, pagedOut: pagedOut)
+    }
+
+    private func nextEvictionCandidate(from window: ContextWindow) -> EvictionCandidate? {
+        var candidates: [EvictionCandidate] = []
+
+        for (index, slice) in window.retrieval.enumerated() {
+            candidates.append(EvictionCandidate(source: .retrieval, index: index, slice: slice))
+        }
+
+        for (index, slice) in window.memory.enumerated() {
+            candidates.append(EvictionCandidate(source: .memory, index: index, slice: slice))
+        }
+
+        let evictableHistoryCount = max(0, window.history.count - keepRecentHistoryTurns)
+        for (index, slice) in window.history.prefix(evictableHistoryCount).enumerated() {
+            candidates.append(EvictionCandidate(source: .history, index: index, slice: slice))
+        }
+
+        return candidates.min { lhs, rhs in
+            if lhs.slice.importance != rhs.slice.importance {
+                return lhs.slice.importance < rhs.slice.importance
+            }
+
+            if lhs.sourcePriority != rhs.sourcePriority {
+                return lhs.sourcePriority < rhs.sourcePriority
+            }
+
+            return lhs.index < rhs.index
+        }
+    }
+}
+
+private struct EvictionCandidate {
+    let source: ContextSource
+    let index: Int
+    let slice: ContextSlice
+
+    var sourcePriority: Int {
+        switch source {
+        case .retrieval:
+            return 0
+        case .memory:
+            return 1
+        case .history:
+            return 2
+        default:
+            return 3
+        }
+    }
+}

--- a/Sources/MembraneContextCore/MembraneContextCoreBackend.swift
+++ b/Sources/MembraneContextCore/MembraneContextCoreBackend.swift
@@ -1,0 +1,118 @@
+import Foundation
+import ContextCore
+import MembraneCore
+
+public actor MembraneContextCoreBackend: MembraneContextBackend {
+    public let backendID = "contextcore"
+
+    private let configuration: ContextConfiguration
+    private let fileManager: FileManager
+    private var lastSnapshot: ContextSnapshot?
+
+    public init(
+        configuration: ContextConfiguration = .default,
+        fileManager: FileManager = .default
+    ) {
+        self.configuration = configuration
+        self.fileManager = fileManager
+    }
+
+    public func prepare(
+        request: ContextRequest,
+        budget: ContextBudget,
+        snapshot: ContextSnapshot?
+    ) async throws -> MembraneBackendPreparation {
+        if let snapshot {
+            lastSnapshot = snapshot.normalized()
+        }
+
+        let context = try await makeContext(from: request)
+        let window = try await context.buildWindow(
+            currentTask: request.userInput,
+            maxTokens: budget.totalTokens
+        )
+
+        let contextualPrompt = makePrompt(
+            basePrompt: request.basePrompt.isEmpty ? request.userInput : request.basePrompt,
+            supplementalContext: window.formatted(style: .raw)
+        )
+
+        let backendState = try await checkpointData(for: context)
+        let backendSnapshot = ContextSnapshot(
+            budget: snapshot?.budget ?? .init(totalTokens: budget.totalTokens),
+            csoSummaries: [],
+            pagingCursor: nil,
+            toolState: snapshot?.toolState ?? .init(mode: .allowAll, loadedToolNames: [], allowListToolNames: [], usageCounts: []),
+            pointerIDs: snapshot?.pointerIDs ?? [],
+            backendID: backendID,
+            backendState: backendState
+        ).normalized()
+        lastSnapshot = backendSnapshot
+
+        return MembraneBackendPreparation(
+            plan: ContextPlan(
+                prompt: contextualPrompt,
+                systemPrompt: request.systemPrompt,
+                toolPlan: request.toolPlan,
+                budget: budget,
+                metadata: request.metadata
+            ),
+            snapshot: backendSnapshot
+        )
+    }
+
+    public func restore(snapshot: ContextSnapshot?) async throws {
+        lastSnapshot = snapshot?.normalized()
+    }
+
+    public func snapshot() async throws -> ContextSnapshot? {
+        lastSnapshot
+    }
+
+    private func makeContext(from request: ContextRequest) async throws -> AgentContext {
+        let context = try AgentContext(configuration: configuration)
+        let sessionID = UUID(uuidString: request.metadata.sessionID) ?? UUID()
+        try await context.beginSession(id: sessionID, systemPrompt: request.systemPrompt)
+
+        let slices = request.memories + request.retrieval
+        for slice in slices {
+            try await context.append(
+                turn: Turn(
+                    role: .assistant,
+                    content: slice.content,
+                    timestamp: Date(),
+                    tokenCount: max(1, slice.tokenCount)
+                )
+            )
+        }
+
+        return context
+    }
+
+    private func makePrompt(basePrompt: String, supplementalContext: String) -> String {
+        let trimmedContext = supplementalContext.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmedContext.isEmpty == false else {
+            return basePrompt
+        }
+        return """
+        \(basePrompt)
+
+        Relevant Context:
+        \(trimmedContext)
+        """
+    }
+
+    private func checkpointData(for context: AgentContext) async throws -> Data {
+        let url = temporaryCheckpointURL()
+        try await context.checkpoint(to: url)
+        defer { try? fileManager.removeItem(at: url) }
+        return try Data(contentsOf: url)
+    }
+
+    private func temporaryCheckpointURL() -> URL {
+        let base = fileManager.temporaryDirectory
+            .appendingPathComponent("membrane-contextcore", isDirectory: true)
+        try? fileManager.createDirectory(at: base, withIntermediateDirectories: true)
+        return base.appendingPathComponent(UUID().uuidString).appendingPathExtension("json")
+    }
+}

--- a/Sources/MembraneCore/Backends/MembraneContextBackend.swift
+++ b/Sources/MembraneCore/Backends/MembraneContextBackend.swift
@@ -1,0 +1,22 @@
+public struct MembraneBackendPreparation: Sendable {
+    public let plan: ContextPlan
+    public let snapshot: ContextSnapshot?
+
+    public init(plan: ContextPlan, snapshot: ContextSnapshot? = nil) {
+        self.plan = plan
+        self.snapshot = snapshot
+    }
+}
+
+public protocol MembraneContextBackend: Sendable {
+    var backendID: String { get }
+
+    func prepare(
+        request: ContextRequest,
+        budget: ContextBudget,
+        snapshot: ContextSnapshot?
+    ) async throws -> MembraneBackendPreparation
+
+    func restore(snapshot: ContextSnapshot?) async throws
+    func snapshot() async throws -> ContextSnapshot?
+}

--- a/Sources/MembraneCore/Budget/BucketID.swift
+++ b/Sources/MembraneCore/Budget/BucketID.swift
@@ -1,0 +1,11 @@
+public enum BucketID: String, Sendable, CaseIterable, Codable, Hashable {
+    case system
+    case history
+    case memory
+    case tools
+    case retrieval
+    case toolIO
+    case outputReserve
+    case protocolOverhead
+    case safetyMargin
+}

--- a/Sources/MembraneCore/Budget/BudgetProfile.swift
+++ b/Sources/MembraneCore/Budget/BudgetProfile.swift
@@ -1,0 +1,56 @@
+public enum BudgetProfile: Sendable, Equatable {
+    case foundationModels4K
+    case openModel8K
+    case cloud200K
+    case custom(buckets: [BucketID: Int])
+
+    public func ceilings(for totalTokens: Int) -> [BucketID: Int] {
+        switch self {
+        case .foundationModels4K:
+            return [
+                .system: 400,
+                .history: 800,
+                .memory: 300,
+                .tools: 500,
+                .retrieval: 900,
+                .toolIO: 0,
+                .outputReserve: 1000,
+                .protocolOverhead: 0,
+                .safetyMargin: 196,
+            ]
+        case .openModel8K:
+            return [
+                .system: 500,
+                .history: 1500,
+                .memory: 800,
+                .tools: 800,
+                .retrieval: 2500,
+                .toolIO: 0,
+                .outputReserve: 2000,
+                .protocolOverhead: 0,
+                .safetyMargin: 92,
+            ]
+        case .cloud200K:
+            let system = totalTokens / 20
+            let outputReserve = totalTokens / 5
+            let tools = totalTokens / 10
+            let history = totalTokens / 4
+            let retrieval = totalTokens / 4
+            let memory = totalTokens / 10
+            let accounted = system + outputReserve + tools + history + retrieval + memory
+            return [
+                .system: system,
+                .history: history,
+                .memory: memory,
+                .tools: tools,
+                .retrieval: retrieval,
+                .toolIO: 0,
+                .outputReserve: outputReserve,
+                .protocolOverhead: 0,
+                .safetyMargin: max(totalTokens - accounted, 0),
+            ]
+        case .custom(let buckets):
+            return buckets
+        }
+    }
+}

--- a/Sources/MembraneCore/Budget/ContextBudget.swift
+++ b/Sources/MembraneCore/Budget/ContextBudget.swift
@@ -1,0 +1,118 @@
+import OrderedCollections
+
+public struct ContextBudget: Sendable {
+    public struct BucketAllocation: Sendable {
+        public let ceiling: Int
+        public private(set) var allocated: Int
+
+        public var remaining: Int {
+            max(ceiling - allocated, 0)
+        }
+
+        public init(ceiling: Int, allocated: Int = 0) {
+            self.ceiling = ceiling
+            self.allocated = allocated
+        }
+
+        mutating func allocate(_ tokens: Int) {
+            allocated += tokens
+        }
+    }
+
+    public let totalTokens: Int
+    private var buckets: OrderedDictionary<BucketID, BucketAllocation>
+    public private(set) var kvBytesPerToken: Int?
+    public private(set) var kvMemoryBudgetBytes: Int?
+
+    public init(
+        totalTokens: Int,
+        profile: BudgetProfile,
+        kvBytesPerToken: Int? = nil,
+        kvMemoryBudgetBytes: Int? = nil
+    ) {
+        self.totalTokens = totalTokens
+        self.kvBytesPerToken = kvBytesPerToken
+        self.kvMemoryBudgetBytes = kvMemoryBudgetBytes
+
+        let profileCeilings = profile.ceilings(for: totalTokens)
+        var ordered = OrderedDictionary<BucketID, BucketAllocation>()
+        for bucket in BucketID.allCases {
+            let ceiling = max(profileCeilings[bucket] ?? 0, 0)
+            ordered[bucket] = BucketAllocation(ceiling: ceiling)
+        }
+        self.buckets = ordered
+    }
+
+    public func ceiling(for bucket: BucketID) -> Int {
+        buckets[bucket]?.ceiling ?? 0
+    }
+
+    public func remaining(for bucket: BucketID) -> Int {
+        buckets[bucket]?.remaining ?? 0
+    }
+
+    public func allocated(for bucket: BucketID) -> Int {
+        buckets[bucket]?.allocated ?? 0
+    }
+
+    private mutating func setKVSizing(kvBytesPerToken: Int?, kvMemoryBudgetBytes: Int?) {
+        self.kvBytesPerToken = kvBytesPerToken
+        self.kvMemoryBudgetBytes = kvMemoryBudgetBytes
+    }
+
+    public func withKVSizing(kvBytesPerToken: Int?, kvMemoryBudgetBytes: Int?) -> ContextBudget {
+        var copy = self
+        copy.setKVSizing(kvBytesPerToken: kvBytesPerToken, kvMemoryBudgetBytes: kvMemoryBudgetBytes)
+        return copy
+    }
+
+    public var totalAllocated: Int {
+        buckets.values.reduce(0) { partial, allocation in
+            partial + allocation.allocated
+        }
+    }
+
+    public var totalRemaining: Int {
+        max(totalTokens - totalAllocated, 0)
+    }
+
+    public var maxSequenceLength: Int? {
+        guard let bytesPerToken = kvBytesPerToken,
+              let memoryBudget = kvMemoryBudgetBytes,
+              bytesPerToken > 0 else {
+            return nil
+        }
+
+        return memoryBudget / bytesPerToken
+    }
+
+    public mutating func allocate(_ tokens: Int, to bucket: BucketID) throws {
+        guard tokens >= 0 else {
+            throw MembraneError.budgetExceeded(bucket: bucket, requested: tokens, available: 0)
+        }
+
+        guard var allocation = buckets[bucket] else {
+            throw MembraneError.budgetExceeded(bucket: bucket, requested: tokens, available: 0)
+        }
+
+        let available = min(allocation.remaining, totalRemaining)
+        guard tokens <= available else {
+            throw MembraneError.budgetExceeded(bucket: bucket, requested: tokens, available: available)
+        }
+
+        allocation.allocate(tokens)
+        buckets[bucket] = allocation
+    }
+
+    public mutating func reset(_ bucket: BucketID) {
+        guard let allocation = buckets[bucket] else {
+            return
+        }
+
+        buckets[bucket] = BucketAllocation(ceiling: allocation.ceiling)
+    }
+
+    public var bucketAllocations: [BucketID: Int] {
+        Dictionary(uniqueKeysWithValues: buckets.map { ($0.key, $0.value.allocated) })
+    }
+}

--- a/Sources/MembraneCore/Errors/MembraneError.swift
+++ b/Sources/MembraneCore/Errors/MembraneError.swift
@@ -1,0 +1,36 @@
+public enum RecoveryStrategy: Sendable {
+    case compressMore
+    case evictAndRetry
+    case offloadToDisk
+    case fallbackToInMemory
+    case fail
+}
+
+public enum MembraneError: Error, Sendable {
+    case budgetExceeded(bucket: BucketID, requested: Int, available: Int)
+    case contextWindowExceeded(totalTokens: Int, limit: Int)
+    case kvMemoryExceeded(bytes: Int, limit: Int)
+    case compressionFailed(stage: String, reason: String)
+    case csoUpdateFailed(reason: String)
+    case surrogateGenerationFailed(reason: String)
+    case pagingStorageUnavailable(reason: String)
+    case kvSwapIOError(reason: String)
+    case pointerResolutionFailed(pointerID: String)
+    case stageTimeout(stage: String, elapsed: Duration)
+    case checkpointRecoveryFailed(reason: String)
+
+    public var recoveryStrategy: RecoveryStrategy {
+        switch self {
+        case .budgetExceeded:
+            return .compressMore
+        case .contextWindowExceeded:
+            return .evictAndRetry
+        case .kvMemoryExceeded:
+            return .offloadToDisk
+        case .pagingStorageUnavailable:
+            return .fallbackToInMemory
+        default:
+            return .fail
+        }
+    }
+}

--- a/Sources/MembraneCore/MembraneCore.swift
+++ b/Sources/MembraneCore/MembraneCore.swift
@@ -1,0 +1,1 @@
+// MembraneCore — Protocols, value types, and budget algebra for context management.

--- a/Sources/MembraneCore/Pipeline/MembraneStage.swift
+++ b/Sources/MembraneCore/Pipeline/MembraneStage.swift
@@ -1,0 +1,11 @@
+/// Pipeline stage contract.
+///
+/// Budget authority is the standalone `budget` parameter. Wrapper types carry
+/// snapshots for convenience, but each stage must apply decisions using the
+/// explicit budget passed into `process`.
+public protocol MembraneStage: Actor, Sendable {
+    associatedtype Input: Sendable
+    associatedtype Output: Sendable
+
+    func process(_ input: Input, budget: ContextBudget) async throws -> Output
+}

--- a/Sources/MembraneCore/Pipeline/StageTypes.swift
+++ b/Sources/MembraneCore/Pipeline/StageTypes.swift
@@ -1,0 +1,79 @@
+public protocol IntakeStage: MembraneStage where Input == ContextRequest, Output == ContextWindow {}
+public protocol BudgetStage: MembraneStage where Input == ContextWindow, Output == BudgetedContext {}
+public protocol CompressStage: MembraneStage where Input == BudgetedContext, Output == CompressedContext {}
+public protocol PageStage: MembraneStage where Input == CompressedContext, Output == PagedContext {}
+public protocol EmitStage: MembraneStage where Input == PagedContext, Output == ContextPlan {}
+
+public struct BudgetedContext: Sendable {
+    public let window: ContextWindow
+    public let budget: ContextBudget
+
+    public init(window: ContextWindow, budget: ContextBudget) {
+        self.window = window
+        self.budget = budget
+    }
+}
+
+public struct CompressionReport: Sendable {
+    public let originalTokens: Int
+    public let compressedTokens: Int
+    public let techniquesApplied: [String]
+
+    public var ratio: Double {
+        Double(compressedTokens) / Double(max(originalTokens, 1))
+    }
+
+    public init(originalTokens: Int, compressedTokens: Int, techniquesApplied: [String]) {
+        self.originalTokens = originalTokens
+        self.compressedTokens = compressedTokens
+        self.techniquesApplied = techniquesApplied
+    }
+}
+
+public struct CompressedContext: Sendable {
+    public let window: ContextWindow
+    public let budget: ContextBudget
+    public let compressionReport: CompressionReport
+
+    public init(window: ContextWindow, budget: ContextBudget, compressionReport: CompressionReport) {
+        self.window = window
+        self.budget = budget
+        self.compressionReport = compressionReport
+    }
+}
+
+public struct PagedContext: Sendable {
+    public let window: ContextWindow
+    public let budget: ContextBudget
+    public let pagedOut: [ContextSlice]
+
+    public init(window: ContextWindow, budget: ContextBudget, pagedOut: [ContextSlice]) {
+        self.window = window
+        self.budget = budget
+        self.pagedOut = pagedOut
+    }
+}
+
+public struct ContextPlan: Sendable {
+    public let prompt: String
+    public let systemPrompt: String
+    public let toolPlan: ToolPlan
+    public let budget: ContextBudget
+    public let metadata: ContextMetadata
+
+    public init(
+        prompt: String,
+        systemPrompt: String,
+        toolPlan: ToolPlan,
+        budget: ContextBudget,
+        metadata: ContextMetadata
+    ) {
+        self.prompt = prompt
+        self.systemPrompt = systemPrompt
+        self.toolPlan = toolPlan
+        self.budget = budget
+        self.metadata = metadata
+    }
+}
+
+public typealias PlannedRequest = ContextPlan

--- a/Sources/MembraneCore/Types/CompressionTier.swift
+++ b/Sources/MembraneCore/Types/CompressionTier.swift
@@ -1,0 +1,17 @@
+public enum CompressionTier: String, Sendable, Codable, Comparable {
+    case full
+    case gist
+    case micro
+
+    public var tokenBudgetMultiplier: Double {
+        switch self {
+        case .full: return 1.0
+        case .gist: return 0.25
+        case .micro: return 0.08
+        }
+    }
+
+    public static func < (lhs: CompressionTier, rhs: CompressionTier) -> Bool {
+        lhs.tokenBudgetMultiplier < rhs.tokenBudgetMultiplier
+    }
+}

--- a/Sources/MembraneCore/Types/ContextRequest.swift
+++ b/Sources/MembraneCore/Types/ContextRequest.swift
@@ -1,0 +1,42 @@
+public struct ContextRequest: Sendable {
+    public let systemPrompt: String
+    public let basePrompt: String
+    public let userInput: String
+    public let tools: [ToolManifest]
+    public let toolPlan: ToolPlan
+    public let history: [ContextSlice]
+    public let memories: [ContextSlice]
+    public let retrieval: [ContextSlice]
+    public let pointers: [MemoryPointer]
+    public let metadata: ContextMetadata
+    public let recallQuery: String?
+    public let recallLimit: Int
+
+    public init(
+        systemPrompt: String = "",
+        basePrompt: String = "",
+        userInput: String,
+        tools: [ToolManifest] = [],
+        toolPlan: ToolPlan = .allowAll,
+        history: [ContextSlice] = [],
+        memories: [ContextSlice] = [],
+        retrieval: [ContextSlice] = [],
+        pointers: [MemoryPointer] = [],
+        metadata: ContextMetadata = ContextMetadata(),
+        recallQuery: String? = nil,
+        recallLimit: Int = 3
+    ) {
+        self.systemPrompt = systemPrompt
+        self.basePrompt = basePrompt
+        self.userInput = userInput
+        self.tools = tools
+        self.toolPlan = toolPlan
+        self.history = history
+        self.memories = memories
+        self.retrieval = retrieval
+        self.pointers = pointers
+        self.metadata = metadata
+        self.recallQuery = recallQuery
+        self.recallLimit = max(1, recallLimit)
+    }
+}

--- a/Sources/MembraneCore/Types/ContextSlice.swift
+++ b/Sources/MembraneCore/Types/ContextSlice.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public struct ContextSlice: Sendable, Equatable {
+    public let content: String
+    public let tokenCount: Int
+    public let importance: Double
+    public let source: ContextSource
+    public let tier: CompressionTier
+    public let timestamp: ContinuousClock.Instant
+
+    public init(
+        content: String,
+        tokenCount: Int,
+        importance: Double = 0.8,
+        source: ContextSource,
+        tier: CompressionTier = .full,
+        timestamp: ContinuousClock.Instant = .now
+    ) {
+        self.content = content
+        self.tokenCount = tokenCount
+        self.importance = importance
+        self.source = source
+        self.tier = tier
+        self.timestamp = timestamp
+    }
+}

--- a/Sources/MembraneCore/Types/ContextSnapshot.swift
+++ b/Sources/MembraneCore/Types/ContextSnapshot.swift
@@ -1,0 +1,206 @@
+import Foundation
+
+public struct ContextSnapshot: Sendable, Codable, Equatable {
+    private enum Bounds {
+        static let maxBudgetAllocations = 64
+        static let maxLoadedToolNames = 128
+        static let maxAllowListToolNames = 128
+        static let maxUsageCounts = 256
+        static let maxCSOSummaries = 256
+        static let maxPointerIDs = 512
+    }
+
+    public struct BudgetSnapshot: Sendable, Codable, Equatable {
+        public struct BucketAllocationSnapshot: Sendable, Codable, Equatable {
+            public let bucketID: String
+            public let allocatedTokens: Int
+
+            public init(bucketID: String, allocatedTokens: Int) {
+                self.bucketID = bucketID
+                self.allocatedTokens = allocatedTokens
+            }
+        }
+
+        public let totalTokens: Int
+        public let allocations: [BucketAllocationSnapshot]
+        public let kvBytesPerToken: Int?
+        public let kvMemoryBudgetBytes: Int?
+        public let maxSequenceLength: Int?
+
+        public init(
+            totalTokens: Int,
+            allocations: [BucketAllocationSnapshot] = [],
+            kvBytesPerToken: Int? = nil,
+            kvMemoryBudgetBytes: Int? = nil,
+            maxSequenceLength: Int? = nil
+        ) {
+            self.totalTokens = totalTokens
+            self.allocations = allocations
+            self.kvBytesPerToken = kvBytesPerToken
+            self.kvMemoryBudgetBytes = kvMemoryBudgetBytes
+            self.maxSequenceLength = maxSequenceLength
+        }
+    }
+
+    public struct PagingCursor: Sendable, Codable, Equatable {
+        public let pageIndex: Int
+        public let lastEvictedFrameID: String?
+
+        public init(pageIndex: Int, lastEvictedFrameID: String?) {
+            self.pageIndex = pageIndex
+            self.lastEvictedFrameID = lastEvictedFrameID
+        }
+    }
+
+    public struct ToolState: Sendable, Codable, Equatable {
+        public enum Mode: String, Sendable, Codable, Equatable {
+            case allowAll
+            case allowList
+            case jit
+        }
+
+        public struct UsageCount: Sendable, Codable, Equatable {
+            public let toolName: String
+            public let count: Int
+
+            public init(toolName: String, count: Int) {
+                self.toolName = toolName
+                self.count = count
+            }
+        }
+
+        public let mode: Mode
+        public let loadedToolNames: [String]
+        public let allowListToolNames: [String]
+        public let usageCounts: [UsageCount]
+
+        public init(
+            mode: Mode,
+            loadedToolNames: [String],
+            allowListToolNames: [String],
+            usageCounts: [UsageCount]
+        ) {
+            self.mode = mode
+            self.loadedToolNames = loadedToolNames
+            self.allowListToolNames = allowListToolNames
+            self.usageCounts = usageCounts
+        }
+    }
+
+    public let budget: BudgetSnapshot
+    public let csoSummaries: [String]
+    public let pagingCursor: PagingCursor?
+    public let toolState: ToolState
+    public let pointerIDs: [String]
+    public let backendID: String?
+    public let backendState: Data?
+
+    public init(
+        budget: BudgetSnapshot,
+        csoSummaries: [String] = [],
+        pagingCursor: PagingCursor? = nil,
+        toolState: ToolState,
+        pointerIDs: [String] = [],
+        backendID: String? = nil,
+        backendState: Data? = nil
+    ) {
+        self.budget = budget
+        self.csoSummaries = csoSummaries
+        self.pagingCursor = pagingCursor
+        self.toolState = toolState
+        self.pointerIDs = pointerIDs
+        self.backendID = backendID
+        self.backendState = backendState
+    }
+
+    public func normalized() -> ContextSnapshot {
+        let normalizedAllocations = budget.allocations
+            .sorted { lhs, rhs in
+                if lhs.bucketID != rhs.bucketID {
+                    return lhs.bucketID < rhs.bucketID
+                }
+                return lhs.allocatedTokens < rhs.allocatedTokens
+            }
+            .prefix(Bounds.maxBudgetAllocations)
+            .map { $0 }
+
+        var usageByToolName: [String: Int] = [:]
+        usageByToolName.reserveCapacity(toolState.usageCounts.count)
+        for usage in toolState.usageCounts {
+            usageByToolName[usage.toolName, default: 0] += usage.count
+        }
+
+        let normalizedUsageCounts = usageByToolName
+            .map { ToolState.UsageCount(toolName: $0.key, count: $0.value) }
+            .sorted { lhs, rhs in
+                if lhs.toolName != rhs.toolName {
+                    return lhs.toolName < rhs.toolName
+                }
+                return lhs.count < rhs.count
+            }
+            .prefix(Bounds.maxUsageCounts)
+            .map { $0 }
+
+        let normalizedToolState = ToolState(
+            mode: toolState.mode,
+            loadedToolNames: Self.sortedUnique(toolState.loadedToolNames, limit: Bounds.maxLoadedToolNames),
+            allowListToolNames: Self.sortedUnique(toolState.allowListToolNames, limit: Bounds.maxAllowListToolNames),
+            usageCounts: normalizedUsageCounts
+        )
+
+        return ContextSnapshot(
+            budget: BudgetSnapshot(
+                totalTokens: budget.totalTokens,
+                allocations: normalizedAllocations,
+                kvBytesPerToken: budget.kvBytesPerToken,
+                kvMemoryBudgetBytes: budget.kvMemoryBudgetBytes,
+                maxSequenceLength: budget.maxSequenceLength
+            ),
+            csoSummaries: Self.sortedUnique(csoSummaries, limit: Bounds.maxCSOSummaries),
+            pagingCursor: pagingCursor,
+            toolState: normalizedToolState,
+            pointerIDs: Self.sortedUnique(pointerIDs, limit: Bounds.maxPointerIDs),
+            backendID: backendID,
+            backendState: backendState
+        )
+    }
+
+    private static func sortedUnique(_ values: [String], limit: Int) -> [String] {
+        Array(Set(values)).sorted().prefix(limit).map { $0 }
+    }
+}
+
+public struct ContextProvenance: Sendable, Codable, Equatable {
+    public let backendID: String
+    public let recordID: String
+    public let kind: String
+    public let metadata: [String: String]
+
+    public init(
+        backendID: String,
+        recordID: String,
+        kind: String,
+        metadata: [String: String] = [:]
+    ) {
+        self.backendID = backendID
+        self.recordID = recordID
+        self.kind = kind
+        self.metadata = metadata
+    }
+}
+
+public struct ContextRecallCandidate: Sendable, Codable, Equatable {
+    public let content: String
+    public let score: Double?
+    public let provenance: ContextProvenance
+
+    public init(content: String, score: Double? = nil, provenance: ContextProvenance) {
+        self.content = content
+        self.score = score
+        self.provenance = provenance
+    }
+}
+
+public protocol ContextRecallStore: Sendable {
+    func recall(query: String, limit: Int) async throws -> [ContextRecallCandidate]
+}

--- a/Sources/MembraneCore/Types/ContextSource.swift
+++ b/Sources/MembraneCore/Types/ContextSource.swift
@@ -1,0 +1,8 @@
+public enum ContextSource: String, Sendable, Codable, Hashable {
+    case system
+    case history
+    case memory
+    case tool
+    case retrieval
+    case pointer
+}

--- a/Sources/MembraneCore/Types/ContextStateObject.swift
+++ b/Sources/MembraneCore/Types/ContextStateObject.swift
@@ -1,0 +1,85 @@
+public struct ContextStateObject: Sendable, Codable {
+    public private(set) var entities: [String]
+    public var decisions: [String]
+    public var openQuestions: [String]
+    public var keyFacts: [String]
+    public var turnCount: Int
+
+    public init(
+        entities: [String] = [],
+        decisions: [String] = [],
+        openQuestions: [String] = [],
+        keyFacts: [String] = [],
+        turnCount: Int = 0
+    ) {
+        self.entities = []
+        self.decisions = decisions
+        self.openQuestions = openQuestions
+        self.keyFacts = keyFacts
+        self.turnCount = turnCount
+        for entity in entities {
+            addEntity(entity)
+        }
+        trimBounds()
+    }
+
+    public mutating func addEntity(_ entity: String) {
+        guard !entity.isEmpty else {
+            return
+        }
+
+        if !entities.contains(entity) {
+            entities.append(entity)
+        }
+
+        if entities.count > 50 {
+            entities = Array(entities.suffix(50))
+        }
+    }
+
+    public mutating func merge(with other: ContextStateObject) {
+        for entity in other.entities {
+            addEntity(entity)
+        }
+
+        decisions.append(contentsOf: other.decisions)
+        openQuestions.append(contentsOf: other.openQuestions)
+        keyFacts.append(contentsOf: other.keyFacts)
+        turnCount = max(turnCount, other.turnCount)
+        trimBounds()
+    }
+
+    public func formatted() -> String {
+        var lines: [String] = []
+        if !entities.isEmpty {
+            lines.append("Entities: \(entities.joined(separator: ", "))")
+        }
+        if !decisions.isEmpty {
+            lines.append("Decisions: \(decisions.joined(separator: "; "))")
+        }
+        if !openQuestions.isEmpty {
+            lines.append("OpenQuestions: \(openQuestions.joined(separator: "; "))")
+        }
+        if !keyFacts.isEmpty {
+            lines.append("KeyFacts: \(keyFacts.joined(separator: "; "))")
+        }
+        lines.append("TurnCount: \(turnCount)")
+        return lines.joined(separator: "\n")
+    }
+
+    public var estimatedTokenCount: Int {
+        max(formatted().count / 4, 1)
+    }
+
+    package mutating func trimBounds() {
+        if decisions.count > 20 {
+            decisions = Array(decisions.suffix(20))
+        }
+        if openQuestions.count > 10 {
+            openQuestions = Array(openQuestions.suffix(10))
+        }
+        if keyFacts.count > 30 {
+            keyFacts = Array(keyFacts.suffix(30))
+        }
+    }
+}

--- a/Sources/MembraneCore/Types/ContextWindow.swift
+++ b/Sources/MembraneCore/Types/ContextWindow.swift
@@ -1,0 +1,53 @@
+public struct ContextWindow: Sendable {
+    public var systemPrompt: ContextSlice
+    public var memory: [ContextSlice]
+    public var tools: [ToolManifest]
+    public var toolPlan: ToolPlan
+    public var history: [ContextSlice]
+    public var retrieval: [ContextSlice]
+    public var pointers: [MemoryPointer]
+    public var metadata: ContextMetadata
+
+    public init(
+        systemPrompt: ContextSlice,
+        memory: [ContextSlice],
+        tools: [ToolManifest],
+        toolPlan: ToolPlan,
+        history: [ContextSlice],
+        retrieval: [ContextSlice],
+        pointers: [MemoryPointer],
+        metadata: ContextMetadata
+    ) {
+        self.systemPrompt = systemPrompt
+        self.memory = memory
+        self.tools = tools
+        self.toolPlan = toolPlan
+        self.history = history
+        self.retrieval = retrieval
+        self.pointers = pointers
+        self.metadata = metadata
+    }
+
+    public var totalTokenCount: Int {
+        systemPrompt.tokenCount
+        + memory.reduce(0) { $0 + $1.tokenCount }
+        + history.reduce(0) { $0 + $1.tokenCount }
+        + retrieval.reduce(0) { $0 + $1.tokenCount }
+    }
+}
+
+public struct ContextMetadata: Sendable, Equatable {
+    public var turnNumber: Int
+    public var sessionID: String
+    public var modelProfile: BudgetProfile
+
+    public init(
+        turnNumber: Int = 0,
+        sessionID: String = "",
+        modelProfile: BudgetProfile = .foundationModels4K
+    ) {
+        self.turnNumber = turnNumber
+        self.sessionID = sessionID
+        self.modelProfile = modelProfile
+    }
+}

--- a/Sources/MembraneCore/Types/MemoryPointer.swift
+++ b/Sources/MembraneCore/Types/MemoryPointer.swift
@@ -1,0 +1,21 @@
+public struct MemoryPointer: Sendable, Hashable, Codable {
+    public enum DataType: String, Sendable, Codable, Hashable {
+        case document
+        case matrix
+        case image
+        case binary
+        case code
+    }
+
+    public let id: String
+    public let dataType: DataType
+    public let byteSize: Int
+    public let summary: String
+
+    public init(id: String, dataType: DataType, byteSize: Int, summary: String) {
+        self.id = id
+        self.dataType = dataType
+        self.byteSize = byteSize
+        self.summary = summary
+    }
+}

--- a/Sources/MembraneCore/Types/ModelArchitectureInfo.swift
+++ b/Sources/MembraneCore/Types/ModelArchitectureInfo.swift
@@ -1,0 +1,34 @@
+public struct ModelArchitectureInfo: Sendable, Codable, Equatable {
+    public let numLayers: Int
+    public let numQueryHeads: Int
+    public let numKVHeads: Int
+    public let headDim: Int
+
+    public init(
+        numLayers: Int,
+        numQueryHeads: Int,
+        numKVHeads: Int,
+        headDim: Int
+    ) {
+        self.numLayers = numLayers
+        self.numQueryHeads = numQueryHeads
+        self.numKVHeads = numKVHeads
+        self.headDim = headDim
+    }
+
+    public var gqaRatio: Int {
+        guard numKVHeads > 0 else {
+            return 0
+        }
+        return numQueryHeads / numKVHeads
+    }
+
+    /// Approximate KV cache bytes per token for fp16 K/V:
+    /// 2 (K+V) * layers * KV heads * head dimension * 2 bytes/fp16 scalar.
+    public var kvBytesPerToken: Int {
+        guard numLayers > 0, numKVHeads > 0, headDim > 0 else {
+            return 0
+        }
+        return 2 * numLayers * numKVHeads * headDim * 2
+    }
+}

--- a/Sources/MembraneCore/Types/PointerStore.swift
+++ b/Sources/MembraneCore/Types/PointerStore.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public protocol PointerStore: Sendable {
+    func store(payload: Data, dataType: MemoryPointer.DataType, summary: String) async throws -> MemoryPointer
+    func resolve(pointerID: String) async throws -> Data
+    func delete(pointerID: String) async
+}

--- a/Sources/MembraneCore/Types/RAPTORNode.swift
+++ b/Sources/MembraneCore/Types/RAPTORNode.swift
@@ -1,0 +1,21 @@
+public struct RAPTORNode: Sendable, Codable, Equatable {
+    public let id: String
+    public let parentID: String?
+    public let depth: Int
+    public let text: String
+    public let tokenCount: Int
+
+    public init(
+        id: String,
+        parentID: String?,
+        depth: Int,
+        text: String,
+        tokenCount: Int
+    ) {
+        self.id = id
+        self.parentID = parentID
+        self.depth = depth
+        self.text = text
+        self.tokenCount = tokenCount
+    }
+}

--- a/Sources/MembraneCore/Types/ToolManifest.swift
+++ b/Sources/MembraneCore/Types/ToolManifest.swift
@@ -1,0 +1,19 @@
+public struct ToolManifest: Sendable, Equatable {
+    public let name: String
+    public let description: String
+    public var fullSchema: String?
+
+    public init(name: String, description: String, fullSchema: String? = nil) {
+        self.name = name
+        self.description = description
+        self.fullSchema = fullSchema
+    }
+
+    public var estimatedTokens: Int {
+        if let fullSchema {
+            return max(fullSchema.count / 4, 1)
+        }
+
+        return max((name.count + description.count) / 4, 1)
+    }
+}

--- a/Sources/MembraneCore/Types/ToolPlan.swift
+++ b/Sources/MembraneCore/Types/ToolPlan.swift
@@ -1,0 +1,31 @@
+public struct ToolIndexEntry: Sendable, Equatable, Codable {
+    public let name: String
+    public let description: String
+
+    public init(name: String, description: String) {
+        self.name = name
+        self.description = description
+    }
+}
+
+public enum ToolPlan: Sendable, Equatable, Codable {
+    case allowAll
+    case allowList(toolNames: [String])
+    case jit(index: [ToolIndexEntry], loadedToolNames: [String])
+
+    public static func allowList(normalized toolNames: [String]) -> ToolPlan {
+        .allowList(toolNames: Array(Set(toolNames)).sorted())
+    }
+
+    public static func jit(normalized index: [ToolIndexEntry], loaded loadedToolNames: [String]) -> ToolPlan {
+        .jit(
+            index: index.sorted { lhs, rhs in
+                if lhs.name != rhs.name {
+                    return lhs.name < rhs.name
+                }
+                return lhs.description < rhs.description
+            },
+            loadedToolNames: Array(Set(loadedToolNames)).sorted()
+        )
+    }
+}

--- a/Sources/Swarm/Agents/Agent+Workspace.swift
+++ b/Sources/Swarm/Agents/Agent+Workspace.swift
@@ -86,7 +86,7 @@ private extension Agent {
             .appendingPathComponent(safeCacheNamespace(cacheNamespace), isDirectory: true)
         try FileManager.default.createDirectory(at: memoryDirectory, withIntermediateDirectories: true)
 
-        #if SWARM_INTEGRATIONS
+        #if SWARM_INTEGRATIONS && canImport(ContextCore)
         return try DefaultAgentMemory(configuration: DefaultAgentMemory.Configuration(
             waxStoreURL: memoryDirectory.appendingPathComponent("wax-memory.mv2s")
         ))

--- a/Sources/Swarm/Agents/Agent.swift
+++ b/Sources/Swarm/Agents/Agent.swift
@@ -1129,7 +1129,7 @@ public struct Agent: AgentRuntime, Sendable {
     /// Prefer this over constructing integration types from macros or client code so
     /// trait gating stays inside the Swarm module.
     public static func makeDefaultMemory() throws -> any Memory {
-        #if SWARM_INTEGRATIONS
+        #if SWARM_INTEGRATIONS && canImport(ContextCore)
         if SwarmRuntimeEnvironment.isRunningTests {
             let root = FileManager.default.temporaryDirectory
                 .appendingPathComponent("SwarmDefaultMemoryTests", isDirectory: true)
@@ -1141,6 +1141,7 @@ public struct Agent: AgentRuntime, Sendable {
         }
         return try DefaultAgentMemory()
         #else
+        // Lean builds, or Integrations on non-Apple (no ContextCore link).
         return SlidingWindowMemory()
         #endif
     }
@@ -1362,7 +1363,7 @@ public struct Agent: AgentRuntime, Sendable {
                         query = input
                     }
                     var windowedContext = ""
-                    #if SWARM_INTEGRATIONS
+                    #if SWARM_INTEGRATIONS && canImport(ContextCore)
                     if let defaultMem = activeMemory as? DefaultAgentMemory {
                         windowedContext = await defaultMem.context(for: query, tokenLimit: historyBudget)
                     } else if let ccMemory = activeMemory as? ContextCoreMemory {

--- a/Sources/Swarm/Integration/Membrane/MembraneAgentAdapter.swift
+++ b/Sources/Swarm/Integration/Membrane/MembraneAgentAdapter.swift
@@ -1,5 +1,5 @@
 import Foundation
-#if SWARM_INTEGRATIONS
+#if SWARM_INTEGRATIONS && canImport(Membrane)
 import Membrane
 #endif
 
@@ -104,7 +104,7 @@ public protocol MembraneAgentAdapter: Sendable {
     func snapshotCheckpointData() async throws -> Data?
 }
 
-#if SWARM_INTEGRATIONS
+#if SWARM_INTEGRATIONS && canImport(Membrane)
 public actor DefaultMembraneAgentAdapter: MembraneAgentAdapter {
     public init(configuration: MembraneFeatureConfiguration = .default) {
         self.configuration = configuration

--- a/Sources/Swarm/Integration/Membrane/SessionMembraneAgentAdapter.swift
+++ b/Sources/Swarm/Integration/Membrane/SessionMembraneAgentAdapter.swift
@@ -1,4 +1,4 @@
-#if SWARM_INTEGRATIONS
+#if SWARM_INTEGRATIONS && canImport(Membrane)
 import Foundation
 import Membrane
 import MembraneCore

--- a/Sources/Swarm/Memory/CompositeMemory.swift
+++ b/Sources/Swarm/Memory/CompositeMemory.swift
@@ -25,7 +25,7 @@ actor CompositeMemory: Memory, MemoryPromptDescriptor, MemorySessionLifecycle, M
         self.memoryPromptGuidance = memoryPromptGuidance
         self.memoryPriority = memoryPriority
         self.tokenEstimator = tokenEstimator
-        #if SWARM_INTEGRATIONS
+        #if SWARM_INTEGRATIONS && canImport(ContextCore)
         self.trackedSessionMemory = trackedSessionMemory ?? memories.first { $0 is DefaultAgentMemory }
         #else
         self.trackedSessionMemory = trackedSessionMemory

--- a/Sources/Swarm/Memory/ContextCoreMemory.swift
+++ b/Sources/Swarm/Memory/ContextCoreMemory.swift
@@ -1,8 +1,9 @@
-#if SWARM_INTEGRATIONS
+#if SWARM_INTEGRATIONS && canImport(ContextCore)
 // ContextCoreMemory.swift
 // Swarm Framework
 //
 // ContextCore-backed memory implementation used by default in Swarm.
+// Apple-only: ContextCore is trait-linked only on Apple platforms (Metal/CoreML).
 
 import ContextCore
 import Foundation

--- a/Sources/Swarm/Memory/DefaultAgentMemory.swift
+++ b/Sources/Swarm/Memory/DefaultAgentMemory.swift
@@ -1,9 +1,10 @@
-#if SWARM_INTEGRATIONS
+#if SWARM_INTEGRATIONS && canImport(ContextCore)
 // DefaultAgentMemory.swift
 // Swarm Framework
 //
 // Default agent memory stack combining ContextCore working context with
 // Wax durable recall.
+// Apple-only: requires ContextCore (Metal/CoreML), which is not linked on Linux.
 
 import Foundation
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -44,7 +44,18 @@ HiveCore, Membrane, and ContextCore are native in-tree modules under Swarm
 `Sources/` (internal targets, not separate products). Wax remains an external
 package and is linked only with Integrations. Omitting the trait does **not**
 link Integrations modules into your app, and lean resolve does not pull
-Hive/Membrane/ContextCore packages.
+Hive/Membrane/ContextCore **package identities**. Trait still controls **link**;
+without `SWARM_CORE_ONLY=1`, resolve still downloads Wax, MetalANNS (→ GRDB),
+swift-crypto, swift-mutex, and swift-collections even when Integrations is off.
+
+**Platform note:** ContextCore and the full Membrane session stack need Apple
+frameworks (Metal/CoreML/Accelerate). On Linux, Integrations still enables Hive
+durable workflows, MembraneCore, and web helpers; default memory falls back to
+`SlidingWindowMemory` when ContextCore is unavailable.
+
+**Embeddings:** the CoreML `minilm-l6-v2.mlpackage` model is not bundled with
+Swarm. Without it, Integrations `DefaultAgentMemory` uses deterministic
+pseudo-embeddings until you supply the model under ContextCore resources.
 
 ### Xcode
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -40,9 +40,11 @@ Enable Integrations when you need any of:
 )
 ```
 
-SwiftPM may still **resolve** temporary remote packages (Hive/Membrane/ContextCore/Wax)
-listed in Swarm’s manifest until they are vendored in-tree; omitting the trait does
-**not** link those products into your app.
+HiveCore, Membrane, and ContextCore are native in-tree modules under Swarm
+`Sources/` (internal targets, not separate products). Wax remains an external
+package and is linked only with Integrations. Omitting the trait does **not**
+link Integrations modules into your app, and lean resolve does not pull
+Hive/Membrane/ContextCore packages.
 
 ### Xcode
 

--- a/docs/reference/front-facing-api.md
+++ b/docs/reference/front-facing-api.md
@@ -25,7 +25,12 @@ memory, Membrane adapters, and web helpers:
 HiveCore, Membrane, and ContextCore are native in-tree `Sources/` targets
 (internal modules, not separate products), linked only with Integrations.
 Wax remains a remote package + trait-gated product. Lean resolve does not pull
-Hive/Membrane/ContextCore package identities. See README Install.
+Hive/Membrane/ContextCore package identities, but still resolves Wax, MetalANNS
+(→ GRDB), swift-crypto, swift-mutex, and swift-collections unless
+`SWARM_CORE_ONLY=1`. ContextCore / full Membrane session stack are Apple-only
+(Metal/CoreML); Linux Integrations keeps Hive + MembraneCore + web helpers.
+`DefaultAgentMemory` (ContextCore + Wax) uses fallback pseudo-embeddings when
+the optional CoreML `minilm-l6-v2.mlpackage` is not present. See README Install.
 
 ## 1) Entry point and global configuration
 

--- a/docs/reference/front-facing-api.md
+++ b/docs/reference/front-facing-api.md
@@ -22,8 +22,10 @@ memory, Membrane adapters, and web helpers:
 | Durable execute with checkpoint / `resumeFrom` | Throws | Full Hive durable engine |
 | Membrane / web helpers | Unavailable or no-op | Linked and active |
 
-SwiftPM may still resolve temporary remotes listed in `Package.swift`; the trait
-controls **link**, not always package resolution. See README Install.
+HiveCore, Membrane, and ContextCore are native in-tree `Sources/` targets
+(internal modules, not separate products), linked only with Integrations.
+Wax remains a remote package + trait-gated product. Lean resolve does not pull
+Hive/Membrane/ContextCore package identities. See README Install.
 
 ## 1) Entry point and global configuration
 


### PR DESCRIPTION
## Summary

- Copy **HiveCore**, **Membrane** (`MembraneCore` / `MembraneContextCore` / `Membrane`), and **ContextCore** (`ContextCoreTypes` / `ContextCoreShaders` / `ContextCoreEngine` / `ContextCore`) into `Sources/` as **internal** SPM targets (no new library products).
- Remove remote packages `christopherkarani/{Hive,Membrane,ContextCore}` so lean resolve no longer pulls package identities `hive`, `membrane`, or `contextcore`.
- Trait-link those modules only when **Integrations** is on; keep **Wax** remote + trait-gated and **MetalANNS** remote for the ContextCore chain.
- Docs (`README`, `CLAUDE.md`, getting-started, front-facing-api) updated: H/M/CC are native under Integrations; Integrations stays **default off**; swift-syntax floor remains **≥ 601**.

## Why

Swarm is the source of truth for Integrations graph/memory paths. Vendoring avoids temporary remote resolution of Hive/Membrane/ContextCore for lean consumers while preserving module names (`import HiveCore`, `import Membrane`, `import ContextCore`).

## Test plan

- [x] `rg -n 'christopherkarani/(Hive|Membrane|ContextCore)' Package.swift` → empty
- [x] Lean resolve: no package identities `hive` / `membrane` / `contextcore`
- [x] `swift build`
- [x] `swift test --no-parallel` (1708 passed)
- [x] `swift build --traits Integrations`
- [x] `swift test --no-parallel --traits Integrations` (1838 passed)
- [x] `swift test --no-parallel --traits Integrations --filter HiveSwarmTests` (54 passed)
- [x] `swift run --traits Integrations SwarmCapabilityShowcase matrix` (all scenarios passed)
- [x] Adversarial review: no blockers (Wax/MetalANNS may still resolve when declared under `!coreOnly` — expected)

## Notes / follow-ups

- Standalone Hive/Membrane/ContextCore repos can be archived later; dual-repo sync is out of scope.
- Wax vendor remains a later step. MetalANNS stays remote.
- Linux Integrations vs Metal/MetalANNS remains a residual platform risk (same class as before for ContextCore on Apple frameworks).