### PR TITLE
fix: ship WaxChat example with Integrations and demo-gated memory turns

### DIFF
--- a/Examples/WaxChat/.gitignore
+++ b/Examples/WaxChat/.gitignore
@@ -1,0 +1,4 @@
+.build/
+.swiftpm/
+*.resolved
+DerivedData/

--- a/Examples/WaxChat/Package.swift
+++ b/Examples/WaxChat/Package.swift
@@ -1,0 +1,49 @@
+// swift-tools-version: 6.2
+import PackageDescription
+
+let package = Package(
+    name: "WaxChat",
+    platforms: [.macOS(.v26)],
+    products: [
+        .executable(name: "WaxChat", targets: ["WaxChat"]),
+        .library(name: "WaxChatCore", targets: ["WaxChatCore"]),
+    ],
+    dependencies: [
+        // WaxMemory + WebSearchTool require Integrations.
+        .package(name: "Swarm", path: "../../", traits: ["Integrations"]),
+    ],
+    targets: [
+        .target(
+            name: "WaxChatCore",
+            dependencies: [
+                .product(name: "Swarm", package: "Swarm"),
+            ],
+            path: "Sources/WaxChatCore",
+            swiftSettings: [
+                .enableExperimentalFeature("StrictConcurrency"),
+            ]
+        ),
+        .executableTarget(
+            name: "WaxChat",
+            dependencies: [
+                "WaxChatCore",
+                .product(name: "Swarm", package: "Swarm"),
+            ],
+            path: "Sources/WaxChat",
+            swiftSettings: [
+                .enableExperimentalFeature("StrictConcurrency"),
+            ]
+        ),
+        .testTarget(
+            name: "WaxChatCoreTests",
+            dependencies: [
+                "WaxChatCore",
+                .product(name: "Swarm", package: "Swarm"),
+            ],
+            path: "Tests/WaxChatCoreTests",
+            swiftSettings: [
+                .enableExperimentalFeature("StrictConcurrency"),
+            ]
+        ),
+    ]
+)

--- a/Examples/WaxChat/README.md
+++ b/Examples/WaxChat/README.md
@@ -1,0 +1,59 @@
+# WaxChat
+
+Standalone on-device chat AI app built on **Swarm**. Separate package from the Swarm library targets.
+
+## Capabilities
+
+| Capability | How |
+|---|---|
+| **Foundation Models** | Live path uses `FoundationModelsInferenceProvider` when Apple Intelligence is available |
+| **Web search** | Explicit `WebSearchTool` (`websearch`) on the agent; live when `TAVILY_API_KEY` is set |
+| **Wax memory** | Explicit `WaxMemory` store (durable `.mv2s`). Multi-turn uses `InMemorySession` + `syncSessionTurnsToWax` so conversation turns are stored/recalled on the Wax path (Swarm does not auto-persist explicit memory without a session) |
+| **Demo mode** | `--demo` uses a scripted provider so CI/sandbox runs without Apple Intelligence |
+
+## Layout
+
+```
+WaxChat/
+├── Package.swift          # path-depends on local Swarm (../../)
+├── Sources/
+│   ├── WaxChatCore/       # testable agent factory + session orchestration
+│   └── WaxChat/           # CLI entry point
+└── Tests/
+    └── WaxChatCoreTests/
+```
+
+## Run
+
+From this directory:
+
+```bash
+# Deterministic walkthrough (no Apple Intelligence / no API keys required)
+swift run WaxChat --demo
+
+# Live on-device Foundation Models (requires Apple Intelligence)
+swift run WaxChat
+swift run WaxChat "What's the weather story for Kyoto this week?"
+
+# Optional live websearch backend
+export TAVILY_API_KEY=tvly-...
+swift run WaxChat "Search for Swarm Foundation Models agents"
+```
+
+## Tests
+
+```bash
+swift test --package-path .
+# or from this directory:
+swift test
+```
+
+Tests drive the shipped `ChatAgentFactory` / `ChatSession` path: websearch registration, Wax store→recall, and demo orchestration markers.
+
+## Environment
+
+| Variable | Required | Purpose |
+|---|---|---|
+| `TAVILY_API_KEY` | No | Enables live Tavily websearch; without it, websearch still runs (local/empty results) |
+
+Requires **macOS 26+** and a path dependency on the Swarm package at `../../`.

--- a/Examples/WaxChat/Sources/WaxChat/main.swift
+++ b/Examples/WaxChat/Sources/WaxChat/main.swift
@@ -1,0 +1,64 @@
+// WaxChat — on-device chat AI using Swarm + Foundation Models + websearch + Wax memory.
+//
+// Usage:
+//   swift run WaxChat              # live Foundation Models when available
+//   swift run WaxChat --demo       # scripted provider (always deterministic)
+//   swift run WaxChat --help
+
+import Foundation
+import Swarm
+import WaxChatCore
+
+@main
+struct WaxChatMain {
+    static func main() async {
+        do {
+            try await run(arguments: Array(CommandLine.arguments.dropFirst()))
+        } catch {
+            fputs("WaxChat error: \(error)\n", stderr)
+            exit(1)
+        }
+    }
+}
+
+private func run(arguments: [String]) async throws {
+    if arguments.contains("-h") || arguments.contains("--help") {
+        print(
+            """
+            WaxChat — on-device Swarm chat with Foundation Models, websearch, and Wax memory
+
+            Usage:
+              swift run WaxChat [--demo] [prompt]
+
+            Options:
+              --demo   Use a scripted inference provider (no Foundation Models required)
+              --help   Show this help
+
+            Environment:
+              TAVILY_API_KEY   Optional. Enables live websearch via Tavily when set.
+
+            Without --demo, uses Apple Foundation Models when the system model is available.
+            Memory is Wax-backed (durable). Websearch is always registered on the agent.
+            """
+        )
+        return
+    }
+
+    let demoMode = arguments.contains("--demo")
+    let promptParts = arguments.filter { $0 != "--demo" }
+    let userPrompt = promptParts.isEmpty
+        ? DemoMarkers.defaultPrimaryPrompt
+        : promptParts.joined(separator: " ")
+
+    // Demo uses isolated temp stores so runs don't clobber interactive memory.
+    // Live mode uses Application Support for durable personal context.
+    let configuration = demoMode
+        ? ChatAgentConfiguration.temporary(demoMode: true)
+        : ChatAgentConfiguration.appSupport(demoMode: false)
+
+    _ = try await ChatSession.run(
+        prompt: userPrompt,
+        configuration: configuration,
+        printStream: true
+    )
+}

--- a/Examples/WaxChat/Sources/WaxChatCore/ChatAgentFactory.swift
+++ b/Examples/WaxChat/Sources/WaxChatCore/ChatAgentFactory.swift
@@ -1,0 +1,222 @@
+// ChatAgentFactory.swift
+// WaxChat — agent construction: Foundation Models / demo provider, websearch, Wax memory.
+
+import Foundation
+import Swarm
+
+/// Configuration for building a WaxChat agent.
+public struct ChatAgentConfiguration: Sendable {
+    /// When true, use the deterministic scripted inference provider.
+    public var demoMode: Bool
+    /// Persistent Wax memory store URL.
+    public var waxStoreURL: URL
+    /// WebSearchTool local artifact store URL.
+    public var webSearchStoreURL: URL
+    /// Optional Tavily API key for live websearch. Falls back to `TAVILY_API_KEY`.
+    /// Pass `""` to force offline websearch (no env fallback).
+    public var webSearchAPIKey: String?
+    /// System instructions for the agent.
+    public var instructions: String
+    /// Display name for agent configuration.
+    public var agentName: String
+
+    public init(
+        demoMode: Bool,
+        waxStoreURL: URL,
+        webSearchStoreURL: URL,
+        webSearchAPIKey: String? = nil,
+        instructions: String = ChatAgentConfiguration.defaultInstructions,
+        agentName: String = "WaxChat"
+    ) {
+        self.demoMode = demoMode
+        self.waxStoreURL = waxStoreURL
+        self.webSearchStoreURL = webSearchStoreURL
+        self.webSearchAPIKey = webSearchAPIKey
+        self.instructions = instructions
+        self.agentName = agentName
+    }
+
+    public static let defaultInstructions = """
+    You are a helpful on-device assistant with durable Wax memory and websearch.
+    Prefer the websearch tool when the user needs current or external information.
+    Recall facts from Wax memory when the user asks about earlier conversation.
+    """
+
+    /// Builds configuration with per-run temporary store paths (tests / isolated demos).
+    ///
+    /// Demo mode forces an empty websearch key so the tool path stays offline-deterministic
+    /// (local/empty results) even if `TAVILY_API_KEY` is present in the environment.
+    public static func temporary(demoMode: Bool) -> ChatAgentConfiguration {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("WaxChat-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return ChatAgentConfiguration(
+            demoMode: demoMode,
+            waxStoreURL: root.appendingPathComponent("wax-memory.mv2s"),
+            webSearchStoreURL: root.appendingPathComponent("WebMemory", isDirectory: true),
+            webSearchAPIKey: demoMode ? "" : ProcessInfo.processInfo.environment["TAVILY_API_KEY"]
+        )
+    }
+
+    /// Application Support store for interactive live use.
+    public static func appSupport(demoMode: Bool) -> ChatAgentConfiguration {
+        let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? FileManager.default.temporaryDirectory
+        let root = base
+            .appendingPathComponent("WaxChat", isDirectory: true)
+        try? FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return ChatAgentConfiguration(
+            demoMode: demoMode,
+            waxStoreURL: root.appendingPathComponent("wax-memory.mv2s"),
+            webSearchStoreURL: root.appendingPathComponent("WebMemory", isDirectory: true),
+            webSearchAPIKey: ProcessInfo.processInfo.environment["TAVILY_API_KEY"]
+        )
+    }
+}
+
+/// Resolved wiring produced by ``ChatAgentFactory``.
+public struct ChatAgentBundle: Sendable {
+    public let agent: Agent
+    /// Concrete Wax store used as the agent's explicit memory (durable path).
+    public let waxMemory: WaxMemory
+    public let modeLabel: String
+    public let waxStoreURL: URL
+    public let webSearchStoreURL: URL
+    public let toolNames: [String]
+    public let usesWaxMemory: Bool
+    public let usesWebSearch: Bool
+    public let isDemoMode: Bool
+}
+
+/// Builds Swarm agents for on-device chat with Foundation Models, websearch, and Wax memory.
+public enum ChatAgentFactory {
+    /// Creates the inference provider for the given mode.
+    ///
+    /// - Demo: always returns ``DemoScriptedProvider``.
+    /// - Live: uses ``FoundationModelsInferenceProvider`` when available; otherwise throws.
+    public static func makeProvider(
+        demoMode: Bool,
+        instructions: String = ChatAgentConfiguration.defaultInstructions
+    ) throws -> (provider: any InferenceProvider, modeLabel: String) {
+        if demoMode {
+            return (DemoScriptedProvider(), "demo (scripted)")
+        }
+
+        #if canImport(FoundationModels)
+            if #available(macOS 26.0, iOS 26.0, visionOS 26.0, *) {
+                if let fm = FoundationModelsInferenceProvider.ifAvailable(
+                    configuration: .init(instructions: instructions)
+                ) {
+                    return (fm, "foundation-models (live)")
+                }
+                throw ChatAgentFactoryError.foundationModelsUnavailable(
+                    "Foundation Models system model is not available. Re-run with --demo or enable Apple Intelligence."
+                )
+            } else {
+                throw ChatAgentFactoryError.foundationModelsUnavailable(
+                    "This OS is below Foundation Models availability. Use --demo."
+                )
+            }
+        #else
+            throw ChatAgentFactoryError.foundationModelsUnavailable(
+                "FoundationModels is not importable on this platform. Use --demo."
+            )
+        #endif
+    }
+
+    /// Explicit websearch tool with a controllable local store (and optional live key).
+    ///
+    /// When `webSearchAPIKey` is non-nil (including empty string for demo), that value is used
+    /// as-is. When nil, falls back to `TAVILY_API_KEY` for live interactive runs.
+    public static func makeWebSearchTool(configuration: ChatAgentConfiguration) -> WebSearchTool {
+        let resolvedKey: String?
+        if let configured = configuration.webSearchAPIKey {
+            let trimmed = configured.trimmingCharacters(in: .whitespacesAndNewlines)
+            resolvedKey = trimmed.isEmpty ? nil : trimmed
+        } else {
+            let env = ProcessInfo.processInfo.environment["TAVILY_API_KEY"]?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            resolvedKey = (env?.isEmpty == false) ? env : nil
+        }
+
+        try? FileManager.default.createDirectory(
+            at: configuration.webSearchStoreURL,
+            withIntermediateDirectories: true
+        )
+
+        return WebSearchTool(
+            configuration: WebSearchTool.Configuration(
+                apiKey: resolvedKey,
+                persistFetchedArtifacts: resolvedKey != nil,
+                storeURL: configuration.webSearchStoreURL,
+                enabled: true
+            )
+        )
+    }
+
+    /// Wax-backed durable memory at the configured store URL.
+    public static func makeWaxMemory(url: URL) async throws -> WaxMemory {
+        let parent = url.deletingLastPathComponent()
+        try? FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+        return try await WaxMemory(url: url)
+    }
+
+    /// Full agent construction: provider + websearch tool + Wax memory.
+    public static func makeAgent(configuration: ChatAgentConfiguration) async throws -> ChatAgentBundle {
+        let (provider, modeLabel) = try makeProvider(
+            demoMode: configuration.demoMode,
+            instructions: configuration.instructions
+        )
+        return try await makeAgent(configuration: configuration, provider: provider, modeLabel: modeLabel)
+    }
+
+    /// Agent construction with an injected provider (used by tests).
+    public static func makeAgent(
+        configuration: ChatAgentConfiguration,
+        provider: any InferenceProvider,
+        modeLabel: String
+    ) async throws -> ChatAgentBundle {
+        let waxMemory = try await makeWaxMemory(url: configuration.waxStoreURL)
+        let webSearch = makeWebSearchTool(configuration: configuration)
+
+        // WebSearchTool is AnyJSONTool; pass it via the tools array init so the
+        // tool is explicitly registered (ToolBuilder's AnyJSONTool expression is internal).
+        //
+        // Explicit memory disables Swarm's defaultMemory auto-persist path, so
+        // ChatSession always pairs this agent with an InMemorySession and syncs
+        // session turns into `waxMemory` after each run.
+        let agent = try Agent(
+            tools: [webSearch],
+            instructions: configuration.instructions,
+            configuration: .default.name(configuration.agentName),
+            memory: waxMemory,
+            inferenceProvider: provider
+        )
+
+        let toolNames = agent.tools.map(\.name)
+        let usesWebSearch = toolNames.contains { $0.lowercased() == "websearch" }
+
+        return ChatAgentBundle(
+            agent: agent,
+            waxMemory: waxMemory,
+            modeLabel: modeLabel,
+            waxStoreURL: configuration.waxStoreURL,
+            webSearchStoreURL: configuration.webSearchStoreURL,
+            toolNames: toolNames,
+            usesWaxMemory: true,
+            usesWebSearch: usesWebSearch,
+            isDemoMode: configuration.demoMode
+        )
+    }
+}
+
+public enum ChatAgentFactoryError: Error, CustomStringConvertible, Sendable {
+    case foundationModelsUnavailable(String)
+
+    public var description: String {
+        switch self {
+        case let .foundationModelsUnavailable(message):
+            message
+        }
+    }
+}

--- a/Examples/WaxChat/Sources/WaxChatCore/ChatSession.swift
+++ b/Examples/WaxChat/Sources/WaxChatCore/ChatSession.swift
@@ -1,0 +1,263 @@
+// ChatSession.swift
+// End-to-end chat orchestration used by the CLI and tests.
+
+import Foundation
+import Swarm
+
+/// Result of a full WaxChat run (primary stream + multi-turn memory check).
+public struct ChatRunResult: Sendable {
+    public let primaryOutput: String
+    public let invokedToolNames: [String]
+    public let modeLabel: String
+    public let turn1Output: String
+    public let turn2Output: String
+    public let waxStoreURL: URL
+    public let toolNames: [String]
+    public let usesWaxMemory: Bool
+    public let usesWebSearch: Bool
+    public let isDemoMode: Bool
+    /// True when the live Wax store (same URL) can recall the multi-turn fact after turn 1.
+    public let waxRecalledFavoriteCity: Bool
+    /// Context string returned by reopened WaxMemory after turn 1 (for tests / diagnostics).
+    public let waxRecallContext: String
+    public let demoChecksPassed: Bool
+}
+
+public enum ChatSessionError: Error, CustomStringConvertible, Sendable {
+    case demoChecksFailed(String)
+
+    public var description: String {
+        switch self {
+        case let .demoChecksFailed(message):
+            message
+        }
+    }
+}
+
+/// Runs the real chat path: stream primary prompt, then multi-turn conversation for memory.
+///
+/// Swarm only auto-persists no-session turns into *default* memory. Explicit ``WaxMemory``
+/// therefore requires a ``Session`` for multi-turn transcript plus an explicit sync of
+/// session turns into Wax so durable store→recall works on the shipped path.
+public enum ChatSession {
+    /// Executes a representative chat against a factory-built agent.
+    public static func run(
+        prompt: String,
+        configuration: ChatAgentConfiguration,
+        printStream: Bool = false
+    ) async throws -> ChatRunResult {
+        let bundle = try await ChatAgentFactory.makeAgent(configuration: configuration)
+        return try await run(prompt: prompt, bundle: bundle, printStream: printStream)
+    }
+
+    /// Same as ``run(prompt:configuration:printStream:)`` with a pre-built bundle (tests).
+    public static func run(
+        prompt: String,
+        bundle: ChatAgentBundle,
+        printStream: Bool = false
+    ) async throws -> ChatRunResult {
+        if printStream {
+            print("Swarm \(Swarm.version) · mode=\(bundle.modeLabel)")
+            print("wax=\(bundle.waxStoreURL.path)")
+            print("tools=\(bundle.toolNames.joined(separator: ","))")
+            print("--- stream ---")
+        }
+
+        // Session is the multi-turn transcript source of truth for Agent.run/stream.
+        let session = InMemorySession(sessionId: "waxchat-\(UUID().uuidString)")
+
+        var streamed = ""
+        var invokedToolNames: [String] = []
+
+        for try await event in bundle.agent.stream(prompt, session: session) {
+            switch event {
+            case let .output(.token(token)):
+                if printStream {
+                    print(token, terminator: "")
+                    fflush(stdout)
+                }
+                streamed += token
+            case let .tool(.completed(call, _)):
+                invokedToolNames.append(call.toolName)
+                if printStream {
+                    print("\n[tool: \(call.toolName)]", terminator: "")
+                    fflush(stdout)
+                }
+            case let .lifecycle(.completed(result)):
+                if streamed.isEmpty {
+                    streamed = result.output
+                    if printStream {
+                        print(result.output, terminator: "")
+                    }
+                }
+                if printStream {
+                    print("\n--- done (\(result.duration)) ---")
+                }
+            case let .lifecycle(.failed(error)):
+                throw error
+            default:
+                break
+            }
+        }
+
+        // Persist primary turn(s) into Wax (session already has them; explicit memory does not).
+        try await syncSessionTurnsToWax(session: session, waxMemory: bundle.waxMemory)
+
+        // Kyoto multi-turn memory proof is demo-only — live CLI must return after the user prompt.
+        let turn1Output: String
+        let turn2Output: String
+        let waxRecalledFavoriteCity: Bool
+        let waxProofContext: String
+        let messagesAfterTurn1Count: Int
+
+        if bundle.isDemoMode {
+            if printStream {
+                print("--- conversation (Wax memory multi-turn) ---")
+            }
+
+            let conversation = Conversation(with: bundle.agent, session: session)
+            let first = try await conversation.send(DemoMarkers.turn1UserPrompt)
+            try await syncSessionTurnsToWax(session: session, waxMemory: bundle.waxMemory)
+
+            // Prove the Wax path after turn 1 via the live store (`add` flushes to disk).
+            let waxRecallContext = await bundle.waxMemory.context(
+                for: DemoMarkers.waxRecallQuery,
+                tokenLimit: 4_000
+            )
+            let messagesAfterTurn1 = await bundle.waxMemory.allMessages()
+            let messageCorpus = messagesAfterTurn1.map(\.content).joined(separator: "\n")
+            waxRecalledFavoriteCity =
+                waxRecallContext.lowercased().contains(DemoMarkers.favoriteCity.lowercased())
+                || messageCorpus.lowercased().contains(DemoMarkers.favoriteCity.lowercased())
+            waxProofContext = waxRecallContext.isEmpty ? messageCorpus : waxRecallContext
+            messagesAfterTurn1Count = messagesAfterTurn1.count
+
+            let second = try await conversation.send(DemoMarkers.turn2UserPrompt)
+            try await syncSessionTurnsToWax(session: session, waxMemory: bundle.waxMemory)
+            turn1Output = first.output
+            turn2Output = second.output
+
+            if printStream {
+                print("turn1: \(turn1Output)")
+                print("turn2: \(turn2Output)")
+                print("wax_recall_after_turn1: \(waxRecalledFavoriteCity ? "ok" : "miss")")
+                if !waxProofContext.isEmpty {
+                    let preview = waxProofContext.prefix(160).replacingOccurrences(of: "\n", with: " ")
+                    print("wax_context_preview: \(preview)")
+                }
+            }
+        } else {
+            turn1Output = ""
+            turn2Output = ""
+            waxRecalledFavoriteCity = false
+            waxProofContext = ""
+            messagesAfterTurn1Count = 0
+        }
+
+        let demoChecksPassed = evaluateDemoChecks(
+            isDemoMode: bundle.isDemoMode,
+            primaryOutput: streamed,
+            invokedToolNames: invokedToolNames,
+            turn2Output: turn2Output,
+            waxRecalledFavoriteCity: waxRecalledFavoriteCity,
+            waxRecallContext: waxProofContext
+        )
+
+        if bundle.isDemoMode, !demoChecksPassed {
+            throw ChatSessionError.demoChecksFailed(
+                """
+                demo expected websearch + primary markers + Wax store recall of \(DemoMarkers.favoriteCity); \
+                got stream=\(streamed) tools=\(invokedToolNames) turn2=\(turn2Output) \
+                waxRecall=\(waxRecalledFavoriteCity) messages=\(messagesAfterTurn1Count) \
+                waxContext=\(waxProofContext.prefix(200))
+                """
+            )
+        }
+
+        if printStream, bundle.isDemoMode {
+            print("demo checks: websearch=ok primary=ok memory=ok (wax store)")
+        }
+
+        if printStream {
+            print("primary_output=\(streamed)")
+        }
+
+        return ChatRunResult(
+            primaryOutput: streamed,
+            invokedToolNames: invokedToolNames,
+            modeLabel: bundle.modeLabel,
+            turn1Output: turn1Output,
+            turn2Output: turn2Output,
+            waxStoreURL: bundle.waxStoreURL,
+            toolNames: bundle.toolNames,
+            usesWaxMemory: bundle.usesWaxMemory,
+            usesWebSearch: bundle.usesWebSearch,
+            isDemoMode: bundle.isDemoMode,
+            waxRecalledFavoriteCity: waxRecalledFavoriteCity,
+            waxRecallContext: waxProofContext,
+            demoChecksPassed: demoChecksPassed
+        )
+    }
+
+    /// Copies user/assistant session turns into explicit Wax memory (idempotent by message id).
+    ///
+    /// Swarm only auto-persists no-session turns when `activeMemory === defaultMemory`.
+    /// Explicit ``WaxMemory`` must be filled from the session transcript on this path.
+    public static func syncSessionTurnsToWax(
+        session: InMemorySession,
+        waxMemory: WaxMemory
+    ) async throws {
+        let items = try await session.getAllItems()
+        for message in items where message.role == .user || message.role == .assistant {
+            await waxMemory.add(message)
+        }
+    }
+
+    /// Re-opens the on-disk Wax store and searches for `expectedFact`.
+    ///
+    /// This is the durability proof used by demo checks and unit tests — not the
+    /// scripted inference provider.
+    public static func reopenWaxAndRecall(
+        storeURL: URL,
+        query: String,
+        expectedFact: String
+    ) async throws -> (context: String, containsFact: Bool) {
+        // Open a fresh handle. Callers must not hold another WaxMemory on the same
+        // file that blocks exclusive access; ChatSession releases the live agent
+        // handle only after the run returns, so for mid-run reopen we rely on
+        // GRDB/Wax allowing a second reader after flush (add flushes).
+        //
+        // Prefer recalling through a second factory-built handle when possible;
+        // if exclusive lock fails, fall back to reading via a temporary copy is
+        // not needed in practice because WaxMemory.add flushes and the same
+        // process can reopen after the live actor is not mid-write.
+        let reopened = try await ChatAgentFactory.makeWaxMemory(url: storeURL)
+        let context = await reopened.context(for: query, tokenLimit: 4_000)
+        let contains = context.lowercased().contains(expectedFact.lowercased())
+        return (context, contains)
+    }
+
+    /// Demo success criteria used by the CLI and tests.
+    public static func evaluateDemoChecks(
+        isDemoMode: Bool,
+        primaryOutput: String,
+        invokedToolNames: [String],
+        turn2Output: String,
+        waxRecalledFavoriteCity: Bool,
+        waxRecallContext: String
+    ) -> Bool {
+        guard isDemoMode else { return true }
+
+        let okWebSearch = invokedToolNames.contains { $0.lowercased() == "websearch" }
+        let lowerPrimary = primaryOutput.lowercased()
+        let okPrimary =
+            lowerPrimary.contains("websearch")
+            || lowerPrimary.contains("swarm")
+            || lowerPrimary.contains("foundation")
+        // Memory proof is Wax store recall of the multi-turn fact — not only turn2 text.
+        let okWax = waxRecalledFavoriteCity
+            && waxRecallContext.lowercased().contains(DemoMarkers.favoriteCity.lowercased())
+        let okTurn2 = turn2Output.lowercased().contains(DemoMarkers.favoriteCity.lowercased())
+        return okWebSearch && okPrimary && okWax && okTurn2
+    }
+}

--- a/Examples/WaxChat/Sources/WaxChatCore/DemoScriptedProvider.swift
+++ b/Examples/WaxChat/Sources/WaxChatCore/DemoScriptedProvider.swift
@@ -1,0 +1,116 @@
+// DemoScriptedProvider.swift
+// Deterministic inference provider for CI / machines without Apple Intelligence.
+
+import Foundation
+import Swarm
+
+/// Scripted provider that exercises websearch tool calling and multi-turn memory recall.
+///
+/// Turn sequence for a typical demo run:
+/// 1. First tool-capable turn → request `websearch`
+/// 2. After tool result → finalize with a primary answer containing demo markers
+/// 3. Conversation turn 1 → acknowledge a stored fact
+/// 4. Conversation turn 2 → recall that fact **only if** the prompt already contains it
+///    (injected from Wax memory context / session history). Hardcoding Kyoto without
+///    prompt evidence is intentionally avoided so demo memory checks are not fake.
+public actor DemoScriptedProvider: InferenceProvider {
+    private var toolPhase = 0
+    private var chatTurn = 0
+
+    public init() {}
+
+    public func generate(prompt: String, options: InferenceOptions) async throws -> String {
+        "ok"
+    }
+
+    public nonisolated func stream(prompt: String, options: InferenceOptions) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in
+            for token in DemoMarkers.primaryStreamTokens {
+                continuation.yield(token)
+            }
+            continuation.finish()
+        }
+    }
+
+    public func generateWithToolCalls(
+        prompt: String,
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) async throws -> InferenceResponse {
+        let hasWebSearch = tools.contains { $0.name.lowercased() == "websearch" }
+        let lowerPrompt = prompt.lowercased()
+
+        // Primary agent.stream / run path: request websearch, then answer.
+        if toolPhase == 0, hasWebSearch {
+            toolPhase = 1
+            return InferenceResponse(
+                toolCalls: [
+                    .init(
+                        id: "demo-websearch",
+                        name: "websearch",
+                        arguments: [
+                            "mode": .string("search"),
+                            "query": .string(DemoMarkers.searchQuery),
+                            "maxResults": .int(3),
+                        ]
+                    ),
+                ],
+                finishReason: .toolCall
+            )
+        }
+
+        if toolPhase == 1 {
+            toolPhase = 2
+            return InferenceResponse(
+                content: DemoMarkers.primaryAnswer,
+                finishReason: .completed
+            )
+        }
+
+        // Multi-turn Conversation path.
+        // Session history (and/or Wax-injected memory context) must carry the fact
+        // for turn 2 — we do not invent Kyoto without prompt evidence.
+        chatTurn += 1
+        if chatTurn == 1 {
+            return InferenceResponse(
+                content: DemoMarkers.turn1Answer,
+                finishReason: .completed
+            )
+        }
+
+        if lowerPrompt.contains(DemoMarkers.favoriteCity.lowercased()) {
+            return InferenceResponse(
+                content: DemoMarkers.turn2Answer,
+                finishReason: .completed
+            )
+        }
+
+        return InferenceResponse(
+            content: "I do not remember any favorite city from prior turns.",
+            finishReason: .completed
+        )
+    }
+}
+
+/// Fixed content markers asserted by demo mode and unit tests.
+public enum DemoMarkers: Sendable {
+    public static let searchQuery = "Swift Swarm on-device agents"
+    public static let primaryAnswer =
+        "Based on websearch for Swift Swarm on-device agents: Swarm runs agents with Foundation Models on device."
+    public static let primaryStreamTokens = [
+        "Based ", "on ", "websearch ", "for ", "Swift ", "Swarm ",
+        "on-device ", "agents: ", "Swarm ", "runs ", "agents ",
+        "with ", "Foundation ", "Models ", "on ", "device.",
+    ]
+    public static let favoriteCity = "Kyoto"
+    public static let turn1Answer = "Got it — favorite city Kyoto saved to Wax memory."
+    public static let turn2Answer = "Your favorite city is Kyoto."
+    public static let turn1UserPrompt = "My favorite city is Kyoto."
+    public static let turn2UserPrompt = "What is my favorite city?"
+    /// Query used when probing Wax for the multi-turn fact.
+    public static let waxRecallQuery = "favorite city"
+
+    public static var defaultPrimaryPrompt: String {
+        "Search the web for Swift Swarm on-device agents and summarize in one short sentence."
+    }
+}

--- a/Examples/WaxChat/Tests/WaxChatCoreTests/ChatAgentFactoryTests.swift
+++ b/Examples/WaxChat/Tests/WaxChatCoreTests/ChatAgentFactoryTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Swarm
+import Testing
+@testable import WaxChatCore
+
+@Suite("ChatAgentFactory")
+struct ChatAgentFactoryTests {
+    @Test("Factory registers websearch and wires Wax-backed memory")
+    func factoryRegistersWebSearchAndWaxMemory() async throws {
+        let configuration = ChatAgentConfiguration.temporary(demoMode: true)
+        defer { try? FileManager.default.removeItem(at: configuration.waxStoreURL.deletingLastPathComponent()) }
+
+        let bundle = try await ChatAgentFactory.makeAgent(configuration: configuration)
+
+        #expect(bundle.usesWebSearch)
+        #expect(bundle.toolNames.map { $0.lowercased() }.contains("websearch"))
+        #expect(bundle.usesWaxMemory)
+        #expect(bundle.waxStoreURL.path == configuration.waxStoreURL.path)
+        #expect(bundle.webSearchStoreURL.path == configuration.webSearchStoreURL.path)
+        #expect(bundle.isDemoMode)
+        #expect(bundle.modeLabel.contains("demo"))
+
+        // Memory on the agent is the explicit Wax override (not only .conversation).
+        let memory = try #require(bundle.agent.memory)
+        #expect(memory is WaxMemory)
+        // Bundle exposes the same concrete Wax handle used for session→Wax sync.
+        #expect(await bundle.waxMemory.count == 0)
+    }
+
+    @Test("makeWebSearchTool is named websearch and enabled")
+    func makeWebSearchToolIsNamedAndEnabled() {
+        let configuration = ChatAgentConfiguration.temporary(demoMode: true)
+        defer { try? FileManager.default.removeItem(at: configuration.waxStoreURL.deletingLastPathComponent()) }
+
+        let tool = ChatAgentFactory.makeWebSearchTool(configuration: configuration)
+        #expect(tool.name == "websearch")
+        #expect(tool.isEnabled)
+    }
+
+    @Test("Demo provider resolves without Foundation Models")
+    func demoProviderResolves() throws {
+        let (provider, label) = try ChatAgentFactory.makeProvider(demoMode: true)
+        #expect(label.contains("demo"))
+        #expect(provider is DemoScriptedProvider)
+    }
+}

--- a/Examples/WaxChat/Tests/WaxChatCoreTests/ChatSessionDemoTests.swift
+++ b/Examples/WaxChat/Tests/WaxChatCoreTests/ChatSessionDemoTests.swift
@@ -1,0 +1,144 @@
+import Foundation
+import Swarm
+import Testing
+@testable import WaxChatCore
+
+@Suite("ChatSession demo orchestration")
+struct ChatSessionDemoTests {
+    @Test("Demo session invokes websearch, persists turn1 to Wax, and recalls multi-turn fact")
+    func demoSessionPersistsAndRecallsViaWax() async throws {
+        let configuration = ChatAgentConfiguration.temporary(demoMode: true)
+        defer { try? FileManager.default.removeItem(at: configuration.waxStoreURL.deletingLastPathComponent()) }
+
+        // Real entry orchestration used by the executable.
+        let result = try await ChatSession.run(
+            prompt: DemoMarkers.defaultPrimaryPrompt,
+            configuration: configuration,
+            printStream: false
+        )
+
+        #expect(result.isDemoMode)
+        #expect(result.usesWebSearch)
+        #expect(result.usesWaxMemory)
+        #expect(result.demoChecksPassed)
+
+        #expect(result.invokedToolNames.map { $0.lowercased() }.contains("websearch"))
+        #expect(result.toolNames.map { $0.lowercased() }.contains("websearch"))
+
+        let primary = result.primaryOutput.lowercased()
+        #expect(primary.contains("websearch") || primary.contains("swarm"))
+        #expect(result.turn2Output.lowercased().contains(DemoMarkers.favoriteCity.lowercased()))
+        #expect(!result.primaryOutput.isEmpty)
+
+        // Criterion 4: multi-turn fact is in the Wax store (not only scripted turn2 text).
+        #expect(result.waxRecalledFavoriteCity)
+        #expect(result.waxRecallContext.lowercased().contains(DemoMarkers.favoriteCity.lowercased()))
+    }
+
+    @Test("After ChatSession run, reopening WaxMemory at store URL still contains the turn1 fact")
+    func reopenedWaxStoreContainsTurn1Fact() async throws {
+        let configuration = ChatAgentConfiguration.temporary(demoMode: true)
+        let storeRoot = configuration.waxStoreURL.deletingLastPathComponent()
+        defer { try? FileManager.default.removeItem(at: storeRoot) }
+
+        let result = try await ChatSession.run(
+            prompt: DemoMarkers.defaultPrimaryPrompt,
+            configuration: configuration,
+            printStream: false
+        )
+        #expect(result.waxRecalledFavoriteCity)
+
+        // Fresh handle after the run (agent/Wax actor from the run are not retained).
+        let reopened = try await ChatAgentFactory.makeWaxMemory(url: result.waxStoreURL)
+        let context = await reopened.context(for: DemoMarkers.waxRecallQuery, tokenLimit: 4_000)
+        #expect(context.lowercased().contains(DemoMarkers.favoriteCity.lowercased()))
+
+        let messages = await reopened.allMessages()
+        let joined = messages.map(\.content).joined(separator: "\n").lowercased()
+        #expect(joined.contains(DemoMarkers.favoriteCity.lowercased()))
+        #expect(messages.contains { $0.role == .user && $0.content.contains(DemoMarkers.favoriteCity) })
+    }
+
+    @Test("syncSessionTurnsToWax writes session user/assistant turns into WaxMemory")
+    func syncSessionTurnsToWaxWritesUserAndAssistant() async throws {
+        let configuration = ChatAgentConfiguration.temporary(demoMode: true)
+        defer { try? FileManager.default.removeItem(at: configuration.waxStoreURL.deletingLastPathComponent()) }
+
+        let wax = try await ChatAgentFactory.makeWaxMemory(url: configuration.waxStoreURL)
+        let session = InMemorySession(sessionId: "sync-test")
+        try await session.addItems([
+            .user("My favorite city is Kyoto."),
+            .assistant("Saved Kyoto."),
+        ])
+
+        try await ChatSession.syncSessionTurnsToWax(session: session, waxMemory: wax)
+
+        #expect(await wax.count == 2)
+        let context = await wax.context(for: "favorite city", tokenLimit: 4_000)
+        #expect(context.lowercased().contains("kyoto"))
+    }
+
+    @Test("Non-demo session runs only the user prompt (no Kyoto demo turns)")
+    func liveSessionSkipsDemoMemoryTurns() async throws {
+        let configuration = ChatAgentConfiguration.temporary(demoMode: false)
+        defer { try? FileManager.default.removeItem(at: configuration.waxStoreURL.deletingLastPathComponent()) }
+
+        // Scripted provider keeps the test offline; demoMode:false must skip Kyoto turns.
+        let bundle = try await ChatAgentFactory.makeAgent(
+            configuration: configuration,
+            provider: DemoScriptedProvider(),
+            modeLabel: "test-non-demo"
+        )
+        #expect(!bundle.isDemoMode)
+
+        let result = try await ChatSession.run(
+            prompt: "Say hello once.",
+            bundle: bundle,
+            printStream: false
+        )
+
+        #expect(!result.isDemoMode)
+        #expect(result.turn1Output.isEmpty)
+        #expect(result.turn2Output.isEmpty)
+        #expect(!result.waxRecalledFavoriteCity)
+        #expect(result.waxRecallContext.isEmpty)
+        #expect(result.demoChecksPassed)
+    }
+
+    @Test("evaluateDemoChecks requires websearch, primary content, and Wax store recall")
+    func evaluateDemoChecksCriteria() {
+        #expect(
+            ChatSession.evaluateDemoChecks(
+                isDemoMode: true,
+                primaryOutput: DemoMarkers.primaryAnswer,
+                invokedToolNames: ["websearch"],
+                turn2Output: DemoMarkers.turn2Answer,
+                waxRecalledFavoriteCity: true,
+                waxRecallContext: "favorite city is Kyoto"
+            )
+        )
+
+        #expect(
+            !ChatSession.evaluateDemoChecks(
+                isDemoMode: true,
+                primaryOutput: DemoMarkers.primaryAnswer,
+                invokedToolNames: [],
+                turn2Output: DemoMarkers.turn2Answer,
+                waxRecalledFavoriteCity: true,
+                waxRecallContext: "favorite city is Kyoto"
+            )
+        )
+
+        // Scripted turn2 alone is not enough without Wax proof.
+        #expect(
+            !ChatSession.evaluateDemoChecks(
+                isDemoMode: true,
+                primaryOutput: DemoMarkers.primaryAnswer,
+                invokedToolNames: ["websearch"],
+                turn2Output: DemoMarkers.turn2Answer,
+                waxRecalledFavoriteCity: false,
+                waxRecallContext: ""
+            )
+        )
+    }
+}

--- a/Examples/WaxChat/Tests/WaxChatCoreTests/WaxMemoryIntegrationTests.swift
+++ b/Examples/WaxChat/Tests/WaxChatCoreTests/WaxMemoryIntegrationTests.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Swarm
+import Testing
+@testable import WaxChatCore
+
+@Suite("Wax memory store/recall")
+struct WaxMemoryIntegrationTests {
+    @Test("WaxMemory store then recall returns stored content via factory path")
+    func storeThenRecallViaFactoryWaxMemory() async throws {
+        let configuration = ChatAgentConfiguration.temporary(demoMode: true)
+        defer { try? FileManager.default.removeItem(at: configuration.waxStoreURL.deletingLastPathComponent()) }
+
+        let unique = "waxchat-recall-\(UUID().uuidString.replacingOccurrences(of: "-", with: ""))"
+        let content = "\(unique) favorite city is \(DemoMarkers.favoriteCity)"
+
+        // Drive the shipped factory helper — not a reimplementation.
+        // Scope the first handle so the store file is not locked when reopening.
+        do {
+            let memory = try await ChatAgentFactory.makeWaxMemory(url: configuration.waxStoreURL)
+            await memory.add(.user(content))
+
+            let context = await memory.context(for: unique, tokenLimit: 4_000)
+            #expect(context.contains(unique))
+            #expect(context.lowercased().contains(DemoMarkers.favoriteCity.lowercased()))
+            #expect(await memory.count == 1)
+        }
+
+        // Re-open the same store URL to prove durability beyond the first instance.
+        let reopened = try await ChatAgentFactory.makeWaxMemory(url: configuration.waxStoreURL)
+        let reopenedContext = await reopened.context(for: unique, tokenLimit: 4_000)
+        #expect(reopenedContext.contains(unique))
+        #expect(await reopened.count >= 1)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -133,12 +133,14 @@ Two minimal, buildable apps under `Examples/` stress the public API:
 | Example | What it proves |
 | --- | --- |
 | [`Examples/OnDeviceChat`](Examples/OnDeviceChat) | Foundation Models chat with `@Tool`, streaming, and multi-turn `Conversation` (zero API keys; `--demo` for CI) |
-| [`Examples/MultiAgentPipeline`](Examples/MultiAgentPipeline) | Sequential + parallel workflows and durable checkpoint/resume (`--demo` for CI) |
+| [`Examples/MultiAgentPipeline`](Examples/MultiAgentPipeline) | Sequential + parallel workflows and durable checkpoint/resume (`--demo` for CI; requires Integrations) |
+| [`Examples/WaxChat`](Examples/WaxChat) | Wax durable memory + websearch chat (`--demo` for CI; requires Integrations) |
 | [`Examples/CodeReviewer`](Examples/CodeReviewer) | Lightweight CLI that links Swarm and prints a deterministic review plan |
 
 ```bash
 cd Examples/OnDeviceChat && swift run OnDeviceChat --demo
 cd Examples/MultiAgentPipeline && swift run MultiAgentPipeline --demo
+cd Examples/WaxChat && swift run WaxChat --demo
 ```
 
 ### Optional demos


### PR DESCRIPTION
## Summary
- Add `Examples/WaxChat` (Swarm + Wax memory + websearch) with `traits: [\"Integrations\"]`.
- Gate Kyoto multi-turn memory demo turns behind `isDemoMode` so live CLI runs only the user prompt.
- Cover the live-skip path with a unit test; list WaxChat in the root README examples table.

## Test plan
- [x] `cd Examples/WaxChat && swift test` (9 passed)
- [x] `cd Examples/WaxChat && swift run WaxChat --demo` (exit 0)


Made with [Cursor](https://cursor.com)