### PR TITLE
fix: disable Wax MiniLM default traits under Integrations

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -63,7 +63,16 @@ if enableIntegrationModules {
         // collections/MetalANNS). With Integrations off, SPM does not pin them.
         // SWARM_CORE_ONLY=1 or SWARM_OMIT_INTEGRATION_TARGETS=1 drops this block.
         .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.13.5"),
-        .package(url: "https://github.com/christopherkarani/Wax.git", exact: "0.1.23"),
+        // Wax defaults MiniLMEmbeddings ON (~43MB CoreML bundle). Swarm default
+        // runtime paths leave enableVectorSearch=false and never require MiniLM
+        // embedders, so disable Wax package defaults (SE-0450 traits: []).
+        // Consumers that need BuiltInEmbeddings.miniLM can re-enable via their
+        // own Wax dependency traits: ["MiniLMEmbeddings"] (or [.defaults]).
+        .package(
+            url: "https://github.com/christopherkarani/Wax.git",
+            exact: "0.1.23",
+            traits: []
+        ),
         .package(url: "https://github.com/christopherkarani/MetalANNS.git", exact: "0.1.3"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "3.7.0"),
         .package(url: "https://github.com/swhitty/swift-mutex.git", from: "0.0.6"),


### PR DESCRIPTION
## Summary

- Disable Wax package default traits from Swarm (`traits: []` on the exact `0.1.23` pin) so Integrations no longer builds the unused MiniLM CoreML stack (~43MB).
- Aligns the Integrations graph with runtime defaults: `enableVectorSearch = false`, no `BuiltInEmbeddings` / MiniLM call sites, default `WaxMemory` / `DefaultAgentMemory` / web artifact store still use FTS-only Wax.
- Lean resolve remains unchanged (wax still trait-gated and denied by `verify-lean-resolve.sh`). GRDB + MetalANNS remain for intentional FTS / ContextCore paths.

## Context

Wax 0.1.23 defaults `MiniLMEmbeddings` ON. Swarm never required MiniLM on default Integrations paths, so consumers paid for a CoreML model they did not open. SE-0450 lets the consumer pass `traits: []` to turn defaults off while keeping the full `Wax` product (`Wax.Memory`, FrameStore, adapters).

Consumers that need built-in MiniLM can re-enable via their own Wax dependency traits (`["MiniLMEmbeddings"]` or `[.defaults]`).

## Test plan

- [x] Cold lean: `rm -rf .build Package.resolved && swift package resolve && bash scripts/ci/verify-lean-resolve.sh` (PASS, no wax)
- [x] Cold Integrations resolve pins `wax@0.1.23` (+ grdb, metalanns, …)
- [x] `swift build --traits Integrations --product Swarm` — no `WaxVectorSearchMiniLM` module/bundle
- [x] `swift test --no-parallel --traits Integrations --filter 'WaxMemoryTests|WaxIntegrationTests|ContextCoreDefaultMemoryTests'` — 22 passed
- [ ] CI: lean lane + full Integrations lane on this PR