### PR TITLE
fix: native structured outputs + multi-call capture in FM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,9 +174,9 @@ let result = try await agent.run("Summarize my notes.")
 Notes that matter in production:
 
 - **Availability**: use `FoundationModelsInferenceProvider.ifAvailable()` or check `FoundationModelsInferenceProvider.isAvailable` before assuming the system model is ready.
-- **Tool calling**: Swarm bridges `@Tool` / `ToolSchema` to Apple's `FoundationModels.Tool` and executes tools in the agent loop with guardrails intact (capture mode, default). Opt in to experimental [native session mode](docs/guide/foundation-models.md) for parallel tool calls and token streaming with tools.
+- **Tool calling**: Swarm bridges `@Tool` / `ToolSchema` to Apple's `FoundationModels.Tool` and executes tools in the agent loop with guardrails intact (capture mode, default — all tool calls from a parallel group are recovered). Opt in to experimental [native session mode](docs/guide/foundation-models.md) for Apple's inner tool loop and token streaming with tools.
 - **Streaming tool calls**: not advertised as token-level tool streaming; `Agent.stream` observes the same `run` loop via `AgentEvent` (lifecycle, tools, and `.output(.token)` chunks). Foundation Models yields incremental text deltas; providers without a streaming API emit the full response as a single chunk.
-- **Structured outputs**: `runStructured` asks the model (prompt instruction) and parses JSON. It is not enforced schema generation — invalid JSON fails at parse time.
+- **Structured outputs**: `runStructured` uses Foundation Models guided generation when the JSON Schema maps onto `GenerationSchema` (`source: .providerNative`); otherwise it is prompt instruction + parse (`source: .promptFallback`). `.jsonObject` always uses the fallback path.
 - **Dynamic profiles**: `.foundationModels(profile:)` re-resolves instructions/tools/history every turn (WWDC 2026–aligned Swarm API).
 - **Linux / CI**: Foundation Models is compile-time gated; inject a mock or custom `InferenceProvider`, or use the deterministic `--demo` modes in `Examples/`.
 

--- a/Sources/Swarm/Agents/Agent.swift
+++ b/Sources/Swarm/Agents/Agent.swift
@@ -1261,16 +1261,21 @@ public struct Agent: AgentRuntime, Sendable {
     func finalizeAssistantResponse(
         content: String,
         request: StructuredOutputRequest?,
-        provider: any InferenceProvider
+        provider _: any InferenceProvider
     ) throws -> FinalAssistantResponse {
         guard let request else {
             return FinalAssistantResponse(content: content, structuredOutput: nil)
         }
 
-        let source: StructuredOutputResult.Source = providerCapabilities(for: provider).contains(.structuredOutputs)
-            ? .providerNative
-            : .promptFallback
-        let structuredOutput = try StructuredOutputParser.parse(content, request: request, source: source)
+        // Text remaining after a tool loop (or native session) was produced
+        // without `respond(to:schema:)`. Label it prompt-fallback even when the
+        // provider advertises `.structuredOutputs` — native guided generation
+        // reports `.providerNative` from `generateStructured` itself.
+        let structuredOutput = try StructuredOutputParser.parse(
+            content,
+            request: request,
+            source: .promptFallback
+        )
         return FinalAssistantResponse(content: structuredOutput.rawJSON, structuredOutput: structuredOutput)
     }
 

--- a/Sources/Swarm/Core/StructuredOutput.swift
+++ b/Sources/Swarm/Core/StructuredOutput.swift
@@ -1,6 +1,13 @@
 import Foundation
 
 /// Provider-agnostic structured output request owned by Swarm.
+///
+/// ``jsonObject`` asks for any JSON value via prompt instruction; it cannot be
+/// lowered onto Foundation Models `GenerationSchema` (no property set to
+/// guide). ``jsonSchema(name:schemaJSON:)`` uses native guided generation when
+/// the schema is inside the documented GenerationSchema subset; otherwise the
+/// same prompt+parse path runs and ``StructuredOutputResult/source`` stays
+/// ``StructuredOutputResult/Source/promptFallback``.
 public enum StructuredOutputFormat: Sendable, Equatable, Codable {
     case jsonObject
     case jsonSchema(name: String, schemaJSON: String)
@@ -37,6 +44,13 @@ public struct StructuredOutputRequest: Sendable, Equatable, Codable {
 
 /// Parsed structured output emitted by a provider or Swarm fallback path.
 public struct StructuredOutputResult: Sendable, Equatable, Codable {
+    /// How the JSON was produced.
+    ///
+    /// - ``providerNative``: the inference backend constrained generation
+    ///   (Foundation Models `respond(to:schema:)` when the schema maps).
+    /// - ``promptFallback``: Swarm appended JSON instructions and parsed the
+    ///   reply. Used for ``StructuredOutputFormat/jsonObject``, unmappable
+    ///   schemas, and providers without guided generation.
     public enum Source: String, Sendable, Equatable, Codable {
         case providerNative = "provider_native"
         case promptFallback = "prompt_fallback"
@@ -45,6 +59,9 @@ public struct StructuredOutputResult: Sendable, Equatable, Codable {
     public var format: StructuredOutputFormat
     public var rawJSON: String
     public var value: SendableValue
+    /// Which production path emitted ``rawJSON``. Survives on
+    /// ``StructuredAgentResult/structuredOutput`` and as
+    /// `structured_output.source` on ``AgentResult/metadata``.
     public var source: Source
 
     public init(

--- a/Sources/Swarm/Providers/FoundationModels/FoundationModelsExecutingTool.swift
+++ b/Sources/Swarm/Providers/FoundationModels/FoundationModelsExecutingTool.swift
@@ -161,7 +161,7 @@ struct FoundationModelsExecutingTool: FoundationModels.Tool {
 extension FoundationModelsToolBridge {
     /// Builds executing Foundation Models tools from Swarm schemas.
     ///
-    /// Unlike ``makeCaptureTools(from:)``, these tools run Swarm tools (with
+    /// Unlike ``makeCaptureTools(from:store:)``, these tools run Swarm tools (with
     /// guardrails and observers) inside `LanguageModelSession`'s own loop.
     static func makeExecutingTools(
         from tools: [ToolSchema],

--- a/Sources/Swarm/Providers/FoundationModels/FoundationModelsInferenceProvider.swift
+++ b/Sources/Swarm/Providers/FoundationModels/FoundationModelsInferenceProvider.swift
@@ -67,9 +67,18 @@ public struct FoundationModelsProviderConfiguration: Sendable, Equatable {
 /// Swarm tools are bridged to `FoundationModels.Tool` at request time. The model
 /// produces structured arguments via guided generation.
 ///
-/// **Capture mode (default):** capture tools surface those arguments back to
-/// Swarm so the agent runtime can execute tools with guardrails, observers, and
-/// retries intact. One tool call is recovered per turn.
+/// **Capture mode (default):** capture tools record their arguments into a
+/// per-turn store and return a sentinel so Apple can invoke every tool in a
+/// parallel group. Swarm recovers **all** calls from the first `ToolCalls`
+/// group and executes them in the agent loop with guardrails, observers, and
+/// retries intact. Assistant text that accompanied those calls is preserved;
+/// sentinel-mediated final text is discarded.
+///
+/// **Structured outputs:** ``generateStructured`` uses native guided
+/// generation (`respond(to:schema:)`) when the JSON Schema maps onto
+/// `GenerationSchema`. ``StructuredOutputFormat/jsonObject`` and schemas
+/// outside that subset stay prompt-instruction + parse, labeled
+/// ``StructuredOutputResult/Source/promptFallback``.
 ///
 /// **Native session mode (experimental):** executing tools run inside Apple's
 /// session loop. Opt in with ``AgentConfiguration/foundationModelsExecution``.
@@ -267,9 +276,10 @@ public struct FoundationModelsInferenceProvider: InferenceProvider,
             }
         }
 
+        let store = FoundationModelsToolCaptureStore()
         let fmTools: [any FoundationModels.Tool]
         do {
-            fmTools = try FoundationModelsToolBridge.makeCaptureTools(from: effectiveTools)
+            fmTools = try FoundationModelsToolBridge.makeCaptureTools(from: effectiveTools, store: store)
         } catch {
             throw AgentError.generationFailed(
                 reason: "Failed to bridge Swarm tools to FoundationModels.Tool: \(error)"
@@ -283,9 +293,17 @@ public struct FoundationModelsInferenceProvider: InferenceProvider,
             options: resolved.options
         )
         let generationOptions = makeGenerationOptions(from: resolved.options)
+        let startCount = session.transcript.count
 
         do {
             let response = try await session.respond(to: prompt, options: generationOptions)
+            let turnEntries = Array(session.transcript.dropFirst(startCount))
+            if let captured = await FoundationModelsToolBridge.inferenceResponse(
+                store: store,
+                turnEntries: turnEntries
+            ) {
+                return captured
+            }
             let content = applyStopSequences(response.content, options: resolved.options)
             return InferenceResponse(
                 content: content,
@@ -293,7 +311,12 @@ public struct FoundationModelsInferenceProvider: InferenceProvider,
                 finishReason: .completed
             )
         } catch {
-            if let captured = FoundationModelsToolBridge.inferenceResponse(from: error) {
+            let turnEntries = Array(session.transcript.dropFirst(startCount))
+            if let captured = await FoundationModelsToolBridge.inferenceResponse(
+                store: store,
+                turnEntries: turnEntries,
+                error: error
+            ) {
                 return captured
             }
             throw mapError(error)
@@ -307,16 +330,59 @@ public struct FoundationModelsInferenceProvider: InferenceProvider,
         request: StructuredOutputRequest,
         options: InferenceOptions
     ) async throws -> StructuredOutputResult {
-        // Prefer prompt instruction + parse for portability; native schema generation
-        // requires a GenerationSchema derived from the request which may not always
-        // map 1:1 from Swarm's JSON schema representation.
-        var structuredOptions = options
-        structuredOptions.structuredOutput = request
-        let text = try await generate(prompt: prompt, options: structuredOptions)
-        return try StructuredOutputParser.parse(text, request: request, source: .promptFallback)
+        try await generateStructured(messages: [.user(prompt)], request: request, options: options)
     }
 
     public func generateStructured(
+        messages: [InferenceMessage],
+        request: StructuredOutputRequest,
+        options: InferenceOptions
+    ) async throws -> StructuredOutputResult {
+        let resolved = resolveTurn(messages: messages, tools: [], options: options)
+        switch FoundationModelsStructuredSchemaMapping.evaluate(request) {
+        case let .mapped(mapped):
+            do {
+                let schema = try FoundationModelsSchemaConversion.generationSchema(from: mapped)
+                var promptOptions = resolved.options
+                promptOptions.structuredOutput = nil
+                let prompt = flattenPrompt(
+                    messages: resolved.messages,
+                    tools: [],
+                    options: promptOptions
+                )
+                let session = makeSession(tools: [], instructions: resolved.instructions)
+                let generationOptions = makeGenerationOptions(from: resolved.options)
+                let response = try await session.respond(
+                    to: prompt,
+                    schema: schema,
+                    includeSchemaInPrompt: true,
+                    options: generationOptions
+                )
+                return StructuredOutputResult(
+                    format: request.format,
+                    rawJSON: response.content.jsonString,
+                    value: FoundationModelsSchemaConversion.sendableValue(from: response.content),
+                    source: .providerNative
+                )
+            } catch is GenerationSchema.SchemaError {
+                return try await generateStructuredPromptFallback(
+                    messages: messages,
+                    request: request,
+                    options: options
+                )
+            } catch {
+                throw mapError(error)
+            }
+        case .unsupported:
+            return try await generateStructuredPromptFallback(
+                messages: messages,
+                request: request,
+                options: options
+            )
+        }
+    }
+
+    private func generateStructuredPromptFallback(
         messages: [InferenceMessage],
         request: StructuredOutputRequest,
         options: InferenceOptions

--- a/Sources/Swarm/Providers/FoundationModels/FoundationModelsSchemaConversion.swift
+++ b/Sources/Swarm/Providers/FoundationModels/FoundationModelsSchemaConversion.swift
@@ -12,6 +12,31 @@ import FoundationModels
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
 enum FoundationModelsSchemaConversion {
+    /// Builds a guided-generation schema from a mapped structured-output request.
+    ///
+    /// Call ``FoundationModelsStructuredSchemaMapping/evaluate(_:)`` first; this
+    /// lowering is mechanical and throws only if Apple rejects the tree.
+    static func generationSchema(
+        from mapped: FoundationModelsMappedGenerationSchema
+    ) throws -> GenerationSchema {
+        let dependencies = try mapped.definitions.map { definition in
+            try namedDynamicSchema(definition, typeName: definition.name)
+        }
+        let root = try namedDynamicSchema(mapped, typeName: mapped.name)
+        return try GenerationSchema(root: root, dependencies: dependencies)
+    }
+
+    /// Builds a guided-generation schema for a structured-output request, or throws
+    /// if the request is outside the supported GenerationSchema subset.
+    static func generationSchema(for request: StructuredOutputRequest) throws -> GenerationSchema {
+        switch FoundationModelsStructuredSchemaMapping.evaluate(request) {
+        case let .mapped(mapped):
+            return try generationSchema(from: mapped)
+        case let .unsupported(reason):
+            throw reason
+        }
+    }
+
     /// Builds a guided-generation schema for a Swarm tool's argument object.
     static func argumentSchema(for tool: ToolSchema) throws -> GenerationSchema {
         let properties = tool.parameters.map { parameter in
@@ -154,7 +179,65 @@ enum FoundationModelsSchemaConversion {
         }
     }
 
-    private static func sanitizeTypeName(_ raw: String) -> String {
+    private static func namedDynamicSchema(
+        _ mapped: FoundationModelsMappedGenerationSchema,
+        typeName: String
+    ) throws -> DynamicGenerationSchema {
+        if let values = mapped.stringEnum {
+            return DynamicGenerationSchema(
+                name: sanitizeTypeName(typeName),
+                description: mapped.description,
+                anyOf: values
+            )
+        }
+        let properties = try mapped.properties.map { property in
+            DynamicGenerationSchema.Property(
+                name: property.name,
+                description: property.description,
+                schema: try dynamicSchema(for: property.type, name: "\(typeName)_\(property.name)"),
+                isOptional: property.isOptional
+            )
+        }
+        return DynamicGenerationSchema(
+            name: sanitizeTypeName(typeName),
+            description: mapped.description,
+            properties: properties
+        )
+    }
+
+    private static func dynamicSchema(
+        for type: FoundationModelsMappedType,
+        name: String
+    ) throws -> DynamicGenerationSchema {
+        switch type {
+        case .string:
+            return DynamicGenerationSchema(type: String.self)
+        case .integer:
+            return DynamicGenerationSchema(type: Int.self)
+        case .number:
+            return DynamicGenerationSchema(type: Double.self)
+        case .boolean:
+            return DynamicGenerationSchema(type: Bool.self)
+        case let .stringEnum(values):
+            return DynamicGenerationSchema(
+                name: sanitizeTypeName(name),
+                description: nil,
+                anyOf: values
+            )
+        case let .array(element, minItems, maxItems):
+            return DynamicGenerationSchema(
+                arrayOf: try dynamicSchema(for: element, name: "\(name)_Element"),
+                minimumElements: minItems,
+                maximumElements: maxItems
+            )
+        case let .object(schema):
+            return try namedDynamicSchema(schema, typeName: schema.name)
+        case let .reference(refName):
+            return DynamicGenerationSchema(referenceTo: sanitizeTypeName(refName))
+        }
+    }
+
+    static func sanitizeTypeName(_ raw: String) -> String {
         let filtered = raw.map { character -> Character in
             character.isLetter || character.isNumber ? character : "_"
         }

--- a/Sources/Swarm/Providers/FoundationModels/FoundationModelsSchemaConversion.swift
+++ b/Sources/Swarm/Providers/FoundationModels/FoundationModelsSchemaConversion.swift
@@ -49,7 +49,7 @@ enum FoundationModelsSchemaConversion {
         }
 
         let root = DynamicGenerationSchema(
-            name: sanitizeTypeName("\(tool.name)_Arguments"),
+            name: FoundationModelsGenerationTypeName.sanitize("\(tool.name)_Arguments"),
             description: "Arguments for \(tool.name)",
             properties: properties
         )
@@ -166,13 +166,13 @@ enum FoundationModelsSchemaConversion {
                 )
             }
             return DynamicGenerationSchema(
-                name: sanitizeTypeName(name),
+                name: FoundationModelsGenerationTypeName.sanitize(name),
                 description: nil,
                 properties: nested
             )
         case let .oneOf(options):
             return DynamicGenerationSchema(
-                name: sanitizeTypeName(name),
+                name: FoundationModelsGenerationTypeName.sanitize(name),
                 description: nil,
                 anyOf: options
             )
@@ -185,7 +185,7 @@ enum FoundationModelsSchemaConversion {
     ) throws -> DynamicGenerationSchema {
         if let values = mapped.stringEnum {
             return DynamicGenerationSchema(
-                name: sanitizeTypeName(typeName),
+                name: FoundationModelsGenerationTypeName.sanitize(typeName),
                 description: mapped.description,
                 anyOf: values
             )
@@ -199,7 +199,7 @@ enum FoundationModelsSchemaConversion {
             )
         }
         return DynamicGenerationSchema(
-            name: sanitizeTypeName(typeName),
+            name: FoundationModelsGenerationTypeName.sanitize(typeName),
             description: mapped.description,
             properties: properties
         )
@@ -220,7 +220,7 @@ enum FoundationModelsSchemaConversion {
             return DynamicGenerationSchema(type: Bool.self)
         case let .stringEnum(values):
             return DynamicGenerationSchema(
-                name: sanitizeTypeName(name),
+                name: FoundationModelsGenerationTypeName.sanitize(name),
                 description: nil,
                 anyOf: values
             )
@@ -233,19 +233,8 @@ enum FoundationModelsSchemaConversion {
         case let .object(schema):
             return try namedDynamicSchema(schema, typeName: schema.name)
         case let .reference(refName):
-            return DynamicGenerationSchema(referenceTo: sanitizeTypeName(refName))
+            return DynamicGenerationSchema(referenceTo: FoundationModelsGenerationTypeName.sanitize(refName))
         }
-    }
-
-    static func sanitizeTypeName(_ raw: String) -> String {
-        let filtered = raw.map { character -> Character in
-            character.isLetter || character.isNumber ? character : "_"
-        }
-        var name = String(filtered)
-        if name.isEmpty || name.first?.isNumber == true {
-            name = "T_\(name)"
-        }
-        return name
     }
 }
 #endif

--- a/Sources/Swarm/Providers/FoundationModels/FoundationModelsStructuredSchema.swift
+++ b/Sources/Swarm/Providers/FoundationModels/FoundationModelsStructuredSchema.swift
@@ -63,7 +63,7 @@ indirect enum FoundationModelsMappedType: Sendable, Equatable {
 ///
 /// ``StructuredOutputFormat/jsonObject`` has no schema, so it cannot be guided
 /// and stays prompt-instruction + parse. Also rejected (honest
-/// ``StructuredOutputResult/Source-swift.enum/promptFallback``):
+/// ``StructuredOutputResult/Source/promptFallback``):
 ///
 /// - `additionalProperties: true` or a nested schema (free-form keys)
 /// - `pattern`, `format`, `minLength`, `maxLength`
@@ -171,8 +171,7 @@ private struct Parser {
         let object = try parser.parseObjectSchema(
             node,
             name: rootName,
-            path: "$",
-            allowNestedDefinitions: false
+            path: "$"
         )
         return FoundationModelsMappedGenerationSchema(
             name: object.name,
@@ -201,7 +200,7 @@ private struct Parser {
             return []
         }
 
-        definitionNames = Set(defsNode.keys.map(Self.sanitizeTypeName))
+        definitionNames = Set(defsNode.keys.map(FoundationModelsGenerationTypeName.sanitize))
         var result: [FoundationModelsMappedGenerationSchema] = []
         result.reserveCapacity(defsNode.count)
         for key in defsNode.keys.sorted() {
@@ -214,7 +213,6 @@ private struct Parser {
             try rejectUnknownKeys(in: defNode, path: "$/$defs/\(key)")
             let mapped: FoundationModelsMappedGenerationSchema
             if defNode["enum"] != nil, defNode["properties"] == nil {
-                try rejectUnknownKeys(in: defNode, path: "$/$defs/\(key)")
                 guard case let .stringEnum(values) = try parseStringEnum(
                     defNode["enum"] as Any,
                     path: "$/$defs/\(key)"
@@ -224,7 +222,7 @@ private struct Parser {
                     )
                 }
                 mapped = FoundationModelsMappedGenerationSchema(
-                    name: Self.sanitizeTypeName(key),
+                    name: FoundationModelsGenerationTypeName.sanitize(key),
                     description: defNode["description"] as? String,
                     properties: [],
                     stringEnum: values,
@@ -233,9 +231,8 @@ private struct Parser {
             } else {
                 mapped = try parseObjectSchema(
                     defNode,
-                    name: Self.sanitizeTypeName(key),
-                    path: "$/$defs/\(key)",
-                    allowNestedDefinitions: false
+                    name: FoundationModelsGenerationTypeName.sanitize(key),
+                    path: "$/$defs/\(key)"
                 )
             }
             result.append(mapped)
@@ -246,12 +243,9 @@ private struct Parser {
     private func parseObjectSchema(
         _ node: [String: Any],
         name: String,
-        path: String,
-        allowNestedDefinitions: Bool
+        path: String
     ) throws -> FoundationModelsMappedGenerationSchema {
-        if !allowNestedDefinitions, node["$defs"] != nil || node["definitions"] != nil,
-           path != "$"
-        {
+        if path != "$", node["$defs"] != nil || node["definitions"] != nil {
             throw FoundationModelsStructuredSchemaMapping.Reason.unsupportedKeyword(
                 "$defs",
                 path: path
@@ -260,9 +254,8 @@ private struct Parser {
 
         try rejectOpenAdditionalProperties(in: node, path: path)
 
-        if let ref = node["$ref"] as? String {
+        if node["$ref"] != nil {
             try rejectRefComposition(in: node, path: path)
-            _ = try resolveReference(ref)
             throw FoundationModelsStructuredSchemaMapping.Reason.unsupportedType(
                 "$ref as whole object schema",
                 path: path
@@ -305,7 +298,7 @@ private struct Parser {
         }
 
         return FoundationModelsMappedGenerationSchema(
-            name: Self.sanitizeTypeName(name),
+            name: FoundationModelsGenerationTypeName.sanitize(name),
             description: node["description"] as? String ?? node["title"] as? String,
             properties: properties,
             stringEnum: nil,
@@ -347,8 +340,7 @@ private struct Parser {
                 let nested = try parseObjectSchema(
                     node,
                     name: anonymousName,
-                    path: path,
-                    allowNestedDefinitions: false
+                    path: path
                 )
                 return .object(nested)
             }
@@ -411,7 +403,7 @@ private struct Parser {
         } else {
             throw FoundationModelsStructuredSchemaMapping.Reason.invalidReference(ref)
         }
-        let name = Self.sanitizeTypeName(String(ref.dropFirst(prefix.count)))
+        let name = FoundationModelsGenerationTypeName.sanitize(String(ref.dropFirst(prefix.count)))
         guard !name.isEmpty, definitionNames.contains(name) else {
             throw FoundationModelsStructuredSchemaMapping.Reason.unresolvedReference(ref)
         }
@@ -469,8 +461,11 @@ private struct Parser {
         "$defs", "definitions", "$ref",
         "minItems", "maxItems",
     ]
+}
 
-    static func sanitizeTypeName(_ raw: String) -> String {
+/// Sanitizes JSON Schema type names for Foundation Models `GenerationSchema`.
+enum FoundationModelsGenerationTypeName {
+    static func sanitize(_ raw: String) -> String {
         let filtered = raw.map { character -> Character in
             character.isLetter || character.isNumber ? character : "_"
         }

--- a/Sources/Swarm/Providers/FoundationModels/FoundationModelsStructuredSchema.swift
+++ b/Sources/Swarm/Providers/FoundationModels/FoundationModelsStructuredSchema.swift
@@ -1,0 +1,483 @@
+// FoundationModelsStructuredSchema.swift
+// Swarm Framework
+//
+// Pure JSON Schema → GenerationSchema subset mapping. No FoundationModels
+// import: Linux CI can assert supported vs unsupported constructs.
+
+import Foundation
+
+/// Intermediate representation of a JSON Schema that Foundation Models
+/// `GenerationSchema` can express.
+///
+/// Built by ``FoundationModelsStructuredSchemaMapping`` so the Apple-only
+/// conversion in ``FoundationModelsSchemaConversion`` stays a mechanical
+/// lowering of this tree.
+struct FoundationModelsMappedGenerationSchema: Sendable, Equatable {
+    var name: String
+    var description: String?
+    var properties: [FoundationModelsMappedProperty]
+    /// When non-nil, this named schema is a string enum (`anyOf` choices) rather than an object.
+    var stringEnum: [String]?
+    var definitions: [FoundationModelsMappedGenerationSchema]
+}
+
+struct FoundationModelsMappedProperty: Sendable, Equatable {
+    var name: String
+    var description: String?
+    var isOptional: Bool
+    var type: FoundationModelsMappedType
+}
+
+indirect enum FoundationModelsMappedType: Sendable, Equatable {
+    case string
+    case integer
+    case number
+    case boolean
+    case stringEnum([String])
+    case array(element: FoundationModelsMappedType, minItems: Int?, maxItems: Int?)
+    case object(FoundationModelsMappedGenerationSchema)
+    case reference(String)
+}
+
+/// Evaluates whether a Swarm structured-output request maps onto Apple
+/// Foundation Models guided generation.
+///
+/// ## Supported subset
+///
+/// Native `GenerationSchema` is used only when the request is
+/// ``StructuredOutputFormat/jsonSchema(name:schemaJSON:)`` and the schema is a
+/// **closed object** whose constraints GenerationSchema can enforce:
+///
+/// - Root `type: object` with `properties` (and optional `required`)
+/// - Property types: `string`, `integer`, `number`, `boolean`
+/// - Nested objects and arrays (`items` as a single schema)
+/// - `enum` of strings (maps to `anyOf` choices)
+/// - `minItems` / `maxItems` on arrays
+/// - Local `$ref` to root `$defs` / `definitions` (object or string-enum targets)
+/// - `additionalProperties: false` (or omitted — guided generation already
+///   forbids extra keys, which still validates against an open JSON Schema)
+/// - Metadata ignored: `$schema`, `$id`, `$comment`, `title`, `description`,
+///   `default`, `examples`, `deprecated`
+///
+/// ## Explicitly unsupported
+///
+/// ``StructuredOutputFormat/jsonObject`` has no schema, so it cannot be guided
+/// and stays prompt-instruction + parse. Also rejected (honest
+/// ``StructuredOutputResult/Source-swift.enum/promptFallback``):
+///
+/// - `additionalProperties: true` or a nested schema (free-form keys)
+/// - `pattern`, `format`, `minLength`, `maxLength`
+/// - numeric `minimum` / `maximum` / `exclusive*` / `multipleOf`
+/// - `oneOf` / `anyOf` / `allOf` / `not` / `if` / `then` / `else`
+/// - `const`, `uniqueItems`, tuple `items` / `prefixItems`
+/// - type unions (`type` as an array), remote `$ref`, unknown keywords
+enum FoundationModelsStructuredSchemaMapping: Sendable, Equatable {
+    case mapped(FoundationModelsMappedGenerationSchema)
+    case unsupported(Reason)
+
+    enum Reason: Error, Sendable, Equatable, CustomStringConvertible {
+        case jsonObjectHasNoSchema
+        case invalidSchemaJSON(String)
+        case rootMustBeObject
+        case unsupportedKeyword(String, path: String)
+        case unsupportedType(String, path: String)
+        case invalidEnum(path: String)
+        case unresolvedReference(String)
+        case invalidReference(String)
+        case additionalProperties(path: String)
+        case emptyProperties(path: String)
+
+        var description: String {
+            switch self {
+            case .jsonObjectHasNoSchema:
+                "jsonObject has no schema; Foundation Models GenerationSchema cannot constrain a free-form object"
+            case let .invalidSchemaJSON(detail):
+                "schemaJSON is not valid JSON: \(detail)"
+            case .rootMustBeObject:
+                "root schema must be type: object with properties"
+            case let .unsupportedKeyword(keyword, path):
+                "unsupported JSON Schema keyword '\(keyword)' at \(path)"
+            case let .unsupportedType(type, path):
+                "unsupported JSON Schema type '\(type)' at \(path)"
+            case let .invalidEnum(path):
+                "enum at \(path) must be an array of strings"
+            case let .unresolvedReference(ref):
+                "unresolved $ref '\(ref)'"
+            case let .invalidReference(ref):
+                "$ref '\(ref)' is not a local #/$defs or #/definitions pointer"
+            case let .additionalProperties(path):
+                "additionalProperties at \(path) enables free-form keys that GenerationSchema cannot express"
+            case let .emptyProperties(path):
+                "object at \(path) has no properties; GenerationSchema cannot express a free-form object"
+            }
+        }
+    }
+
+    static func evaluate(_ request: StructuredOutputRequest) -> Self {
+        switch request.format {
+        case .jsonObject:
+            return .unsupported(.jsonObjectHasNoSchema)
+        case let .jsonSchema(name, schemaJSON):
+            return evaluate(name: name, schemaJSON: schemaJSON)
+        }
+    }
+
+    static func evaluate(name: String, schemaJSON: String) -> Self {
+        let trimmed = schemaJSON.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let data = trimmed.data(using: .utf8) else {
+            return .unsupported(.invalidSchemaJSON("not valid UTF-8"))
+        }
+
+        let raw: Any
+        do {
+            raw = try JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
+        } catch {
+            return .unsupported(.invalidSchemaJSON(error.localizedDescription))
+        }
+
+        guard let root = raw as? [String: Any] else {
+            return .unsupported(.rootMustBeObject)
+        }
+
+        do {
+            let mapped = try Parser(rootName: name).parseRoot(root)
+            return .mapped(mapped)
+        } catch let reason as Reason {
+            return .unsupported(reason)
+        } catch {
+            return .unsupported(.invalidSchemaJSON(String(describing: error)))
+        }
+    }
+}
+
+// MARK: - Parser
+
+private struct Parser {
+    let rootName: String
+    private var definitionNames: Set<String> = []
+
+    init(rootName: String) {
+        self.rootName = rootName
+    }
+
+    func parseRoot(_ node: [String: Any]) throws -> FoundationModelsMappedGenerationSchema {
+        try rejectUnknownKeys(in: node, path: "$")
+        try rejectOpenAdditionalProperties(in: node, path: "$")
+
+        var parser = self
+        let definitions = try parser.parseDefinitions(from: node)
+        parser.definitionNames = Set(definitions.map(\.name))
+
+        let object = try parser.parseObjectSchema(
+            node,
+            name: rootName,
+            path: "$",
+            allowNestedDefinitions: false
+        )
+        return FoundationModelsMappedGenerationSchema(
+            name: object.name,
+            description: object.description,
+            properties: object.properties,
+            stringEnum: object.stringEnum,
+            definitions: definitions
+        )
+    }
+
+    private mutating func parseDefinitions(
+        from node: [String: Any]
+    ) throws -> [FoundationModelsMappedGenerationSchema] {
+        let defsNode: [String: Any]
+        if let defs = node["$defs"] as? [String: Any] {
+            if node["definitions"] != nil {
+                throw FoundationModelsStructuredSchemaMapping.Reason.unsupportedKeyword(
+                    "definitions",
+                    path: "$"
+                )
+            }
+            defsNode = defs
+        } else if let defs = node["definitions"] as? [String: Any] {
+            defsNode = defs
+        } else {
+            return []
+        }
+
+        definitionNames = Set(defsNode.keys.map(Self.sanitizeTypeName))
+        var result: [FoundationModelsMappedGenerationSchema] = []
+        result.reserveCapacity(defsNode.count)
+        for key in defsNode.keys.sorted() {
+            guard let defNode = defsNode[key] as? [String: Any] else {
+                throw FoundationModelsStructuredSchemaMapping.Reason.unsupportedType(
+                    "non-object definition",
+                    path: "$/$defs/\(key)"
+                )
+            }
+            try rejectUnknownKeys(in: defNode, path: "$/$defs/\(key)")
+            let mapped: FoundationModelsMappedGenerationSchema
+            if defNode["enum"] != nil, defNode["properties"] == nil {
+                try rejectUnknownKeys(in: defNode, path: "$/$defs/\(key)")
+                guard case let .stringEnum(values) = try parseStringEnum(
+                    defNode["enum"] as Any,
+                    path: "$/$defs/\(key)"
+                ) else {
+                    throw FoundationModelsStructuredSchemaMapping.Reason.invalidEnum(
+                        path: "$/$defs/\(key)"
+                    )
+                }
+                mapped = FoundationModelsMappedGenerationSchema(
+                    name: Self.sanitizeTypeName(key),
+                    description: defNode["description"] as? String,
+                    properties: [],
+                    stringEnum: values,
+                    definitions: []
+                )
+            } else {
+                mapped = try parseObjectSchema(
+                    defNode,
+                    name: Self.sanitizeTypeName(key),
+                    path: "$/$defs/\(key)",
+                    allowNestedDefinitions: false
+                )
+            }
+            result.append(mapped)
+        }
+        return result
+    }
+
+    private func parseObjectSchema(
+        _ node: [String: Any],
+        name: String,
+        path: String,
+        allowNestedDefinitions: Bool
+    ) throws -> FoundationModelsMappedGenerationSchema {
+        if !allowNestedDefinitions, node["$defs"] != nil || node["definitions"] != nil,
+           path != "$"
+        {
+            throw FoundationModelsStructuredSchemaMapping.Reason.unsupportedKeyword(
+                "$defs",
+                path: path
+            )
+        }
+
+        try rejectOpenAdditionalProperties(in: node, path: path)
+
+        if let ref = node["$ref"] as? String {
+            try rejectRefComposition(in: node, path: path)
+            _ = try resolveReference(ref)
+            throw FoundationModelsStructuredSchemaMapping.Reason.unsupportedType(
+                "$ref as whole object schema",
+                path: path
+            )
+        }
+
+        let type = jsonType(of: node)
+        if let type, type != "object" {
+            throw FoundationModelsStructuredSchemaMapping.Reason.rootMustBeObject
+        }
+
+        guard let propertiesNode = node["properties"] as? [String: Any], !propertiesNode.isEmpty else {
+            throw FoundationModelsStructuredSchemaMapping.Reason.emptyProperties(path: path)
+        }
+
+        let required = Set((node["required"] as? [Any] ?? []).compactMap { $0 as? String })
+        var properties: [FoundationModelsMappedProperty] = []
+        properties.reserveCapacity(propertiesNode.count)
+        for key in propertiesNode.keys.sorted() {
+            guard let propertyNode = propertiesNode[key] as? [String: Any] else {
+                throw FoundationModelsStructuredSchemaMapping.Reason.unsupportedType(
+                    "non-object property schema",
+                    path: "\(path).properties.\(key)"
+                )
+            }
+            let propertyPath = "\(path).properties.\(key)"
+            try rejectUnknownKeys(in: propertyNode, path: propertyPath)
+            properties.append(
+                FoundationModelsMappedProperty(
+                    name: key,
+                    description: propertyNode["description"] as? String,
+                    isOptional: !required.contains(key),
+                    type: try parseType(
+                        propertyNode,
+                        path: propertyPath,
+                        anonymousName: "\(name)_\(key)"
+                    )
+                )
+            )
+        }
+
+        return FoundationModelsMappedGenerationSchema(
+            name: Self.sanitizeTypeName(name),
+            description: node["description"] as? String ?? node["title"] as? String,
+            properties: properties,
+            stringEnum: nil,
+            definitions: []
+        )
+    }
+
+    private func parseType(
+        _ node: [String: Any],
+        path: String,
+        anonymousName: String
+    ) throws -> FoundationModelsMappedType {
+        try rejectUnknownKeys(in: node, path: path)
+
+        if let ref = node["$ref"] as? String {
+            try rejectRefComposition(in: node, path: path)
+            return try .reference(resolveReference(ref))
+        }
+
+        if let enumValues = node["enum"] {
+            return try parseStringEnum(enumValues, path: path)
+        }
+
+        try rejectOpenAdditionalProperties(in: node, path: path)
+
+        switch jsonType(of: node) {
+        case "string":
+            return .string
+        case "integer":
+            return .integer
+        case "number":
+            return .number
+        case "boolean":
+            return .boolean
+        case "array":
+            return try parseArray(node, path: path, anonymousName: anonymousName)
+        case "object", .none:
+            if node["properties"] != nil {
+                let nested = try parseObjectSchema(
+                    node,
+                    name: anonymousName,
+                    path: path,
+                    allowNestedDefinitions: false
+                )
+                return .object(nested)
+            }
+            if jsonType(of: node) == "object" {
+                throw FoundationModelsStructuredSchemaMapping.Reason.emptyProperties(path: path)
+            }
+            throw FoundationModelsStructuredSchemaMapping.Reason.unsupportedType(
+                jsonType(of: node) ?? "missing",
+                path: path
+            )
+        case let .some(other):
+            throw FoundationModelsStructuredSchemaMapping.Reason.unsupportedType(other, path: path)
+        }
+    }
+
+    private func parseArray(
+        _ node: [String: Any],
+        path: String,
+        anonymousName: String
+    ) throws -> FoundationModelsMappedType {
+        guard let items = node["items"] as? [String: Any] else {
+            throw FoundationModelsStructuredSchemaMapping.Reason.unsupportedType(
+                "array without object items schema",
+                path: path
+            )
+        }
+        let element = try parseType(
+            items,
+            path: "\(path).items",
+            anonymousName: "\(anonymousName)_Element"
+        )
+        return .array(
+            element: element,
+            minItems: intValue(node["minItems"]),
+            maxItems: intValue(node["maxItems"])
+        )
+    }
+
+    private func parseStringEnum(_ raw: Any, path: String) throws -> FoundationModelsMappedType {
+        guard let values = raw as? [Any], !values.isEmpty else {
+            throw FoundationModelsStructuredSchemaMapping.Reason.invalidEnum(path: path)
+        }
+        var strings: [String] = []
+        strings.reserveCapacity(values.count)
+        for value in values {
+            guard let string = value as? String else {
+                throw FoundationModelsStructuredSchemaMapping.Reason.invalidEnum(path: path)
+            }
+            strings.append(string)
+        }
+        return .stringEnum(strings)
+    }
+
+    private func resolveReference(_ ref: String) throws -> String {
+        let prefix: String
+        if ref.hasPrefix("#/$defs/") {
+            prefix = "#/$defs/"
+        } else if ref.hasPrefix("#/definitions/") {
+            prefix = "#/definitions/"
+        } else {
+            throw FoundationModelsStructuredSchemaMapping.Reason.invalidReference(ref)
+        }
+        let name = Self.sanitizeTypeName(String(ref.dropFirst(prefix.count)))
+        guard !name.isEmpty, definitionNames.contains(name) else {
+            throw FoundationModelsStructuredSchemaMapping.Reason.unresolvedReference(ref)
+        }
+        return name
+    }
+
+    private func rejectRefComposition(in node: [String: Any], path: String) throws {
+        for keyword in ["type", "properties", "items", "enum", "required"] where node[keyword] != nil {
+            throw FoundationModelsStructuredSchemaMapping.Reason.unsupportedKeyword(keyword, path: path)
+        }
+    }
+
+    private func rejectOpenAdditionalProperties(in node: [String: Any], path: String) throws {
+        guard let additional = node["additionalProperties"] else { return }
+        if let flag = additional as? Bool {
+            if flag {
+                throw FoundationModelsStructuredSchemaMapping.Reason.additionalProperties(path: path)
+            }
+            return
+        }
+        if additional is [String: Any] {
+            throw FoundationModelsStructuredSchemaMapping.Reason.additionalProperties(path: path)
+        }
+        throw FoundationModelsStructuredSchemaMapping.Reason.unsupportedKeyword(
+            "additionalProperties",
+            path: path
+        )
+    }
+
+    private func rejectUnknownKeys(in node: [String: Any], path: String) throws {
+        for key in node.keys where !Self.allowedKeys.contains(key) {
+            throw FoundationModelsStructuredSchemaMapping.Reason.unsupportedKeyword(key, path: path)
+        }
+        if node["type"] is [Any] {
+            throw FoundationModelsStructuredSchemaMapping.Reason.unsupportedType("union", path: path)
+        }
+        if node["items"] is [Any] {
+            throw FoundationModelsStructuredSchemaMapping.Reason.unsupportedKeyword("prefixItems", path: path)
+        }
+    }
+
+    private func jsonType(of node: [String: Any]) -> String? {
+        node["type"] as? String
+    }
+
+    private func intValue(_ raw: Any?) -> Int? {
+        if let int = raw as? Int { return int }
+        if let number = raw as? NSNumber { return number.intValue }
+        return nil
+    }
+
+    static let allowedKeys: Set<String> = [
+        "$schema", "$id", "$comment", "title", "description", "default", "examples", "deprecated",
+        "type", "properties", "required", "additionalProperties", "items", "enum",
+        "$defs", "definitions", "$ref",
+        "minItems", "maxItems",
+    ]
+
+    static func sanitizeTypeName(_ raw: String) -> String {
+        let filtered = raw.map { character -> Character in
+            character.isLetter || character.isNumber ? character : "_"
+        }
+        var name = String(filtered)
+        if name.isEmpty || name.first?.isNumber == true {
+            name = "T_\(name)"
+        }
+        return name
+    }
+}

--- a/Sources/Swarm/Providers/FoundationModels/FoundationModelsToolBridge.swift
+++ b/Sources/Swarm/Providers/FoundationModels/FoundationModelsToolBridge.swift
@@ -14,12 +14,38 @@ import Foundation
 #if canImport(FoundationModels)
 import FoundationModels
 
+/// Per-turn store of tool calls captured from Foundation Models.
+///
+/// Capture tools record into this actor and return
+/// ``FoundationModelsCaptureTool/sentinelOutput`` so Apple can invoke every
+/// tool in a parallel `Transcript.ToolCalls` group. Swarm then takes the
+/// **first** tool-call group from the turn transcript (request order) and
+/// discards later inner-loop calls that were based on sentinel results.
+@available(macOS 26.0, iOS 26.0, visionOS 26.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+actor FoundationModelsToolCaptureStore {
+    private var calls: [InferenceResponse.ParsedToolCall] = []
+
+    func record(_ call: InferenceResponse.ParsedToolCall) {
+        calls.append(call)
+    }
+
+    func snapshot() -> [InferenceResponse.ParsedToolCall] {
+        calls
+    }
+
+    var isEmpty: Bool {
+        calls.isEmpty
+    }
+}
+
 /// Error thrown from a capture tool so Swarm can reclaim control of tool execution.
 ///
-/// Foundation Models invokes tools inside `LanguageModelSession.respond(to:)`.
-/// Swarm's agent runtime owns tool execution (guardrails, observers, retries).
-/// Capture tools therefore record the model's structured arguments and throw,
-/// surfacing a single tool-call round-trip that Swarm can execute itself.
+/// The default capture path records calls and returns a sentinel instead of
+/// throwing, so a single `LanguageModelSession.respond` can surface N parallel
+/// tool calls. This error remains for SDK `ToolCallError` wrapping and as a
+/// fallback when a capture tool still throws (tests, later-wave abort).
 @available(macOS 26.0, iOS 26.0, visionOS 26.0, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
@@ -32,6 +58,10 @@ struct FoundationModelsToolCaptureError: Error, Sendable {
 /// Uses guided generation (`GenerationSchema`) for argument typing instead of
 /// prompt-injected JSON envelopes. Arguments are always `GeneratedContent` so
 /// any Swarm schema can be represented without per-tool `@Generable` types.
+///
+/// `call(arguments:)` records the invocation into a per-turn store and returns
+/// ``sentinelOutput`` rather than throwing, so Apple can finish the rest of
+/// the current `ToolCalls` group.
 @available(macOS 26.0, iOS 26.0, visionOS 26.0, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
@@ -39,9 +69,19 @@ struct FoundationModelsCaptureTool: FoundationModels.Tool {
     typealias Arguments = GeneratedContent
     typealias Output = String
 
+    /// Documented sentinel returned in place of a real tool result.
+    ///
+    /// Swarm intercepts the call and executes the tool in the agent loop.
+    /// The model must not treat this string as successful tool output.
+    static let sentinelOutput = """
+    SWARM_CAPTURED: Swarm intercepted this tool call and will execute it after this turn. \
+    This is not a real tool result. Do not call more tools based on this string.
+    """
+
     let name: String
     let description: String
     let parameters: GenerationSchema
+    let store: FoundationModelsToolCaptureStore
     var includesSchemaInInstructions: Bool { true }
 
     func call(arguments: GeneratedContent) async throws -> String {
@@ -50,7 +90,8 @@ struct FoundationModelsCaptureTool: FoundationModels.Tool {
             name: name,
             arguments: FoundationModelsSchemaConversion.argumentDictionary(from: arguments)
         )
-        throw FoundationModelsToolCaptureError(toolCall: parsed)
+        await store.record(parsed)
+        return Self.sentinelOutput
     }
 }
 
@@ -60,17 +101,61 @@ struct FoundationModelsCaptureTool: FoundationModels.Tool {
 enum FoundationModelsToolBridge {
     /// Builds native Foundation Models tools from Swarm schemas.
     ///
-    /// - Parameter tools: Swarm provider-facing tool schemas.
+    /// - Parameters:
+    ///   - tools: Swarm provider-facing tool schemas.
+    ///   - store: Per-turn capture store shared by every returned tool.
     /// - Returns: Type-erased FoundationModels tools ready for `LanguageModelSession`.
-    static func makeCaptureTools(from tools: [ToolSchema]) throws -> [any FoundationModels.Tool] {
+    static func makeCaptureTools(
+        from tools: [ToolSchema],
+        store: FoundationModelsToolCaptureStore
+    ) throws -> [any FoundationModels.Tool] {
         try tools.map { schema in
             let parameters = try FoundationModelsSchemaConversion.argumentSchema(for: schema)
             return FoundationModelsCaptureTool(
                 name: schema.name,
                 description: schema.description,
-                parameters: parameters
+                parameters: parameters,
+                store: store
             )
         }
+    }
+
+    /// Builds an inference response from captured calls and this turn's transcript.
+    ///
+    /// Policy:
+    /// - Prefer the first `Transcript.toolCalls` group (Apple's request order).
+    /// - Carry assistant text that appeared **before** that group.
+    /// - Discard post-tool `response` text (it was generated from sentinel output).
+    /// - If the transcript has no tool-call group, fall back to the store snapshot.
+    /// - If a capture tool still threw, merge that call when the store is empty.
+    static func inferenceResponse(
+        store: FoundationModelsToolCaptureStore,
+        turnEntries: [Transcript.Entry],
+        error: Error? = nil
+    ) async -> InferenceResponse? {
+        let stored = await store.snapshot()
+        let fromTranscript = firstWave(from: turnEntries)
+        let calls: [InferenceResponse.ParsedToolCall]
+        let accompanying: String?
+
+        if let fromTranscript, !fromTranscript.calls.isEmpty {
+            calls = fromTranscript.calls
+            accompanying = fromTranscript.accompanyingContent
+        } else if !stored.isEmpty {
+            calls = stored
+            accompanying = nil
+        } else if let error, let thrown = inferenceResponse(from: error) {
+            return thrown
+        } else {
+            return nil
+        }
+
+        let trimmed = accompanying?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return InferenceResponse(
+            content: (trimmed?.isEmpty == false) ? trimmed : nil,
+            toolCalls: calls,
+            finishReason: .toolCall
+        )
     }
 
     /// Extracts a Swarm tool-call response from a Foundation Models error, if present.
@@ -99,6 +184,44 @@ enum FoundationModelsToolBridge {
             return inferenceResponse(from: underlying)
         }
 
+        return nil
+    }
+
+    // MARK: - Transcript first wave
+
+    struct FirstWave: Sendable {
+        var accompanyingContent: String?
+        var calls: [InferenceResponse.ParsedToolCall]
+    }
+
+    static func firstWave(from entries: [Transcript.Entry]) -> FirstWave? {
+        var accompanying: [String] = []
+        for entry in entries {
+            switch entry {
+            case let .response(response):
+                let text = FoundationModelsNativeTranscriptMapper.concatenatedText(response.segments)
+                if !text.isEmpty {
+                    accompanying.append(text)
+                }
+            case let .toolCalls(calls):
+                let parsed = calls.map { call in
+                    InferenceResponse.ParsedToolCall(
+                        id: call.id,
+                        name: call.toolName,
+                        arguments: FoundationModelsSchemaConversion.argumentDictionary(from: call.arguments)
+                    )
+                }
+                guard !parsed.isEmpty else { continue }
+                let joined = accompanying.joined(separator: "\n")
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                return FirstWave(
+                    accompanyingContent: joined.isEmpty ? nil : joined,
+                    calls: parsed
+                )
+            default:
+                continue
+            }
+        }
         return nil
     }
 }

--- a/Sources/Swarm/Providers/FoundationModels/FoundationModelsToolBridge.swift
+++ b/Sources/Swarm/Providers/FoundationModels/FoundationModelsToolBridge.swift
@@ -34,10 +34,6 @@ actor FoundationModelsToolCaptureStore {
     func snapshot() -> [InferenceResponse.ParsedToolCall] {
         calls
     }
-
-    var isEmpty: Bool {
-        calls.isEmpty
-    }
 }
 
 /// Error thrown from a capture tool so Swarm can reclaim control of tool execution.
@@ -123,11 +119,17 @@ enum FoundationModelsToolBridge {
     /// Builds an inference response from captured calls and this turn's transcript.
     ///
     /// Policy:
-    /// - Prefer the first `Transcript.toolCalls` group (Apple's request order).
-    /// - Carry assistant text that appeared **before** that group.
-    /// - Discard post-tool `response` text (it was generated from sentinel output).
-    /// - If the transcript has no tool-call group, fall back to the store snapshot.
-    /// - If a capture tool still threw, merge that call when the store is empty.
+    /// - Prefer the first non-empty `Transcript.toolCalls` group that appears
+    ///   **before** any post-tool response (Apple's request order).
+    /// - Empty placeholder groups are skipped only until that first real group
+    ///   or a post-tool `.response` (sentinel-mediated text).
+    /// - Carry assistant text that appeared **before** the first tool-call marker.
+    /// - Discard post-tool `response` text.
+    /// - Fall back to the store only when the transcript recorded **no**
+    ///   `toolCalls` entries (session aborted before Apple wrote a group).
+    ///   Once a `toolCalls` marker exists, later-wave store contents are ignored.
+    /// - If a capture tool still threw and nothing else was recovered, use the
+    ///   throw-path converter.
     static func inferenceResponse(
         store: FoundationModelsToolCaptureStore,
         turnEntries: [Transcript.Entry],
@@ -141,7 +143,7 @@ enum FoundationModelsToolBridge {
         if let fromTranscript, !fromTranscript.calls.isEmpty {
             calls = fromTranscript.calls
             accompanying = fromTranscript.accompanyingContent
-        } else if !stored.isEmpty {
+        } else if fromTranscript == nil, !stored.isEmpty {
             calls = stored
             accompanying = nil
         } else if let error, let thrown = inferenceResponse(from: error) {
@@ -196,14 +198,21 @@ enum FoundationModelsToolBridge {
 
     static func firstWave(from entries: [Transcript.Entry]) -> FirstWave? {
         var accompanying: [String] = []
-        for entry in entries {
+        var sawToolCalls = false
+        entryLoop: for entry in entries {
             switch entry {
             case let .response(response):
+                if sawToolCalls {
+                    // Sentinel-mediated continuation. Do not treat later tool
+                    // groups as the first wave.
+                    break entryLoop
+                }
                 let text = FoundationModelsNativeTranscriptMapper.concatenatedText(response.segments)
                 if !text.isEmpty {
                     accompanying.append(text)
                 }
             case let .toolCalls(calls):
+                sawToolCalls = true
                 let parsed = calls.map { call in
                     InferenceResponse.ParsedToolCall(
                         id: call.id,
@@ -211,18 +220,27 @@ enum FoundationModelsToolBridge {
                         arguments: FoundationModelsSchemaConversion.argumentDictionary(from: call.arguments)
                     )
                 }
-                guard !parsed.isEmpty else { continue }
-                let joined = accompanying.joined(separator: "\n")
-                    .trimmingCharacters(in: .whitespacesAndNewlines)
-                return FirstWave(
-                    accompanyingContent: joined.isEmpty ? nil : joined,
-                    calls: parsed
-                )
+                if !parsed.isEmpty {
+                    let joined = accompanying.joined(separator: "\n")
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                    return FirstWave(
+                        accompanyingContent: joined.isEmpty ? nil : joined,
+                        calls: parsed
+                    )
+                }
             default:
                 continue
             }
         }
-        return nil
+        guard sawToolCalls else {
+            return nil
+        }
+        let joined = accompanying.joined(separator: "\n")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return FirstWave(
+            accompanyingContent: joined.isEmpty ? nil : joined,
+            calls: []
+        )
     }
 }
 #endif

--- a/Tests/SwarmTests/Agents/AgentTranscriptContractTests.swift
+++ b/Tests/SwarmTests/Agents/AgentTranscriptContractTests.swift
@@ -145,6 +145,27 @@ struct AgentTranscriptContractTests {
         #expect(transcript.entries.last?.structuredOutput?.result.source == .providerNative)
     }
 
+    @Test("tool-loop text parse does not claim providerNative from capabilities")
+    func toolLoopStructuredParseDoesNotClaimProviderNative() async throws {
+        let provider = MockInferenceProvider(
+            capabilities: [.structuredOutputs, .conversationMessages, .nativeToolCalling]
+        )
+        await provider.setToolCallResponses([
+            InferenceResponse(content: #"{"answer":"ok"}"#, finishReason: .completed),
+        ])
+        let agent = try Agent(
+            tools: [MockTool(name: "noop", result: .string("unused"))],
+            instructions: "Return structured JSON.",
+            inferenceProvider: provider
+        )
+        let result = try await agent.runStructured(
+            "Return a JSON answer.",
+            request: StructuredOutputRequest(format: .jsonObject)
+        )
+        #expect(result.structuredOutput.source == .promptFallback)
+        #expect(metadataString("structured_output.source", from: result.agentResult.metadata) == "prompt_fallback")
+    }
+
     @Test("InMemorySession branch keeps transcript replay-compatible and isolated")
     func inMemorySessionBranchKeepsTranscriptReplayCompatible() async throws {
         let provider = MockInferenceProvider()

--- a/Tests/SwarmTests/Providers/FoundationModelsNativeToolBridgeTests.swift
+++ b/Tests/SwarmTests/Providers/FoundationModelsNativeToolBridgeTests.swift
@@ -172,6 +172,137 @@ struct FoundationModelsSchemaConversionTests {
         #expect(response.content?.contains("Sentinel-mediated") != true)
     }
 
+    @Test("Store fallback is used only when the transcript has no toolCalls marker")
+    @available(macOS 26.0, iOS 26.0, visionOS 26.0, *)
+    func storeFallbackWhenTranscriptHasNoToolCalls() async throws {
+        let store = FoundationModelsToolCaptureStore()
+        await store.record(
+            InferenceResponse.ParsedToolCall(
+                id: "s1",
+                name: "lookup",
+                arguments: ["query": .string("swift")]
+            )
+        )
+        await store.record(
+            InferenceResponse.ParsedToolCall(
+                id: "s2",
+                name: "weather",
+                arguments: ["city": .string("Tokyo")]
+            )
+        )
+        await store.record(
+            InferenceResponse.ParsedToolCall(
+                id: "s3",
+                name: "lookup",
+                arguments: ["query": .string("later-wave")]
+            )
+        )
+        let entries: [Transcript.Entry] = [
+            .response(Transcript.Response(
+                assetIDs: [],
+                segments: [.text(Transcript.TextSegment(content: "Working…"))]
+            )),
+        ]
+        let error = FoundationModelsToolCaptureError(
+            toolCall: InferenceResponse.ParsedToolCall(
+                name: "clock",
+                arguments: ["tz": .string("JST")]
+            )
+        )
+        let response = try #require(
+            await FoundationModelsToolBridge.inferenceResponse(
+                store: store,
+                turnEntries: entries,
+                error: error
+            )
+        )
+        #expect(response.toolCalls.map(\.name) == ["lookup", "weather", "lookup"])
+        #expect(response.toolCalls.compactMap(\.id) == ["s1", "s2", "s3"])
+        #expect(response.content == nil)
+    }
+
+    @Test("Empty placeholder then post-tool response does not recover a later wave")
+    @available(macOS 26.0, iOS 26.0, visionOS 26.0, *)
+    func emptyPlaceholderThenLaterWaveIsNotFirstWave() async throws {
+        let store = FoundationModelsToolCaptureStore()
+        await store.record(
+            InferenceResponse.ParsedToolCall(
+                id: "first",
+                name: "lookup",
+                arguments: ["query": .string("swift")]
+            )
+        )
+        await store.record(
+            InferenceResponse.ParsedToolCall(
+                id: "later",
+                name: "weather",
+                arguments: ["city": .string("Tokyo")]
+            )
+        )
+        let later = Transcript.ToolCall(
+            id: "c-later",
+            toolName: "weather",
+            arguments: GeneratedContent(properties: ["city": "Tokyo"])
+        )
+        let entries: [Transcript.Entry] = [
+            .response(Transcript.Response(
+                assetIDs: [],
+                segments: [.text(Transcript.TextSegment(content: "Let me look that up."))]
+            )),
+            .toolCalls(Transcript.ToolCalls([])),
+            .response(Transcript.Response(
+                assetIDs: [],
+                segments: [.text(Transcript.TextSegment(content: "Sentinel-mediated final."))]
+            )),
+            .toolCalls(Transcript.ToolCalls([later])),
+        ]
+        let response = await FoundationModelsToolBridge.inferenceResponse(
+            store: store,
+            turnEntries: entries
+        )
+        #expect(response == nil)
+    }
+
+    @Test("Empty placeholder before a real parallel group still recovers that group")
+    @available(macOS 26.0, iOS 26.0, visionOS 26.0, *)
+    func emptyPlaceholderThenRealGroupIsFirstWave() async throws {
+        let store = FoundationModelsToolCaptureStore()
+        let lookup = Transcript.ToolCall(
+            id: "c1",
+            toolName: "lookup",
+            arguments: GeneratedContent(properties: ["query": "swift"])
+        )
+        let weather = Transcript.ToolCall(
+            id: "c2",
+            toolName: "weather",
+            arguments: GeneratedContent(properties: ["city": "Tokyo"])
+        )
+        let later = Transcript.ToolCall(
+            id: "c3",
+            toolName: "clock",
+            arguments: GeneratedContent(properties: ["tz": "JST"])
+        )
+        let entries: [Transcript.Entry] = [
+            .response(Transcript.Response(
+                assetIDs: [],
+                segments: [.text(Transcript.TextSegment(content: "Checking."))]
+            )),
+            .toolCalls(Transcript.ToolCalls([])),
+            .toolCalls(Transcript.ToolCalls([lookup, weather])),
+            .response(Transcript.Response(
+                assetIDs: [],
+                segments: [.text(Transcript.TextSegment(content: "Sentinel-mediated final."))]
+            )),
+            .toolCalls(Transcript.ToolCalls([later])),
+        ]
+        let response = try #require(
+            await FoundationModelsToolBridge.inferenceResponse(store: store, turnEntries: entries)
+        )
+        #expect(response.toolCalls.map(\.name) == ["lookup", "weather"])
+        #expect(response.content == "Checking.")
+        #expect(response.content?.contains("Sentinel-mediated") != true)
+    }
+
     @Test("Single-call turn still returns one ParsedToolCall")
     @available(macOS 26.0, iOS 26.0, visionOS 26.0, *)
     func singleCallTurnMatchesPreviousBehavior() async throws {

--- a/Tests/SwarmTests/Providers/FoundationModelsNativeToolBridgeTests.swift
+++ b/Tests/SwarmTests/Providers/FoundationModelsNativeToolBridgeTests.swift
@@ -42,9 +42,35 @@ struct FoundationModelsSchemaConversionTests {
         #expect(dictionary["limit"]?.intValue == 3 || dictionary["limit"]?.doubleValue == 3)
     }
 
-    @Test("Capture tools throw FoundationModelsToolCaptureError")
+    @Test("Builds GenerationSchema from a mapped structured-output request")
     @available(macOS 26.0, iOS 26.0, visionOS 26.0, *)
-    func captureToolsThrow() async throws {
+    func buildsStructuredOutputGenerationSchema() throws {
+        let request = StructuredOutputRequest(
+            format: .jsonSchema(
+                name: "Answer",
+                schemaJSON: """
+                {
+                  "type": "object",
+                  "properties": {
+                    "city": { "type": "string" },
+                    "ok": { "type": "boolean" }
+                  },
+                  "required": ["city"]
+                }
+                """
+            )
+        )
+        let generationSchema = try FoundationModelsSchemaConversion.generationSchema(for: request)
+        let debug = generationSchema.debugDescription
+        #expect(debug.contains("city"))
+        #expect(debug.contains("ok"))
+        #expect(debug.contains("Answer"))
+    }
+
+    @Test("Capture tools record into the store and return the sentinel")
+    @available(macOS 26.0, iOS 26.0, visionOS 26.0, *)
+    func captureToolsRecordAndReturnSentinel() async throws {
+        let store = FoundationModelsToolCaptureStore()
         let parameters = try FoundationModelsSchemaConversion.argumentSchema(
             for: ToolSchema(
                 name: "echo",
@@ -57,20 +83,137 @@ struct FoundationModelsSchemaConversionTests {
         let tool = FoundationModelsCaptureTool(
             name: "echo",
             description: "Echo",
-            parameters: parameters
+            parameters: parameters,
+            store: store
         )
         let arguments = GeneratedContent(properties: ["text": "hello"])
+        let output = try await tool.call(arguments: arguments)
+        #expect(output == FoundationModelsCaptureTool.sentinelOutput)
 
-        do {
-            _ = try await tool.call(arguments: arguments)
-            Issue.record("Expected capture error")
-        } catch let error as FoundationModelsToolCaptureError {
-            #expect(error.toolCall.name == "echo")
-            #expect(error.toolCall.arguments["text"]?.stringValue == "hello")
-            let response = try #require(FoundationModelsToolBridge.inferenceResponse(from: error))
-            #expect(response.finishReason == .toolCall)
-            #expect(response.toolCalls.first?.name == "echo")
-        }
+        let snapshot = await store.snapshot()
+        #expect(snapshot.count == 1)
+        #expect(snapshot[0].name == "echo")
+        #expect(snapshot[0].arguments["text"]?.stringValue == "hello")
+    }
+
+    @Test("Simulated multi-call turn yields all N ParsedToolCalls in request order")
+    @available(macOS 26.0, iOS 26.0, visionOS 26.0, *)
+    func simulatedMultiCallTurnYieldsAllCallsInOrder() async throws {
+        let store = FoundationModelsToolCaptureStore()
+        let schemas = [
+            ToolSchema(
+                name: "lookup",
+                description: "Look up",
+                parameters: [ToolParameter(name: "query", description: "Query", type: .string)]
+            ),
+            ToolSchema(
+                name: "weather",
+                description: "Weather",
+                parameters: [ToolParameter(name: "city", description: "City", type: .string)]
+            ),
+            ToolSchema(
+                name: "clock",
+                description: "Clock",
+                parameters: [ToolParameter(name: "tz", description: "Timezone", type: .string)]
+            ),
+        ]
+        let tools = try FoundationModelsToolBridge.makeCaptureTools(from: schemas, store: store)
+        #expect(tools.count == 3)
+        let lookupTool = try #require(tools[0] as? FoundationModelsCaptureTool)
+        let weatherTool = try #require(tools[1] as? FoundationModelsCaptureTool)
+        let clockTool = try #require(tools[2] as? FoundationModelsCaptureTool)
+
+        _ = try await lookupTool.call(arguments: GeneratedContent(properties: ["query": "swift"]))
+        _ = try await weatherTool.call(arguments: GeneratedContent(properties: ["city": "Tokyo"]))
+        _ = try await clockTool.call(arguments: GeneratedContent(properties: ["tz": "JST"]))
+
+        let lookup = Transcript.ToolCall(
+            id: "c1",
+            toolName: "lookup",
+            arguments: GeneratedContent(properties: ["query": "swift"])
+        )
+        let weather = Transcript.ToolCall(
+            id: "c2",
+            toolName: "weather",
+            arguments: GeneratedContent(properties: ["city": "Tokyo"])
+        )
+        let clock = Transcript.ToolCall(
+            id: "c3",
+            toolName: "clock",
+            arguments: GeneratedContent(properties: ["tz": "JST"])
+        )
+        let later = Transcript.ToolCall(
+            id: "c4",
+            toolName: "lookup",
+            arguments: GeneratedContent(properties: ["query": "sentinel-based"])
+        )
+        let entries: [Transcript.Entry] = [
+            .response(Transcript.Response(
+                assetIDs: [],
+                segments: [.text(Transcript.TextSegment(content: "Let me look those up."))]
+            )),
+            .toolCalls(Transcript.ToolCalls([lookup, weather, clock])),
+            .response(Transcript.Response(
+                assetIDs: [],
+                segments: [.text(Transcript.TextSegment(content: "Sentinel-mediated final."))]
+            )),
+            .toolCalls(Transcript.ToolCalls([later])),
+        ]
+
+        let response = try #require(
+            await FoundationModelsToolBridge.inferenceResponse(store: store, turnEntries: entries)
+        )
+        #expect(response.finishReason == .toolCall)
+        #expect(response.toolCalls.map(\.name) == ["lookup", "weather", "clock"])
+        #expect(response.toolCalls[0].arguments["query"]?.stringValue == "swift")
+        #expect(response.toolCalls[1].arguments["city"]?.stringValue == "Tokyo")
+        #expect(response.toolCalls[2].arguments["tz"]?.stringValue == "JST")
+        #expect(response.content == "Let me look those up.")
+        #expect(response.content?.contains("Sentinel-mediated") != true)
+    }
+
+    @Test("Single-call turn still returns one ParsedToolCall")
+    @available(macOS 26.0, iOS 26.0, visionOS 26.0, *)
+    func singleCallTurnMatchesPreviousBehavior() async throws {
+        let store = FoundationModelsToolCaptureStore()
+        let call = Transcript.ToolCall(
+            id: "only",
+            toolName: "lookup",
+            arguments: GeneratedContent(properties: ["query": "swift"])
+        )
+        await store.record(
+            InferenceResponse.ParsedToolCall(
+                id: "store-id",
+                name: "lookup",
+                arguments: ["query": .string("swift")]
+            )
+        )
+        let entries: [Transcript.Entry] = [
+            .toolCalls(Transcript.ToolCalls([call])),
+        ]
+        let response = try #require(
+            await FoundationModelsToolBridge.inferenceResponse(store: store, turnEntries: entries)
+        )
+        #expect(response.finishReason == .toolCall)
+        #expect(response.toolCalls.count == 1)
+        #expect(response.toolCalls[0].name == "lookup")
+        #expect(response.content == nil)
+    }
+
+    @Test("Thrown capture error still converts to a single-call InferenceResponse")
+    @available(macOS 26.0, iOS 26.0, visionOS 26.0, *)
+    func thrownCaptureErrorStillConverts() throws {
+        let error = FoundationModelsToolCaptureError(
+            toolCall: InferenceResponse.ParsedToolCall(
+                name: "echo",
+                arguments: ["text": .string("hello")]
+            )
+        )
+        let response = try #require(FoundationModelsToolBridge.inferenceResponse(from: error))
+        #expect(response.finishReason == .toolCall)
+        #expect(response.toolCalls.count == 1)
+        #expect(response.toolCalls[0].name == "echo")
+        #expect(response.content == nil)
     }
 }
 
@@ -132,10 +275,58 @@ struct FoundationModelsInferenceProviderTests {
 
         #expect(response.finishReason == .toolCall || response.finishReason == .completed)
         if response.finishReason == .toolCall {
-            #expect(response.toolCalls.count == 1)
+            #expect(response.toolCalls.count >= 1)
             #expect(response.toolCalls[0].name == "lookup")
             #expect(response.toolCalls[0].arguments["query"] != nil)
         }
+    }
+
+    @Test(
+        "Live native structured output uses guided generation when the schema maps",
+        .enabled(if: FoundationModelsLiveTestGate.isEnabled)
+    )
+    @available(macOS 26.0, iOS 26.0, visionOS 26.0, *)
+    func liveNativeStructuredOutput() async throws {
+        guard let provider = FoundationModelsInferenceProvider.ifAvailable() else {
+            return
+        }
+        let request = StructuredOutputRequest(
+            format: .jsonSchema(
+                name: "City",
+                schemaJSON: """
+                {
+                  "type": "object",
+                  "properties": { "city": { "type": "string" } },
+                  "required": ["city"],
+                  "additionalProperties": false
+                }
+                """
+            )
+        )
+        let result = try await provider.generateStructured(
+            prompt: "Name one city in France. Use the schema.",
+            request: request,
+            options: InferenceOptions()
+        )
+        #expect(result.source == .providerNative)
+        #expect(result.value.dictionaryValue?["city"]?.stringValue?.isEmpty == false)
+    }
+
+    @Test(
+        "Live jsonObject structured output stays prompt fallback",
+        .enabled(if: FoundationModelsLiveTestGate.isEnabled)
+    )
+    @available(macOS 26.0, iOS 26.0, visionOS 26.0, *)
+    func liveJSONObjectStaysPromptFallback() async throws {
+        guard let provider = FoundationModelsInferenceProvider.ifAvailable() else {
+            return
+        }
+        let result = try await provider.generateStructured(
+            prompt: "Reply with JSON {\"ok\": true} and nothing else.",
+            request: StructuredOutputRequest(format: .jsonObject),
+            options: InferenceOptions()
+        )
+        #expect(result.source == .promptFallback)
     }
 }
 

--- a/Tests/SwarmTests/Providers/FoundationModelsStructuredSchemaTests.swift
+++ b/Tests/SwarmTests/Providers/FoundationModelsStructuredSchemaTests.swift
@@ -1,0 +1,295 @@
+import Foundation
+@testable import Swarm
+import Testing
+
+@Suite("FoundationModels Structured Schema Mapping")
+struct FoundationModelsStructuredSchemaMappingTests {
+    @Test("jsonObject has no schema and cannot be guided")
+    func jsonObjectIsUnsupported() {
+        let result = FoundationModelsStructuredSchemaMapping.evaluate(
+            StructuredOutputRequest(format: .jsonObject)
+        )
+        #expect(result == .unsupported(.jsonObjectHasNoSchema))
+    }
+
+    @Test("Closed object with string, integer, number, boolean maps")
+    func closedObjectScalarsMap() throws {
+        let schema = """
+        {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string", "description": "Display name" },
+            "count": { "type": "integer" },
+            "score": { "type": "number" },
+            "ok": { "type": "boolean" }
+          },
+          "required": ["name", "ok"]
+        }
+        """
+        let mapped = try #require(mappedSchema(name: "Answer", json: schema))
+        #expect(mapped.name == "Answer")
+        #expect(mapped.properties.map(\.name) == ["count", "name", "ok", "score"])
+        #expect(mapped.properties.first { $0.name == "name" }?.isOptional == false)
+        #expect(mapped.properties.first { $0.name == "count" }?.isOptional == true)
+        #expect(mapped.properties.first { $0.name == "name" }?.type == .string)
+        #expect(mapped.properties.first { $0.name == "count" }?.type == .integer)
+        #expect(mapped.properties.first { $0.name == "score" }?.type == .number)
+        #expect(mapped.properties.first { $0.name == "ok" }?.type == .boolean)
+    }
+
+    @Test("Nested object and array of objects map")
+    func nestedObjectAndArrayMap() throws {
+        let schema = """
+        {
+          "type": "object",
+          "properties": {
+            "tags": { "type": "array", "items": { "type": "string" }, "minItems": 1, "maxItems": 5 },
+            "address": {
+              "type": "object",
+              "properties": { "city": { "type": "string" } },
+              "required": ["city"],
+              "additionalProperties": false
+            }
+          },
+          "required": ["tags"]
+        }
+        """
+        let mapped = try #require(mappedSchema(name: "Place", json: schema))
+        guard case let .array(element, minItems, maxItems) = mapped.properties.first(where: { $0.name == "tags" })?.type else {
+            Issue.record("expected array tags")
+            return
+        }
+        #expect(element == .string)
+        #expect(minItems == 1)
+        #expect(maxItems == 5)
+
+        guard case let .object(address) = mapped.properties.first(where: { $0.name == "address" })?.type else {
+            Issue.record("expected nested address object")
+            return
+        }
+        #expect(address.properties.map(\.name) == ["city"])
+    }
+
+    @Test("String enum maps")
+    func stringEnumMaps() throws {
+        let schema = """
+        {
+          "type": "object",
+          "properties": {
+            "status": { "enum": ["open", "closed"] }
+          },
+          "required": ["status"]
+        }
+        """
+        let mapped = try #require(mappedSchema(name: "Ticket", json: schema))
+        #expect(mapped.properties.first?.type == .stringEnum(["open", "closed"]))
+    }
+
+    @Test("Local $ref to $defs object maps")
+    func localRefToDefsMaps() throws {
+        let schema = """
+        {
+          "type": "object",
+          "properties": {
+            "home": { "$ref": "#/$defs/Address" }
+          },
+          "required": ["home"],
+          "$defs": {
+            "Address": {
+              "type": "object",
+              "properties": { "city": { "type": "string" } },
+              "required": ["city"]
+            }
+          }
+        }
+        """
+        let mapped = try #require(mappedSchema(name: "Person", json: schema))
+        #expect(mapped.properties.first?.type == .reference("Address"))
+        #expect(mapped.definitions.map(\.name) == ["Address"])
+        #expect(mapped.definitions.first?.properties.map(\.name) == ["city"])
+    }
+
+    @Test("additionalProperties true is unsupported")
+    func additionalPropertiesTrueIsUnsupported() {
+        let schema = """
+        {
+          "type": "object",
+          "properties": { "name": { "type": "string" } },
+          "additionalProperties": true
+        }
+        """
+        #expect(
+            FoundationModelsStructuredSchemaMapping.evaluate(
+                StructuredOutputRequest(format: .jsonSchema(name: "Open", schemaJSON: schema))
+            ) == .unsupported(.additionalProperties(path: "$"))
+        )
+    }
+
+    @Test("additionalProperties schema is unsupported")
+    func additionalPropertiesSchemaIsUnsupported() {
+        let schema = """
+        {
+          "type": "object",
+          "properties": { "name": { "type": "string" } },
+          "additionalProperties": { "type": "string" }
+        }
+        """
+        #expect(
+            FoundationModelsStructuredSchemaMapping.evaluate(
+                StructuredOutputRequest(format: .jsonSchema(name: "Map", schemaJSON: schema))
+            ) == .unsupported(.additionalProperties(path: "$"))
+        )
+    }
+
+    @Test("pattern is an unsupported keyword")
+    func patternIsUnsupported() {
+        expectUnsupportedKeyword(
+            schema: """
+            {
+              "type": "object",
+              "properties": { "code": { "type": "string", "pattern": "^[A-Z]+$" } }
+            }
+            """,
+            keyword: "pattern",
+            path: "$.properties.code"
+        )
+    }
+
+    @Test("minimum is an unsupported keyword")
+    func minimumIsUnsupported() {
+        expectUnsupportedKeyword(
+            schema: """
+            {
+              "type": "object",
+              "properties": { "n": { "type": "integer", "minimum": 0 } }
+            }
+            """,
+            keyword: "minimum",
+            path: "$.properties.n"
+        )
+    }
+
+    @Test("oneOf is an unsupported keyword")
+    func oneOfIsUnsupported() {
+        expectUnsupportedKeyword(
+            schema: """
+            {
+              "type": "object",
+              "properties": {
+                "value": { "oneOf": [{ "type": "string" }, { "type": "integer" }] }
+              }
+            }
+            """,
+            keyword: "oneOf",
+            path: "$.properties.value"
+        )
+    }
+
+    @Test("format is an unsupported keyword")
+    func formatIsUnsupported() {
+        expectUnsupportedKeyword(
+            schema: """
+            {
+              "type": "object",
+              "properties": { "email": { "type": "string", "format": "email" } }
+            }
+            """,
+            keyword: "format",
+            path: "$.properties.email"
+        )
+    }
+
+    @Test("type union is unsupported")
+    func typeUnionIsUnsupported() {
+        let schema = """
+        {
+          "type": "object",
+          "properties": { "name": { "type": ["string", "null"] } }
+        }
+        """
+        let result = FoundationModelsStructuredSchemaMapping.evaluate(
+            StructuredOutputRequest(format: .jsonSchema(name: "Union", schemaJSON: schema))
+        )
+        #expect(result == .unsupported(.unsupportedType("union", path: "$.properties.name")))
+    }
+
+    @Test("object without properties is unsupported")
+    func emptyObjectIsUnsupported() {
+        let schema = """
+        { "type": "object" }
+        """
+        let result = FoundationModelsStructuredSchemaMapping.evaluate(
+            StructuredOutputRequest(format: .jsonSchema(name: "Empty", schemaJSON: schema))
+        )
+        #expect(result == .unsupported(.emptyProperties(path: "$")))
+    }
+
+    @Test("root array is unsupported")
+    func rootArrayIsUnsupported() {
+        let schema = """
+        { "type": "array", "items": { "type": "string" } }
+        """
+        let result = FoundationModelsStructuredSchemaMapping.evaluate(
+            StructuredOutputRequest(format: .jsonSchema(name: "List", schemaJSON: schema))
+        )
+        #expect(result == .unsupported(.rootMustBeObject))
+    }
+
+    @Test("invalid JSON is unsupported")
+    func invalidJSONIsUnsupported() {
+        let result = FoundationModelsStructuredSchemaMapping.evaluate(
+            StructuredOutputRequest(format: .jsonSchema(name: "Bad", schemaJSON: "{not json"))
+        )
+        guard case .unsupported(.invalidSchemaJSON) = result else {
+            Issue.record("expected invalidSchemaJSON, got \(result)")
+            return
+        }
+    }
+
+    @Test("remote $ref is unsupported")
+    func remoteRefIsUnsupported() {
+        let schema = """
+        {
+          "type": "object",
+          "properties": { "home": { "$ref": "https://example.com/schema.json" } }
+        }
+        """
+        let result = FoundationModelsStructuredSchemaMapping.evaluate(
+            StructuredOutputRequest(format: .jsonSchema(name: "Remote", schemaJSON: schema))
+        )
+        #expect(result == .unsupported(.invalidReference("https://example.com/schema.json")))
+    }
+
+    @Test("mixed-type enum is unsupported")
+    func mixedEnumIsUnsupported() {
+        let schema = """
+        {
+          "type": "object",
+          "properties": { "value": { "enum": ["a", 1] } }
+        }
+        """
+        let result = FoundationModelsStructuredSchemaMapping.evaluate(
+            StructuredOutputRequest(format: .jsonSchema(name: "Mixed", schemaJSON: schema))
+        )
+        #expect(result == .unsupported(.invalidEnum(path: "$.properties.value")))
+    }
+
+    private func mappedSchema(name: String, json: String) -> FoundationModelsMappedGenerationSchema? {
+        switch FoundationModelsStructuredSchemaMapping.evaluate(
+            StructuredOutputRequest(format: .jsonSchema(name: name, schemaJSON: json))
+        ) {
+        case let .mapped(mapped):
+            return mapped
+        case let .unsupported(reason):
+            Issue.record("expected mapped schema, got \(reason)")
+            return nil
+        }
+    }
+
+    private func expectUnsupportedKeyword(schema: String, keyword: String, path: String) {
+        let result = FoundationModelsStructuredSchemaMapping.evaluate(
+            StructuredOutputRequest(format: .jsonSchema(name: "Probe", schemaJSON: schema))
+        )
+        #expect(result == .unsupported(.unsupportedKeyword(keyword, path: path)))
+    }
+}

--- a/docs/guide/foundation-models.md
+++ b/docs/guide/foundation-models.md
@@ -40,7 +40,7 @@ let agent = try Agent("Be helpful.", configuration: config,
 | | Capture (default) | Native session (experimental) |
 |---|---|---|
 | Tool loop owner | Swarm agent loop | `LanguageModelSession` |
-| Parallel tool calls | No (one captured call per turn) | Yes (Apple's session loop) |
+| Parallel tool calls | Yes (first `ToolCalls` group per turn) | Yes (Apple's session loop) |
 | Transcript / KV reuse | No (session rebuilt every Swarm iteration) | Transcript copied across `Agent.run` turns; Apple owns the inner loop |
 | Token streaming with tools | No | Yes (`Agent.stream` yields incremental tokens) |
 | Per-iteration memory injection | Yes | **No** — memory is injected when the native session starts |
@@ -48,9 +48,19 @@ let agent = try Agent("Be helpful.", configuration: config,
 | Mid-loop checkpoints | Yes | **No** |
 | Per-turn guardrail interception | Yes (wraps Swarm's loop) | **No** — input/tool guardrails run **inside** each tool body |
 
-Native mode exists so you can take Apple's session loop when you want parallel
+Native mode exists so you can take Apple's session loop when you want multi-round
 tools and real streaming. Capture stays the default because Swarm-side control
 (guardrails, checkpoints, memory injection) is the framework's differentiator.
+Capture now recovers every tool call in the first parallel group of a turn
+(previously only the first call) and keeps any assistant text that accompanied
+those calls.
+
+## Structured outputs
+
+When the requested JSON Schema maps onto `GenerationSchema`, capture-mode
+`generateStructured` uses `LanguageModelSession.respond(to:schema:)` and labels
+the result `.providerNative`. `.jsonObject` and unmappable schemas stay
+prompt-instruction + parse (`.promptFallback`).
 
 Under `strict4k`, native mode sends the same windowed/`PromptEnvelope` string
 capture uses — not the raw conversation history.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -380,11 +380,11 @@ agent.environment(\.inferenceProvider, myCustomProvider)
 
 ### Capture vs native session (experimental)
 
-By default Swarm **captures** Foundation Models tool calls and executes them in
-the agent loop (guardrails, checkpoints, per-iteration memory). Opt in to
-experimental native session mode for parallel tool calls and token streaming
-with tools — see [Foundation Models](foundation-models.md) for the trade-off
-table.
+By default Swarm **captures** Foundation Models tool calls (including a parallel
+group in one turn) and executes them in the agent loop (guardrails, checkpoints,
+per-iteration memory). Opt in to experimental native session mode for Apple's
+inner tool loop and token streaming with tools — see
+[Foundation Models](foundation-models.md) for the trade-off table.
 
 ```swift
 let config = AgentConfiguration.default
@@ -393,9 +393,9 @@ let config = AgentConfiguration.default
 
 ### Structured output
 
-`runStructured` asks the model (prompt instruction) and parses the reply as
-JSON. It is not enforced schema generation — invalid JSON fails at parse time
-rather than being constrained by a native generation schema.
+`runStructured` uses Foundation Models guided generation when the JSON Schema
+maps onto `GenerationSchema` (result `source` is `.providerNative`). `.jsonObject`
+and unmappable schemas stay prompt-instruction + parse (`.promptFallback`).
 
 ### Provider resolution order
 

--- a/docs/reference/api-catalog.md
+++ b/docs/reference/api-catalog.md
@@ -3,7 +3,7 @@
 Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for high-risk public rows on 2026-07-28 (Conduit hard-removed in 0.6).
 
 - Scope: all `.swift` files under `Sources/Swarm/`, excluding `Internal/GraphRuntime/`
-- Source files scanned: 161
+- Source files scanned: 162
 - Public/open symbols cataloged: 2436
 
 ## 1. Swarm (entry point)

--- a/docs/reference/front-facing-api.md
+++ b/docs/reference/front-facing-api.md
@@ -532,7 +532,9 @@ Built-in inference is Apple Foundation Models only. Custom backends implement
 
 Opt in to experimental native session mode with
 ``AgentConfiguration/foundationModelsExecution(_:)``. Capture remains the
-default. See the [Foundation Models guide](/guide/foundation-models).
+default and now recovers a full parallel tool-call group per turn. Structured
+outputs use guided generation when the JSON Schema maps; otherwise prompt+parse.
+See the [Foundation Models guide](/guide/foundation-models).
 
 You can register a user-authored `FoundationModels.Tool` in `@ToolBuilder`
 (wrapped as ``FoundationModelsNativeTool``).


### PR DESCRIPTION
## Summary

Chunk I of the Swarm remediation series. Chunk H is **merged** (`feat: opt-in Foundation Models native session mode` #127). This branch is from that `main`. Native session mode is untouched; this is the **default capture path** plus structured outputs.

### Task 1 — Native `GenerationSchema` structured outputs

`FoundationModelsInferenceProvider.generateStructured` now calls `LanguageModelSession.respond(to:schema:)` when the request maps onto Apple's guided-generation subset, and labels the result `.providerNative`. Unmappable requests (and `.jsonObject`) stay prompt-instruction + parse with `.promptFallback`. The source field already existed; it now survives honestly on `StructuredAgentResult.structuredOutput.source` and `AgentResult.metadata["structured_output.source"]`.

**Supported GenerationSchema subset** (allowlist; anything else is detected and falls back):

- Root `type: object` with `properties` (optional `required`)
- Property types: `string`, `integer`, `number`, `boolean`
- Nested objects and arrays (`items` as a single schema; `minItems` / `maxItems`)
- `enum` of strings (`anyOf` choices)
- Local `$ref` to root `$defs` / `definitions` (object or string-enum targets)
- `additionalProperties: false`, or omitted (closed generation still validates against an open JSON Schema)
- Metadata ignored: `$schema`, `$id`, `$comment`, `title`, `description`, `default`, `examples`, `deprecated`

**Explicitly unsupported** (honest fallback, not silent drop):

- `.jsonObject` — no schema, so `GenerationSchema` cannot constrain a free-form object
- `additionalProperties: true` or a nested schema (free-form keys)
- `pattern`, `format`, `minLength`, `maxLength`
- numeric `minimum` / `maximum` / `exclusive*` / `multipleOf`
- `oneOf` / `anyOf` / `allOf` / `not` / `if` / `then` / `else`
- `const`, `uniqueItems`, tuple `items` / `prefixItems`, type unions, remote `$ref`, unknown keywords

Pure mapping tests run on Linux CI (`FoundationModelsStructuredSchemaMapping`). Apple lowering is `FoundationModelsSchemaConversion.generationSchema(from:)`.

### Task 2 — Capture ALL tool calls per turn

**Mechanism:** record + sentinel, then first-wave-from-transcript.

Capture tools used to **throw** on first invocation, so `respond` aborted and sibling parallel calls were lost (`toolCalls: [one]`, `content: nil`). They now record into a per-turn `FoundationModelsToolCaptureStore` actor and return a documented sentinel (`SWARM_CAPTURED: … Do not call more tools based on this string.`). After `respond` returns (or throws), Swarm takes the **first** `Transcript.toolCalls` group (Apple's request order). Assistant text that appeared **before** that group is carried on `InferenceResponse.content`. Post-tool / sentinel-mediated final text is discarded.

The throw-path converter (`inferenceResponse(from:)`) is kept for `LanguageModelSession.ToolCallError` wrapping and tests. It is no longer the happy path.

**Why not throw-then-re-prompt:** that still loses the rest of the first parallel group. **Why not return every stored call:** if the model continues after the sentinel, later arguments are contaminated. First-wave extraction avoids executing those.

**Evidence (CI-safe):** a simulated 3-call turn plus a later-wave call recovers exactly `[lookup, weather, clock]` in order, with accompanying `"Let me look those up."` and without the sentinel final. Single-call turns still yield one `ParsedToolCall` and `content == nil` when there is no pre-tool text. Live multi-call measurement is gated (`SWARM_FM_LIVE_TESTS=1`); CI has no Apple Intelligence. If the model keeps calling tools after the sentinel, first-wave extraction still holds — the waste is extra inner-loop tokens, not wrong Swarm tool execution.

### Before / after (parallel tool-call turns)

| | Before | After |
|---|---|---|
| Calls recovered per FM turn | 1 (first throw aborts `respond`) | All calls in the first `ToolCalls` group |
| Later parallel siblings | Lost | Recovered in request order |
| Assistant text with the calls | Dropped (`content: nil`) | Preserved from transcript responses before the first tool group |
| Sentinel-mediated final answer | n/a (throw aborted) | Discarded — Swarm executes real tools and continues the agent loop |

Native session mode (H) is unchanged: Apple still owns that inner loop when opted in.

## Test plan

- [x] `bash scripts/ci/lean-build-test.sh` — **PASS** — `1795 tests in 233 suites` (Chunk H baseline: **1769 / 232**)
- [x] `swift test --no-parallel --traits Integrations` — **PASS** — `1939 tests in 256 suites` (Chunk H baseline: **1913 / 255**)
- [x] `swift run --traits Integrations SwarmCapabilityShowcase matrix` — all rows `passed`
- [x] New tests: mapping allowlist/unsupported constructs (pure), GenerationSchema lowering, sentinel capture store, simulated N-call first wave + content preservation, single-call regression, throw-path leftover, tool-loop source honesty
- [x] SwiftFormat / SwiftLint `--strict` clean on changed files

Delta vs H is the new mapping + capture suites (~+26 tests / +1 suite). No regressions.

### Live on-device tests

CI has no Apple Intelligence. Gated:

```bash
SWARM_FM_LIVE_TESTS=1 swift test --no-parallel --traits Integrations \
  --filter FoundationModelsInferenceProviderTests
```

`SWARM_RUN_LIVE_FOUNDATION_MODELS_TESTS=1` is also accepted.

## Breaking changes

**Does this PR introduce breaking changes?**
- [x] No — additive behavior on the existing capture path and `generateStructured`. `.jsonObject` and unmappable schemas still prompt+parse. Native session mode is unchanged.


Made with [Cursor](https://cursor.com)