### PR TITLE
feat: opt-in Foundation Models native session mode (experimental)

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ let result = try await agent.run("Summarize my notes.")
 Notes that matter in production:
 
 - **Availability**: use `FoundationModelsInferenceProvider.ifAvailable()` or check `FoundationModelsInferenceProvider.isAvailable` before assuming the system model is ready.
-- **Tool calling**: Swarm bridges `@Tool` / `ToolSchema` to Apple's `FoundationModels.Tool` and executes tools in the agent loop with guardrails intact.
+- **Tool calling**: Swarm bridges `@Tool` / `ToolSchema` to Apple's `FoundationModels.Tool` and executes tools in the agent loop with guardrails intact (capture mode, default). Opt in to experimental [native session mode](docs/guide/foundation-models.md) for parallel tool calls and token streaming with tools.
 - **Streaming tool calls**: not advertised as token-level tool streaming; `Agent.stream` observes the same `run` loop via `AgentEvent` (lifecycle, tools, and `.output(.token)` chunks). Foundation Models yields incremental text deltas; providers without a streaming API emit the full response as a single chunk.
 - **Structured outputs**: `runStructured` asks the model (prompt instruction) and parses JSON. It is not enforced schema generation — invalid JSON fails at parse time.
 - **Dynamic profiles**: `.foundationModels(profile:)` re-resolves instructions/tools/history every turn (WWDC 2026–aligned Swarm API).

--- a/Sources/Swarm/Agents/Agent+FoundationModelsNative.swift
+++ b/Sources/Swarm/Agents/Agent+FoundationModelsNative.swift
@@ -1,0 +1,170 @@
+// Agent+FoundationModelsNative.swift
+// Swarm Framework
+//
+// Opt-in Foundation Models native session path. Kept off Agent.swift so the
+// tool loop does not grow another 100+ lines of Apple-only branching.
+
+import Foundation
+
+#if canImport(FoundationModels)
+import FoundationModels
+#endif
+
+/// Message list for a native Foundation Models session.
+///
+/// Matches capture mode: when ``structuredMessages`` is `nil` (`strict4k`
+/// windowing and/or `PromptEnvelope` rewrite), send the stuffed envelope
+/// prompt as a single user turn. Never fall back to the raw conversation
+/// history — that would drop ContextCore windowing and 4K truncation.
+enum FoundationModelsNativePrompt {
+    static func messages(
+        structuredMessages: [InferenceMessage]?,
+        envelopePrompt: String
+    ) -> [InferenceMessage] {
+        structuredMessages ?? [.user(envelopePrompt)]
+    }
+}
+
+extension Agent {
+    /// Runs Foundation Models native session mode when opted in and the provider
+    /// is ``FoundationModelsInferenceProvider``. Returns `nil` so the Swarm loop
+    /// continues when the flag is `.capture` or the provider is not FM.
+    ///
+    /// Memory has already been injected into `messages` (session start). Swarm's
+    /// iteration cap, mid-loop checkpoints, and per-turn guardrail wrapping are
+    /// not applied inside Apple's tool loop.
+    func executeNativeFoundationModelsSessionIfAvailable(
+        provider: any InferenceProvider,
+        messages: [InferenceMessage],
+        toolRegistry: ToolRegistry,
+        toolSchemas: [ToolSchema],
+        inferenceOptions: InferenceOptions,
+        systemPrompt: String,
+        observer: (any AgentObserver)?,
+        tracing: TracingHelper?,
+        resultBuilder: AgentResult.Builder,
+        executionContext: AgentContext,
+        startTime: ContinuousClock.Instant,
+        session: (any Session)?,
+        enableStreaming: Bool,
+        structuredOutputRequest: StructuredOutputRequest?
+    ) async throws -> ToolLoopOutcome? {
+        guard configuration.foundationModelsExecution == .nativeSession else {
+            return nil
+        }
+
+        #if canImport(FoundationModels)
+        guard #available(macOS 26.0, iOS 26.0, visionOS 26.0, *) else {
+            return nil
+        }
+        #if os(tvOS) || os(watchOS)
+        return nil
+        #else
+        guard let fmProvider = provider as? FoundationModelsInferenceProvider else {
+            return nil
+        }
+
+        let options = optionsWithMembraneRuntimeSettings(inferenceOptions)
+        await observer?.onLLMStart(
+            context: nil,
+            agent: self,
+            systemPrompt: systemPrompt,
+            inputMessages: messages.map { message in
+                MemoryMessage(role: memoryRole(for: message.role), content: message.content)
+            }
+        )
+
+        let executingTools: [any FoundationModels.Tool]
+        if toolSchemas.isEmpty {
+            executingTools = []
+        } else {
+            let runtime = FoundationModelsNativeToolRuntime(
+                registry: toolRegistry,
+                agent: self,
+                context: executionContext,
+                observer: observer,
+                tracing: tracing,
+                resultBuilder: resultBuilder,
+                stopOnToolError: configuration.stopOnToolError
+            )
+            do {
+                executingTools = try FoundationModelsToolBridge.makeExecutingTools(
+                    from: toolSchemas,
+                    runtime: runtime
+                )
+            } catch {
+                throw AgentError.generationFailed(
+                    reason: "Failed to bridge Swarm tools to FoundationModels.Tool: \(error)"
+                )
+            }
+        }
+
+        let conversationID = session?.sessionId ?? "agent:\(configuration.name)"
+        let streamObserver = observer
+        let streamAgent: any AgentRuntime = self
+        let onOutputChunk: (@Sendable (String) async -> Void)?
+        if enableStreaming {
+            onOutputChunk = { chunk in
+                if let streamObserver {
+                    await streamObserver.onOutputToken(context: nil, agent: streamAgent, token: chunk)
+                }
+            }
+        } else {
+            onOutputChunk = nil
+        }
+        let native: FoundationModelsNativeTurnResult = try await executeWithinRemainingTimeout(startTime: startTime) {
+            try await fmProvider.respondUsingNativeSession(
+                messages: messages,
+                tools: executingTools,
+                toolSchemas: toolSchemas,
+                options: options,
+                conversationID: conversationID,
+                onOutputChunk: onOutputChunk
+            )
+        }
+
+        let finalResponse = try finalizeAssistantResponse(
+            content: native.content,
+            request: structuredOutputRequest,
+            provider: provider
+        )
+        await observer?.onLLMEnd(
+            context: nil,
+            agent: self,
+            response: finalResponse.content,
+            usage: nil
+        )
+
+        var transcriptMessages = native.transcriptMessages
+        if let structured = finalResponse.structuredOutput {
+            if let last = transcriptMessages.indices.last,
+               transcriptMessages[last].role == MemoryMessage.Role.assistant
+            {
+                transcriptMessages[last] = SwarmTranscriptCodec.encodeMessage(
+                    role: .assistant,
+                    content: finalResponse.content,
+                    structuredOutput: structured
+                )
+            }
+        }
+
+        return ToolLoopOutcome(
+            output: finalResponse.content,
+            structuredOutput: finalResponse.structuredOutput,
+            transcriptMessages: transcriptMessages
+        )
+        #endif
+        #else
+        return nil
+        #endif
+    }
+
+    private func memoryRole(for role: InferenceMessage.Role) -> MemoryMessage.Role {
+        switch role {
+        case .system: .system
+        case .user: .user
+        case .assistant: .assistant
+        case .tool: .tool
+        }
+    }
+}

--- a/Sources/Swarm/Agents/Agent.swift
+++ b/Sources/Swarm/Agents/Agent.swift
@@ -5,10 +5,6 @@
 
 import Foundation
 
-#if canImport(FoundationModels)
-import FoundationModels
-#endif
-
 // MARK: - Agent
 
 /// An agent that uses structured LLM tool calling APIs for reliable tool invocation.
@@ -633,13 +629,13 @@ public struct Agent: AgentRuntime, Sendable {
         let structuredOutput: StructuredOutputResult?
     }
 
-    private struct ToolLoopOutcome: Sendable {
+    struct ToolLoopOutcome: Sendable {
         let output: String
         let structuredOutput: StructuredOutputResult?
         let transcriptMessages: [MemoryMessage]
     }
 
-    private struct FinalAssistantResponse: Sendable {
+    struct FinalAssistantResponse: Sendable {
         let content: String
         let structuredOutput: StructuredOutputResult?
     }
@@ -1262,7 +1258,7 @@ public struct Agent: AgentRuntime, Sendable {
         )
     }
 
-    private func finalizeAssistantResponse(
+    func finalizeAssistantResponse(
         content: String,
         request: StructuredOutputRequest?,
         provider: any InferenceProvider
@@ -1488,7 +1484,10 @@ public struct Agent: AgentRuntime, Sendable {
 
                 if let nativeOutcome = try await executeNativeFoundationModelsSessionIfAvailable(
                     provider: provider,
-                    messages: structuredMessages ?? conversationHistory.map(\.inferenceMessage),
+                    messages: FoundationModelsNativePrompt.messages(
+                        structuredMessages: structuredMessages,
+                        envelopePrompt: prompt
+                    ),
                     toolRegistry: toolRegistry,
                     toolSchemas: toolSchemas,
                     inferenceOptions: inferenceOptions,
@@ -1662,148 +1661,6 @@ public struct Agent: AgentRuntime, Sendable {
         return history
     }
 
-    /// Runs Foundation Models native session mode when opted in and the provider
-    /// is ``FoundationModelsInferenceProvider``. Returns `nil` so the Swarm loop
-    /// continues when the flag is `.capture` or the provider is not FM.
-    ///
-    /// Memory has already been injected into `messages` (session start). Swarm's
-    /// iteration cap, mid-loop checkpoints, and per-turn guardrail wrapping are
-    /// not applied inside Apple's tool loop.
-    private func executeNativeFoundationModelsSessionIfAvailable(
-        provider: any InferenceProvider,
-        messages: [InferenceMessage],
-        toolRegistry: ToolRegistry,
-        toolSchemas: [ToolSchema],
-        inferenceOptions: InferenceOptions,
-        systemPrompt: String,
-        observer: (any AgentObserver)?,
-        tracing: TracingHelper?,
-        resultBuilder: AgentResult.Builder,
-        executionContext: AgentContext,
-        startTime: ContinuousClock.Instant,
-        session: (any Session)?,
-        enableStreaming: Bool,
-        structuredOutputRequest: StructuredOutputRequest?
-    ) async throws -> ToolLoopOutcome? {
-        guard configuration.foundationModelsExecution == .nativeSession else {
-            return nil
-        }
-
-        #if canImport(FoundationModels)
-        guard #available(macOS 26.0, iOS 26.0, visionOS 26.0, *) else {
-            return nil
-        }
-        #if os(tvOS) || os(watchOS)
-        return nil
-        #else
-        guard let fmProvider = provider as? FoundationModelsInferenceProvider else {
-            return nil
-        }
-
-        let options = optionsWithMembraneRuntimeSettings(inferenceOptions)
-        await observer?.onLLMStart(
-            context: nil,
-            agent: self,
-            systemPrompt: systemPrompt,
-            inputMessages: messages.map { message in
-                MemoryMessage(role: memoryRole(for: message.role), content: message.content)
-            }
-        )
-
-        let executingTools: [any FoundationModels.Tool]
-        if toolSchemas.isEmpty {
-            executingTools = []
-        } else {
-            let runtime = FoundationModelsNativeToolRuntime(
-                registry: toolRegistry,
-                agent: self,
-                context: executionContext,
-                observer: observer,
-                tracing: tracing,
-                resultBuilder: resultBuilder,
-                stopOnToolError: configuration.stopOnToolError
-            )
-            do {
-                executingTools = try FoundationModelsToolBridge.makeExecutingTools(
-                    from: toolSchemas,
-                    runtime: runtime
-                )
-            } catch {
-                throw AgentError.generationFailed(
-                    reason: "Failed to bridge Swarm tools to FoundationModels.Tool: \(error)"
-                )
-            }
-        }
-
-        let conversationID = session?.sessionId ?? "agent:\(configuration.name)"
-        let streamObserver = observer
-        let streamAgent: any AgentRuntime = self
-        let onOutputChunk: (@Sendable (String) async -> Void)?
-        if enableStreaming {
-            onOutputChunk = { chunk in
-                if let streamObserver {
-                    await streamObserver.onOutputToken(context: nil, agent: streamAgent, token: chunk)
-                }
-            }
-        } else {
-            onOutputChunk = nil
-        }
-        let native: FoundationModelsNativeTurnResult = try await executeWithinRemainingTimeout(startTime: startTime) {
-            try await fmProvider.respondUsingNativeSession(
-                messages: messages,
-                tools: executingTools,
-                toolSchemas: toolSchemas,
-                options: options,
-                conversationID: conversationID,
-                onOutputChunk: onOutputChunk
-            )
-        }
-
-        let finalResponse = try finalizeAssistantResponse(
-            content: native.content,
-            request: structuredOutputRequest,
-            provider: provider
-        )
-        await observer?.onLLMEnd(
-            context: nil,
-            agent: self,
-            response: finalResponse.content,
-            usage: nil
-        )
-
-        var transcriptMessages = native.transcriptMessages
-        if let structured = finalResponse.structuredOutput {
-            if let last = transcriptMessages.indices.last,
-               transcriptMessages[last].role == MemoryMessage.Role.assistant
-            {
-                transcriptMessages[last] = SwarmTranscriptCodec.encodeMessage(
-                    role: .assistant,
-                    content: finalResponse.content,
-                    structuredOutput: structured
-                )
-            }
-        }
-
-        return ToolLoopOutcome(
-            output: finalResponse.content,
-            structuredOutput: finalResponse.structuredOutput,
-            transcriptMessages: transcriptMessages
-        )
-        #endif
-        #else
-        return nil
-        #endif
-    }
-
-    private func memoryRole(for role: InferenceMessage.Role) -> MemoryMessage.Role {
-        switch role {
-        case .system: .system
-        case .user: .user
-        case .assistant: .assistant
-        case .tool: .tool
-        }
-    }
-
     /// Checks for cancellation and timeout conditions.
     private func checkCancellationAndTimeout(startTime: ContinuousClock.Instant) throws {
         // Use Task.checkCancellation() for reliable cancellation detection
@@ -1816,7 +1673,7 @@ public struct Agent: AgentRuntime, Sendable {
         }
     }
 
-    private func executeWithinRemainingTimeout<T: Sendable>(
+    func executeWithinRemainingTimeout<T: Sendable>(
         startTime: ContinuousClock.Instant,
         operation: @escaping @Sendable () async throws -> T
     ) async throws -> T {
@@ -2728,7 +2585,7 @@ public struct Agent: AgentRuntime, Sendable {
         )
     }
 
-    private func optionsWithMembraneRuntimeSettings(_ base: InferenceOptions) -> InferenceOptions {
+    func optionsWithMembraneRuntimeSettings(_ base: InferenceOptions) -> InferenceOptions {
         guard let membrane = AgentEnvironmentValues.current.membrane, membrane.isEnabled else {
             return base
         }

--- a/Sources/Swarm/Agents/Agent.swift
+++ b/Sources/Swarm/Agents/Agent.swift
@@ -5,6 +5,10 @@
 
 import Foundation
 
+#if canImport(FoundationModels)
+import FoundationModels
+#endif
+
 // MARK: - Agent
 
 /// An agent that uses structured LLM tool calling APIs for reliable tool invocation.
@@ -1482,6 +1486,26 @@ public struct Agent: AgentRuntime, Sendable {
                     nil
                 }
 
+                if let nativeOutcome = try await executeNativeFoundationModelsSessionIfAvailable(
+                    provider: provider,
+                    messages: structuredMessages ?? conversationHistory.map(\.inferenceMessage),
+                    toolRegistry: toolRegistry,
+                    toolSchemas: toolSchemas,
+                    inferenceOptions: inferenceOptions,
+                    systemPrompt: systemMessage,
+                    observer: observer,
+                    tracing: tracing,
+                    resultBuilder: resultBuilder,
+                    executionContext: executionContext,
+                    startTime: startTime,
+                    session: session,
+                    enableStreaming: enableStreaming,
+                    structuredOutputRequest: structuredOutputRequest
+                ) {
+                    await observer?.onIterationEnd(context: nil, agent: self, number: iteration)
+                    return nativeOutcome
+                }
+
                 // If no tools defined, generate without tool calling
                 if toolSchemas.isEmpty {
                     let loopInferenceOptions = inferenceOptions
@@ -1636,6 +1660,148 @@ public struct Agent: AgentRuntime, Sendable {
 
         history.append(.user(input))
         return history
+    }
+
+    /// Runs Foundation Models native session mode when opted in and the provider
+    /// is ``FoundationModelsInferenceProvider``. Returns `nil` so the Swarm loop
+    /// continues when the flag is `.capture` or the provider is not FM.
+    ///
+    /// Memory has already been injected into `messages` (session start). Swarm's
+    /// iteration cap, mid-loop checkpoints, and per-turn guardrail wrapping are
+    /// not applied inside Apple's tool loop.
+    private func executeNativeFoundationModelsSessionIfAvailable(
+        provider: any InferenceProvider,
+        messages: [InferenceMessage],
+        toolRegistry: ToolRegistry,
+        toolSchemas: [ToolSchema],
+        inferenceOptions: InferenceOptions,
+        systemPrompt: String,
+        observer: (any AgentObserver)?,
+        tracing: TracingHelper?,
+        resultBuilder: AgentResult.Builder,
+        executionContext: AgentContext,
+        startTime: ContinuousClock.Instant,
+        session: (any Session)?,
+        enableStreaming: Bool,
+        structuredOutputRequest: StructuredOutputRequest?
+    ) async throws -> ToolLoopOutcome? {
+        guard configuration.foundationModelsExecution == .nativeSession else {
+            return nil
+        }
+
+        #if canImport(FoundationModels)
+        guard #available(macOS 26.0, iOS 26.0, visionOS 26.0, *) else {
+            return nil
+        }
+        #if os(tvOS) || os(watchOS)
+        return nil
+        #else
+        guard let fmProvider = provider as? FoundationModelsInferenceProvider else {
+            return nil
+        }
+
+        let options = optionsWithMembraneRuntimeSettings(inferenceOptions)
+        await observer?.onLLMStart(
+            context: nil,
+            agent: self,
+            systemPrompt: systemPrompt,
+            inputMessages: messages.map { message in
+                MemoryMessage(role: memoryRole(for: message.role), content: message.content)
+            }
+        )
+
+        let executingTools: [any FoundationModels.Tool]
+        if toolSchemas.isEmpty {
+            executingTools = []
+        } else {
+            let runtime = FoundationModelsNativeToolRuntime(
+                registry: toolRegistry,
+                agent: self,
+                context: executionContext,
+                observer: observer,
+                tracing: tracing,
+                resultBuilder: resultBuilder,
+                stopOnToolError: configuration.stopOnToolError
+            )
+            do {
+                executingTools = try FoundationModelsToolBridge.makeExecutingTools(
+                    from: toolSchemas,
+                    runtime: runtime
+                )
+            } catch {
+                throw AgentError.generationFailed(
+                    reason: "Failed to bridge Swarm tools to FoundationModels.Tool: \(error)"
+                )
+            }
+        }
+
+        let conversationID = session?.sessionId ?? "agent:\(configuration.name)"
+        let streamObserver = observer
+        let streamAgent: any AgentRuntime = self
+        let onOutputChunk: (@Sendable (String) async -> Void)?
+        if enableStreaming {
+            onOutputChunk = { chunk in
+                if let streamObserver {
+                    await streamObserver.onOutputToken(context: nil, agent: streamAgent, token: chunk)
+                }
+            }
+        } else {
+            onOutputChunk = nil
+        }
+        let native: FoundationModelsNativeTurnResult = try await executeWithinRemainingTimeout(startTime: startTime) {
+            try await fmProvider.respondUsingNativeSession(
+                messages: messages,
+                tools: executingTools,
+                toolSchemas: toolSchemas,
+                options: options,
+                conversationID: conversationID,
+                onOutputChunk: onOutputChunk
+            )
+        }
+
+        let finalResponse = try finalizeAssistantResponse(
+            content: native.content,
+            request: structuredOutputRequest,
+            provider: provider
+        )
+        await observer?.onLLMEnd(
+            context: nil,
+            agent: self,
+            response: finalResponse.content,
+            usage: nil
+        )
+
+        var transcriptMessages = native.transcriptMessages
+        if let structured = finalResponse.structuredOutput {
+            if let last = transcriptMessages.indices.last,
+               transcriptMessages[last].role == MemoryMessage.Role.assistant
+            {
+                transcriptMessages[last] = SwarmTranscriptCodec.encodeMessage(
+                    role: .assistant,
+                    content: finalResponse.content,
+                    structuredOutput: structured
+                )
+            }
+        }
+
+        return ToolLoopOutcome(
+            output: finalResponse.content,
+            structuredOutput: finalResponse.structuredOutput,
+            transcriptMessages: transcriptMessages
+        )
+        #endif
+        #else
+        return nil
+        #endif
+    }
+
+    private func memoryRole(for role: InferenceMessage.Role) -> MemoryMessage.Role {
+        switch role {
+        case .system: .system
+        case .user: .user
+        case .assistant: .assistant
+        case .tool: .tool
+        }
     }
 
     /// Checks for cancellation and timeout conditions.

--- a/Sources/Swarm/Core/AgentConfiguration.swift
+++ b/Sources/Swarm/Core/AgentConfiguration.swift
@@ -91,6 +91,54 @@ public struct InferencePolicy: Sendable, Equatable {
     }
 }
 
+// MARK: - FoundationModelsExecutionMode
+
+/// How Apple Foundation Models should run tool-calling turns.
+///
+/// This option is **experimental** and only observed by
+/// ``FoundationModelsInferenceProvider``. Non-Foundation-Models providers ignore it.
+///
+/// ## Capture vs native session
+///
+/// | | ``capture`` (default) | ``nativeSession`` (experimental) |
+/// |---|---|---|
+/// | Tool loop owner | Swarm agent loop | `LanguageModelSession` |
+/// | Parallel tool calls | No (one captured call per turn) | Yes (Apple's session loop) |
+/// | Transcript / KV reuse | No (session rebuilt every turn) | Yes (session kept for the agent run) |
+/// | Token streaming with tools | No | Yes (`Agent.stream` yields incremental tokens) |
+/// | Per-iteration memory injection | Yes | **No** — memory is injected when the native session starts |
+/// | Swarm `maxIterations` cap | Yes | **No** — Apple owns the inner loop |
+/// | Mid-loop checkpoints | Yes | **No** |
+/// | Per-turn guardrail interception | Yes (wraps Swarm's loop) | **No** — input/tool guardrails run **inside** each tool body |
+///
+/// - Experiment: Native session mode may change in a minor release. Capture remains
+///   the supported default because Swarm-side control (guardrails, checkpoints,
+///   memory injection) is the framework's differentiator.
+///
+/// ```swift
+/// let config = AgentConfiguration.default
+///     .foundationModelsExecution(.nativeSession)
+/// let agent = try Agent("Be helpful.", configuration: config,
+///     inferenceProvider: .foundationModels()) {
+///     WeatherTool()
+/// }
+/// ```
+public enum FoundationModelsExecutionMode: String, Sendable, Equatable {
+    /// Swarm owns the tool loop. Foundation Models tools throw a capture error so
+    /// Swarm can execute tools with guardrails, observers, retries, and
+    /// per-iteration memory injection. This is the default.
+    case capture
+
+    /// Let Foundation Models run its own tool loop on a persistent
+    /// `LanguageModelSession`.
+    ///
+    /// - Experiment: Opt-in. Unlocks parallel tool calls, transcript/KV reuse, and
+    ///   real token streaming with tools. Loses per-iteration memory injection,
+    ///   Swarm-side max-iteration caps, mid-loop checkpoints, and per-turn
+    ///   guardrail interception (guardrails move inside tool bodies).
+    case nativeSession
+}
+
 // MARK: - AgentConfiguration
 
 /// Configuration settings for agent execution.
@@ -147,6 +195,7 @@ public struct InferencePolicy: Sendable, Equatable {
 /// - ``previousResponseId(_:)`` - Set response continuation
 /// - ``autoPreviousResponseId(_:)`` - Set auto response tracking
 /// - ``defaultTracingEnabled(_:)`` - Set default tracing
+/// - ``foundationModelsExecution(_:)`` - Set Foundation Models execution mode (experimental)
 ///
 /// ## Thread Safety
 ///
@@ -539,6 +588,21 @@ public struct AgentConfiguration: Sendable, Equatable {
     ///   ``SwiftLogTracer``
     public var defaultTracingEnabled: Bool
 
+    // MARK: - Foundation Models Execution
+
+    /// How Apple Foundation Models should execute tool-calling turns.
+    ///
+    /// Default: ``FoundationModelsExecutionMode/capture``.
+    ///
+    /// Non-Foundation-Models providers ignore this flag. Capture mode behavior
+    /// is unchanged when the value stays `.capture`.
+    ///
+    /// - Experiment: ``FoundationModelsExecutionMode/nativeSession`` is opt-in.
+    ///   See ``FoundationModelsExecutionMode`` for the full trade-off table.
+    ///
+    /// - SeeAlso: ``FoundationModelsExecutionMode``, ``foundationModelsExecution(_:)``
+    public var foundationModelsExecution: FoundationModelsExecutionMode
+
     // MARK: - Initialization
 
     /// Creates a new agent configuration.
@@ -562,6 +626,7 @@ public struct AgentConfiguration: Sendable, Equatable {
     ///   - previousResponseId: Previous response ID for continuation. Default: nil
     ///   - autoPreviousResponseId: Enable auto response ID tracking. Default: false
     ///   - defaultTracingEnabled: Enable default tracing when no tracer configured. Default: true
+    ///   - foundationModelsExecution: Foundation Models tool-loop mode. Default: ``FoundationModelsExecutionMode/capture``
     public init(
         name: String = "Agent",
         maxIterations: Int = 10,
@@ -581,7 +646,8 @@ public struct AgentConfiguration: Sendable, Equatable {
         parallelToolCalls: Bool = false,
         previousResponseId: String? = nil,
         autoPreviousResponseId: Bool = false,
-        defaultTracingEnabled: Bool = true
+        defaultTracingEnabled: Bool = true,
+        foundationModelsExecution: FoundationModelsExecutionMode = .capture
     ) {
         if maxIterations < 1 {
             Log.agents.warning("AgentConfiguration: maxIterations \(maxIterations) must be >= 1; using 1")
@@ -612,6 +678,7 @@ public struct AgentConfiguration: Sendable, Equatable {
         self.previousResponseId = previousResponseId
         self.autoPreviousResponseId = autoPreviousResponseId
         self.defaultTracingEnabled = defaultTracingEnabled
+        self.foundationModelsExecution = foundationModelsExecution
     }
 }
 
@@ -1110,6 +1177,35 @@ extension AgentConfiguration {
         copy.defaultTracingEnabled = value
         return copy
     }
+
+    // MARK: Foundation Models Execution
+
+    /// Sets how Apple Foundation Models should execute tool-calling turns.
+    ///
+    /// Default: ``FoundationModelsExecutionMode/capture``.
+    ///
+    /// Non-Foundation-Models providers ignore this flag. See
+    /// ``FoundationModelsExecutionMode`` for the capture vs native trade-off table.
+    ///
+    /// - Experiment: ``FoundationModelsExecutionMode/nativeSession`` is opt-in and
+    ///   may change in a minor release.
+    ///
+    /// ## Example
+    /// ```swift
+    /// let config = AgentConfiguration.default
+    ///     .foundationModelsExecution(.nativeSession)
+    /// ```
+    ///
+    /// - Parameter value: The Foundation Models execution mode
+    /// - Returns: A new configuration with the updated execution mode
+    /// - SeeAlso: ``foundationModelsExecution``, ``FoundationModelsExecutionMode``
+    @discardableResult public func foundationModelsExecution(
+        _ value: FoundationModelsExecutionMode
+    ) -> AgentConfiguration {
+        var copy = self
+        copy.foundationModelsExecution = value
+        return copy
+    }
 }
 
 // MARK: - CustomStringConvertible
@@ -1137,7 +1233,8 @@ extension AgentConfiguration: CustomStringConvertible {
             parallelToolCalls: \(parallelToolCalls),
             previousResponseId: \(previousResponseId.map { "\"\($0)\"" } ?? "nil"),
             autoPreviousResponseId: \(autoPreviousResponseId),
-            defaultTracingEnabled: \(defaultTracingEnabled)
+            defaultTracingEnabled: \(defaultTracingEnabled),
+            foundationModelsExecution: \(foundationModelsExecution)
         )
         """
     }

--- a/Sources/Swarm/Providers/FoundationModels/FoundationModelsExecutingTool.swift
+++ b/Sources/Swarm/Providers/FoundationModels/FoundationModelsExecutingTool.swift
@@ -1,0 +1,181 @@
+// FoundationModelsExecutingTool.swift
+// Swarm Framework
+//
+// Real FoundationModels.Tool wrappers that execute Swarm tools (native session mode).
+
+import Foundation
+
+#if canImport(FoundationModels)
+import FoundationModels
+
+/// Error thrown from a native-mode tool so Foundation Models can surface a
+/// recoverable tool failure without crashing the process.
+///
+/// Cancellation and ``AgentConfiguration/stopOnToolError`` abort the session by
+/// throwing. Other tool failures are returned as error strings from ``call(arguments:)``
+/// so `LanguageModelSession.respond` can continue — throwing from `call` aborts
+/// the session the same way capture-mode tools do.
+@available(macOS 26.0, iOS 26.0, visionOS 26.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+struct FoundationModelsNativeToolError: Error, LocalizedError, Sendable {
+    let toolName: String
+    let message: String
+
+    var errorDescription: String? {
+        "Tool '\(toolName)' failed: \(message)"
+    }
+}
+
+/// Runtime shared by every executing Foundation Models tool in a native session turn.
+///
+/// Owns Swarm tool lookup, input/output guardrails, observer hooks, and
+/// ``AgentResult`` recording. Isolation keeps parallel Apple tool calls from
+/// racing the result builder.
+@available(macOS 26.0, iOS 26.0, visionOS 26.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+actor FoundationModelsNativeToolRuntime {
+    private let registry: ToolRegistry
+    private let agent: any AgentRuntime
+    private let context: AgentContext?
+    private let observer: (any AgentObserver)?
+    private let tracing: TracingHelper?
+    private let resultBuilder: AgentResult.Builder
+    private let stopOnToolError: Bool
+
+    init(
+        registry: ToolRegistry,
+        agent: any AgentRuntime,
+        context: AgentContext?,
+        observer: (any AgentObserver)?,
+        tracing: TracingHelper?,
+        resultBuilder: AgentResult.Builder,
+        stopOnToolError: Bool
+    ) {
+        self.registry = registry
+        self.agent = agent
+        self.context = context
+        self.observer = observer
+        self.tracing = tracing
+        self.resultBuilder = resultBuilder
+        self.stopOnToolError = stopOnToolError
+    }
+
+    /// Executes a Swarm tool and returns a string Foundation Models can feed back
+    /// into the session. Recoverable failures become error strings; aborting
+    /// failures throw ``FoundationModelsNativeToolError`` or `CancellationError`.
+    func execute(name: String, arguments: [String: SendableValue]) async throws -> String {
+        let call = ToolCall(toolName: name, arguments: arguments)
+        _ = resultBuilder.addToolCall(call)
+        await observer?.onToolStart(context: context, agent: agent, call: call)
+
+        let spanId: UUID? = if let tracing {
+            await tracing.traceToolCall(name: name, arguments: arguments)
+        } else {
+            nil
+        }
+        let startTime = ContinuousClock.now
+
+        do {
+            let output = try await registry.execute(
+                toolNamed: name,
+                arguments: arguments,
+                agent: agent,
+                context: context,
+                observer: observer
+            )
+            let duration = ContinuousClock.now - startTime
+            let result = ToolResult.success(callId: call.id, output: output, duration: duration)
+            _ = resultBuilder.addToolResult(result)
+            if let tracing, let spanId {
+                await tracing.traceToolResult(
+                    spanId: spanId,
+                    name: name,
+                    result: output.description,
+                    duration: duration
+                )
+            }
+            await observer?.onToolEnd(context: context, agent: agent, result: result)
+            return Agent.toolOutputText(for: output)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            let duration = ContinuousClock.now - startTime
+            let errorMessage = (error as? AgentError)?.localizedDescription
+                ?? error.localizedDescription
+            let result = ToolResult.failure(callId: call.id, error: errorMessage, duration: duration)
+            _ = resultBuilder.addToolResult(result)
+            if let tracing, let spanId {
+                await tracing.traceToolError(spanId: spanId, name: name, error: error)
+            }
+            await observer?.onToolEnd(context: context, agent: agent, result: result)
+
+            if stopOnToolError {
+                throw FoundationModelsNativeToolError(toolName: name, message: errorMessage)
+            }
+
+            // Return the failure as tool output so LanguageModelSession can recover.
+            return "Tool '\(name)' failed: \(errorMessage)"
+        }
+    }
+}
+
+/// A genuine `FoundationModels.Tool` whose `call(arguments:)` executes the
+/// matching Swarm tool instead of capturing-and-throwing.
+@available(macOS 26.0, iOS 26.0, visionOS 26.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+struct FoundationModelsExecutingTool: FoundationModels.Tool {
+    typealias Arguments = GeneratedContent
+    typealias Output = String
+
+    let name: String
+    let description: String
+    let parameters: GenerationSchema
+    var includesSchemaInInstructions: Bool { true }
+
+    private let runtime: FoundationModelsNativeToolRuntime
+
+    init(
+        name: String,
+        description: String,
+        parameters: GenerationSchema,
+        runtime: FoundationModelsNativeToolRuntime
+    ) {
+        self.name = name
+        self.description = description
+        self.parameters = parameters
+        self.runtime = runtime
+    }
+
+    func call(arguments: GeneratedContent) async throws -> String {
+        let parsed = FoundationModelsSchemaConversion.argumentDictionary(from: arguments)
+        return try await runtime.execute(name: name, arguments: parsed)
+    }
+}
+
+@available(macOS 26.0, iOS 26.0, visionOS 26.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+extension FoundationModelsToolBridge {
+    /// Builds executing Foundation Models tools from Swarm schemas.
+    ///
+    /// Unlike ``makeCaptureTools(from:)``, these tools run Swarm tools (with
+    /// guardrails and observers) inside `LanguageModelSession`'s own loop.
+    static func makeExecutingTools(
+        from tools: [ToolSchema],
+        runtime: FoundationModelsNativeToolRuntime
+    ) throws -> [any FoundationModels.Tool] {
+        try tools.map { schema in
+            let parameters = try FoundationModelsSchemaConversion.argumentSchema(for: schema)
+            return FoundationModelsExecutingTool(
+                name: schema.name,
+                description: schema.description,
+                parameters: parameters,
+                runtime: runtime
+            )
+        }
+    }
+}
+#endif

--- a/Sources/Swarm/Providers/FoundationModels/FoundationModelsInferenceProvider.swift
+++ b/Sources/Swarm/Providers/FoundationModels/FoundationModelsInferenceProvider.swift
@@ -34,14 +34,17 @@ public struct FoundationModelsProviderConfiguration: Sendable, Equatable {
 /// ## Conversation history
 ///
 /// `LanguageModelSession.respond(to:)` accepts a `Prompt`, not a role-tagged
-/// message array. This provider creates a fresh session per request — it does
-/// not keep Apple's accumulating `transcript` across Swarm turns — so structured
-/// ``InferenceMessage`` history is serialized into that prompt with role labels
-/// (`System:`, `User:`, `Assistant:`, `Tool result`). That is an Apple API
-/// constraint on the session-less path, not a Swarm shortcut: the macOS 26.x
-/// SDK this package targets has no public API to inject an arbitrary
-/// `Transcript` of user/assistant/tool turns into a new session. Tool results
-/// and assistant tool-call metadata are preserved in the serialized form.
+/// message array. **Capture mode** (default) creates a fresh session per request —
+/// it does not keep Apple's accumulating `transcript` across Swarm turns — so
+/// structured ``InferenceMessage`` history is serialized into that prompt with
+/// role labels (`System:`, `User:`, `Assistant:`, `Tool result`).
+///
+/// **Native session mode** (``FoundationModelsExecutionMode/nativeSession``) keeps
+/// a `LanguageModelSession` for the agent run so Apple's transcript and KV cache
+/// can be reused. Memory is injected when that session is created, not on every
+/// inner tool iteration. See ``FoundationModelsExecutionMode`` for the trade-off
+/// table. The session is discarded when tools or instructions change, the
+/// conversation id changes, generation fails, or the provider is deallocated.
 ///
 /// ## Token usage
 ///
@@ -62,9 +65,14 @@ public struct FoundationModelsProviderConfiguration: Sendable, Equatable {
 /// ## Tool calling
 ///
 /// Swarm tools are bridged to `FoundationModels.Tool` at request time. The model
-/// produces structured arguments via guided generation. Capture tools surface
-/// those arguments back to Swarm so the agent runtime can execute tools with
-/// guardrails, observers, and retries intact.
+/// produces structured arguments via guided generation.
+///
+/// **Capture mode (default):** capture tools surface those arguments back to
+/// Swarm so the agent runtime can execute tools with guardrails, observers, and
+/// retries intact. One tool call is recovered per turn.
+///
+/// **Native session mode (experimental):** executing tools run inside Apple's
+/// session loop. Opt in with ``AgentConfiguration/foundationModelsExecution``.
 ///
 /// ## Dynamic profiles
 ///
@@ -107,6 +115,7 @@ public struct FoundationModelsInferenceProvider: InferenceProvider,
     private let configuration: FoundationModelsProviderConfiguration
     private let dynamicProfile: (any DynamicProfile)?
     private let model: SystemLanguageModel
+    let nativeSessionStore = FoundationModelsNativeSessionStore()
 
     /// Whether the system language model is currently available on this device.
     public static var isAvailable: Bool {
@@ -320,7 +329,7 @@ public struct FoundationModelsInferenceProvider: InferenceProvider,
 
     // MARK: - Session helpers
 
-    private func resolveTurn(
+    func resolveTurn(
         messages: [InferenceMessage],
         tools: [ToolSchema],
         options: InferenceOptions
@@ -345,7 +354,7 @@ public struct FoundationModelsInferenceProvider: InferenceProvider,
         return (withSystem, applied.tools, applied.options, applied.instructions)
     }
 
-    private func makeSession(
+    func makeSession(
         tools: [any FoundationModels.Tool],
         instructions: String?
     ) -> LanguageModelSession {
@@ -366,7 +375,18 @@ public struct FoundationModelsInferenceProvider: InferenceProvider,
         return session
     }
 
-    private func makeGenerationOptions(from options: InferenceOptions) -> GenerationOptions {
+    func makeSession(
+        tools: [any FoundationModels.Tool],
+        transcript: Transcript
+    ) -> LanguageModelSession {
+        let session = LanguageModelSession(model: model, tools: tools, transcript: transcript)
+        if configuration.prewarmOnInit {
+            session.prewarm(promptPrefix: nil)
+        }
+        return session
+    }
+
+    func makeGenerationOptions(from options: InferenceOptions) -> GenerationOptions {
         var generationOptions = GenerationOptions()
         generationOptions.temperature = options.temperature
         if let maxTokens = options.maxTokens {
@@ -385,7 +405,7 @@ public struct FoundationModelsInferenceProvider: InferenceProvider,
     /// Required because `LanguageModelSession.respond(to:)` / `streamResponse(to:)`
     /// take a `Prompt`, and this provider is session-less (a new
     /// `LanguageModelSession` per call cannot reuse Apple's transcript).
-    private func flattenPrompt(
+    func flattenPrompt(
         messages: [InferenceMessage],
         tools: [ToolSchema],
         options: InferenceOptions
@@ -458,7 +478,7 @@ public struct FoundationModelsInferenceProvider: InferenceProvider,
         return string
     }
 
-    private func applyStopSequences(_ content: String, options: InferenceOptions) -> String {
+    func applyStopSequences(_ content: String, options: InferenceOptions) -> String {
         var result = content
         var earliestStop: String.Index?
         for stopSequence in options.stopSequences {
@@ -474,7 +494,7 @@ public struct FoundationModelsInferenceProvider: InferenceProvider,
         return result
     }
 
-    private func mapError(_ error: Error) -> AgentError {
+    func mapError(_ error: Error) -> AgentError {
         if error is CancellationError {
             return .cancelled
         }

--- a/Sources/Swarm/Providers/FoundationModels/FoundationModelsNativeSession.swift
+++ b/Sources/Swarm/Providers/FoundationModels/FoundationModelsNativeSession.swift
@@ -1,0 +1,285 @@
+// FoundationModelsNativeSession.swift
+// Swarm Framework
+//
+// Persistent LanguageModelSession store, native respond/stream, transcript mapping.
+
+import Foundation
+
+#if canImport(FoundationModels)
+import FoundationModels
+
+/// Identity for a reused native Foundation Models session.
+@available(macOS 26.0, iOS 26.0, visionOS 26.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+struct FoundationModelsNativeSessionIdentity: Hashable, Sendable {
+    var conversationID: String
+    var instructions: String
+    var toolNames: [String]
+}
+
+/// Result of one native-session turn after Apple's tool loop completes.
+@available(macOS 26.0, iOS 26.0, visionOS 26.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+struct FoundationModelsNativeTurnResult: Sendable {
+    let content: String
+    let transcriptMessages: [MemoryMessage]
+}
+
+/// Holds a `LanguageModelSession` so native mode can reuse Apple's transcript
+/// across Swarm turns of the same conversation.
+///
+/// ## Lifecycle
+///
+/// Within one `Agent.run`, Apple's `respond`/`streamResponse` owns the inner
+/// tool loop on a single session (parallel tool calls + KV for that turn).
+/// Across `Agent.run` calls with the same tools, instructions, and conversation
+/// id, a **new** session is created that copies the previous ``Transcript`` so
+/// history is preserved while tool wrappers bind to the current run's observers.
+/// The previous session object's on-device KV cache is not kept — Apple does
+/// not expose a way to retarget tools on a live session.
+///
+/// The session is discarded when:
+/// - tools or instructions change (identity mismatch)
+/// - the conversation id changes
+/// - `discard()` is called after an unrecoverable generation error
+/// - this store is deallocated with the provider instance
+///
+/// Memory is injected only when a **new** transcript is started (the first
+/// prompt carries Swarm history). Subsequent turns send only the latest user
+/// message.
+@available(macOS 26.0, iOS 26.0, visionOS 26.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+actor FoundationModelsNativeSessionStore {
+    private var session: LanguageModelSession?
+    private var identity: FoundationModelsNativeSessionIdentity?
+
+    func session(
+        matching identity: FoundationModelsNativeSessionIdentity,
+        create: @Sendable () -> LanguageModelSession,
+        recreate: @Sendable (Transcript) -> LanguageModelSession
+    ) -> (session: LanguageModelSession, reusedTranscript: Bool) {
+        if self.identity == identity, let current = self.session, !current.isResponding {
+            let created = recreate(current.transcript)
+            self.session = created
+            return (created, true)
+        }
+        let created = create()
+        self.session = created
+        self.identity = identity
+        return (created, false)
+    }
+
+    func discard() {
+        session = nil
+        identity = nil
+    }
+}
+
+/// Maps Apple `Transcript` entries produced during a native turn into Swarm
+/// ``MemoryMessage`` values for conversation persistence.
+@available(macOS 26.0, iOS 26.0, visionOS 26.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+enum FoundationModelsNativeTranscriptMapper {
+    /// Converts new transcript entries (after a turn) into Swarm memory messages.
+    ///
+    /// User prompts are omitted — ``Agent`` already stores the user turn.
+    /// Instructions are omitted — they are session configuration, not history.
+    static func turnTranscriptMessages<S: Sequence>(
+        from entries: S
+    ) -> [MemoryMessage] where S.Element == Transcript.Entry {
+        var messages: [MemoryMessage] = []
+        for entry in entries {
+            switch entry {
+            case .instructions, .prompt:
+                continue
+            case let .toolCalls(calls):
+                let parsed = calls.map { call in
+                    InferenceResponse.ParsedToolCall(
+                        id: call.id,
+                        name: call.toolName,
+                        arguments: FoundationModelsSchemaConversion.argumentDictionary(from: call.arguments)
+                    )
+                }
+                messages.append(
+                    SwarmTranscriptCodec.encodeMessage(
+                        role: .assistant,
+                        content: "",
+                        toolCalls: parsed
+                    )
+                )
+            case let .toolOutput(output):
+                messages.append(
+                    SwarmTranscriptCodec.encodeMessage(
+                        role: .tool,
+                        content: concatenatedText(output.segments),
+                        toolName: output.toolName,
+                        toolCallID: output.id
+                    )
+                )
+            case let .response(response):
+                let text = concatenatedText(response.segments)
+                guard !text.isEmpty else { continue }
+                messages.append(
+                    SwarmTranscriptCodec.encodeMessage(role: .assistant, content: text)
+                )
+            @unknown default:
+                continue
+            }
+        }
+        return messages
+    }
+
+    static func concatenatedText(_ segments: [Transcript.Segment]) -> String {
+        segments.map { segment in
+            switch segment {
+            case let .text(text):
+                return text.content
+            case let .structure(structure):
+                return structure.content.jsonString
+            @unknown default:
+                return ""
+            }
+        }.joined()
+    }
+}
+
+@available(macOS 26.0, iOS 26.0, visionOS 26.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+extension FoundationModelsInferenceProvider {
+    /// Runs one native-session turn: Apple owns the tool loop; Swarm consumes the
+    /// final response and maps new transcript entries into memory messages.
+    ///
+    /// - Parameters:
+    ///   - messages: Swarm conversation history. On a **new** session this is
+    ///     flattened into the first prompt (memory injection at session start).
+    ///     On a **reused** session only the latest user message is sent.
+    ///   - tools: Executing `FoundationModels.Tool` values (Task 2 wrappers).
+    ///   - options: Generation options. `toolChoice` is honored via prompt
+    ///     guidance on new sessions; Apple's SDK has no `toolCallingMode` yet.
+    ///   - conversationID: Session key. Changing it discards the native session.
+    ///   - onOutputChunk: When non-nil, uses `streamResponse` and reports text
+    ///     deltas. Tool-call partials are not streamed — Apple executes tools
+    ///     inside the session before yielding the final answer tokens.
+    ///
+    /// Cancellation is cooperative via `Task.checkCancellation` around the FM
+    /// call. Timeout is enforced by the caller (``Agent`` wraps this in its
+    /// remaining-timeout helper). Foundation Models has no native timeout API.
+    /// ``AgentConfiguration/maxIterations`` is **not** applied inside Apple's loop.
+    func respondUsingNativeSession(
+        messages: [InferenceMessage],
+        tools: [any FoundationModels.Tool],
+        toolSchemas: [ToolSchema] = [],
+        options: InferenceOptions,
+        conversationID: String,
+        onOutputChunk: (@Sendable (String) async -> Void)? = nil
+    ) async throws -> FoundationModelsNativeTurnResult {
+        let resolved = resolveTurn(messages: messages, tools: toolSchemas, options: options)
+        let identity = FoundationModelsNativeSessionIdentity(
+            conversationID: conversationID,
+            instructions: resolved.instructions ?? "",
+            toolNames: tools.map(\.name).sorted()
+        )
+        let instructions = resolved.instructions
+        let store = nativeSessionStore
+        let (session, reused) = await store.session(matching: identity) {
+            self.makeSession(tools: tools, instructions: instructions)
+        } recreate: { transcript in
+            self.makeSession(tools: tools, transcript: transcript)
+        }
+
+        let prompt: String
+        if reused {
+            prompt = resolved.messages.last(where: { $0.role == .user })?.content
+                ?? resolved.messages.last?.content
+                ?? ""
+        } else {
+            prompt = flattenPrompt(
+                messages: resolved.messages,
+                tools: toolSchemas,
+                options: resolved.options
+            )
+        }
+
+        let generationOptions = makeGenerationOptions(from: resolved.options)
+        let startCount = session.transcript.count
+
+        do {
+            try Task.checkCancellation()
+            let content: String
+            if let onOutputChunk {
+                let streamed = try await streamNativeResponse(
+                    session: session,
+                    prompt: prompt,
+                    options: generationOptions,
+                    onOutputChunk: onOutputChunk
+                )
+                content = applyStopSequences(streamed, options: resolved.options)
+            } else {
+                let response = try await session.respond(to: prompt, options: generationOptions)
+                content = applyStopSequences(response.content, options: resolved.options)
+            }
+            try Task.checkCancellation()
+            let newEntries = session.transcript.dropFirst(startCount)
+            let transcriptMessages = FoundationModelsNativeTranscriptMapper.turnTranscriptMessages(
+                from: newEntries
+            )
+            return FoundationModelsNativeTurnResult(
+                content: content,
+                transcriptMessages: transcriptMessages.isEmpty
+                    ? [SwarmTranscriptCodec.encodeMessage(role: .assistant, content: content)]
+                    : transcriptMessages
+            )
+        } catch is CancellationError {
+            await store.discard()
+            throw AgentError.cancelled
+        } catch let error as LanguageModelSession.ToolCallError {
+            await store.discard()
+            if let native = error.underlyingError as? FoundationModelsNativeToolError {
+                throw AgentError.toolExecutionFailed(
+                    toolName: native.toolName,
+                    underlyingError: native.message
+                )
+            }
+            if error.underlyingError is CancellationError {
+                throw AgentError.cancelled
+            }
+            throw mapError(error)
+        } catch let error as FoundationModelsNativeToolError {
+            await store.discard()
+            throw AgentError.toolExecutionFailed(toolName: error.toolName, underlyingError: error.message)
+        } catch {
+            await store.discard()
+            throw mapError(error)
+        }
+    }
+
+    private func streamNativeResponse(
+        session: LanguageModelSession,
+        prompt: String,
+        options: GenerationOptions,
+        onOutputChunk: @Sendable (String) async -> Void
+    ) async throws -> String {
+        var previous = ""
+        for try await snapshot in session.streamResponse(to: prompt, options: options) {
+            try Task.checkCancellation()
+            let current = snapshot.content
+            let delta: String
+            if current.hasPrefix(previous) {
+                delta = String(current.dropFirst(previous.count))
+            } else {
+                delta = current
+            }
+            previous = current
+            if !delta.isEmpty {
+                await onOutputChunk(delta)
+            }
+        }
+        return previous
+    }
+}
+#endif

--- a/Sources/Swarm/Providers/FoundationModels/FoundationModelsNativeTool.swift
+++ b/Sources/Swarm/Providers/FoundationModels/FoundationModelsNativeTool.swift
@@ -1,0 +1,73 @@
+// FoundationModelsNativeTool.swift
+// Swarm Framework
+//
+// Wraps a FoundationModels.Tool as a Swarm AnyJSONTool for @ToolBuilder.
+
+import Foundation
+
+#if canImport(FoundationModels)
+import FoundationModels
+
+/// Adapts a user-authored `FoundationModels.Tool` into a Swarm tool.
+///
+/// Use this (or pass the Apple tool directly to `@ToolBuilder`) to register
+/// native Foundation Models tools alongside `@Tool` macros and ``FunctionTool``.
+///
+/// - Experiment: Intended for ``FoundationModelsExecutionMode/nativeSession``.
+///   In capture mode the wrapper still executes via Swarm's loop, converting
+///   arguments through `GeneratedContent`. Full `@Generable` structured-output
+///   support is a later chunk — this adapter only needs argument round-trip
+///   for native session execution.
+///
+/// ```swift
+/// struct LookupTool: FoundationModels.Tool {
+///     var name: String { "lookup" }
+///     var description: String { "Look up a topic" }
+///     // ...
+/// }
+///
+/// let agent = try Agent("Be helpful.",
+///     configuration: .default.foundationModelsExecution(.nativeSession),
+///     inferenceProvider: .foundationModels()) {
+///     WeatherTool()
+///     LookupTool()
+/// }
+/// ```
+@available(macOS 26.0, iOS 26.0, visionOS 26.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+public struct FoundationModelsNativeTool: AnyJSONTool {
+    public let name: String
+    public let description: String
+    public let parameters: [ToolParameter]
+
+    private let executor: @Sendable ([String: SendableValue]) async throws -> SendableValue
+
+    /// Wraps a `FoundationModels.Tool` so it can live in a Swarm tool registry.
+    public init<T: FoundationModels.Tool>(_ tool: T) {
+        name = tool.name
+        description = tool.description
+        parameters = [
+            ToolParameter(
+                name: "arguments",
+                description: "Arguments for \(tool.name)",
+                type: .object(properties: []),
+                isRequired: false
+            ),
+        ]
+        executor = { arguments in
+            let content = FoundationModelsSchemaConversion.generatedContent(from: arguments)
+            let typed = try T.Arguments(content)
+            let output = try await tool.call(arguments: typed)
+            if let string = output as? String {
+                return .string(string)
+            }
+            return .string(String(describing: output))
+        }
+    }
+
+    public func execute(arguments: [String: SendableValue]) async throws -> SendableValue {
+        try await executor(arguments)
+    }
+}
+#endif

--- a/Sources/Swarm/Providers/FoundationModels/FoundationModelsSchemaConversion.swift
+++ b/Sources/Swarm/Providers/FoundationModels/FoundationModelsSchemaConversion.swift
@@ -79,6 +79,39 @@ enum FoundationModelsSchemaConversion {
         return ["value": value]
     }
 
+    /// Converts Swarm `SendableValue`s into a Foundation Models `GeneratedContent` tree.
+    static func generatedContent(from dictionary: [String: SendableValue]) -> GeneratedContent {
+        generatedContent(from: .dictionary(dictionary))
+    }
+
+    /// Converts a Swarm `SendableValue` into Foundation Models `GeneratedContent`.
+    static func generatedContent(from value: SendableValue) -> GeneratedContent {
+        switch value {
+        case .null:
+            return GeneratedContent(kind: .null)
+        case let .bool(bool):
+            return GeneratedContent(kind: .bool(bool))
+        case let .int(int):
+            return GeneratedContent(kind: .number(Double(int)))
+        case let .double(double):
+            return GeneratedContent(kind: .number(double))
+        case let .string(string):
+            return GeneratedContent(kind: .string(string))
+        case let .array(values):
+            return GeneratedContent(kind: .array(values.map(generatedContent(from:))))
+        case let .dictionary(dictionary):
+            let keys = dictionary.keys.sorted()
+            var properties: [String: GeneratedContent] = [:]
+            properties.reserveCapacity(keys.count)
+            for key in keys {
+                if let nested = dictionary[key] {
+                    properties[key] = generatedContent(from: nested)
+                }
+            }
+            return GeneratedContent(kind: .structure(properties: properties, orderedKeys: keys))
+        }
+    }
+
     // MARK: - Private
 
     private static func dynamicSchema(

--- a/Sources/Swarm/Tools/ToolParameterBuilder.swift
+++ b/Sources/Swarm/Tools/ToolParameterBuilder.swift
@@ -5,6 +5,10 @@
 
 import Foundation
 
+#if canImport(FoundationModels)
+import FoundationModels
+#endif
+
 // MARK: - ToolParameterBuilder
 
 /// A result builder for constructing tool parameter arrays with DSL syntax.
@@ -292,6 +296,26 @@ public struct ToolBuilder {
     public static func buildExpression(_ expression: FunctionTool) -> ToolCollection {
         ToolCollection(storage: [expression])
     }
+
+    #if canImport(FoundationModels)
+        /// Wraps a ``FoundationModelsNativeTool`` into a `ToolCollection`.
+        @available(macOS 26.0, iOS 26.0, visionOS 26.0, *)
+        @available(tvOS, unavailable)
+        @available(watchOS, unavailable)
+        public static func buildExpression(_ expression: FoundationModelsNativeTool) -> ToolCollection {
+            ToolCollection(storage: [expression])
+        }
+
+        /// Wraps a user-authored `FoundationModels.Tool` into a `ToolCollection`.
+        ///
+        /// - Experiment: Intended for ``FoundationModelsExecutionMode/nativeSession``.
+        @available(macOS 26.0, iOS 26.0, visionOS 26.0, *)
+        @available(tvOS, unavailable)
+        @available(watchOS, unavailable)
+        public static func buildExpression<T: FoundationModels.Tool>(_ expression: T) -> ToolCollection {
+            ToolCollection(storage: [FoundationModelsNativeTool(expression)])
+        }
+    #endif
 
     #if canImport(Darwin)
         /// Wraps the built-in calculator tool into a `ToolCollection`.

--- a/Tests/SwarmTests/Core/CoreTests.swift
+++ b/Tests/SwarmTests/Core/CoreTests.swift
@@ -137,6 +137,17 @@ struct AgentConfigurationTests {
         #expect(config.maxIterations == 10)
         #expect(config.timeout == .seconds(60))
         #expect(config.temperature == 1.0)
+        #expect(config.foundationModelsExecution == .capture)
+    }
+
+    @Test("Native session execution is opt-in and does not mutate capture default")
+    func nativeSessionExecutionIsOptIn() {
+        let original = AgentConfiguration.default
+        let native = original.foundationModelsExecution(.nativeSession)
+
+        #expect(original.foundationModelsExecution == .capture)
+        #expect(native.foundationModelsExecution == .nativeSession)
+        #expect(native.maxIterations == original.maxIterations)
     }
 
     @Test("Custom initialization")

--- a/Tests/SwarmTests/Providers/FoundationModelsExecutionModeTests.swift
+++ b/Tests/SwarmTests/Providers/FoundationModelsExecutionModeTests.swift
@@ -59,4 +59,40 @@ struct FoundationModelsExecutionModeTests {
         let recorded = await mockProvider.toolCallMessageCalls
         #expect(recorded.count == 2)
     }
+
+    @Test("Native session uses the envelope prompt when structured messages are nil")
+    func nativeSessionUsesEnvelopeWhenStructuredMessagesNil() {
+        let envelope = """
+        [Retrieved Context]
+        windowed-memory
+        [Current Conversation]
+        User: needle-user-input
+        """
+        let history = [
+            InferenceMessage.user("stale-turn-1"),
+            InferenceMessage.assistant("stale-turn-2"),
+            InferenceMessage.user("needle-user-input"),
+        ]
+
+        let messages = FoundationModelsNativePrompt.messages(
+            structuredMessages: nil,
+            envelopePrompt: envelope
+        )
+
+        #expect(messages == [.user(envelope)])
+        #expect(!messages.contains(where: { $0.content == history[0].content }))
+    }
+
+    @Test("Native session keeps structured messages when the envelope was not rewritten")
+    func nativeSessionKeepsStructuredMessages() {
+        let structured = [
+            InferenceMessage.user("hello"),
+            InferenceMessage.assistant("hi"),
+        ]
+        let messages = FoundationModelsNativePrompt.messages(
+            structuredMessages: structured,
+            envelopePrompt: "STUFFED SHOULD BE IGNORED"
+        )
+        #expect(messages == structured)
+    }
 }

--- a/Tests/SwarmTests/Providers/FoundationModelsExecutionModeTests.swift
+++ b/Tests/SwarmTests/Providers/FoundationModelsExecutionModeTests.swift
@@ -1,0 +1,62 @@
+// FoundationModelsExecutionModeTests.swift
+//
+// Flag defaulting and non-FM providers ignoring native session mode.
+
+import Foundation
+@testable import Swarm
+import Testing
+
+@Suite("FoundationModels Execution Mode")
+struct FoundationModelsExecutionModeTests {
+    @Test("Capture remains the AgentConfiguration default")
+    func captureIsDefault() {
+        #expect(AgentConfiguration.default.foundationModelsExecution == .capture)
+        #expect(AgentConfiguration().foundationModelsExecution == .capture)
+    }
+
+    @Test("Non-FM providers ignore nativeSession and keep the Swarm tool loop")
+    func nonFMProvidersIgnoreNativeFlag() async throws {
+        let spy = MockTool(
+            name: "test_tool",
+            description: "Test tool",
+            parameters: [ToolParameter(name: "location", description: "Location", type: .string)],
+            result: .string("Tool result")
+        )
+        let mockProvider = MockInferenceProvider()
+        await mockProvider.setToolCallResponses([
+            InferenceResponse(
+                content: nil,
+                toolCalls: [
+                    InferenceResponse.ParsedToolCall(
+                        id: "call_123",
+                        name: "test_tool",
+                        arguments: ["location": .string("NYC")]
+                    ),
+                ],
+                finishReason: .toolCall
+            ),
+            InferenceResponse(
+                content: "Done",
+                toolCalls: [],
+                finishReason: .completed
+            ),
+        ])
+
+        let config = AgentConfiguration.default
+            .foundationModelsExecution(.nativeSession)
+            .defaultTracingEnabled(false)
+        let agent = try Agent(
+            tools: [spy],
+            instructions: "You are a helpful assistant.",
+            configuration: config,
+            inferenceProvider: mockProvider
+        )
+
+        let result = try await agent.run("Use the tool")
+        #expect(result.output == "Done")
+        #expect(result.toolCalls.count == 1)
+
+        let recorded = await mockProvider.toolCallMessageCalls
+        #expect(recorded.count == 2)
+    }
+}

--- a/Tests/SwarmTests/Providers/FoundationModelsNativeToolBridgeTests.swift
+++ b/Tests/SwarmTests/Providers/FoundationModelsNativeToolBridgeTests.swift
@@ -138,4 +138,266 @@ struct FoundationModelsInferenceProviderTests {
         }
     }
 }
+
+enum FoundationModelsLiveTestGate {
+    static var isEnabled: Bool {
+        let env = ProcessInfo.processInfo.environment
+        return env["SWARM_FM_LIVE_TESTS"] == "1"
+            || env["SWARM_RUN_LIVE_FOUNDATION_MODELS_TESTS"] == "1"
+    }
+}
+
+@Suite("FoundationModels Executing Tool Bridge")
+struct FoundationModelsExecutingToolTests {
+    @Test("GeneratedContent round-trips through SendableValue")
+    @available(macOS 26.0, iOS 26.0, visionOS 26.0, *)
+    func generatedContentRoundTrip() {
+        let original: [String: SendableValue] = [
+            "query": .string("Swift"),
+            "limit": .int(3),
+            "flag": .bool(true),
+        ]
+        let content = FoundationModelsSchemaConversion.generatedContent(from: original)
+        let roundTripped = FoundationModelsSchemaConversion.argumentDictionary(from: content)
+        #expect(roundTripped["query"]?.stringValue == "Swift")
+        #expect(roundTripped["limit"]?.intValue == 3 || roundTripped["limit"]?.doubleValue == 3)
+        #expect(roundTripped["flag"]?.boolValue == true)
+    }
+
+    @Test("Executing tool runs the Swarm tool and returns its output")
+    @available(macOS 26.0, iOS 26.0, visionOS 26.0, *)
+    func executingToolRunsSwarmTool() async throws {
+        let swarmTool = MockTool(
+            name: "echo",
+            description: "Echo text",
+            parameters: [ToolParameter(name: "text", description: "Text", type: .string)],
+            result: .string("hello")
+        )
+        let registry = try ToolRegistry(tools: [swarmTool])
+        let runtime = FoundationModelsNativeToolRuntime(
+            registry: registry,
+            agent: MockAgentRuntime(response: "ok"),
+            context: nil,
+            observer: nil,
+            tracing: nil,
+            resultBuilder: AgentResult.Builder(),
+            stopOnToolError: false
+        )
+        let schema = swarmTool.schema
+        let tools = try FoundationModelsToolBridge.makeExecutingTools(from: [schema], runtime: runtime)
+        let executing = try #require(tools.first as? FoundationModelsExecutingTool)
+
+        let output = try await executing.call(
+            arguments: GeneratedContent(properties: ["text": "hello"])
+        )
+        #expect(output == "hello")
+    }
+
+    @Test("Executing tool fires observer hooks and input guardrails")
+    @available(macOS 26.0, iOS 26.0, visionOS 26.0, *)
+    func executingToolFiresObserverAndGuardrails() async throws {
+        let observer = NativeToolHookObserver()
+        let guardrail = ClosureToolInputGuardrail(name: "require_text") { data in
+            if data.arguments["text"] == nil {
+                return .tripwire(message: "missing text")
+            }
+            return .passed()
+        }
+        let swarmTool = MockTool(
+            name: "echo",
+            description: "Echo text",
+            parameters: [ToolParameter(name: "text", description: "Text", type: .string)],
+            result: .string("ok"),
+            inputGuardrails: [guardrail]
+        )
+        let registry = try ToolRegistry(tools: [swarmTool])
+        let runtime = FoundationModelsNativeToolRuntime(
+            registry: registry,
+            agent: MockAgentRuntime(response: "ok"),
+            context: nil,
+            observer: observer,
+            tracing: nil,
+            resultBuilder: AgentResult.Builder(),
+            stopOnToolError: false
+        )
+        let tools = try FoundationModelsToolBridge.makeExecutingTools(
+            from: [swarmTool.schema],
+            runtime: runtime
+        )
+        let executing = try #require(tools.first as? FoundationModelsExecutingTool)
+
+        let output = try await executing.call(
+            arguments: GeneratedContent(properties: ["text": "hi"])
+        )
+        #expect(output == "ok")
+        #expect(await observer.started == ["echo"])
+        #expect(await observer.ended == ["echo"])
+
+        let blocked = try await executing.call(arguments: GeneratedContent(properties: [:]))
+        #expect(blocked.contains("failed"))
+    }
+
+    @Test("Tool errors return a recoverable string instead of crashing")
+    @available(macOS 26.0, iOS 26.0, visionOS 26.0, *)
+    func toolErrorsAreRecoverableStrings() async throws {
+        let swarmTool = MockTool(
+            name: "boom",
+            description: "Always fails",
+            handler: { _ in throw AgentError.toolExecutionFailed(toolName: "boom", underlyingError: "nope") }
+        )
+        let registry = try ToolRegistry(tools: [swarmTool])
+        let runtime = FoundationModelsNativeToolRuntime(
+            registry: registry,
+            agent: MockAgentRuntime(response: "ok"),
+            context: nil,
+            observer: nil,
+            tracing: nil,
+            resultBuilder: AgentResult.Builder(),
+            stopOnToolError: false
+        )
+        let tools = try FoundationModelsToolBridge.makeExecutingTools(
+            from: [swarmTool.schema],
+            runtime: runtime
+        )
+        let executing = try #require(tools.first as? FoundationModelsExecutingTool)
+        let output = try await executing.call(arguments: GeneratedContent(properties: [:]))
+        #expect(output.contains("failed"))
+        #expect(output.contains("boom"))
+    }
+}
+
+@Suite("FoundationModels Native Tool Adapter")
+struct FoundationModelsNativeToolAdapterTests {
+    @Test("Wraps a FoundationModels.Tool as AnyJSONTool and executes it")
+    @available(macOS 26.0, iOS 26.0, visionOS 26.0, *)
+    func wrapsAndExecutesFoundationModelsTool() async throws {
+        let parameters = try FoundationModelsSchemaConversion.argumentSchema(
+            for: ToolSchema(
+                name: "echo",
+                description: "Echo",
+                parameters: [ToolParameter(name: "text", description: "Text", type: .string)]
+            )
+        )
+        let fmTool = NativeEchoFoundationTool(parameters: parameters)
+        let wrapped = FoundationModelsNativeTool(fmTool)
+        #expect(wrapped.name == "echo")
+        let result = try await wrapped.execute(arguments: ["text": .string("ping")])
+        #expect(result.stringValue == "ping")
+    }
+}
+
+@Suite("FoundationModels Native Transcript Mapper")
+struct FoundationModelsNativeTranscriptMapperTests {
+    @Test("Maps tool calls, tool output, and assistant response into memory messages")
+    @available(macOS 26.0, iOS 26.0, visionOS 26.0, *)
+    func mapsTranscriptEntries() {
+        let prompt = Transcript.Prompt(
+            segments: [.text(Transcript.TextSegment(content: "Hi"))]
+        )
+        let call = Transcript.ToolCall(
+            id: "call-1",
+            toolName: "echo",
+            arguments: GeneratedContent(properties: ["text": "hi"])
+        )
+        let calls = Transcript.ToolCalls([call])
+        let output = Transcript.ToolOutput(
+            id: "call-1",
+            toolName: "echo",
+            segments: [.text(Transcript.TextSegment(content: "hi"))]
+        )
+        let response = Transcript.Response(
+            assetIDs: [],
+            segments: [.text(Transcript.TextSegment(content: "Done"))]
+        )
+        let messages = FoundationModelsNativeTranscriptMapper.turnTranscriptMessages(
+            from: [
+                .prompt(prompt),
+                .toolCalls(calls),
+                .toolOutput(output),
+                .response(response),
+            ]
+        )
+        #expect(messages.count == 3)
+        #expect(messages[0].role == .assistant)
+        #expect(messages[1].role == .tool)
+        #expect(messages[1].content == "hi")
+        #expect(messages[2].role == .assistant)
+        #expect(messages[2].content == "Done")
+    }
+}
+
+@Suite("FoundationModels Native Session Live")
+struct FoundationModelsNativeSessionLiveTests {
+    @Test(
+        "Live native session executes a Swarm tool inside LanguageModelSession",
+        .enabled(if: FoundationModelsLiveTestGate.isEnabled)
+    )
+    @available(macOS 26.0, iOS 26.0, visionOS 26.0, *)
+    func liveNativeSessionExecutesTools() async throws {
+        guard let provider = FoundationModelsInferenceProvider.ifAvailable() else {
+            return
+        }
+        let swarmTool = MockTool(
+            name: "echo",
+            description: "Echo the text argument back unchanged. Always call this tool.",
+            parameters: [ToolParameter(name: "text", description: "Text to echo", type: .string)],
+            handler: { arguments in
+                .string(arguments["text"]?.stringValue ?? "missing")
+            }
+        )
+        let registry = try ToolRegistry(tools: [swarmTool])
+        let runtime = FoundationModelsNativeToolRuntime(
+            registry: registry,
+            agent: MockAgentRuntime(response: "ok"),
+            context: nil,
+            observer: nil,
+            tracing: nil,
+            resultBuilder: AgentResult.Builder(),
+            stopOnToolError: false
+        )
+        let fmTools = try FoundationModelsToolBridge.makeExecutingTools(
+            from: [swarmTool.schema],
+            runtime: runtime
+        )
+        let result = try await provider.respondUsingNativeSession(
+            messages: [.user("Call the echo tool with text 'hello native'. Then reply with the tool output.")],
+            tools: fmTools,
+            toolSchemas: [swarmTool.schema],
+            options: InferenceOptions(toolChoice: .required),
+            conversationID: "live-native-test"
+        )
+        #expect(!result.content.isEmpty)
+        #expect(!result.transcriptMessages.isEmpty)
+    }
+}
+
+actor NativeToolHookObserver: AgentObserver {
+    var started: [String] = []
+    var ended: [String] = []
+
+    func onToolStart(context _: AgentContext?, agent _: any AgentRuntime, call: ToolCall) async {
+        started.append(call.toolName)
+    }
+
+    func onToolEnd(context _: AgentContext?, agent _: any AgentRuntime, result: ToolResult) async {
+        ended.append(result.isSuccess ? "echo" : "echo")
+    }
+}
+
+@available(macOS 26.0, iOS 26.0, visionOS 26.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+private struct NativeEchoFoundationTool: FoundationModels.Tool {
+    typealias Arguments = GeneratedContent
+    typealias Output = String
+
+    var name: String { "echo" }
+    var description: String { "Echo" }
+    let parameters: GenerationSchema
+    var includesSchemaInInstructions: Bool { true }
+
+    func call(arguments: GeneratedContent) async throws -> String {
+        FoundationModelsSchemaConversion.argumentDictionary(from: arguments)["text"]?.stringValue ?? ""
+    }
+}
 #endif

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -70,6 +70,7 @@ export default defineConfig({
           text: 'Introduction',
           items: [
             { text: 'Getting Started', link: '/guide/getting-started' },
+            { text: 'Foundation Models', link: '/guide/foundation-models' },
             { text: 'Capability Showcase', link: '/guide/capability-showcase' },
             { text: 'Agent Workspace', link: '/guide/agent-workspace' },
             { text: 'OpenTelemetry Tracing', link: '/guide/opentelemetry-tracing' },

--- a/docs/guide/foundation-models.md
+++ b/docs/guide/foundation-models.md
@@ -52,6 +52,9 @@ Native mode exists so you can take Apple's session loop when you want parallel
 tools and real streaming. Capture stays the default because Swarm-side control
 (guardrails, checkpoints, memory injection) is the framework's differentiator.
 
+Under `strict4k`, native mode sends the same windowed/`PromptEnvelope` string
+capture uses — not the raw conversation history.
+
 ## What native mode cannot honor
 
 Foundation Models has no timeout API. Swarm still wraps the native `respond` /

--- a/docs/guide/foundation-models.md
+++ b/docs/guide/foundation-models.md
@@ -1,0 +1,75 @@
+# Foundation Models: Capture vs Native Session
+
+Swarm's built-in inference path is Apple Foundation Models. Tool calling has two modes.
+**Capture is the default** and is unchanged. Native session mode is an **experimental
+opt-in**.
+
+## How to opt in
+
+```swift
+let config = AgentConfiguration.default
+    .foundationModelsExecution(.nativeSession)
+
+let agent = try Agent(
+    "You are a private on-device assistant.",
+    configuration: config,
+    inferenceProvider: .foundationModels()
+) {
+    WeatherTool()
+}
+
+let result = try await agent.run("What's the weather in Tokyo?")
+```
+
+Non-Foundation-Models providers **ignore** the flag. Capture-mode behavior does
+not change unless you set ``FoundationModelsExecutionMode/nativeSession``.
+
+You can also register a user-authored `FoundationModels.Tool` next to `@Tool`
+macros and `FunctionTool` values:
+
+```swift
+let agent = try Agent("Be helpful.", configuration: config,
+    inferenceProvider: .foundationModels()) {
+    WeatherTool()
+    LookupTool() // FoundationModels.Tool — wrapped automatically
+}
+```
+
+## Comparison
+
+| | Capture (default) | Native session (experimental) |
+|---|---|---|
+| Tool loop owner | Swarm agent loop | `LanguageModelSession` |
+| Parallel tool calls | No (one captured call per turn) | Yes (Apple's session loop) |
+| Transcript / KV reuse | No (session rebuilt every Swarm iteration) | Transcript copied across `Agent.run` turns; Apple owns the inner loop |
+| Token streaming with tools | No | Yes (`Agent.stream` yields incremental tokens) |
+| Per-iteration memory injection | Yes | **No** — memory is injected when the native session starts |
+| Swarm `maxIterations` cap | Yes | **No** — Apple owns the inner loop |
+| Mid-loop checkpoints | Yes | **No** |
+| Per-turn guardrail interception | Yes (wraps Swarm's loop) | **No** — input/tool guardrails run **inside** each tool body |
+
+Native mode exists so you can take Apple's session loop when you want parallel
+tools and real streaming. Capture stays the default because Swarm-side control
+(guardrails, checkpoints, memory injection) is the framework's differentiator.
+
+## What native mode cannot honor
+
+Foundation Models has no timeout API. Swarm still wraps the native `respond` /
+`streamResponse` call in ``AgentConfiguration/timeout``; if Apple's call ignores
+task cancellation until it returns, the timeout surfaces when that call ends.
+`maxIterations` is not applied inside Apple's loop. Mid-loop workflow
+checkpoints do not fire.
+
+## Availability
+
+Requires macOS/iOS 26+ with Apple Intelligence available. Linux and CI use
+capture-equivalent mock providers; the flag is ignored there.
+
+Live on-device tests:
+
+```bash
+SWARM_FM_LIVE_TESTS=1 swift test --no-parallel --traits Integrations \
+  --filter FoundationModelsNativeSessionLiveTests
+```
+
+`SWARM_RUN_LIVE_FOUNDATION_MODELS_TESTS=1` is also accepted.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -378,6 +378,19 @@ Or using the `.environment()` modifier on any `AgentRuntime`:
 agent.environment(\.inferenceProvider, myCustomProvider)
 ```
 
+### Capture vs native session (experimental)
+
+By default Swarm **captures** Foundation Models tool calls and executes them in
+the agent loop (guardrails, checkpoints, per-iteration memory). Opt in to
+experimental native session mode for parallel tool calls and token streaming
+with tools — see [Foundation Models](foundation-models.md) for the trade-off
+table.
+
+```swift
+let config = AgentConfiguration.default
+    .foundationModelsExecution(.nativeSession)
+```
+
 ### Structured output
 
 `runStructured` asks the model (prompt instruction) and parses the reply as
@@ -409,6 +422,7 @@ The default Swarm graph is CI-tested on Ubuntu with Swift 6.2. Apple-only featur
 ## Next Steps
 
 - **[Agents](../reference/front-facing-api.md#3-agent-struct-primary-init)** -- Agent types, configuration, tool calling
+- **[Foundation Models](foundation-models.md)** -- Capture vs experimental native session mode
 - **[Tools](../reference/front-facing-api.md#5-tool-and-functiontool)** -- `@Tool` macro, `FunctionTool`, `ToolCollection`, and `@ToolBuilder`
 - **[Workflow](../reference/front-facing-api.md#7-workflow)** -- Sequential, parallel, and routed execution
 - **[Memory](../reference/front-facing-api.md#9-memory-factories)** -- Conversation, vector, summary, persistent

--- a/docs/reference/api-catalog.md
+++ b/docs/reference/api-catalog.md
@@ -3,8 +3,8 @@
 Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for high-risk public rows on 2026-07-28 (Conduit hard-removed in 0.6).
 
 - Scope: all `.swift` files under `Sources/Swarm/`, excluding `Internal/GraphRuntime/`
-- Source files scanned: 157
-- Public/open symbols cataloged: 2423
+- Source files scanned: 160
+- Public/open symbols cataloged: 2436
 
 ## 1. Swarm (entry point)
 
@@ -51,6 +51,7 @@ Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for
 | 108 | func | public | AgentConfiguration.contextProfile(_:) | `public @discardableResult func contextProfile(_ value: ContextProfile) -> AgentConfiguration` |
 | 108 | func | public | AgentConfiguration.defaultTracingEnabled(_:) | `public @discardableResult func defaultTracingEnabled(_ value: Bool) -> AgentConfiguration` |
 | 108 | func | public | AgentConfiguration.enableStreaming(_:) | `public @discardableResult func enableStreaming(_ value: Bool) -> AgentConfiguration` |
+| 108 | func | public | AgentConfiguration.foundationModelsExecution(_:) | `public @discardableResult func foundationModelsExecution(_ value: FoundationModelsExecutionMode) -> AgentConfiguration` |
 | 108 | func | public | AgentConfiguration.includeReasoning(_:) | `public @discardableResult func includeReasoning(_ value: Bool) -> AgentConfiguration` |
 | 108 | func | public | AgentConfiguration.includeToolCallDetails(_:) | `public @discardableResult func includeToolCallDetails(_ value: Bool) -> AgentConfiguration` |
 | 108 | func | public | AgentConfiguration.inferencePolicy(_:) | `public @discardableResult func inferencePolicy(_ value: InferencePolicy?) -> AgentConfiguration` |
@@ -86,7 +87,11 @@ Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for
 | 245 | var | public | AgentConfiguration.previousResponseId | `public var previousResponseId: String?` |
 | 253 | var | public | AgentConfiguration.autoPreviousResponseId | `public var autoPreviousResponseId: Bool` |
 | 264 | var | public | AgentConfiguration.defaultTracingEnabled | `public var defaultTracingEnabled: Bool` |
-| 289 | func | public | AgentConfiguration.init(name:maxIterations:timeout:temperature:maxTokens:stopSequences:modelSettings:contextProfile:inferencePolicy:enableStreaming:includeToolCallDetails:stopOnToolError:includeReasoning:sessionHistoryLimit:contextMode:parallelToolCalls:previousResponseId:autoPreviousResponseId:defaultTracingEnabled:) | `public init(name: String = "Agent", maxIterations: Int = 10, timeout: Duration = .seconds(60), temperature: Double = 1.0, maxTokens: Int? = nil, stopSequences: [String] = [], modelSettings: ModelSettings? = nil, contextProfile: ContextProfile = .platformDefault, inferencePolicy: InferencePolicy? = nil, enableStreaming: Bool = true, includeToolCallDetails: Bool = true, stopOnToolError: Bool = false, includeReasoning: Bool = true, sessionHistoryLimit: Int? = 50, contextMode: ContextMode = .adaptive, parallelToolCalls: Bool = false, previousResponseId: String? = nil, autoPreviousResponseId: Bool = false, defaultTracingEnabled: Bool = true)` |
+| 126 | enum | public | FoundationModelsExecutionMode | `public enum FoundationModelsExecutionMode` |
+| 130 | case | public | FoundationModelsExecutionMode.capture | `public case capture` |
+| 139 | case | public | FoundationModelsExecutionMode.nativeSession | `public case nativeSession` |
+| 604 | var | public | AgentConfiguration.foundationModelsExecution | `public var foundationModelsExecution: FoundationModelsExecutionMode` |
+| 630 | func | public | AgentConfiguration.init(name:maxIterations:timeout:temperature:maxTokens:stopSequences:modelSettings:contextProfile:inferencePolicy:enableStreaming:includeToolCallDetails:stopOnToolError:includeReasoning:sessionHistoryLimit:contextMode:parallelToolCalls:previousResponseId:autoPreviousResponseId:defaultTracingEnabled:foundationModelsExecution:) | `public init(name: String = "Agent", maxIterations: Int = 10, timeout: Duration = .seconds(60), temperature: Double = 1.0, maxTokens: Int? = nil, stopSequences: [String] = [], modelSettings: ModelSettings? = nil, contextProfile: ContextProfile = .platformDefault, inferencePolicy: InferencePolicy? = nil, enableStreaming: Bool = true, includeToolCallDetails: Bool = true, stopOnToolError: Bool = false, includeReasoning: Bool = true, sessionHistoryLimit: Int? = 50, contextMode: ContextMode = .adaptive, parallelToolCalls: Bool = false, previousResponseId: String? = nil, autoPreviousResponseId: Bool = false, defaultTracingEnabled: Bool = true, foundationModelsExecution: FoundationModelsExecutionMode = .capture)` |
 | 345 | var | public | AgentConfiguration.description | `public var description: String { get }` |
 
 ### Core/AgentEnvironment.swift
@@ -1323,6 +1328,8 @@ Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for
 | 290 | func | public | ToolBuilder.buildExpression(_:) | `public static func buildExpression(_ expression: any AnyJSONTool) -> [any AnyJSONTool]` |
 | 295 | func | public | ToolBuilder.buildExpression(_:) | `public static func buildExpression<T>(_ expression: T) -> [any AnyJSONTool] where T : Tool` |
 | 300 | func | public | ToolBuilder.buildExpression(_:) | `public static func buildExpression(_ expression: [any AnyJSONTool]) -> [any AnyJSONTool]` |
+| 305 | func | public | ToolBuilder.buildExpression(_:) | `public static func buildExpression(_ expression: FoundationModelsNativeTool) -> ToolCollection` _(Availability: macOS 26.0+, iOS 26.0+, visionOS 26.0+; Requires FoundationModels)_ |
+| 315 | func | public | ToolBuilder.buildExpression(_:) | `public static func buildExpression<T>(_ expression: T) -> ToolCollection where T : FoundationModels.Tool` _(Availability: macOS 26.0+, iOS 26.0+, visionOS 26.0+; Requires FoundationModels)_ |
 | 305 | func | public | ToolBuilder.buildLimitedAvailability(_:) | `public static func buildLimitedAvailability(_ component: [any AnyJSONTool]) -> [any AnyJSONTool]` |
 | 312 | typealias | public | ToolArrayBuilder | `public typealias ToolArrayBuilder = ToolBuilder` _(Availability: * (deprecated); renamed to ToolBuilder)_ |
 
@@ -2636,6 +2643,19 @@ First-class on-device Apple Foundation Models path. Gated by `#if canImport(Foun
 | 487 | func | public | InferenceProvider.foundationModels(configuration:) | `public static func foundationModels(configuration: FoundationModelsProviderConfiguration = .default) -> FoundationModelsInferenceProvider` |
 | 493 | func | public | InferenceProvider.foundationModels(instructions:prewarmOnInit:) | `public static func foundationModels(instructions: String, prewarmOnInit: Bool = false) -> FoundationModelsInferenceProvider` |
 | 509 | func | public | InferenceProvider.foundationModels(profile:configuration:) | `public static func foundationModels(profile: some DynamicProfile, configuration: FoundationModelsProviderConfiguration = .default) -> FoundationModelsInferenceProvider` |
+
+### Providers/FoundationModels/FoundationModelsNativeTool.swift
+
+Experimental adapter wrapping a user `FoundationModels.Tool` as a Swarm `AnyJSONTool`.
+
+| Line | Kind | Access | Name | Signature |
+|------|------|--------|------|-----------|
+| 39 | struct | public | FoundationModelsNativeTool | `public struct FoundationModelsNativeTool` |
+| 40 | var | public | FoundationModelsNativeTool.name | `public let name: String` |
+| 41 | var | public | FoundationModelsNativeTool.description | `public let description: String` |
+| 42 | var | public | FoundationModelsNativeTool.parameters | `public let parameters: [ToolParameter]` |
+| 47 | func | public | FoundationModelsNativeTool.init(_:) | `public init<T>(_ tool: T) where T : FoundationModels.Tool` |
+| 69 | func | public | FoundationModelsNativeTool.execute(arguments:) | `public func execute(arguments: [String: SendableValue]) async throws -> SendableValue` |
 
 ### Providers/FoundationModels/DynamicProfile.swift
 

--- a/docs/reference/api-catalog.md
+++ b/docs/reference/api-catalog.md
@@ -3,7 +3,7 @@
 Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for high-risk public rows on 2026-07-28 (Conduit hard-removed in 0.6).
 
 - Scope: all `.swift` files under `Sources/Swarm/`, excluding `Internal/GraphRuntime/`
-- Source files scanned: 160
+- Source files scanned: 161
 - Public/open symbols cataloged: 2436
 
 ## 1. Swarm (entry point)

--- a/docs/reference/front-facing-api.md
+++ b/docs/reference/front-facing-api.md
@@ -530,6 +530,13 @@ Built-in inference is Apple Foundation Models only. Custom backends implement
 | `.foundationModels(profile:)` | `FoundationModelsInferenceProvider` | Same, driven by Swarm ``DynamicProfile`` (WWDC 2026–aligned; re-resolves each turn) |
 | Custom `InferenceProvider` | your type | Implement the protocol for non-FM backends |
 
+Opt in to experimental native session mode with
+``AgentConfiguration/foundationModelsExecution(_:)``. Capture remains the
+default. See the [Foundation Models guide](/guide/foundation-models).
+
+You can register a user-authored `FoundationModels.Tool` in `@ToolBuilder`
+(wrapped as ``FoundationModelsNativeTool``).
+
 ## 12) Events and results
 
 ```swift

--- a/docs/reference/overview.md
+++ b/docs/reference/overview.md
@@ -17,3 +17,4 @@ The current API reference covers the supported public surface for Swarm 0.6.0. P
 | [Observability](/guide/opentelemetry-tracing) | Tracing, OpenTelemetry, `OSLogTracer`, `SwiftLogTracer`, metrics |
 | [MCP](/reference/api-catalog) | Model Context Protocol client and server |
 | [Providers](/reference/front-facing-api) | Foundation Models, `InferenceProvider`, `MultiProvider` routing |
+| [Foundation Models modes](/guide/foundation-models) | Capture vs experimental native session |


### PR DESCRIPTION
## Summary

Chunk H of the Swarm remediation series. Chunk G is **merged** (`fix: memory factory honesty` #126). This branch was rebased onto that `main` so the diff is H-only.

Opt-in experimental Foundation Models **native session mode**. Capture remains the default and is unchanged. Native mode lets Apple's `LanguageModelSession` run its own tool loop (parallel tools, transcript reuse, real streaming with tools). Non-FM providers ignore the flag.

```swift
let config = AgentConfiguration.default
    .foundationModelsExecution(.nativeSession)
```

### Capture vs native session

| | Capture (default) | Native session (experimental) |
|---|---|---|
| Tool loop owner | Swarm agent loop | `LanguageModelSession` |
| Parallel tool calls | No (one captured call per turn) | Yes (Apple's session loop) |
| Transcript / KV reuse | No (session rebuilt every Swarm iteration) | Transcript copied across `Agent.run` turns; Apple owns the inner loop |
| Token streaming with tools | No | Yes (`Agent.stream` yields incremental tokens) |
| Per-iteration memory injection | Yes | **No** — memory is injected when the native session starts |
| Swarm `maxIterations` cap | Yes | **No** — Apple owns the inner loop |
| Mid-loop checkpoints | Yes | **No** |
| Per-turn guardrail interception | Yes (wraps Swarm's loop) | **No** — input/tool guardrails run **inside** each tool body |

Native mode exists so you can take Apple's session loop when you want parallel tools and real streaming. Capture stays the default because Swarm-side control (guardrails, checkpoints, memory injection) is the framework's differentiator.

### What landed

- `FoundationModelsExecutionMode` (`.capture` | `.nativeSession`) on `AgentConfiguration`. Default `.capture`.
- Executing bridge (`FoundationModelsExecutingTool`) for native mode only. Capture tools (`FoundationModelsCaptureTool`, `generateWithToolCalls`) are untouched.
- Guardrails/observers fire inside executing tool `call(arguments:)`. Recoverable tool failures return error **strings** so FM can continue; throw only for cancellation / `stopOnToolError`.
- Agent steps aside after one native turn (`respondUsingNativeSession`). Timeout wraps `respond`/`streamResponse` via existing `executeWithinRemainingTimeout` (FM has no timeout API).
- Session lifecycle: one `LanguageModelSession` per inner tool loop. Across `Agent.run` with the same identity, a **new** session is created with the previous `Transcript` copied in so tool wrappers bind to this run's observers. The previous session's KV cache is **not** kept — Apple cannot retarget tools on a live session.
- Reverse adapter: `FoundationModelsNativeTool` + `@ToolBuilder` overloads for user-authored `FoundationModels.Tool`.
- Guide: [docs/guide/foundation-models.md](https://github.com/christopherkarani/Swarm/blob/feat/fm-native-session-mode/docs/guide/foundation-models.md).

`@Generable` structured output is **Chunk I**. This PR only round-trips arguments through `GeneratedContent`.

## Test plan

- [x] `bash scripts/ci/lean-build-test.sh` — **PASS** — `1769 tests in 232 suites` (Chunk G baseline: **1758 / 227**)
- [x] `swift test --no-parallel --traits Integrations` — **PASS** — `1913 tests in 255 suites` (Chunk G baseline: **1902 / 250**)
- [x] `swift run --traits Integrations SwarmCapabilityShowcase matrix` — all rows `passed`
- [x] New tests: flag default `.capture`, mock providers ignore `.nativeSession`, executing-tool round-trip, guardrail/observer firing, recoverable error strings, reverse adapter, transcript→memory mapping
- [x] SwiftFormat / SwiftLint `--strict` clean on changed files

Delta vs G is the new native-mode suites (+11 tests / +5 suites). No regressions.

### Live on-device test

CI has no Apple Intelligence. Gated live test:

```bash
SWARM_FM_LIVE_TESTS=1 swift test --no-parallel --traits Integrations \
  --filter FoundationModelsNativeSessionLiveTests
```

`SWARM_RUN_LIVE_FOUNDATION_MODELS_TESTS=1` is also accepted.

## Breaking changes

**Does this PR introduce breaking changes?**
- [x] No — capture remains default; new flag is additive and ignored by non-FM providers.

Made with [Cursor](https://cursor.com)