### PR TITLE
fix: loud failures for trait-gated features + honest capability claims

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -198,6 +198,10 @@ var packageTargets: [Target] = [
                         name: "Membrane",
                         condition: .when(platforms: appleIntegrationPlatforms, traits: [integrationTrait])
                     ),
+                    .target(
+                        name: "ContextCore",
+                        condition: .when(platforms: appleIntegrationPlatforms, traits: [integrationTrait])
+                    ),
                 ]
             }
             return dependencies
@@ -344,6 +348,7 @@ if enableIntegrationModules {
             dependencies: [
                 "ContextCoreEngine",
                 "ContextCoreTypes",
+                .product(name: "Logging", package: "swift-log"),
                 .product(
                     name: "MetalANNS",
                     package: "MetalANNS",

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ let result = try await Workflow()
   <img alt="Swarm API Flow" src="docs/public/api-flow.gif" width="600" />
 </div>
 
-Two agents, one pipeline, compiled to a DAG with crash recovery and Swift concurrency safety.
+Two agents, one pipeline, compiled to a DAG. Crash recovery is opt-in — enable the Integrations trait and durable checkpointing — and Swift concurrency safety is enforced at compile time.
 
 ## Install
 
 Default **link** is **lean**: core Swarm + on-device Foundation Models. Graph/memory/web/Hive paths are trait-gated (off by default) and are not linked into Swarm unless you enable Integrations.
 
-HiveCore, Membrane, and ContextCore are **native in-tree** `Sources/` targets (internal modules — not separate library products). Enabling Integrations **links** those modules plus Wax (still remote) and SwiftSoup; omitting the trait does not link them into Swarm. Lean resolve never pulls Hive/Membrane/ContextCore/Conduit **package identities**, and (with trait-gated product edges) also does **not** pin Wax, MetalANNS→GRDB, swift-crypto, swift-mutex, or SwiftSoup. Always-on remotes remain (swift-syntax, swift-log, MCP sdk, OTel, plus NIO transitives — including `swift-collections` via NIO). `SWARM_CORE_ONLY=1` drops the integration package block entirely. ContextCore / full Membrane session stack require Apple platforms (Metal/CoreML); Linux Integrations still builds Hive + MembraneCore + web helpers. DefaultAgentMemory uses a CoreML embedding model that is **not** bundled — without `minilm-l6-v2.mlpackage`, ContextCore falls back to deterministic pseudo-embeddings.
+HiveCore, Membrane, and ContextCore are **native in-tree** `Sources/` targets (internal modules — not separate library products). Enabling Integrations **links** those modules plus Wax (still remote) and SwiftSoup; omitting the trait does not link them into Swarm. Lean resolve never pulls Hive/Membrane/ContextCore/Conduit **package identities**, and (with trait-gated product edges) also does **not** pin Wax, MetalANNS→GRDB, swift-crypto, swift-mutex, or SwiftSoup. Always-on remotes remain (swift-syntax, swift-log, MCP sdk, OTel, plus NIO transitives — including `swift-collections` via NIO). `SWARM_CORE_ONLY=1` drops the integration package block entirely. ContextCore / full Membrane session stack require Apple platforms (Metal/CoreML); Linux Integrations still builds Hive + MembraneCore + web helpers. DefaultAgentMemory uses a CoreML embedding model that is **not** bundled — without `minilm-l6-v2.mlpackage`, ContextCore falls back to deterministic pseudo-embeddings, logs a once-per-process warning, and `DefaultAgentMemory.isSemanticMemoryAvailable` reports `false`.
 
 **Root-package note:** bare `swift build` / `swift test` on this repo compile every registered target, so integration modules need either `--traits Integrations` or the lean CI helper (`scripts/ci/lean-build-test.sh`). App consumers only build reachable targets and stay lean without that helper.
 
@@ -90,7 +90,7 @@ That is a working agent with type-safe tool calling. Swarm also supports **AGENT
 
 - **Swift concurrency is part of the surface.** Swift 6.2 `StrictConcurrency` is enabled across the package.
 - **Tools stay type-safe.** The `@Tool` macro generates JSON schemas from Swift structs.
-- **Workflows can survive crashes.** Durable workflow checkpointing lets you resume from an explicit checkpoint ID.
+- **Workflows can survive crashes.** Durable checkpointing (Integrations trait) lets you resume from an explicit checkpoint ID.
 - **Built-in inference is on-device Foundation Models.** Inject any `InferenceProvider` for custom backends; the agent loop stays the same.
 - **It is written in Swift all the way down.** `AsyncThrowingStream`, actors, result builders, and macros are first-class here.
 
@@ -175,7 +175,8 @@ Notes that matter in production:
 
 - **Availability**: use `FoundationModelsInferenceProvider.ifAvailable()` or check `FoundationModelsInferenceProvider.isAvailable` before assuming the system model is ready.
 - **Tool calling**: Swarm bridges `@Tool` / `ToolSchema` to Apple's `FoundationModels.Tool` and executes tools in the agent loop with guardrails intact.
-- **Streaming tool calls**: not advertised; streaming is text deltas, tools complete as capture-then-execute turns.
+- **Streaming tool calls**: not advertised as token-level tool streaming; `Agent.stream` observes the same `run` loop via `AgentEvent` (lifecycle, tools, and `.output(.token)` chunks). Foundation Models yields incremental text deltas; providers without a streaming API emit the full response as a single chunk.
+- **Structured outputs**: `runStructured` asks the model (prompt instruction) and parses JSON. It is not enforced schema generation — invalid JSON fails at parse time.
 - **Dynamic profiles**: `.foundationModels(profile:)` re-resolves instructions/tools/history every turn (WWDC 2026–aligned Swarm API).
 - **Linux / CI**: Foundation Models is compile-time gated; inject a mock or custom `InferenceProvider`, or use the deterministic `--demo` modes in `Examples/`.
 
@@ -183,7 +184,7 @@ Notes that matter in production:
 
 ```swift
 // WebSearchTool requires the Integrations trait and an API key
-// (lean builds compile this initializer but throw at execution without Integrations).
+// (lean builds compile this initializer, warn immediately, and throw on execute).
 let researcher = try Agent("Research the topic and extract key facts.",
     inferenceProvider: .foundationModels()) {
     WebSearchTool(apiKey: "YOUR_API_KEY")
@@ -222,6 +223,10 @@ let result = try await Workflow()
 ```
 
 ### Streaming
+
+`Agent.stream` runs the same agent loop as `run`, forwarding `AgentEvent` values through an observer. You get lifecycle, tool, and output events as they happen — not a separate token decoder.
+
+`.output(.token)` is an incremental text chunk when the provider streams (Foundation Models does). If the provider only has a completion API, that event is the full response in one chunk. Tool calls still complete as capture-then-execute turns unless the provider implements tool-call streaming.
 
 ```swift
 for try await event in agent.stream("Summarize the changelog.") {
@@ -320,7 +325,7 @@ for message in await conversation.messages {
 | **Data race safety** | Compile-time | Runtime | Runtime |
 | **On-device LLM** | Foundation Models | n/a | n/a |
 | **Execution model** | Typed `Workflow` graph | Loop-based | Loop-based |
-| **Crash recovery** | Checkpoints | n/a | Partial |
+| **Crash recovery** | Checkpoints (Integrations) | n/a | Partial |
 | **Type-safe tools** | `@Tool` macro (compile-time) | Decorators (runtime) | Runtime |
 | **Streaming** | `AsyncThrowingStream` | Callbacks | Callbacks |
 | **iOS / macOS native** | First-class | n/a | n/a |

--- a/Sources/ContextCore/EmbeddingProviders.swift
+++ b/Sources/ContextCore/EmbeddingProviders.swift
@@ -1,23 +1,74 @@
 import ContextCoreEngine
 import CoreML
 import Foundation
+import Logging
+
+/// Runtime status of ContextCore's default CoreML MiniLM embedder.
+///
+/// When the model is missing, fails to load, or the process is running in the
+/// Simulator, ContextCore falls back to hash-seeded pseudo-vectors. Rankings
+/// from that path are not semantically meaningful.
+public enum SemanticEmbeddingAvailability: Sendable {
+    /// Whether the default CoreML MiniLM model can produce real embeddings.
+    public static var isAvailable: Bool {
+        CoreMLEmbeddingProvider.isRealModelAvailable
+    }
+
+    /// Why real embeddings are unavailable, if they are.
+    public static var unavailabilityReason: String? {
+        CoreMLEmbeddingProvider.unavailabilityReason
+    }
+
+    /// Most recent fallback warning in this process, if any.
+    public static var lastWarningMessage: String? {
+        CoreMLEmbeddingProvider.lastWarningMessage
+    }
+
+    /// Whether `provider` can produce real semantic embeddings.
+    ///
+    /// Custom embedders are treated as available. The default CoreML MiniLM
+    /// path reports ``isAvailable``.
+    public static func isAvailable(for provider: any EmbeddingProvider) -> Bool {
+        if provider is CoreMLEmbeddingProvider {
+            return CoreMLEmbeddingProvider.isRealModelAvailable
+        }
+        if let caching = provider as? CachingEmbeddingProvider {
+            return isAvailable(for: caching.base)
+        }
+        return true
+    }
+
+    /// Resets process-wide fallback diagnostics. Intended for tests.
+    public static func resetForTesting() {
+        CoreMLEmbeddingProvider.resetAvailabilityForTesting()
+    }
+}
 
 internal struct CoreMLEmbeddingProvider: EmbeddingProvider, Sendable {
     internal let dimension: Int = 384
 
-    internal init() {}
+    internal init() {
+        Self.probeAndWarnIfNeeded()
+    }
 
     func embed(_ text: String) async throws -> [Float] {
 #if targetEnvironment(simulator)
+        Self.takeFallback(
+            reason: "CoreML embeddings are unavailable in the Simulator"
+        )
         return Self.deterministicVector(for: text, dimension: dimension)
 #else
         do {
             let model = try Self.loadModel()
+            Self.markRealModelAvailable()
             let inputName = try Self.resolveInputName(for: model)
             let provider = try MLDictionaryFeatureProvider(dictionary: [inputName: text])
             let output = try await model.prediction(from: provider)
             return try Self.extractEmbedding(from: output, model: model)
         } catch {
+            Self.takeFallback(
+                reason: "CoreML model minilm-l6-v2.mlpackage is missing or failed to load (\(error.localizedDescription))"
+            )
             return Self.deterministicVector(for: text, dimension: dimension)
         }
 #endif
@@ -29,10 +80,14 @@ internal struct CoreMLEmbeddingProvider: EmbeddingProvider, Sendable {
         }
 
 #if targetEnvironment(simulator)
+        Self.takeFallback(
+            reason: "CoreML embeddings are unavailable in the Simulator"
+        )
         return texts.map { Self.deterministicVector(for: $0, dimension: dimension) }
 #else
         do {
             let model = try Self.loadModel()
+            Self.markRealModelAvailable()
             let inputName = try Self.resolveInputName(for: model)
             let providers = try texts.map { text in
                 try MLDictionaryFeatureProvider(dictionary: [inputName: text]) as MLFeatureProvider
@@ -48,9 +103,78 @@ internal struct CoreMLEmbeddingProvider: EmbeddingProvider, Sendable {
             }
             return vectors
         } catch {
+            Self.takeFallback(
+                reason: "CoreML model minilm-l6-v2.mlpackage is missing or failed to load (\(error.localizedDescription))"
+            )
             return texts.map { Self.deterministicVector(for: $0, dimension: dimension) }
         }
 #endif
+    }
+
+    fileprivate static var isRealModelAvailable: Bool {
+        probeAndWarnIfNeeded()
+        return availability.snapshot().isRealModelAvailable
+    }
+
+    fileprivate static var unavailabilityReason: String? {
+        probeAndWarnIfNeeded()
+        return availability.snapshot().reason
+    }
+
+    fileprivate static var lastWarningMessage: String? {
+        availability.snapshot().lastWarning
+    }
+
+    fileprivate static func resetAvailabilityForTesting() {
+        availability.reset()
+    }
+
+    private static let availability = EmbeddingAvailabilityState()
+    private static let embeddingLogger = Logger(label: "com.swarm.memory")
+
+    @discardableResult
+    private static func probeAndWarnIfNeeded() -> Bool {
+        let probed = availability.snapshot()
+        if probed.didProbe {
+            return probed.isRealModelAvailable
+        }
+
+        let result = probeModel()
+        availability.storeProbe(available: result.available, reason: result.reason)
+        if !result.available, let reason = result.reason {
+            takeFallback(reason: reason)
+        }
+        return result.available
+    }
+
+    private static func probeModel() -> (available: Bool, reason: String?) {
+#if targetEnvironment(simulator)
+        return (false, "CoreML embeddings are unavailable in the Simulator")
+#else
+        do {
+            _ = try loadModel()
+            return (true, nil)
+        } catch {
+            return (
+                false,
+                "CoreML model minilm-l6-v2.mlpackage is missing or failed to load (\(error.localizedDescription))"
+            )
+        }
+#endif
+    }
+
+    private static func markRealModelAvailable() {
+        availability.storeProbe(available: true, reason: nil)
+    }
+
+    private static func takeFallback(reason: String) {
+        let message = """
+        Real embeddings are unavailable (\(reason)). Semantic recall quality is degraded — \
+        vector rankings are not meaningful until a real embedding model is available.
+        """
+        if availability.recordWarning(message, reason: reason) {
+            embeddingLogger.warning("\(message)")
+        }
     }
 
     private static func loadModel() throws -> MLModel {
@@ -152,7 +276,7 @@ internal struct CoreMLEmbeddingProvider: EmbeddingProvider, Sendable {
 }
 
 internal struct CachingEmbeddingProvider: EmbeddingProvider, Sendable {
-    private let base: any EmbeddingProvider
+    fileprivate let base: any EmbeddingProvider
     private let cache: EmbeddingCache
 
     internal init(
@@ -214,5 +338,56 @@ internal struct CachingEmbeddingProvider: EmbeddingProvider, Sendable {
         }
 
         return orderedResults
+    }
+}
+
+private final class EmbeddingAvailabilityState: @unchecked Sendable {
+    struct Snapshot {
+        var didProbe = false
+        var isRealModelAvailable = false
+        var reason: String?
+        var didWarn = false
+        var lastWarning: String?
+    }
+
+    private let lock = NSLock()
+    private var state = Snapshot()
+
+    func snapshot() -> Snapshot {
+        lock.lock()
+        defer { lock.unlock() }
+        return state
+    }
+
+    func storeProbe(available: Bool, reason: String?) {
+        lock.lock()
+        defer { lock.unlock() }
+        state.didProbe = true
+        state.isRealModelAvailable = available
+        if !available {
+            state.reason = reason
+        } else {
+            state.reason = nil
+        }
+    }
+
+    func recordWarning(_ message: String, reason: String) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        state.didProbe = true
+        state.isRealModelAvailable = false
+        state.reason = reason
+        state.lastWarning = message
+        guard !state.didWarn else {
+            return false
+        }
+        state.didWarn = true
+        return true
+    }
+
+    func reset() {
+        lock.lock()
+        defer { lock.unlock() }
+        state = Snapshot()
     }
 }

--- a/Sources/Swarm/Core/IntegrationsTrait.swift
+++ b/Sources/Swarm/Core/IntegrationsTrait.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Logging
+
+/// Build-time availability of Swarm's Integrations SwiftPM trait.
+///
+/// Lean (default) builds still type-check trait-gated APIs so apps compile, but
+/// the backing implementations are not linked. Query ``isEnabled`` — or a
+/// per-feature `isAvailable` flag — before constructing those APIs, or rebuild
+/// with `--traits Integrations`.
+public enum IntegrationsTrait: Sendable {
+    /// Whether this process was compiled with the `Integrations` SwiftPM trait.
+    public static var isEnabled: Bool {
+        #if SWARM_INTEGRATIONS
+        true
+        #else
+        false
+        #endif
+    }
+
+    /// User-facing message naming the missing trait and the exact rebuild remedy.
+    ///
+    /// - Parameter feature: Short name of the gated capability (for example, `"Web search"`).
+    /// - Returns: A message that names the Integrations trait and how to enable it.
+    public static func requirementMessage(for feature: String) -> String {
+        "\(feature) requires the Integrations trait. Rebuild with `--traits Integrations`, or add `traits: [\"Integrations\"]` to the Swarm package dependency."
+    }
+
+    /// Logs a once-per-process warning when Integrations is missing.
+    ///
+    /// Call from non-throwing initializers and factories whose signatures cannot
+    /// become `throws` without breaking source compatibility on Integrations builds.
+    ///
+    /// - Parameters:
+    ///   - feature: Short name of the gated capability.
+    ///   - logger: Logger used for the warning. Defaults to ``Log/agents``.
+    public static func warnIfUnavailable(feature: String, logger: Logger = Log.agents) {
+        guard !isEnabled else { return }
+        let message = requirementMessage(for: feature)
+        if OnceRecorder.shared.record(feature: feature, message: message) {
+            logger.warning("\(message)")
+        }
+    }
+}
+
+enum IntegrationsTraitTesting {
+    static var warnings: [String] {
+        OnceRecorder.shared.messages
+    }
+
+    static func reset() {
+        OnceRecorder.shared.reset()
+    }
+}
+
+private final class OnceRecorder: @unchecked Sendable {
+    static let shared = OnceRecorder()
+    private let lock = NSLock()
+    private var warnedFeatures: Set<String> = []
+    private var recordedMessages: [String] = []
+
+    var messages: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedMessages
+    }
+
+    func record(feature: String, message: String) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard warnedFeatures.insert(feature).inserted else {
+            return false
+        }
+        recordedMessages.append(message)
+        return true
+    }
+
+    func reset() {
+        lock.lock()
+        defer { lock.unlock() }
+        warnedFeatures.removeAll()
+        recordedMessages.removeAll()
+    }
+}

--- a/Sources/Swarm/Core/SwarmConfiguration.swift
+++ b/Sources/Swarm/Core/SwarmConfiguration.swift
@@ -77,6 +77,7 @@ public extension Swarm {
     /// 3. `Swarm.webConfiguration` (set here)
     /// 4. No ambient web tool
     static func configure(web configuration: WebSearchTool.Configuration) async {
+        IntegrationsTrait.warnIfUnavailable(feature: "Web search")
         await Configuration.shared.setWebConfiguration(configuration)
     }
 

--- a/Sources/Swarm/Memory/DefaultAgentMemory.swift
+++ b/Sources/Swarm/Memory/DefaultAgentMemory.swift
@@ -6,6 +6,7 @@
 // Wax durable recall.
 // Apple-only: requires ContextCore (Metal/CoreML), which is not linked on Linux.
 
+import ContextCore
 import Foundation
 
 /// Default Swarm memory stack.
@@ -41,6 +42,15 @@ public actor DefaultAgentMemory: Memory, MemoryPromptDescriptor, MemorySessionLi
     public nonisolated let memoryPriority: MemoryPriorityHint = .primary
     public nonisolated let allowsAutomaticSessionSeeding = true
 
+    /// Whether this memory stack can produce real semantic embeddings.
+    ///
+    /// Returns `false` when ContextCore's default CoreML MiniLM model is missing,
+    /// failed to load, or the process is running in the Simulator. Rankings then
+    /// use hash-seeded pseudo-vectors and semantic recall quality is degraded.
+    /// Custom embedding providers injected through
+    /// ``ContextCoreMemoryConfiguration`` are treated as available.
+    public nonisolated let isSemanticMemoryAvailable: Bool
+
     /// Composite count across the deduplicated working and durable layers.
     public var count: Int {
         get async { await compositeMessages().count }
@@ -56,6 +66,9 @@ public actor DefaultAgentMemory: Memory, MemoryPromptDescriptor, MemorySessionLi
         self.contextMemory = try ContextCoreMemory(configuration: configuration.contextCoreConfiguration)
         self.memoryPromptTitle = "ContextCore + Wax Memory Context"
         self.memoryPromptGuidance = "Use the ContextCore section first for current-session context. Use the Wax section only for durable recall that does not conflict."
+        self.isSemanticMemoryAvailable = SemanticEmbeddingAvailability.isAvailable(
+            for: configuration.contextCoreConfiguration.contextConfiguration.embeddingProvider
+        )
     }
 
     public func add(_ message: MemoryMessage) async {
@@ -479,6 +492,16 @@ public actor DefaultAgentMemory: Memory, MemoryPromptDescriptor, MemorySessionLi
         guard text.count > maxCharacters else { return text }
         let end = text.index(text.startIndex, offsetBy: maxCharacters)
         return String(text[..<end])
+    }
+}
+
+enum SemanticMemoryDiagnostics {
+    static var lastWarning: String? {
+        SemanticEmbeddingAvailability.lastWarningMessage
+    }
+
+    static func reset() {
+        SemanticEmbeddingAvailability.resetForTesting()
     }
 }
 #endif

--- a/Sources/Swarm/Tools/WebSearchTool.swift
+++ b/Sources/Swarm/Tools/WebSearchTool.swift
@@ -215,6 +215,15 @@ public struct WebSearchTool: AnyJSONTool, Sendable {
         resolvedConfiguration.enabled
     }
 
+    /// Whether live web search, fetch, and grounding are linked in this build.
+    ///
+    /// Lean builds still type-check ``WebSearchTool`` so agent graphs compile, but
+    /// ``execute()`` throws until you rebuild with `--traits Integrations` (or add
+    /// `traits: ["Integrations"]` to the Swarm package dependency).
+    public static var isAvailable: Bool {
+        IntegrationsTrait.isEnabled
+    }
+
     // Legacy mutable properties preserved for direct-call compatibility.
     public var mode: String
     public var query: String
@@ -235,6 +244,7 @@ public struct WebSearchTool: AnyJSONTool, Sendable {
     private let legacyAPIKey: String?
 
     public init(apiKey: String) {
+        IntegrationsTrait.warnIfUnavailable(feature: "Web search")
         configuration = nil
         legacyAPIKey = apiKey
         mode = Mode.search.rawValue
@@ -254,6 +264,7 @@ public struct WebSearchTool: AnyJSONTool, Sendable {
     }
 
     public init(configuration: Configuration) {
+        IntegrationsTrait.warnIfUnavailable(feature: "Web search")
         self.configuration = configuration
         legacyAPIKey = configuration.apiKey
         mode = Mode.search.rawValue
@@ -283,7 +294,7 @@ public struct WebSearchTool: AnyJSONTool, Sendable {
         #else
         throw AgentError.toolExecutionFailed(
             toolName: name,
-            underlyingError: "Web search requires the Integrations trait."
+            underlyingError: IntegrationsTrait.requirementMessage(for: "Web search")
         )
         #endif
     }
@@ -298,7 +309,7 @@ public struct WebSearchTool: AnyJSONTool, Sendable {
         #else
         throw AgentError.toolExecutionFailed(
             toolName: name,
-            underlyingError: "Web search requires the Integrations trait."
+            underlyingError: IntegrationsTrait.requirementMessage(for: "Web search")
         )
         #endif
     }

--- a/Sources/Swarm/Workflow/Workflow+Durable.swift
+++ b/Sources/Swarm/Workflow/Workflow+Durable.swift
@@ -7,6 +7,15 @@ public extension Workflow {
     struct Durable: Sendable {
         fileprivate let workflow: Workflow
 
+        /// Whether the durable Hive engine is linked in this build.
+        ///
+        /// Configuration APIs (``checkpoint(id:policy:)``, ``checkpointing(_:)``)
+        /// still type-check on lean builds. ``execute(_:resumeFrom:)`` throws when
+        /// checkpointing is configured until you rebuild with `--traits Integrations`.
+        public static var isAvailable: Bool {
+            IntegrationsTrait.isEnabled
+        }
+
         public enum CheckpointPolicy: Sendable {
             case onCompletion
             case everyStep
@@ -14,6 +23,10 @@ public extension Workflow {
 
         /// Enables workflow checkpointing for this workflow.
         public func checkpoint(id: String, policy: CheckpointPolicy = .onCompletion) -> Workflow {
+            IntegrationsTrait.warnIfUnavailable(
+                feature: "Durable workflow checkpointing",
+                logger: Log.orchestration
+            )
             var copy = workflow
             copy.advancedConfiguration.checkpoint = Workflow.CheckpointConfiguration(
                 id: id,
@@ -24,6 +37,10 @@ public extension Workflow {
 
         /// Configures checkpoint persistence for durable workflow execution.
         public func checkpointing(_ checkpointing: WorkflowCheckpointing) -> Workflow {
+            IntegrationsTrait.warnIfUnavailable(
+                feature: "Durable workflow checkpointing",
+                logger: Log.orchestration
+            )
             var copy = workflow
             copy.advancedConfiguration.checkpointing = checkpointing
             return copy
@@ -91,8 +108,8 @@ extension Workflow {
         }
         #else
         if checkpointID != nil || advancedConfiguration.checkpoint != nil || advancedConfiguration.checkpointing != nil {
-            throw WorkflowError.invalidWorkflow(
-                reason: "Durable workflow execution requires the Integrations trait."
+            throw WorkflowError.durableRuntimeUnavailable(
+                reason: IntegrationsTrait.requirementMessage(for: "Durable workflow execution")
             )
         }
         return try await executeWithTimeout {

--- a/Sources/Swarm/Workflow/WorkflowCheckpointing.swift
+++ b/Sources/Swarm/Workflow/WorkflowCheckpointing.swift
@@ -2,6 +2,16 @@ import Foundation
 
 /// Checkpoint persistence configuration for advanced workflows.
 public struct WorkflowCheckpointing: Sendable {
+    /// Whether durable checkpoint stores are linked in this build.
+    ///
+    /// Lean builds still type-check these factories so workflow graphs compile, but
+    /// ``Workflow/Durable/execute(_:resumeFrom:)`` throws until you rebuild with
+    /// `--traits Integrations` (or add `traits: ["Integrations"]` to the Swarm
+    /// package dependency).
+    public static var isAvailable: Bool {
+        IntegrationsTrait.isEnabled
+    }
+
     #if SWARM_INTEGRATIONS
     let backend: any WorkflowDurableCheckpointStore
 
@@ -14,19 +24,27 @@ public struct WorkflowCheckpointing: Sendable {
 
     /// In-memory checkpoint persistence.
     public static func inMemory() -> WorkflowCheckpointing {
+        IntegrationsTrait.warnIfUnavailable(
+            feature: "Durable workflow checkpointing",
+            logger: Log.orchestration
+        )
         #if SWARM_INTEGRATIONS
-        WorkflowCheckpointing(backend: WorkflowInMemoryCheckpointStore())
+        return WorkflowCheckpointing(backend: WorkflowInMemoryCheckpointStore())
         #else
-        WorkflowCheckpointing()
+        return WorkflowCheckpointing()
         #endif
     }
 
     /// File-system checkpoint persistence rooted at `directory`.
     public static func fileSystem(directory: URL) -> WorkflowCheckpointing {
+        IntegrationsTrait.warnIfUnavailable(
+            feature: "Durable workflow checkpointing",
+            logger: Log.orchestration
+        )
         #if SWARM_INTEGRATIONS
-        WorkflowCheckpointing(backend: WorkflowFileCheckpointStore(directory: directory))
+        return WorkflowCheckpointing(backend: WorkflowFileCheckpointStore(directory: directory))
         #else
-        WorkflowCheckpointing()
+        return WorkflowCheckpointing()
         #endif
     }
 }

--- a/Tests/SwarmTests/Core/IntegrationsTraitGateTests.swift
+++ b/Tests/SwarmTests/Core/IntegrationsTraitGateTests.swift
@@ -1,0 +1,117 @@
+import Foundation
+@testable import Swarm
+import Testing
+
+@Suite("Integrations trait gates")
+struct IntegrationsTraitGateTests {
+    @Test("requirement message names the trait and the rebuild remedy")
+    func requirementMessageNamesTraitAndRemedy() {
+        let message = IntegrationsTrait.requirementMessage(for: "Web search")
+        #expect(message.contains("Web search"))
+        #expect(message.contains("Integrations trait"))
+        #expect(message.contains("--traits Integrations"))
+        #expect(message.contains("traits: [\"Integrations\"]"))
+    }
+
+    @Test("WebSearchTool reports availability and fails at construction-time warning plus execute")
+    func webSearchToolFailsEarly() async throws {
+        IntegrationsTraitTesting.reset()
+        #expect(WebSearchTool.isAvailable == IntegrationsTrait.isEnabled)
+
+        let tool = WebSearchTool(apiKey: "test-key")
+
+        #if SWARM_INTEGRATIONS
+        #expect(IntegrationsTraitTesting.warnings.isEmpty)
+        #else
+        #expect(
+            IntegrationsTraitTesting.warnings.contains { warning in
+                warning.contains("Web search")
+                    && warning.contains("--traits Integrations")
+                    && warning.contains("traits: [\"Integrations\"]")
+            }
+        )
+
+        do {
+            _ = try await tool.execute()
+            Issue.record("WebSearchTool.execute should throw on lean builds")
+        } catch let error as AgentError {
+            let description = String(describing: error)
+            #expect(description.contains("Web search"))
+            #expect(description.contains("Integrations trait"))
+            #expect(description.contains("--traits Integrations"))
+            #expect(description.contains("traits: [\"Integrations\"]"))
+        }
+
+        do {
+            _ = try await tool.execute(arguments: ["query": .string("swift")])
+            Issue.record("WebSearchTool.execute(arguments:) should throw on lean builds")
+        } catch let error as AgentError {
+            let description = String(describing: error)
+            #expect(description.contains("--traits Integrations"))
+        }
+        #endif
+    }
+
+    @Test("durable checkpoint factories warn immediately and execute throws the remedy on lean")
+    func durableCheckpointingFailsEarly() async throws {
+        IntegrationsTraitTesting.reset()
+        #expect(WorkflowCheckpointing.isAvailable == IntegrationsTrait.isEnabled)
+        #expect(Workflow.Durable.isAvailable == IntegrationsTrait.isEnabled)
+
+        _ = WorkflowCheckpointing.inMemory()
+        let workflow = Workflow()
+            .step(MockAgentRuntime(response: "ok"))
+            .durable.checkpoint(id: "lean-trap")
+            .durable.checkpointing(.fileSystem(directory: FileManager.default.temporaryDirectory))
+
+        #if SWARM_INTEGRATIONS
+        #expect(IntegrationsTraitTesting.warnings.isEmpty)
+        #else
+        #expect(
+            IntegrationsTraitTesting.warnings.contains { warning in
+                warning.contains("Durable workflow checkpointing")
+                    && warning.contains("--traits Integrations")
+                    && warning.contains("traits: [\"Integrations\"]")
+            }
+        )
+
+        do {
+            _ = try await workflow.durable.execute("hello")
+            Issue.record("durable execute should throw on lean builds when checkpointing is configured")
+        } catch let error as WorkflowError {
+            let description = error.localizedDescription
+            #expect(description.contains("Durable workflow execution"))
+            #expect(description.contains("Integrations trait"))
+            #expect(description.contains("--traits Integrations"))
+            #expect(description.contains("traits: [\"Integrations\"]"))
+        }
+        #endif
+    }
+
+    @Test("ambient web configuration warns at the Swarm.configure touchpoint on lean")
+    func configureWebWarnsOnLean() async {
+        await withSwarmConfigurationIsolation {
+            IntegrationsTraitTesting.reset()
+            await Swarm.configure(web: WebSearchTool.Configuration(apiKey: "test-key", enabled: true))
+
+            #if SWARM_INTEGRATIONS
+            #expect(IntegrationsTraitTesting.warnings.isEmpty)
+            #else
+            #expect(
+                IntegrationsTraitTesting.warnings.contains { warning in
+                    warning.contains("Web search") && warning.contains("--traits Integrations")
+                }
+            )
+            #endif
+        }
+    }
+
+    @Test("Memory.vector is not trait-gated")
+    func vectorMemoryIsAvailableWithoutIntegrations() async {
+        let memory: VectorMemory = .vector(
+            embeddingProvider: MockEmbeddingProvider(),
+            similarityThreshold: 0.75
+        )
+        #expect(await memory.isEmpty)
+    }
+}

--- a/Tests/SwarmTests/Memory/SemanticMemoryAvailabilityTests.swift
+++ b/Tests/SwarmTests/Memory/SemanticMemoryAvailabilityTests.swift
@@ -1,0 +1,74 @@
+#if SWARM_INTEGRATIONS && canImport(ContextCore)
+import ContextCore
+import Foundation
+@testable import Swarm
+import Testing
+
+@Suite("Semantic memory availability")
+struct SemanticMemoryAvailabilityTests {
+    @Test("fallback path logs once and reports semantic memory unavailable")
+    func fallbackPathLogsAndReportsUnavailable() async throws {
+        SemanticMemoryDiagnostics.reset()
+        let url = try makeTemporaryWaxURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+
+        let memory = try DefaultAgentMemory(configuration: .init(waxStoreURL: url))
+        _ = await memory.context(for: "semantic recall probe", tokenLimit: 64)
+
+        #expect(memory.isSemanticMemoryAvailable == false)
+        let warning = try #require(SemanticMemoryDiagnostics.lastWarning)
+        #expect(warning.contains("Real embeddings are unavailable"))
+        #expect(warning.contains("Semantic recall quality is degraded"))
+        #expect(warning.contains("vector rankings are not meaningful"))
+    }
+
+    @Test("custom embedding provider reports semantic memory available")
+    func customProviderReportsAvailable() throws {
+        SemanticMemoryDiagnostics.reset()
+        let url = try makeTemporaryWaxURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+
+        var contextConfiguration = ContextConfiguration.default
+        contextConfiguration.embeddingProvider = FixedSemanticEmbeddingProvider()
+
+        let memory = try DefaultAgentMemory(
+            configuration: .init(
+                contextCoreConfiguration: ContextCoreMemoryConfiguration(
+                    contextConfiguration: contextConfiguration
+                ),
+                waxStoreURL: url
+            )
+        )
+
+        #expect(memory.isSemanticMemoryAvailable == true)
+    }
+}
+
+private struct FixedSemanticEmbeddingProvider: ContextCore.EmbeddingProvider, Sendable {
+    let dimension = 384
+
+    func embed(_ text: String) async throws -> [Float] {
+        var vector = [Float](repeating: 0, count: dimension)
+        vector[0] = Float(text.hashValue % 100) / 100
+        return vector
+    }
+
+    func embedBatch(_ texts: [String]) async throws -> [[Float]] {
+        var results: [[Float]] = []
+        results.reserveCapacity(texts.count)
+        for text in texts {
+            results.append(try await embed(text))
+        }
+        return results
+    }
+}
+
+private func makeTemporaryWaxURL() throws -> URL {
+    let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+        "swarm-semantic-memory-tests-\(UUID().uuidString)",
+        isDirectory: true
+    )
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    return root.appendingPathComponent("wax-memory-\(UUID().uuidString).mv2s")
+}
+#endif

--- a/Tests/SwarmTests/V3/ReadmeProviderCompileTests.swift
+++ b/Tests/SwarmTests/V3/ReadmeProviderCompileTests.swift
@@ -112,7 +112,7 @@ struct ReadmeProviderCompileTests {
     @Test("README Multi-agent pipeline sample compiles")
     func readmeMultiAgentPipelineCompiles() throws {
         let mock = MockInferenceProvider(responses: ["facts", "summary"])
-        // WebSearchTool(apiKey:) exists on lean; execution requires Integrations.
+        // WebSearchTool(apiKey:) exists on lean; construction warns and execute requires Integrations.
         let researcher = try Agent(
             "Research the topic and extract key facts.",
             inferenceProvider: mock
@@ -213,7 +213,7 @@ struct ReadmeProviderCompileTests {
 
     @Test("README Crash-resumable workflows sample compiles")
     func readmeCrashResumableCompiles() throws {
-        // Construction is lean-safe; durable.execute requires Integrations at runtime.
+        // Construction is lean-safe (warns); durable.execute requires Integrations at runtime.
         let mock = MockInferenceProvider(responses: ["done"])
         let monitor = try Agent("Emit a short status.", inferenceProvider: mock)
         let checkpointsURL = FileManager.default.temporaryDirectory

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -28,7 +28,7 @@ Enable Integrations when you need any of:
 | Capability | Without Integrations (lean) | With `traits: ["Integrations"]` |
 |------------|----------------------------|----------------------------------|
 | Default agent memory | `SlidingWindowMemory` | ContextCore + Wax `DefaultAgentMemory` |
-| Durable Hive checkpoint/resume | Configuration type-checks; execute with checkpoint/resume configured throws | Full durable engine |
+| Durable Hive checkpoint/resume | Configuration type-checks; factories warn immediately; execute with checkpoint/resume configured throws | Full durable engine |
 | Membrane adapters | No-op / unavailable backends | Real Membrane session adapters |
 | Web helpers (`websearch`, page fetch/HTML parse) | Not injected / gated | Full web tool support |
 
@@ -57,7 +57,9 @@ durable workflows, MembraneCore, and web helpers; default memory falls back to
 
 **Embeddings:** the CoreML `minilm-l6-v2.mlpackage` model is not bundled with
 Swarm. Without it, Integrations `DefaultAgentMemory` uses deterministic
-pseudo-embeddings until you supply the model under ContextCore resources.
+pseudo-embeddings, logs a once-per-process warning, and
+`isSemanticMemoryAvailable` is `false` until you supply the model under
+ContextCore resources or inject a real embedding provider.
 
 ### Xcode
 
@@ -210,7 +212,13 @@ print(result.tokenUsage)   // TokenUsage(inputTokens:, outputTokens:)
 
 ### Streaming with `stream()`
 
-Stream `AgentEvent` values in real time -- ideal for live UI:
+`Agent.stream` runs the same loop as `run` and forwards `AgentEvent` values
+through an observer — lifecycle, tool, and output events as they occur.
+
+`.output(.token)` is an incremental text chunk when the provider streams
+(Foundation Models does). If the provider only has a completion API, that
+event is the full response in one chunk. This is not a separate token-level
+decoder sitting in front of `run`.
 
 ```swift
 for try await event in agent.stream("Tell me about Swift concurrency.") {
@@ -289,14 +297,18 @@ Durable Hive checkpoint/resume requires the **`Integrations`** SwiftPM trait
 Without Integrations:
 
 - `.durable.checkpoint` / `.checkpointing` and `WorkflowCheckpointing.*` still
-  type-check (configuration-only APIs).
-- `execute` / `.durable.execute` **throws** when checkpointing is configured or
-  `resumeFrom` is non-nil.
+  type-check (configuration-only APIs) and emit a once-per-process warning
+  naming the missing trait and the rebuild remedy
+  (`--traits Integrations` / `traits: ["Integrations"]`).
+- `execute` / `.durable.execute` **throws** `WorkflowError.durableRuntimeUnavailable`
+  when checkpointing is configured or `resumeFrom` is non-nil, with the same
+  remedy in the error message.
 - Bare workflow `run` / `execute` **without** durable configuration still runs as
   a non-durable workflow.
 
 ```swift
-// Requires Integrations trait for checkpoint/resume at execute time
+// Requires Integrations trait for checkpoint/resume at execute time.
+// Lean builds warn at `.checkpoint` / `.checkpointing` and throw on execute.
 let result = try await Workflow()
     .step(fetchAgent)
     .step(analyzeAgent)
@@ -353,6 +365,12 @@ Or using the `.environment()` modifier on any `AgentRuntime`:
 ```swift
 agent.environment(\.inferenceProvider, myCustomProvider)
 ```
+
+### Structured output
+
+`runStructured` asks the model (prompt instruction) and parses the reply as
+JSON. It is not enforced schema generation — invalid JSON fails at parse time
+rather than being constrained by a native generation schema.
 
 ### Provider resolution order
 

--- a/docs/reference/api-catalog.md
+++ b/docs/reference/api-catalog.md
@@ -3,7 +3,7 @@
 Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for high-risk public rows on 2026-07-28 (Conduit hard-removed in 0.6).
 
 - Scope: all `.swift` files under `Sources/Swarm/`, excluding `Internal/GraphRuntime/`
-- Source files scanned: 154
+- Source files scanned: 155
 - Public/open symbols cataloged: 2423
 
 ## 1. Swarm (entry point)

--- a/docs/reference/front-facing-api.md
+++ b/docs/reference/front-facing-api.md
@@ -19,8 +19,9 @@ memory, Membrane adapters, and web helpers:
 | Surface | Lean default | With Integrations |
 |---------|--------------|-------------------|
 | `Agent.makeDefaultMemory()` | `SlidingWindowMemory` | `DefaultAgentMemory` (ContextCore + Wax) |
-| Durable execute with checkpoint / `resumeFrom` | Throws | Full Hive durable engine |
-| Membrane / web helpers | Unavailable or no-op | Linked and active |
+| Durable execute with checkpoint / `resumeFrom` | Warns at checkpoint factories; throws `durableRuntimeUnavailable` | Full Hive durable engine |
+| Membrane / web helpers | Unavailable or no-op; `WebSearchTool` warns at init and throws on execute | Linked and active |
+| Default semantic embeddings | n/a (lean uses `SlidingWindowMemory`) | `DefaultAgentMemory.isSemanticMemoryAvailable` is `false` without MiniLM |
 
 HiveCore, Membrane, and ContextCore are native in-tree `Sources/` targets
 (internal modules, not separate products), linked only with Integrations.
@@ -33,7 +34,8 @@ sdk, OTel, plus NIO transitives including `swift-collections`).
 Membrane session stack are Apple-only (Metal/CoreML); Linux Integrations keeps
 Hive + MembraneCore + web helpers. `DefaultAgentMemory` (ContextCore + Wax)
 uses fallback pseudo-embeddings when the optional CoreML
-`minilm-l6-v2.mlpackage` is not present. See README Install.
+`minilm-l6-v2.mlpackage` is not present, logs a once-per-process warning, and
+exposes `DefaultAgentMemory.isSemanticMemoryAvailable`. See README Install.
 
 ## 1) Entry point and global configuration
 
@@ -252,6 +254,10 @@ Agent("instructions") {
 
 The builder produces an opaque `ToolCollection`; callers supply concrete `Tool` values or `[any Tool]`, and Swarm handles the internal type erasure.
 
+`WebSearchTool` compiles on lean builds. Query `WebSearchTool.isAvailable` (or
+`IntegrationsTrait.isEnabled`) before constructing it; lean inits warn immediately
+and `execute` throws with the rebuild remedy.
+
 ## 6) Conversation
 
 Stateful multi-turn conversation wrapper.
@@ -352,16 +358,18 @@ public struct Workflow: Sendable {
 Requires the **`Integrations`** SwiftPM trait (`traits: ["Integrations"]` or
 `--traits Integrations`) for real checkpoint/resume at **execute** time.
 
-With checkpoint/resume configured (or `resumeFrom` set), lean builds throw that
-durable execution requires Integrations. Without that configuration, bare
-execute still runs as a non-durable workflow. Checkpoint factories and
-`.durable.checkpoint` / `.checkpointing` remain type-checkable in lean mode
-(configuration-only); the trait gate is enforced when execute needs the durable
-engine.
+With checkpoint/resume configured (or `resumeFrom` set), lean builds warn at
+`WorkflowCheckpointing.inMemory()` / `.fileSystem(directory:)` and
+`.durable.checkpoint` / `.checkpointing`, then throw
+`WorkflowError.durableRuntimeUnavailable` with the rebuild remedy. Without that
+configuration, bare execute still runs as a non-durable workflow. Query
+`WorkflowCheckpointing.isAvailable` or `Workflow.Durable.isAvailable` before
+opting in.
 
 ```swift
 public extension Workflow {
     struct Durable: Sendable {
+        static var isAvailable: Bool { get }
         enum CheckpointPolicy: Sendable { case onCompletion, everyStep }
 
         func checkpoint(id: String, policy: CheckpointPolicy = .onCompletion) -> Workflow
@@ -371,7 +379,9 @@ public extension Workflow {
     }
 }
 
-// Configuration-only in lean builds; durable engine requires Integrations at execute
+// Configuration-only in lean builds; factories warn immediately.
+// Durable engine requires Integrations at execute.
+WorkflowCheckpointing.isAvailable
 WorkflowCheckpointing.inMemory()
 WorkflowCheckpointing.fileSystem(directory: URL)
 ```
@@ -422,6 +432,7 @@ When an agent is created without an explicit `memory:` argument, Swarm uses
 public static func makeDefaultMemory() throws -> any Memory
 // Integrations on  → DefaultAgentMemory (ContextCore + Wax)
 // Integrations off → SlidingWindowMemory
+// Query DefaultAgentMemory.isSemanticMemoryAvailable when using the Integrations default.
 ```
 
 Pass an explicit factory when you want a fixed backend regardless of traits:


### PR DESCRIPTION
## Summary

Chunk B of the remediation series. Based on `main` after Chunk A ([#119](https://github.com/christopherkarani/Swarm/pull/119)) merged. Nothing fails silently or late, and public claims match the implementation.

- **Loud embedding fallback:** ContextCore's CoreML MiniLM path logs a once-per-process swift-log warning when it falls back to hash-seeded vectors, and `DefaultAgentMemory.isSemanticMemoryAvailable` reports the runtime truth.
- **Lean traps fail early:** trait-gated APIs warn at the earliest non-throwing touchpoint and throw with a rebuild remedy at the earliest throwing API. Existing public signatures on Integrations builds are unchanged.
- **Honest marketing:** README and getting-started now describe DAG compile vs crash recovery, `Agent.stream` as a `run` observer, and structured output as prompt+parse.

## Lean-trap inventory

| Surface | Before | Mechanism | Justification |
|---|---|---|---|
| `WebSearchTool.init` | Silent construct | `isAvailable` + once-per-process warning | Init is non-throwing; making it `throws` would break Integrations source compatibility |
| `WebSearchTool.execute` / `execute(arguments:)` | Late throw: `"Web search requires the Integrations trait."` | Same error case, full remedy message | Earliest throwing API; backstop if the init warning was ignored |
| `Swarm.configure(web:)` | Silent store; tool never injected on lean | Warning at configure | Earliest ambient-web touchpoint; `configure` is non-throwing |
| `WorkflowCheckpointing.inMemory()` / `.fileSystem(directory:)` | Silent empty stub | `isAvailable` + warning | Factories are non-throwing; cannot add `throws` without an API break |
| `Workflow.Durable.checkpoint` / `checkpointing` | Silent config | `isAvailable` + warning | Same: non-throwing builders |
| `Workflow.durable.execute` when checkpoint / `resumeFrom` is set | Late `invalidWorkflow` jargon | `WorkflowError.durableRuntimeUnavailable` + remedy | Existing error case for this; earliest throwing execute path |
| `Memory.vector(...)` | **Not trait-gated** | Unchanged | Caller-supplied `EmbeddingProvider`; works on lean |
| `Agent.makeDefaultMemory()` | Intentional `SlidingWindowMemory` | Unchanged | Documented lean default, not a trap |
| `DefaultAgentMemory` / `ContextCoreMemory` / `WaxMemory` / `WebSearchSupport` / GraphRuntime | Compile-gated | Unchanged | Unavailable at compile time on lean |
| Lean `DefaultMembraneAgentAdapter` | Silent no-op | Unchanged | Not a late throw with trait jargon |

Remedy string used everywhere:

> `{feature} requires the Integrations trait. Rebuild with `--traits Integrations`, or add `traits: ["Integrations"]` to the Swarm package dependency.`

Query helpers: `IntegrationsTrait.isEnabled`, `WebSearchTool.isAvailable`, `WorkflowCheckpointing.isAvailable`, `Workflow.Durable.isAvailable`.

## Claim corrections (before → after)

**Hero (README)**
- Before: `compiled to a DAG with crash recovery and Swift concurrency safety`
- After: `compiled to a DAG. Crash recovery is opt-in — enable the Integrations trait and durable checkpointing — and Swift concurrency safety is enforced at compile time`

**Why Swarm / crash recovery**
- Before: `Workflows can survive crashes. Durable workflow checkpointing lets you resume from an explicit checkpoint ID.`
- After: names the Integrations trait. Comparison table: `Checkpoints` → `Checkpoints (Integrations)`

**Streaming**
- Before: implied token-level incremental output via `Agent.stream`
- After: `Agent.stream` runs the same loop as `run` and forwards `AgentEvent` through an observer. `.output(.token)` is an incremental chunk when the provider streams (Foundation Models does); otherwise the full completion is one chunk. Tool calls remain capture-then-execute unless the provider implements tool-call streaming.

**Structured outputs**
- Before: not stated (easy to assume native schema generation)
- After: `runStructured` is prompt instruction + JSON parse. Invalid JSON fails at parse time; it is not enforced schema generation.

**Embeddings**
- Before: silent fallback to pseudo-embeddings
- After: once-per-process warning + `DefaultAgentMemory.isSemanticMemoryAvailable`

## Test plan

- [x] `bash scripts/ci/lean-build-test.sh` — **PASS**, 1724 tests / 221 suites
- [x] `swift test --no-parallel --traits Integrations` — **PASS**, 1856 tests / 241 suites
- [x] `swift run --traits Integrations SwarmCapabilityShowcase matrix` — all scenarios passed (embedding fallback warning now visible in matrix logs, as intended)
- [x] SwiftFormat / SwiftLint `--strict` clean on changed Swift files
- [x] New lean tests: `IntegrationsTraitGateTests` (warn + throw + remedy on lean; `isAvailable == true` and no warning on Integrations)
- [x] New Integrations tests: `SemanticMemoryAvailabilityTests` (fallback logs + `isSemanticMemoryAvailable == false`; custom provider reports available)

No Chunk A test-count snapshot was stored in this session. These numbers are on `main` after #119 + #120, with Chunk B's new tests included (lean +5 gate tests; Integrations +7 including semantic-memory).

## Breaking changes

**Does this PR introduce breaking changes?**
- [x] No public signature changes on Integrations builds
- Lean `Workflow.durable.execute` with checkpointing configured now throws `durableRuntimeUnavailable` instead of `invalidWorkflow` (same failure, more accurate case + remedy message)


Made with [Cursor](https://cursor.com)