### PR TITLE
fix: workflow correctness — environment propagation, merge semantics, edge-case errors

### DIFF
--- a/Sources/Swarm/Workflow/Workflow+Timeout.swift
+++ b/Sources/Swarm/Workflow/Workflow+Timeout.swift
@@ -1,0 +1,133 @@
+import Foundation
+
+extension Workflow {
+    /// Runs `operation`, racing it against `timeoutDuration` when configured.
+    ///
+    /// Uses `Task.detached` so a MainActor caller cannot deadlock the
+    /// continuation (an unstructured `Task {}` would be scheduled on MainActor
+    /// and never run). Detached tasks drop `@TaskLocal` values, so the ambient
+    /// `AgentEnvironment` is snapshotted and re-applied inside the worker.
+    func executeWithTimeout(
+        _ operation: @escaping @Sendable () async throws -> AgentResult
+    ) async throws -> AgentResult {
+        guard let timeoutDuration else {
+            return try await operation()
+        }
+
+        let coordinator = WorkflowTimedOperationCoordinator<AgentResult>()
+        let priority = Task.currentPriority
+        let capturedEnvironment = AgentEnvironmentValues.current
+        return try await withTaskCancellationHandler(
+            operation: {
+                try await withCheckedThrowingContinuation { continuation in
+                    coordinator.install(continuation: continuation)
+
+                    let operationTask = Task.detached(priority: priority) {
+                        do {
+                            let result = try await AgentEnvironmentValues.$current.withValue(
+                                capturedEnvironment
+                            ) {
+                                try await operation()
+                            }
+                            coordinator.finish(returning: result)
+                        } catch {
+                            coordinator.finish(throwing: error)
+                        }
+                    }
+                    coordinator.setOperationTask(operationTask)
+
+                    let timeoutTask = Task.detached(priority: priority) {
+                        do {
+                            try await Task.sleep(for: timeoutDuration)
+                            operationTask.cancel()
+                            coordinator.finish(throwing: AgentError.timeout(duration: timeoutDuration))
+                        } catch is CancellationError {
+                            return
+                        } catch {
+                            coordinator.finish(throwing: error)
+                        }
+                    }
+                    coordinator.setTimeoutTask(timeoutTask)
+                }
+            },
+            onCancel: {
+                coordinator.cancelPending(with: CancellationError())
+            }
+        )
+    }
+}
+
+private final class WorkflowTimedOperationCoordinator<T: Sendable>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<T, Error>?
+    private var operationTask: Task<Void, Never>?
+    private var timeoutTask: Task<Void, Never>?
+    private var completed = false
+
+    func install(continuation: CheckedContinuation<T, Error>) {
+        lock.lock()
+        self.continuation = continuation
+        lock.unlock()
+    }
+
+    func setOperationTask(_ task: Task<Void, Never>) {
+        lock.lock()
+        operationTask = task
+        lock.unlock()
+    }
+
+    func setTimeoutTask(_ task: Task<Void, Never>) {
+        lock.lock()
+        timeoutTask = task
+        lock.unlock()
+    }
+
+    func finish(returning value: T) {
+        complete { continuation in
+            continuation.resume(returning: value)
+        }
+    }
+
+    func finish(throwing error: Error) {
+        complete { continuation in
+            continuation.resume(throwing: error)
+        }
+    }
+
+    func cancelPending(with error: Error) {
+        let pendingState = takePendingState()
+        pendingState.operationTask?.cancel()
+        pendingState.timeoutTask?.cancel()
+        pendingState.continuation?.resume(throwing: error)
+    }
+
+    private func complete(_ resume: (CheckedContinuation<T, Error>) -> Void) {
+        let pendingState = takePendingState()
+        pendingState.operationTask?.cancel()
+        pendingState.timeoutTask?.cancel()
+        guard let continuation = pendingState.continuation else { return }
+        resume(continuation)
+    }
+
+    private func takePendingState() -> (
+        continuation: CheckedContinuation<T, Error>?,
+        operationTask: Task<Void, Never>?,
+        timeoutTask: Task<Void, Never>?
+    ) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard completed == false else {
+            return (nil, nil, nil)
+        }
+
+        completed = true
+        let pendingContinuation = continuation
+        let pendingOperationTask = operationTask
+        let pendingTimeoutTask = timeoutTask
+        continuation = nil
+        operationTask = nil
+        timeoutTask = nil
+        return (pendingContinuation, pendingOperationTask, pendingTimeoutTask)
+    }
+}

--- a/Sources/Swarm/Workflow/Workflow.swift
+++ b/Sources/Swarm/Workflow/Workflow.swift
@@ -120,6 +120,7 @@ public struct Workflow: Sendable {
     /// ### Merge Strategies
     /// - ``structured``
     /// - ``indexed``
+    /// - ``firstCompleted``
     /// - ``first``
     /// - ``custom(_:)``
     public enum MergeStrategy: Sendable {
@@ -156,20 +157,28 @@ public struct Workflow: Sendable {
         /// ```
         case indexed
 
-        /// Returns the output of the first agent to complete.
+        /// Returns the output of the first agent to complete, then cancels the rest.
         ///
         /// Use this strategy when you only need one result and want the fastest
-        /// response. Note: All agents still run to completion, but only the
-        /// first completed result is used.
+        /// response. Remaining in-flight agents are cancelled cooperatively once
+        /// a winner is chosen.
         ///
         /// ## Example
         ///
         /// ```swift
         /// let result = try await Workflow()
-        ///     .parallel([fastAgent, slowAgent], merge: .first)
+        ///     .parallel([fastAgent, slowAgent], merge: .firstCompleted)
         ///     .run("Task")
         /// // result.output contains output from whichever agent finished first
         /// ```
+        case firstCompleted
+
+        /// Returns the output of the first agent to complete.
+        ///
+        /// - Important: Use ``firstCompleted`` instead. This case is a deprecated
+        ///   alias with the same first-to-complete semantics, including cancelling
+        ///   remaining agents after a winner is chosen.
+        @available(*, deprecated, renamed: "firstCompleted")
         case first
 
         /// Applies a custom merge function to combine all parallel results.
@@ -444,7 +453,8 @@ public struct Workflow: Sendable {
     ///
     /// - Parameter input: The initial input string for the workflow.
     /// - Returns: The final ``AgentResult`` after all steps complete.
-    /// - Throws: An error if execution fails, times out, or routing fails.
+    /// - Throws: ``WorkflowError/invalidWorkflow(reason:)`` if the workflow has
+    ///   no steps. Also throws if execution fails, times out, or routing fails.
     ///
     /// ## Example
     ///
@@ -531,6 +541,11 @@ public struct Workflow: Sendable {
         if let timeoutDuration {
             let coordinator = WorkflowTimedOperationCoordinator<AgentResult>()
             let priority = Task.currentPriority
+            // `Task.detached` is required so a MainActor caller cannot deadlock
+            // the continuation (an unstructured `Task {}` would be scheduled on
+            // MainActor and never run). Detached tasks drop `@TaskLocal` values,
+            // so re-apply the ambient environment inside the worker.
+            let capturedEnvironment = AgentEnvironmentValues.current
             return try await withTaskCancellationHandler(
                 operation: {
                     try await withCheckedThrowingContinuation { continuation in
@@ -538,7 +553,12 @@ public struct Workflow: Sendable {
 
                         let operationTask = Task.detached(priority: priority) {
                             do {
-                                coordinator.finish(returning: try await operation())
+                                let result = try await AgentEnvironmentValues.$current.withValue(
+                                    capturedEnvironment
+                                ) {
+                                    try await operation()
+                                }
+                                coordinator.finish(returning: result)
                             } catch {
                                 coordinator.finish(throwing: error)
                             }
@@ -568,18 +588,28 @@ public struct Workflow: Sendable {
     }
 
     func executeDirect(input: String) async throws -> AgentResult {
+        guard !steps.isEmpty else {
+            throw WorkflowError.invalidWorkflow(reason: "Workflow has no steps")
+        }
+
         if let repeatCondition {
             var lastResult: AgentResult?
 
             for _ in 0 ..< maxRepeatIterations {
                 let currentInput = lastResult?.output ?? input
-                lastResult = try await runSinglePass(input: currentInput)
-                if repeatCondition(lastResult!) {
-                    return lastResult!
+                let result = try await runSinglePass(input: currentInput)
+                lastResult = result
+                if repeatCondition(result) {
+                    return result
                 }
             }
 
-            return lastResult ?? AgentResult(output: "")
+            guard let lastResult else {
+                throw WorkflowError.invalidWorkflow(
+                    reason: "Workflow repeatUntil completed without producing a result"
+                )
+            }
+            return lastResult
         }
 
         return try await runSinglePass(input: input)
@@ -615,19 +645,29 @@ public struct Workflow: Sendable {
                     }
                 }
 
+                if merge.usesFirstCompletedSemantics {
+                    guard let winner = try await group.next() else {
+                        throw WorkflowError.mergeStrategyFailed(
+                            reason: "Parallel workflow produced no results"
+                        )
+                    }
+                    group.cancelAll()
+                    // Drain cancelled losers so their CancellationError does not
+                    // replace the winning result when the group exits.
+                    while let remaining = await group.nextResult() {
+                        _ = remaining
+                    }
+                    return [winner]
+                }
+
                 var collected: [(Int, AgentResult)] = []
                 for try await result in group {
                     collected.append(result)
                 }
-                return collected
+                return collected.sorted { $0.0 < $1.0 }
             }
 
-            let results = switch merge {
-            case .first:
-                completedResults.map(\.1)
-            default:
-                completedResults.sorted { $0.0 < $1.0 }.map(\.1)
-            }
+            let results = completedResults.map(\.1)
             let mergedOutput = mergeResults(results, strategy: merge)
             return AgentResult(output: mergedOutput)
 
@@ -685,10 +725,10 @@ public struct Workflow: Sendable {
             return results.enumerated().map { idx, result in
                 "[\(idx)]: \(result.output)"
             }.joined(separator: "\n")
-        case .first:
-            return results.first?.output ?? ""
         case .custom(let transform):
             return transform(results)
+        default:
+            return results.first?.output ?? ""
         }
     }
 
@@ -705,10 +745,12 @@ public struct Workflow: Sendable {
                     mergeSignature = "structured"
                 case .indexed:
                     mergeSignature = "indexed"
-                case .first:
-                    mergeSignature = "first"
+                case .firstCompleted:
+                    mergeSignature = "firstCompleted"
                 case .custom:
                     mergeSignature = mergeBehaviorSignature?.value ?? "custom:opaque"
+                default:
+                    mergeSignature = "first"
                 }
                 return "\(index):parallel:\(agentsSignature):\(mergeSignature)"
             case .route(let signature, _):
@@ -724,6 +766,20 @@ public struct Workflow: Sendable {
             "repeat:false:\(maxRepeatIterations)"
         }
         return (["workflowSignature:v2"] + parts + [repeatSignature]).joined(separator: "|")
+    }
+}
+
+extension Workflow.MergeStrategy {
+    /// `.first` is a deprecated alias of `.firstCompleted`.
+    fileprivate var usesFirstCompletedSemantics: Bool {
+        switch self {
+        case .firstCompleted:
+            return true
+        case .structured, .indexed, .custom:
+            return false
+        default:
+            return true
+        }
     }
 }
 

--- a/Sources/Swarm/Workflow/Workflow.swift
+++ b/Sources/Swarm/Workflow/Workflow.swift
@@ -535,58 +535,6 @@ public struct Workflow: Sendable {
     var observer: (any AgentObserver)?
     var advancedConfiguration = AdvancedConfiguration()
 
-    func executeWithTimeout(
-        _ operation: @escaping @Sendable () async throws -> AgentResult
-    ) async throws -> AgentResult {
-        if let timeoutDuration {
-            let coordinator = WorkflowTimedOperationCoordinator<AgentResult>()
-            let priority = Task.currentPriority
-            // `Task.detached` is required so a MainActor caller cannot deadlock
-            // the continuation (an unstructured `Task {}` would be scheduled on
-            // MainActor and never run). Detached tasks drop `@TaskLocal` values,
-            // so re-apply the ambient environment inside the worker.
-            let capturedEnvironment = AgentEnvironmentValues.current
-            return try await withTaskCancellationHandler(
-                operation: {
-                    try await withCheckedThrowingContinuation { continuation in
-                        coordinator.install(continuation: continuation)
-
-                        let operationTask = Task.detached(priority: priority) {
-                            do {
-                                let result = try await AgentEnvironmentValues.$current.withValue(
-                                    capturedEnvironment
-                                ) {
-                                    try await operation()
-                                }
-                                coordinator.finish(returning: result)
-                            } catch {
-                                coordinator.finish(throwing: error)
-                            }
-                        }
-                        coordinator.setOperationTask(operationTask)
-
-                        let timeoutTask = Task.detached(priority: priority) {
-                            do {
-                                try await Task.sleep(for: timeoutDuration)
-                                operationTask.cancel()
-                                coordinator.finish(throwing: AgentError.timeout(duration: timeoutDuration))
-                            } catch is CancellationError {
-                                return
-                            } catch {
-                                coordinator.finish(throwing: error)
-                            }
-                        }
-                        coordinator.setTimeoutTask(timeoutTask)
-                    }
-                },
-                onCancel: {
-                    coordinator.cancelPending(with: CancellationError())
-                }
-            )
-        }
-        return try await operation()
-    }
-
     func executeDirect(input: String) async throws -> AgentResult {
         guard !steps.isEmpty else {
             throw WorkflowError.invalidWorkflow(reason: "Workflow has no steps")
@@ -645,7 +593,7 @@ public struct Workflow: Sendable {
                     }
                 }
 
-                if merge.usesFirstCompletedSemantics {
+                if merge.cancelsLosersAfterFirstResult {
                     guard let winner = try await group.next() else {
                         throw WorkflowError.mergeStrategyFailed(
                             reason: "Parallel workflow produced no results"
@@ -654,9 +602,7 @@ public struct Workflow: Sendable {
                     group.cancelAll()
                     // Drain cancelled losers so their CancellationError does not
                     // replace the winning result when the group exits.
-                    while let remaining = await group.nextResult() {
-                        _ = remaining
-                    }
+                    while await group.nextResult() != nil {}
                     return [winner]
                 }
 
@@ -667,9 +613,7 @@ public struct Workflow: Sendable {
                 return collected.sorted { $0.0 < $1.0 }
             }
 
-            let results = completedResults.map(\.1)
-            let mergedOutput = mergeResults(results, strategy: merge)
-            return AgentResult(output: mergedOutput)
+            return AgentResult(output: merge.mergedOutput(from: completedResults.map(\.1)))
 
         case .route(_, let route):
             guard let selected = route(input) else {
@@ -707,31 +651,6 @@ public struct Workflow: Sendable {
         }
     }
 
-    func mergeResults(_ results: [AgentResult], strategy: MergeStrategy) -> String {
-        switch strategy {
-        case .structured:
-            // Produce a JSON object keyed by index for machine-parseable output.
-            let dict = results.enumerated().reduce(into: [String: String]()) { acc, pair in
-                acc["\(pair.offset)"] = pair.element.output
-            }
-            if let data = try? JSONSerialization.data(withJSONObject: dict, options: .sortedKeys),
-               let json = String(data: data, encoding: .utf8)
-            {
-                return json
-            }
-            // Fallback: indexed format if JSON serialization fails (non-UTF-8 content).
-            fallthrough
-        case .indexed:
-            return results.enumerated().map { idx, result in
-                "[\(idx)]: \(result.output)"
-            }.joined(separator: "\n")
-        case .custom(let transform):
-            return transform(results)
-        default:
-            return results.first?.output ?? ""
-        }
-    }
-
     var workflowSignature: String {
         let parts: [String] = steps.enumerated().map { index, step in
             switch step {
@@ -739,19 +658,7 @@ public struct Workflow: Sendable {
                 return "\(index):single:\(workflowAgentSignature(agent))"
             case .parallel(let agents, let merge, let mergeBehaviorSignature):
                 let agentsSignature = agents.map(workflowAgentSignature).joined(separator: ",")
-                let mergeSignature: String
-                switch merge {
-                case .structured:
-                    mergeSignature = "structured"
-                case .indexed:
-                    mergeSignature = "indexed"
-                case .firstCompleted:
-                    mergeSignature = "firstCompleted"
-                case .custom:
-                    mergeSignature = mergeBehaviorSignature?.value ?? "custom:opaque"
-                default:
-                    mergeSignature = "first"
-                }
+                let mergeSignature = merge.durableSignature(customMerge: mergeBehaviorSignature)
                 return "\(index):parallel:\(agentsSignature):\(mergeSignature)"
             case .route(let signature, _):
                 return "\(index):route:\(signature.value)"
@@ -770,15 +677,51 @@ public struct Workflow: Sendable {
 }
 
 extension Workflow.MergeStrategy {
-    /// `.first` is a deprecated alias of `.firstCompleted`.
-    fileprivate var usesFirstCompletedSemantics: Bool {
+    /// Deprecated `.first` is an alias of `.firstCompleted`.
+    fileprivate var cancelsLosersAfterFirstResult: Bool {
         switch self {
-        case .firstCompleted:
-            return true
         case .structured, .indexed, .custom:
             return false
         default:
             return true
+        }
+    }
+
+    fileprivate func mergedOutput(from results: [AgentResult]) -> String {
+        switch self {
+        case .structured:
+            let dict = results.enumerated().reduce(into: [String: String]()) { acc, pair in
+                acc["\(pair.offset)"] = pair.element.output
+            }
+            if let data = try? JSONSerialization.data(withJSONObject: dict, options: .sortedKeys),
+               let json = String(data: data, encoding: .utf8)
+            {
+                return json
+            }
+            fallthrough
+        case .indexed:
+            return results.enumerated().map { idx, result in
+                "[\(idx)]: \(result.output)"
+            }.joined(separator: "\n")
+        case .custom(let transform):
+            return transform(results)
+        default:
+            return results.first?.output ?? ""
+        }
+    }
+
+    fileprivate func durableSignature(customMerge: Workflow.OpaqueBehaviorSignature?) -> String {
+        switch self {
+        case .structured:
+            return "structured"
+        case .indexed:
+            return "indexed"
+        case .firstCompleted:
+            return "firstCompleted"
+        case .custom:
+            return customMerge?.value ?? "custom:opaque"
+        default:
+            return "first"
         }
     }
 }
@@ -892,79 +835,4 @@ private func workflowOptionalTypeSignature(_ value: Any?) -> String {
 
 private func workflowSignatureComponent(_ value: String) -> String {
     "\(value.utf8.count)#\(value)"
-}
-
-private final class WorkflowTimedOperationCoordinator<T: Sendable>: @unchecked Sendable {
-    private let lock = NSLock()
-    private var continuation: CheckedContinuation<T, Error>?
-    private var operationTask: Task<Void, Never>?
-    private var timeoutTask: Task<Void, Never>?
-    private var completed = false
-
-    func install(continuation: CheckedContinuation<T, Error>) {
-        lock.lock()
-        self.continuation = continuation
-        lock.unlock()
-    }
-
-    func setOperationTask(_ task: Task<Void, Never>) {
-        lock.lock()
-        operationTask = task
-        lock.unlock()
-    }
-
-    func setTimeoutTask(_ task: Task<Void, Never>) {
-        lock.lock()
-        timeoutTask = task
-        lock.unlock()
-    }
-
-    func finish(returning value: T) {
-        complete { continuation in
-            continuation.resume(returning: value)
-        }
-    }
-
-    func finish(throwing error: Error) {
-        complete { continuation in
-            continuation.resume(throwing: error)
-        }
-    }
-
-    func cancelPending(with error: Error) {
-        let pendingState = takePendingState()
-        pendingState.operationTask?.cancel()
-        pendingState.timeoutTask?.cancel()
-        pendingState.continuation?.resume(throwing: error)
-    }
-
-    private func complete(_ resume: (CheckedContinuation<T, Error>) -> Void) {
-        let pendingState = takePendingState()
-        pendingState.operationTask?.cancel()
-        pendingState.timeoutTask?.cancel()
-        guard let continuation = pendingState.continuation else { return }
-        resume(continuation)
-    }
-
-    private func takePendingState() -> (
-        continuation: CheckedContinuation<T, Error>?,
-        operationTask: Task<Void, Never>?,
-        timeoutTask: Task<Void, Never>?
-    ) {
-        lock.lock()
-        defer { lock.unlock() }
-
-        guard completed == false else {
-            return (nil, nil, nil)
-        }
-
-        completed = true
-        let pendingContinuation = continuation
-        let pendingOperationTask = operationTask
-        let pendingTimeoutTask = timeoutTask
-        continuation = nil
-        operationTask = nil
-        timeoutTask = nil
-        return (pendingContinuation, pendingOperationTask, pendingTimeoutTask)
-    }
 }

--- a/Tests/SwarmTests/Mocks/MockAgentRuntime.swift
+++ b/Tests/SwarmTests/Mocks/MockAgentRuntime.swift
@@ -50,7 +50,16 @@ public actor MockAgentRuntime: AgentRuntime {
 
     public func run(_ input: String, session: (any Session)?, observer: (any AgentObserver)?) async throws -> AgentResult {
         if delay > .zero {
-            try await Task.sleep(for: delay)
+            do {
+                try await Task.sleep(for: delay)
+            } catch is CancellationError {
+                cancelled = true
+                throw CancellationError()
+            }
+        }
+        if Task.isCancelled {
+            cancelled = true
+            throw CancellationError()
         }
         if cancelled {
             throw AgentError.cancelled

--- a/Tests/SwarmTests/Workflow/WorkflowTests.swift
+++ b/Tests/SwarmTests/Workflow/WorkflowTests.swift
@@ -62,17 +62,16 @@ struct WorkflowCoreTests {
         #expect(result.output.contains("beta"))
     }
 
-    @Test("parallel with .first merge returns one result")
-    func parallelFirst() async throws {
+    @Test("parallel with .firstCompleted merge returns one result")
+    func parallelFirstCompletedReturnsOneResult() async throws {
         let a = MockAgentRuntime(response: "alpha")
         let b = MockAgentRuntime(response: "beta")
         let result = try await Workflow()
-            .parallel([a, b], merge: .first)
+            .parallel([a, b], merge: .firstCompleted)
             .run("input")
-        // Either alpha or beta — but only one of them.
         let output = result.output
         let containsBoth = output.contains("alpha") && output.contains("beta")
-        #expect(!containsBoth, "first merge should not concatenate")
+        #expect(!containsBoth, "firstCompleted merge should not concatenate")
     }
 
     @Test("parallel with .custom merge applies the closure")
@@ -185,6 +184,149 @@ struct WorkflowCoreTests {
             .run("input")
         #expect(result.output == "tail")
     }
+
+    // MARK: - Empty workflow
+
+    @Test("empty workflow throws invalidWorkflow")
+    func emptyWorkflowThrows() async {
+        do {
+            _ = try await Workflow().run("input")
+            Issue.record("Expected WorkflowError.invalidWorkflow for a workflow with no steps")
+        } catch let error as WorkflowError {
+            guard case .invalidWorkflow(let reason) = error else {
+                Issue.record("Expected invalidWorkflow, got \(error)")
+                return
+            }
+            #expect(reason.contains("no steps"))
+        } catch {
+            Issue.record("Expected WorkflowError, got \(error)")
+        }
+    }
+
+    // MARK: - Timeout environment propagation
+
+    @Test("timeout-wrapped workflow uses ambient task-local inference provider")
+    func timeoutPreservesAmbientTaskLocalProvider() async throws {
+        try await withSwarmConfigurationIsolation {
+            let mock = MockInferenceProvider(responses: ["from-task-local-env"])
+            let agent = try Agent("Reply with the model output.")
+            var env = AgentEnvironment()
+            env.inferenceProvider = mock
+
+            let result = try await AgentEnvironmentValues.$current.withValue(env) {
+                try await Workflow()
+                    .step(agent)
+                    .timeout(.seconds(5))
+                    .run("hello")
+            }
+
+            #expect(result.output == "from-task-local-env")
+            #expect(await mockProviderServicedRequest(mock))
+        }
+    }
+
+    @Test("timeout-wrapped workflow still honors agent.environment provider")
+    func timeoutPreservesAgentEnvironmentModifier() async throws {
+        try await withSwarmConfigurationIsolation {
+            let mock = MockInferenceProvider(responses: ["from-agent-environment"])
+            let agent = try Agent("Reply with the model output.")
+                .environment(\.inferenceProvider, mock as (any InferenceProvider)?)
+
+            let result = try await Workflow()
+                .step(agent)
+                .timeout(.seconds(5))
+                .run("hello")
+
+            #expect(result.output == "from-agent-environment")
+            #expect(await mockProviderServicedRequest(mock))
+        }
+    }
+
+    // MARK: - Parallel merge ordering and cancellation
+
+    @Test("structured merge keeps original step index when a later agent finishes first")
+    func structuredMergeUsesOriginalStepIndex() async throws {
+        let slow = MockAgentRuntime(response: "slow", delay: .milliseconds(80))
+        let fast = MockAgentRuntime(response: "fast", delay: .milliseconds(5))
+        let result = try await Workflow()
+            .parallel([slow, fast], merge: .structured)
+            .run("input")
+
+        let object = try parseJSONObject(result.output)
+        #expect(object["0"] == "slow")
+        #expect(object["1"] == "fast")
+    }
+
+    @Test("indexed merge keeps original step index when a later agent finishes first")
+    func indexedMergeUsesOriginalStepIndex() async throws {
+        let slow = MockAgentRuntime(response: "slow", delay: .milliseconds(80))
+        let fast = MockAgentRuntime(response: "fast", delay: .milliseconds(5))
+        let result = try await Workflow()
+            .parallel([slow, fast], merge: .indexed)
+            .run("input")
+        #expect(result.output == "[0]: slow\n[1]: fast")
+    }
+
+    @Test("custom merge receives results in original step index order")
+    func customMergeUsesOriginalStepIndex() async throws {
+        let slow = MockAgentRuntime(response: "slow", delay: .milliseconds(80))
+        let fast = MockAgentRuntime(response: "fast", delay: .milliseconds(5))
+        let result = try await Workflow()
+            .parallel([slow, fast], merge: .custom { results in
+                results.map(\.output).joined(separator: ",")
+            })
+            .run("input")
+        #expect(result.output == "slow,fast")
+    }
+
+    @Test("firstCompleted returns the fastest branch, not the first agent")
+    func firstCompletedReturnsFastestBranch() async throws {
+        let slow = MockAgentRuntime(response: "slow", delay: .milliseconds(200))
+        let fast = MockAgentRuntime(response: "fast", delay: .milliseconds(10))
+        let result = try await Workflow()
+            .parallel([slow, fast], merge: .firstCompleted)
+            .run("input")
+        #expect(result.output == "fast")
+    }
+
+    @Test("firstCompleted cancels loser tasks instead of waiting for them")
+    func firstCompletedCancelsLosers() async throws {
+        let fast = MockAgentRuntime(response: "fast", delay: .milliseconds(20))
+        let slow = MockAgentRuntime(response: "slow", delay: .milliseconds(5_000))
+        let start = ContinuousClock.now
+        let result = try await Workflow()
+            .parallel([slow, fast], merge: .firstCompleted)
+            .run("input")
+        let elapsed = ContinuousClock.now - start
+
+        #expect(result.output == "fast")
+        #expect(elapsed < .milliseconds(1_000))
+        #expect(await slow.isCancelled)
+    }
+}
+
+private func mockProviderServicedRequest(_ mock: MockInferenceProvider) async -> Bool {
+    let generateCount = await mock.generateCallCount
+    let messageCalls = await mock.generateMessageCalls
+    let toolCallCalls = await mock.toolCallCalls
+    let toolCallMessageCalls = await mock.toolCallMessageCalls
+    return generateCount > 0
+        || !messageCalls.isEmpty
+        || !toolCallCalls.isEmpty
+        || !toolCallMessageCalls.isEmpty
+}
+
+private func parseJSONObject(_ json: String) throws -> [String: String] {
+    let data = Data(json.utf8)
+    let object = try JSONSerialization.jsonObject(with: data)
+    guard let dictionary = object as? [String: String] else {
+        throw WorkflowTestParseError.notStringDictionary(json)
+    }
+    return dictionary
+}
+
+private enum WorkflowTestParseError: Error {
+    case notStringDictionary(String)
 }
 
 private final class WorkflowTestCounter: @unchecked Sendable {

--- a/docs/reference/api-catalog.md
+++ b/docs/reference/api-catalog.md
@@ -3,7 +3,7 @@
 Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for high-risk public rows on 2026-07-28 (Conduit hard-removed in 0.6).
 
 - Scope: all `.swift` files under `Sources/Swarm/`, excluding `Internal/GraphRuntime/`
-- Source files scanned: 155
+- Source files scanned: 156
 - Public/open symbols cataloged: 2423
 
 ## 1. Swarm (entry point)

--- a/docs/reference/api-catalog.md
+++ b/docs/reference/api-catalog.md
@@ -2418,22 +2418,23 @@ Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for
 | Line | Kind | Access | Name | Signature |
 |------|------|--------|------|-----------|
 | 89 | struct | public | Workflow | `public struct Workflow` |
-| 125 | enum | public | Workflow.MergeStrategy | `public enum MergeStrategy` |
-| 140 | case | public | Workflow.MergeStrategy.structured | `public case structured` |
-| 157 | case | public | Workflow.MergeStrategy.indexed | `public case indexed` |
-| 173 | case | public | Workflow.MergeStrategy.first | `public case first` |
-| 193 | case | public | Workflow.MergeStrategy.custom(_:) | `public case custom(@Sendable ([AgentResult]) -> String)` |
-| 209 | func | public | Workflow.init() | `public init()` |
-| 229 | func | public | Workflow.step(_:) | `public func step(_ agent: some AgentRuntime) -> Workflow` |
-| 259 | func | public | Workflow.parallel(_:merge:customMergeSignature:fileID:line:) | `public func parallel(_ agents: [any AgentRuntime], merge: Workflow.MergeStrategy = .structured, customMergeSignature: String? = nil, fileID: StaticString = #fileID, line: UInt = #line) -> Workflow` |
-| 311 | func | public | Workflow.route(_:signature:fileID:line:) | `public func route(_ condition: @escaping @Sendable (String) -> (any AgentRuntime)?, signature: String? = nil, fileID: StaticString = #fileID, line: UInt = #line) -> Workflow` |
-| 326 | func | public | Workflow.route(signature:fileID:line:_:) | `public func route(signature: String, fileID: StaticString = #fileID, line: UInt = #line, _ condition: @escaping @Sendable (String) -> (any AgentRuntime)?) -> Workflow` |
-| 361 | func | public | Workflow.repeatUntil(maxIterations:_:signature:fileID:line:) | `public func repeatUntil(maxIterations: Int = 100, _ condition: @escaping @Sendable (AgentResult) -> Bool, signature: String? = nil, fileID: StaticString = #fileID, line: UInt = #line) -> Workflow` |
-| 381 | func | public | Workflow.repeatUntil(maxIterations:signature:fileID:line:_:) | `public func repeatUntil(maxIterations: Int = 100, signature: String, fileID: StaticString = #fileID, line: UInt = #line, _ condition: @escaping @Sendable (AgentResult) -> Bool) -> Workflow` |
-| 407 | func | public | Workflow.timeout(_:) | `public func timeout(_ duration: Duration) -> Workflow` |
-| 433 | func | public | Workflow.observed(by:) | `public func observed(by observer: some AgentObserver) -> Workflow` |
-| 459 | func | public | Workflow.run(_:) | `public func run(_ input: String) async throws -> AgentResult` |
-| 494 | func | public | Workflow.stream(_:) | `public func stream(_ input: String) -> AsyncThrowingStream<AgentEvent, Error>` |
+| 126 | enum | public | Workflow.MergeStrategy | `public enum MergeStrategy` |
+| 141 | case | public | Workflow.MergeStrategy.structured | `public case structured` |
+| 158 | case | public | Workflow.MergeStrategy.indexed | `public case indexed` |
+| 174 | case | public | Workflow.MergeStrategy.firstCompleted | `public case firstCompleted` |
+| 182 | case | public | Workflow.MergeStrategy.first | `public case first` _(Availability: * (deprecated); renamed to firstCompleted)_ |
+| 202 | case | public | Workflow.MergeStrategy.custom(_:) | `public case custom(@Sendable ([AgentResult]) -> String)` |
+| 218 | func | public | Workflow.init() | `public init()` |
+| 238 | func | public | Workflow.step(_:) | `public func step(_ agent: some AgentRuntime) -> Workflow` |
+| 268 | func | public | Workflow.parallel(_:merge:customMergeSignature:fileID:line:) | `public func parallel(_ agents: [any AgentRuntime], merge: Workflow.MergeStrategy = .structured, customMergeSignature: String? = nil, fileID: StaticString = #fileID, line: UInt = #line) -> Workflow` |
+| 320 | func | public | Workflow.route(_:signature:fileID:line:) | `public func route(_ condition: @escaping @Sendable (String) -> (any AgentRuntime)?, signature: String? = nil, fileID: StaticString = #fileID, line: UInt = #line) -> Workflow` |
+| 335 | func | public | Workflow.route(signature:fileID:line:_:) | `public func route(signature: String, fileID: StaticString = #fileID, line: UInt = #line, _ condition: @escaping @Sendable (String) -> (any AgentRuntime)?) -> Workflow` |
+| 370 | func | public | Workflow.repeatUntil(maxIterations:_:signature:fileID:line:) | `public func repeatUntil(maxIterations: Int = 100, _ condition: @escaping @Sendable (AgentResult) -> Bool, signature: String? = nil, fileID: StaticString = #fileID, line: UInt = #line) -> Workflow` |
+| 390 | func | public | Workflow.repeatUntil(maxIterations:signature:fileID:line:_:) | `public func repeatUntil(maxIterations: Int = 100, signature: String, fileID: StaticString = #fileID, line: UInt = #line, _ condition: @escaping @Sendable (AgentResult) -> Bool) -> Workflow` |
+| 416 | func | public | Workflow.timeout(_:) | `public func timeout(_ duration: Duration) -> Workflow` |
+| 442 | func | public | Workflow.observed(by:) | `public func observed(by observer: some AgentObserver) -> Workflow` |
+| 469 | func | public | Workflow.run(_:) | `public func run(_ input: String) async throws -> AgentResult` |
+| 504 | func | public | Workflow.stream(_:) | `public func stream(_ input: String) -> AsyncThrowingStream<AgentEvent, Error>` |
 
 ### Workflow/WorkflowCheckpointing.swift
 

--- a/docs/reference/front-facing-api.md
+++ b/docs/reference/front-facing-api.md
@@ -297,10 +297,11 @@ Fluent multi-agent pipeline composition.
 
 ```swift
 public struct Workflow: Sendable {
-    public enum MergeStrategy: @unchecked Sendable {
+    public enum MergeStrategy: Sendable {
         case structured
         case indexed
-        case first
+        case firstCompleted
+        case first // deprecated, renamed: firstCompleted
         case custom(@Sendable ([AgentResult]) -> String)
     }
 


### PR DESCRIPTION
## Summary

Chunk C of the remediation series. Branched from `main` after Chunks A (#119) and B (#121) merged. Integrations-trait commits (`fd78b43f`, `1127e0bc`) are reachable.

- Restore ambient `AgentEnvironmentValues` through timeout-wrapped workflow runs
- Add honest `.firstCompleted` merge semantics (cancel losers); deprecate `.first`
- Throw a clear error for empty workflows; remove Workflow force unwraps

## Verified before / after

### Task 1 — TaskLocal environment lost through workflow timeouts

**Before:** `Workflow.executeWithTimeout` ran the operation in `Task.detached`, which does not inherit `@TaskLocal`. An environment set around `workflow.timeout(...).run(...)` vanished; agents fell through to `Swarm.defaultProvider` / Foundation Models / `inferenceProviderUnavailable`. `.environment(\.inferenceProvider, ...)` on the agent still worked because `EnvironmentAgent` re-applies values inside `run`.

**After:** Still uses `Task.detached` (required — see audit). Snapshots `AgentEnvironmentValues.current` on the caller and re-applies it with `withValue` inside the detached worker. Ambient task-local providers and agent-level `.environment` both work. Non-cooperative timeout still returns without waiting (`FrameworkDXRegressionTests`).

### Task 2 — Parallel merge: `.first` is a lie + losers keep running

**Before:** `.first` already returned the first *completed* result (task-group collection order), not the first agent in the array — the name was the lie. All parallel agents ran to completion. Structured/indexed/custom results were already sorted by original step index after collection.

**After:**
- Added `.firstCompleted` with first-to-complete semantics
- Deprecated `.first` with `@available(*, deprecated, renamed: "firstCompleted")` (same semantics, including cancel)
- After a winner is chosen, remaining tasks are `cancelAll()`'d and drained so `CancellationError` does not replace the winner
- Non-first strategies still sort by original step index (regression tests with delayed agents)

### Task 3 — Empty workflow

**Before:** `try await Workflow().run("input")` returned `AgentResult(output: "")`.

**After:** Throws `WorkflowError.invalidWorkflow(reason: "Workflow has no steps")`.

### Task 4 — Force unwraps in Workflow

**Before:** `executeDirect` force-unwrapped `lastResult!` in the `repeatUntil` loop.

**After:** Bind the result with `let` / `guard`. No `try!` / `as!` in `Sources/Swarm/Workflow/`.

**Out of scope (listed only):**
- `Sources/SwarmCapabilityShowcaseSupport/CapabilityShowcase.swift` — `try! Agent(...)`
- DocC examples in `InputGuardrail.swift` / `OutputGuardrail.swift` — `try! NSRegularExpression`

## Task.detached audit (`Sources/Swarm`)

| Site | Inherits task-locals? | Why detached | Action |
|------|----------------------|--------------|--------|
| `Workflow.executeWithTimeout` operation | No | Unstructured `Task {}` deadlocks a MainActor `withCheckedThrowingContinuation`; a throwing task-group race waits for non-cooperative children | Keep detached; snapshot + re-apply `AgentEnvironmentValues` |
| `Workflow.executeWithTimeout` timeout sleeper | N/A (does not read locals) | Same timeout race | Keep detached |

No other `Task.detached` in `Sources/Swarm`. Remaining gap: `TraceContext`'s private `@TaskLocal` is also dropped across the operation detach (no public rebind API).

## Test plan

- [x] `WorkflowCoreTests` — empty workflow, ambient + agent-level env through timeout, merge index order, `.firstCompleted` fastest branch, loser cancellation
- [x] `FrameworkDXRegressionTests.workflowTimeoutReturnsWithoutWaitingForNonCooperativeWork`
- [x] `DocumentationFreshnessTests`
- [x] SwiftFormat `--lint` / SwiftLint `--strict` on changed Swift files

## Baseline comparison

| Lane | Result |
|------|--------|
| `bash scripts/ci/lean-build-test.sh` | **1732 tests / 221 suites PASS** (`lean-build-test: PASS`) |
| `swift test --no-parallel --traits Integrations` | **1864 tests / 241 suites PASS** |
| `swift run --traits Integrations SwarmCapabilityShowcase matrix` | All 14 scenarios **passed**, including `workflow-core` |

No regressions vs Chunk A/B `main`. New workflow tests included in both lanes.

## API

- Additive: `Workflow.MergeStrategy.firstCompleted`
- Deprecated (not removed): `Workflow.MergeStrategy.first` → `firstCompleted`
- Empty `run` now throws instead of returning a blank result (behavior fix)


Made with [Cursor](https://cursor.com)