### PR TITLE
feat: wire resilience policies into Agent.run

### DIFF
--- a/Sources/Swarm/Agents/Agent+FoundationModelsNative.swift
+++ b/Sources/Swarm/Agents/Agent+FoundationModelsNative.swift
@@ -116,7 +116,7 @@ extension Agent {
             startTime: startTime,
             observer: observer,
             tracing: tracing,
-            allowsRetry: executingTools.isEmpty
+            retryPolicy: executingTools.isEmpty ? nil : .noRetry
         ) {
             try await fmProvider.respondUsingNativeSession(
                 messages: messages,

--- a/Sources/Swarm/Agents/Agent+FoundationModelsNative.swift
+++ b/Sources/Swarm/Agents/Agent+FoundationModelsNative.swift
@@ -112,7 +112,12 @@ extension Agent {
         } else {
             onOutputChunk = nil
         }
-        let native: FoundationModelsNativeTurnResult = try await executeWithinRemainingTimeout(startTime: startTime) {
+        let native: FoundationModelsNativeTurnResult = try await executeProviderInference(
+            startTime: startTime,
+            observer: observer,
+            tracing: tracing,
+            allowsRetry: executingTools.isEmpty
+        ) {
             try await fmProvider.respondUsingNativeSession(
                 messages: messages,
                 tools: executingTools,

--- a/Sources/Swarm/Agents/Agent+Resilience.swift
+++ b/Sources/Swarm/Agents/Agent+Resilience.swift
@@ -1,0 +1,168 @@
+// Agent+Resilience.swift
+// Swarm Framework
+//
+// Wraps provider inference with rate limiting, circuit breaking, and retry.
+
+import Foundation
+
+extension Agent {
+    /// Executes a provider inference call under the configured resilience policies.
+    ///
+    /// Always bounded by the remaining ``AgentConfiguration/timeout``. When no
+    /// resilience policies are active, this is equivalent to
+    /// ``executeWithinRemainingTimeout(startTime:operation:)``.
+    ///
+    /// - Parameters:
+    ///   - startTime: Run start used to compute remaining timeout.
+    ///   - observer: Optional observer; retries fire ``AgentObserver/onInferenceRetry(context:agent:attempt:error:)``.
+    ///   - tracing: Optional tracing helper; retries emit a `.metric` trace event.
+    ///   - allowsRetry: When `false`, skip retry (still honor limiter + breaker).
+    ///     Used for Foundation Models native session turns that execute tools
+    ///     inside Apple's loop so those tools are not replayed.
+    ///   - operation: The inference call.
+    func executeProviderInference<T: Sendable>(
+        startTime: ContinuousClock.Instant,
+        observer: (any AgentObserver)?,
+        tracing: TracingHelper?,
+        allowsRetry: Bool = true,
+        operation: @escaping @Sendable () async throws -> T
+    ) async throws -> T {
+        try await executeWithinRemainingTimeout(startTime: startTime) {
+            try await self.resilienceRuntime.execute(
+                configuration: self.configuration.resilience,
+                agentName: self.configuration.name,
+                agent: self,
+                observer: observer,
+                tracing: tracing,
+                allowsRetry: allowsRetry,
+                operation: operation
+            )
+        }
+    }
+}
+
+// MARK: - AgentResilienceRuntime
+
+/// Per-agent actors for circuit breaking and rate limiting.
+///
+/// Scoped to an ``Agent`` instance and shared across its runs. Distinct agent
+/// values get distinct runtimes.
+actor AgentResilienceRuntime {
+    func execute<T: Sendable>(
+        configuration: ResilienceConfiguration,
+        agentName: String,
+        agent: any AgentRuntime,
+        observer: (any AgentObserver)?,
+        tracing: TracingHelper?,
+        allowsRetry: Bool,
+        operation: @escaping @Sendable () async throws -> T
+    ) async throws -> T {
+        guard configuration.hasActivePolicies else {
+            return try await operation()
+        }
+
+        if let limiter = rateLimiter(for: configuration.rateLimit) {
+            try await limiter.acquire()
+        }
+
+        let invoke: @Sendable () async throws -> T = {
+            try await Self.invokeWithRetry(
+                configuration: configuration,
+                allowsRetry: allowsRetry,
+                agent: agent,
+                observer: observer,
+                tracing: tracing,
+                operation: operation
+            )
+        }
+
+        if let breaker = circuitBreaker(for: configuration.circuitBreaker, agentName: agentName) {
+            return try await breaker.execute(invoke)
+        }
+
+        return try await invoke()
+    }
+
+    // MARK: Private
+
+    private var circuitBreakerInstance: CircuitBreaker?
+    private var rateLimiterInstance: RateLimiter?
+
+    private func circuitBreaker(
+        for settings: CircuitBreakerSettings?,
+        agentName: String
+    ) -> CircuitBreaker? {
+        guard let settings else { return nil }
+        if let circuitBreakerInstance {
+            return circuitBreakerInstance
+        }
+
+        let resolvedName: String
+        if let explicitName = settings.name, !explicitName.isEmpty {
+            resolvedName = explicitName
+        } else {
+            let trimmed = agentName.trimmingCharacters(in: .whitespacesAndNewlines)
+            resolvedName = "agent:\(trimmed.isEmpty ? "Agent" : trimmed):inference"
+        }
+
+        let breaker = CircuitBreaker(
+            name: resolvedName,
+            failureThreshold: settings.failureThreshold,
+            successThreshold: settings.successThreshold,
+            resetTimeout: settings.resetTimeout,
+            halfOpenMaxRequests: settings.halfOpenMaxRequests
+        )
+        circuitBreakerInstance = breaker
+        return breaker
+    }
+
+    private func rateLimiter(for settings: RateLimitSettings?) -> RateLimiter? {
+        guard let settings else { return nil }
+        if let rateLimiterInstance {
+            return rateLimiterInstance
+        }
+
+        let limiter = RateLimiter(
+            maxTokens: settings.maxTokens,
+            refillRatePerSecond: settings.refillRatePerSecond
+        )
+        rateLimiterInstance = limiter
+        return limiter
+    }
+
+    private static func invokeWithRetry<T: Sendable>(
+        configuration: ResilienceConfiguration,
+        allowsRetry: Bool,
+        agent: any AgentRuntime,
+        observer: (any AgentObserver)?,
+        tracing: TracingHelper?,
+        operation: @escaping @Sendable () async throws -> T
+    ) async throws -> T {
+        let policy = configuration.retryPolicy
+        guard allowsRetry, policy.maxAttempts > 0 else {
+            return try await operation()
+        }
+
+        let retryPolicy = RetryPolicy(
+            maxAttempts: policy.maxAttempts,
+            backoff: policy.backoff,
+            shouldRetry: { error in
+                InferenceRetryability.isRetryable(error)
+            },
+            onRetry: { attempt, error in
+                Log.agents.warning(
+                    "Inference retry attempt \(attempt): \(error.localizedDescription)"
+                )
+                await observer?.onInferenceRetry(
+                    context: nil,
+                    agent: agent,
+                    attempt: attempt,
+                    error: error
+                )
+                await tracing?.traceInferenceRetry(attempt: attempt, error: error)
+            }
+        )
+
+        return try await retryPolicy.execute(operation)
+    }
+}

--- a/Sources/Swarm/Agents/Agent+Resilience.swift
+++ b/Sources/Swarm/Agents/Agent+Resilience.swift
@@ -16,59 +16,45 @@ extension Agent {
     ///   - startTime: Run start used to compute remaining timeout.
     ///   - observer: Optional observer; retries fire ``AgentObserver/onInferenceRetry(context:agent:attempt:error:)``.
     ///   - tracing: Optional tracing helper; retries emit a `.metric` trace event.
-    ///   - allowsRetry: When `false`, skip retry (still honor limiter + breaker).
-    ///     Used for Foundation Models native session turns that execute tools
-    ///     inside Apple's loop so those tools are not replayed.
+    ///   - retryPolicy: Override for this call. Pass ``RetryPolicy/noRetry`` to skip
+    ///     retry while still honoring limiter and breaker (Foundation Models native
+    ///     session turns that execute tools inside Apple's loop). `nil` uses
+    ///     ``ResilienceConfiguration/retryPolicy``.
     ///   - operation: The inference call.
     func executeProviderInference<T: Sendable>(
         startTime: ContinuousClock.Instant,
         observer: (any AgentObserver)?,
         tracing: TracingHelper?,
-        allowsRetry: Bool = true,
+        retryPolicy: RetryPolicy? = nil,
         operation: @escaping @Sendable () async throws -> T
     ) async throws -> T {
-        try await executeWithinRemainingTimeout(startTime: startTime) {
-            try await self.resilienceRuntime.execute(
-                configuration: self.configuration.resilience,
-                agentName: self.configuration.name,
-                agent: self,
+        let policy = retryPolicy ?? configuration.resilience.retryPolicy
+        return try await executeWithinRemainingTimeout(startTime: startTime) {
+            try await self.performResilientInference(
+                retryPolicy: policy,
                 observer: observer,
                 tracing: tracing,
-                allowsRetry: allowsRetry,
                 operation: operation
             )
         }
     }
-}
 
-// MARK: - AgentResilienceRuntime
-
-/// Per-agent actors for circuit breaking and rate limiting.
-///
-/// Scoped to an ``Agent`` instance and shared across its runs. Distinct agent
-/// values get distinct runtimes.
-actor AgentResilienceRuntime {
-    func execute<T: Sendable>(
-        configuration: ResilienceConfiguration,
-        agentName: String,
-        agent: any AgentRuntime,
+    private func performResilientInference<T: Sendable>(
+        retryPolicy: RetryPolicy,
         observer: (any AgentObserver)?,
         tracing: TracingHelper?,
-        allowsRetry: Bool,
         operation: @escaping @Sendable () async throws -> T
     ) async throws -> T {
-        guard configuration.hasActivePolicies else {
+        if inferenceRateLimiter == nil,
+           inferenceCircuitBreaker == nil,
+           retryPolicy.maxAttempts == 0 {
             return try await operation()
         }
 
-        if let limiter = rateLimiter(for: configuration.rateLimit) {
-            try await limiter.acquire()
-        }
-
+        let agent: any AgentRuntime = self
         let invoke: @Sendable () async throws -> T = {
             try await Self.invokeWithRetry(
-                configuration: configuration,
-                allowsRetry: allowsRetry,
+                policy: retryPolicy,
                 agent: agent,
                 observer: observer,
                 tracing: tracing,
@@ -76,70 +62,25 @@ actor AgentResilienceRuntime {
             )
         }
 
-        if let breaker = circuitBreaker(for: configuration.circuitBreaker, agentName: agentName) {
+        if let limiter = inferenceRateLimiter {
+            try await limiter.acquire()
+        }
+
+        if let breaker = inferenceCircuitBreaker {
             return try await breaker.execute(invoke)
         }
 
         return try await invoke()
     }
 
-    // MARK: Private
-
-    private var circuitBreakerInstance: CircuitBreaker?
-    private var rateLimiterInstance: RateLimiter?
-
-    private func circuitBreaker(
-        for settings: CircuitBreakerSettings?,
-        agentName: String
-    ) -> CircuitBreaker? {
-        guard let settings else { return nil }
-        if let circuitBreakerInstance {
-            return circuitBreakerInstance
-        }
-
-        let resolvedName: String
-        if let explicitName = settings.name, !explicitName.isEmpty {
-            resolvedName = explicitName
-        } else {
-            let trimmed = agentName.trimmingCharacters(in: .whitespacesAndNewlines)
-            resolvedName = "agent:\(trimmed.isEmpty ? "Agent" : trimmed):inference"
-        }
-
-        let breaker = CircuitBreaker(
-            name: resolvedName,
-            failureThreshold: settings.failureThreshold,
-            successThreshold: settings.successThreshold,
-            resetTimeout: settings.resetTimeout,
-            halfOpenMaxRequests: settings.halfOpenMaxRequests
-        )
-        circuitBreakerInstance = breaker
-        return breaker
-    }
-
-    private func rateLimiter(for settings: RateLimitSettings?) -> RateLimiter? {
-        guard let settings else { return nil }
-        if let rateLimiterInstance {
-            return rateLimiterInstance
-        }
-
-        let limiter = RateLimiter(
-            maxTokens: settings.maxTokens,
-            refillRatePerSecond: settings.refillRatePerSecond
-        )
-        rateLimiterInstance = limiter
-        return limiter
-    }
-
     private static func invokeWithRetry<T: Sendable>(
-        configuration: ResilienceConfiguration,
-        allowsRetry: Bool,
+        policy: RetryPolicy,
         agent: any AgentRuntime,
         observer: (any AgentObserver)?,
         tracing: TracingHelper?,
         operation: @escaping @Sendable () async throws -> T
     ) async throws -> T {
-        let policy = configuration.retryPolicy
-        guard allowsRetry, policy.maxAttempts > 0 else {
+        guard policy.maxAttempts > 0 else {
             return try await operation()
         }
 
@@ -147,9 +88,10 @@ actor AgentResilienceRuntime {
             maxAttempts: policy.maxAttempts,
             backoff: policy.backoff,
             shouldRetry: { error in
-                InferenceRetryability.isRetryable(error)
+                InferenceRetryability.isRetryable(error) && policy.shouldRetry(error)
             },
             onRetry: { attempt, error in
+                await policy.onRetry?(attempt, error)
                 Log.agents.warning(
                     "Inference retry attempt \(attempt): \(error.localizedDescription)"
                 )

--- a/Sources/Swarm/Agents/Agent.swift
+++ b/Sources/Swarm/Agents/Agent.swift
@@ -615,6 +615,7 @@ public struct Agent: AgentRuntime, Sendable {
 
     private var toolRegistry: ToolRegistry
     private let cancellationState = ActiveRunCancellationState()
+    let resilienceRuntime = AgentResilienceRuntime()
     private static let autoResponseTracker = ResponseTracker()
     private static let defaultMemorySessionTracker = DefaultMemorySessionTracker()
     private static let responseIDMetadataKey = "response.id"
@@ -1513,7 +1514,11 @@ public struct Agent: AgentRuntime, Sendable {
                 // If no tools defined, generate without tool calling
                 if toolSchemas.isEmpty {
                     let loopInferenceOptions = inferenceOptions
-                    let response = try await executeWithinRemainingTimeout(startTime: startTime) {
+                    let response = try await executeProviderInference(
+                        startTime: startTime,
+                        observer: observer,
+                        tracing: tracing
+                    ) {
                         try await generateWithoutTools(
                             provider: provider,
                             prompt: prompt,
@@ -1543,7 +1548,11 @@ public struct Agent: AgentRuntime, Sendable {
                 // Generate response with tool calls
                 let loopInferenceOptions = inferenceOptions
                 let response = if useToolStreaming {
-                    try await executeWithinRemainingTimeout(startTime: startTime) {
+                    try await executeProviderInference(
+                        startTime: startTime,
+                        observer: observer,
+                        tracing: tracing
+                    ) {
                         try await generateWithToolsStreaming(
                             provider: provider,
                             prompt: prompt,
@@ -1555,7 +1564,11 @@ public struct Agent: AgentRuntime, Sendable {
                         )
                     }
                 } else {
-                    try await executeWithinRemainingTimeout(startTime: startTime) {
+                    try await executeProviderInference(
+                        startTime: startTime,
+                        observer: observer,
+                        tracing: tracing
+                    ) {
                         try await generateWithTools(
                             provider: provider,
                             prompt: prompt,

--- a/Sources/Swarm/Agents/Agent.swift
+++ b/Sources/Swarm/Agents/Agent.swift
@@ -264,6 +264,10 @@ public struct Agent: AgentRuntime, Sendable {
         self.guardrailRunnerConfiguration = guardrailRunnerConfiguration
         _handoffs = handoffs
         toolRegistry = try ToolRegistry(tools: tools)
+        inferenceCircuitBreaker = configuration.resilience.makeCircuitBreaker(
+            agentName: configuration.name
+        )
+        inferenceRateLimiter = configuration.resilience.makeRateLimiter()
     }
 
     /// Convenience initializer that takes an unlabeled inference provider.
@@ -615,7 +619,10 @@ public struct Agent: AgentRuntime, Sendable {
 
     private var toolRegistry: ToolRegistry
     private let cancellationState = ActiveRunCancellationState()
-    let resilienceRuntime = AgentResilienceRuntime()
+    /// Created from ``AgentConfiguration/resilience`` at init. Copies of this value share the actor.
+    let inferenceCircuitBreaker: CircuitBreaker?
+    /// Created from ``AgentConfiguration/resilience`` at init. Copies of this value share the actor.
+    let inferenceRateLimiter: RateLimiter?
     private static let autoResponseTracker = ResponseTracker()
     private static let defaultMemorySessionTracker = DefaultMemorySessionTracker()
     private static let responseIDMetadataKey = "response.id"

--- a/Sources/Swarm/Core/AgentConfiguration.swift
+++ b/Sources/Swarm/Core/AgentConfiguration.swift
@@ -196,6 +196,7 @@ public enum FoundationModelsExecutionMode: String, Sendable, Equatable {
 /// - ``autoPreviousResponseId(_:)`` - Set auto response tracking
 /// - ``defaultTracingEnabled(_:)`` - Set default tracing
 /// - ``foundationModelsExecution(_:)`` - Set Foundation Models execution mode (experimental)
+/// - ``resilience(_:)`` - Set retry, circuit-breaker, and rate-limit policies for inference
 ///
 /// ## Thread Safety
 ///
@@ -603,6 +604,22 @@ public struct AgentConfiguration: Sendable, Equatable {
     /// - SeeAlso: ``FoundationModelsExecutionMode``, ``foundationModelsExecution(_:)``
     public var foundationModelsExecution: FoundationModelsExecutionMode
 
+    // MARK: - Resilience Settings
+
+    /// Retry, circuit-breaker, and rate-limit policies for **provider inference**.
+    ///
+    /// Default: ``ResilienceConfiguration/disabled`` (``RetryPolicy/noRetry``, no
+    /// breaker, no limiter). That default is a no-op — agent execution matches
+    /// Swarm before this field existed.
+    ///
+    /// Policies wrap provider inference only. Tool execution is never retried.
+    /// Retries consume the remaining ``timeout`` budget and cannot outlive the
+    /// run. Circuit-breaker and rate-limiter state is scoped per ``Agent``
+    /// instance. See ``ResilienceConfiguration`` and ``InferenceRetryability``.
+    ///
+    /// - SeeAlso: ``resilience(_:)``, ``ResilienceConfiguration``
+    public var resilience: ResilienceConfiguration
+
     // MARK: - Initialization
 
     /// Creates a new agent configuration.
@@ -627,6 +644,7 @@ public struct AgentConfiguration: Sendable, Equatable {
     ///   - autoPreviousResponseId: Enable auto response ID tracking. Default: false
     ///   - defaultTracingEnabled: Enable default tracing when no tracer configured. Default: true
     ///   - foundationModelsExecution: Foundation Models tool-loop mode. Default: ``FoundationModelsExecutionMode/capture``
+    ///   - resilience: Retry / circuit-breaker / rate-limit policies for inference. Default: ``ResilienceConfiguration/disabled``
     public init(
         name: String = "Agent",
         maxIterations: Int = 10,
@@ -647,7 +665,8 @@ public struct AgentConfiguration: Sendable, Equatable {
         previousResponseId: String? = nil,
         autoPreviousResponseId: Bool = false,
         defaultTracingEnabled: Bool = true,
-        foundationModelsExecution: FoundationModelsExecutionMode = .capture
+        foundationModelsExecution: FoundationModelsExecutionMode = .capture,
+        resilience: ResilienceConfiguration = .disabled
     ) {
         if maxIterations < 1 {
             Log.agents.warning("AgentConfiguration: maxIterations \(maxIterations) must be >= 1; using 1")
@@ -679,6 +698,7 @@ public struct AgentConfiguration: Sendable, Equatable {
         self.autoPreviousResponseId = autoPreviousResponseId
         self.defaultTracingEnabled = defaultTracingEnabled
         self.foundationModelsExecution = foundationModelsExecution
+        self.resilience = resilience
     }
 }
 
@@ -1206,6 +1226,30 @@ extension AgentConfiguration {
         copy.foundationModelsExecution = value
         return copy
     }
+
+    // MARK: Resilience Settings
+
+    /// Sets retry, circuit-breaker, and rate-limit policies for provider inference.
+    ///
+    /// Default: ``ResilienceConfiguration/disabled``.
+    ///
+    /// Tool execution is never wrapped. See ``ResilienceConfiguration`` for
+    /// timeout interaction, breaker scoping, and the retryability table.
+    ///
+    /// ## Example
+    /// ```swift
+    /// let config = AgentConfiguration.default
+    ///     .resilience(ResilienceConfiguration(retryPolicy: .standard))
+    /// ```
+    ///
+    /// - Parameter value: The resilience configuration
+    /// - Returns: A new configuration with the updated resilience policies
+    /// - SeeAlso: ``resilience``, ``ResilienceConfiguration``, ``InferenceRetryability``
+    @discardableResult public func resilience(_ value: ResilienceConfiguration) -> AgentConfiguration {
+        var copy = self
+        copy.resilience = value
+        return copy
+    }
 }
 
 // MARK: - CustomStringConvertible
@@ -1234,7 +1278,8 @@ extension AgentConfiguration: CustomStringConvertible {
             previousResponseId: \(previousResponseId.map { "\"\($0)\"" } ?? "nil"),
             autoPreviousResponseId: \(autoPreviousResponseId),
             defaultTracingEnabled: \(defaultTracingEnabled),
-            foundationModelsExecution: \(foundationModelsExecution)
+            foundationModelsExecution: \(foundationModelsExecution),
+            resilience: \(String(describing: resilience))
         )
         """
     }

--- a/Sources/Swarm/Core/AgentError.swift
+++ b/Sources/Swarm/Core/AgentError.swift
@@ -39,10 +39,18 @@ import Foundation
 ///
 /// ## Retryable Errors
 ///
-/// Some errors are transient and can be retried:
+/// Use ``AgentError/isRetryable`` (and ``InferenceRetryability/isRetryable(_:)``
+/// for any `Error`) to decide whether ``Agent`` may retry a provider inference
+/// failure. Transient:
 /// - ``rateLimitExceeded(retryAfter:)``
 /// - ``inferenceProviderUnavailable(reason:)``
 /// - ``generationFailed(reason:)``
+/// - ``embeddingFailed(reason:)``
+///
+/// ``timeout(duration:)`` is **not** retryable — it is the run deadline.
+/// Provider timeouts arrive as ``generationFailed(reason:)`` or `URLError.timedOut`.
+/// Cancellation, guardrail rejection, schema/parse errors, and tool failures
+/// are never retried.
 ///
 /// ## Error Categories
 ///
@@ -720,6 +728,41 @@ extension AgentError: CustomDebugStringConvertible {
             "AgentError.internalError(reason: \(reason))"
         case .toolCallingUnsupported:
             "AgentError.toolCallingUnsupported"
+        }
+    }
+}
+
+// MARK: - Retryability
+
+extension AgentError {
+    /// Whether ``Agent`` may retry this error on a **provider inference** call.
+    ///
+    /// See ``InferenceRetryability`` for the full classification table, including
+    /// non-`AgentError` types.
+    public var isRetryable: Bool {
+        switch self {
+        case .rateLimitExceeded,
+             .inferenceProviderUnavailable,
+             .generationFailed,
+             .embeddingFailed:
+            true
+        case .cancelled,
+             .timeout,
+             .invalidInput,
+             .invalidLoop,
+             .maxIterationsExceeded,
+             .guardrailViolation,
+             .contentFiltered,
+             .invalidToolArguments,
+             .toolExecutionFailed,
+             .toolNotFound,
+             .contextWindowExceeded,
+             .unsupportedLanguage,
+             .modelNotAvailable,
+             .agentNotFound,
+             .internalError,
+             .toolCallingUnsupported:
+            false
         }
     }
 }

--- a/Sources/Swarm/Core/AgentEvent.swift
+++ b/Sources/Swarm/Core/AgentEvent.swift
@@ -146,6 +146,11 @@ public enum AgentEvent: Sendable {
 
         /// An LLM call completed with usage telemetry.
         case llmCompleted(model: String?, promptTokens: Int?, completionTokens: Int?, duration: TimeInterval)
+
+        /// Provider inference will be retried after a transient failure.
+        ///
+        /// `attempt` is 1-indexed (the first retry is `1`).
+        case inferenceRetry(attempt: Int, message: String)
     }
 
 }
@@ -452,6 +457,8 @@ extension AgentEvent.Observation: Equatable {
             lM == rM && lP == rP
         case let (.llmCompleted(lM, lP, lC, lD), .llmCompleted(rM, rP, rC, rD)):
             lM == rM && lP == rP && lC == rC && lD == rD
+        case let (.inferenceRetry(lA, lM), .inferenceRetry(rA, rM)):
+            lA == rA && lM == rM
         default:
             false
         }

--- a/Sources/Swarm/Core/EventStreamHooks.swift
+++ b/Sources/Swarm/Core/EventStreamHooks.swift
@@ -104,6 +104,13 @@ internal struct EventStreamObserver: AgentObserver {
             duration: 0 // Duration not available without explicit tracking
         )))
     }
+
+    func onInferenceRetry(context _: AgentContext?, agent _: any AgentRuntime, attempt: Int, error: Error) async {
+        continuation.yield(.observation(.inferenceRetry(
+            attempt: attempt,
+            message: error.localizedDescription
+        )))
+    }
 }
 
 // MARK: - ToolCallStore

--- a/Sources/Swarm/Core/RunHooks.swift
+++ b/Sources/Swarm/Core/RunHooks.swift
@@ -163,6 +163,19 @@ public protocol AgentObserver: Sendable {
     ///   - agent: The agent completing an iteration.
     ///   - number: The iteration number.
     func onIterationEnd(context: AgentContext?, agent: any AgentRuntime, number: Int) async
+
+    /// Called before a retried provider inference attempt.
+    ///
+    /// Fired only when ``ResilienceConfiguration/retryPolicy`` allows retries and
+    /// the previous attempt failed with a retryable error. `attempt` is 1-indexed
+    /// (the first retry is `1`). The initial attempt does not invoke this hook.
+    ///
+    /// - Parameters:
+    ///   - context: Optional agent context for orchestration scenarios.
+    ///   - agent: The agent retrying inference.
+    ///   - attempt: The retry number (1-indexed, excluding the original attempt).
+    ///   - error: The error that triggered the retry.
+    func onInferenceRetry(context: AgentContext?, agent: any AgentRuntime, attempt: Int, error: Error) async
 }
 
 // MARK: - AgentObserver Default Implementations
@@ -212,6 +225,9 @@ public extension AgentObserver {
 
     /// Default no-op implementation for iteration end.
     func onIterationEnd(context _: AgentContext?, agent _: any AgentRuntime, number _: Int) async {}
+
+    /// Default no-op implementation for inference retries.
+    func onInferenceRetry(context _: AgentContext?, agent _: any AgentRuntime, attempt _: Int, error _: Error) async {}
 }
 
 // MARK: - CompositeObserver
@@ -407,6 +423,16 @@ package struct CompositeObserver: AgentObserver {
         }
     }
 
+    package func onInferenceRetry(context: AgentContext?, agent: any AgentRuntime, attempt: Int, error: Error) async {
+        await withTaskGroup(of: Void.self) { group in
+            for hook in observers {
+                group.addTask {
+                    await hook.onInferenceRetry(context: context, agent: agent, attempt: attempt, error: error)
+                }
+            }
+        }
+    }
+
     // MARK: Private
 
     /// The observer to delegate to.
@@ -563,6 +589,17 @@ public struct LoggingObserver: AgentObserver {
             ""
         }
         Log.agents.info("Iteration started\(contextId) - number: \(number)")
+    }
+
+    public func onInferenceRetry(context: AgentContext?, agent _: any AgentRuntime, attempt: Int, error: Error) async {
+        let contextId = if let context {
+            " [context: \(context.executionId)]"
+        } else {
+            ""
+        }
+        Log.agents.warning(
+            "Inference retry\(contextId) - attempt: \(attempt), error: \(error.localizedDescription)"
+        )
     }
 
     // MARK: Private

--- a/Sources/Swarm/Observability/TracingHelper.swift
+++ b/Sources/Swarm/Observability/TracingHelper.swift
@@ -417,6 +417,28 @@ public struct TracingHelper: Sendable {
         ))
     }
 
+    /// Trace a retried provider inference attempt.
+    ///
+    /// - Parameters:
+    ///   - attempt: 1-indexed retry number (the first retry is `1`).
+    ///   - error: The error that triggered the retry.
+    public func traceInferenceRetry(attempt: Int, error: Error) async {
+        guard let tracer else { return }
+        await tracer.trace(TraceEvent(
+            traceId: traceId,
+            kind: .metric,
+            level: .warning,
+            message: "Inference retry attempt \(attempt)",
+            metadata: [
+                "metric_name": .string("inference_retry"),
+                "attempt": .int(attempt),
+                "failure_kind": .string(String(reflecting: Swift.type(of: error)))
+            ],
+            agentName: agentName,
+            error: ErrorInfo(from: error)
+        ))
+    }
+
     // MARK: Private
 
     /// Start time of the traced operation

--- a/Sources/Swarm/Resilience/InferenceRetryability.swift
+++ b/Sources/Swarm/Resilience/InferenceRetryability.swift
@@ -13,9 +13,10 @@ import FoundationNetworking
 
 /// Classifies whether a provider-inference failure may be retried by ``Agent``.
 ///
-/// ``Agent`` wraps **provider inference only**. This helper is the single
-/// retryability gate: even if a ``RetryPolicy``'s `shouldRetry` closure returns
-/// `true`, permanent failures listed below are never retried.
+/// ``Agent`` wraps **provider inference only**. This helper is the hard
+/// retryability gate: a ``RetryPolicy``'s `shouldRetry` may further restrict
+/// retries, but even if it returns `true`, permanent failures listed below are
+/// never retried.
 ///
 /// ## Retryable (transient)
 ///

--- a/Sources/Swarm/Resilience/InferenceRetryability.swift
+++ b/Sources/Swarm/Resilience/InferenceRetryability.swift
@@ -1,0 +1,97 @@
+// InferenceRetryability.swift
+// Swarm Framework
+//
+// Classification of errors that Agent may retry on provider inference calls.
+
+import Foundation
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+// MARK: - InferenceRetryability
+
+/// Classifies whether a provider-inference failure may be retried by ``Agent``.
+///
+/// ``Agent`` wraps **provider inference only**. This helper is the single
+/// retryability gate: even if a ``RetryPolicy``'s `shouldRetry` closure returns
+/// `true`, permanent failures listed below are never retried.
+///
+/// ## Retryable (transient)
+///
+/// | Error | Reason |
+/// |---|---|
+/// | ``AgentError/rateLimitExceeded(retryAfter:)`` | Provider rate limit |
+/// | ``AgentError/inferenceProviderUnavailable(reason:)`` | Transient backend unavailability |
+/// | ``AgentError/generationFailed(reason:)`` | Provider 5xx / internal generation failure |
+/// | ``AgentError/embeddingFailed(reason:)`` | Transient embedding backend failure |
+/// | `URLError` network / timeout codes | Connectivity loss, DNS, TCP, idle timeout |
+///
+/// ## Not retryable (permanent)
+///
+/// | Error | Reason |
+/// |---|---|
+/// | `CancellationError`, ``AgentError/cancelled`` | Caller aborted the run |
+/// | ``AgentError/timeout(duration:)`` | The **run** deadline expired; retries must not outlive it |
+/// | ``AgentError/invalidInput(reason:)``, ``AgentError/invalidLoop(reason:)`` | Caller / configuration error |
+/// | ``AgentError/maxIterationsExceeded(iterations:)`` | Loop bound, not a transient blip |
+/// | ``AgentError/guardrailViolation(reason:)``, ``GuardrailError`` | Safety rejection |
+/// | ``AgentError/contentFiltered(reason:)`` | Provider safety filter |
+/// | ``AgentError/invalidToolArguments(toolName:reason:)`` | Schema / parse failure |
+/// | ``AgentError/toolExecutionFailed(toolName:underlyingError:)``, ``AgentError/toolNotFound(name:)`` | Tool path (never wrapped) |
+/// | ``AgentError/contextWindowExceeded(tokenCount:limit:)`` | Input too large |
+/// | ``AgentError/unsupportedLanguage(language:)``, ``AgentError/modelNotAvailable(model:)`` | Configuration / capability |
+/// | ``AgentError/agentNotFound(name:)``, ``AgentError/internalError(reason:)``, ``AgentError/toolCallingUnsupported`` | Non-transient |
+/// | ``ResilienceError/circuitBreakerOpen(serviceName:)`` | Breaker already short-circuited |
+/// | ``ResilienceError/retriesExhausted(attempts:lastError:)`` | Budget already spent |
+/// | Unknown `Error` types | Fail closed — do not retry unclassified failures |
+///
+/// Provider timeouts surface as ``AgentError/generationFailed(reason:)`` or
+/// `URLError.timedOut`, which **are** retryable, as long as the run deadline
+/// has not fired.
+public enum InferenceRetryability: Sendable {
+    /// Returns whether ``Agent`` may retry this error on a provider inference call.
+    ///
+    /// - Parameter error: The error thrown by inference (or a wrapper around it).
+    /// - Returns: `true` only for the transient failures listed above.
+    public static func isRetryable(_ error: Error) -> Bool {
+        if error is CancellationError {
+            return false
+        }
+
+        if let agentError = error as? AgentError {
+            return agentError.isRetryable
+        }
+
+        if let resilienceError = error as? ResilienceError {
+            switch resilienceError {
+            case .circuitBreakerOpen, .retriesExhausted, .allFallbacksFailed:
+                return false
+            }
+        }
+
+        if error is GuardrailError {
+            return false
+        }
+
+        if let urlError = error as? URLError {
+            return isRetryable(urlError)
+        }
+
+        return false
+    }
+
+    private static func isRetryable(_ urlError: URLError) -> Bool {
+        switch urlError.code {
+        case .timedOut,
+             .cannotFindHost,
+             .cannotConnectToHost,
+             .networkConnectionLost,
+             .dnsLookupFailed,
+             .notConnectedToInternet:
+            true
+        default:
+            false
+        }
+    }
+}

--- a/Sources/Swarm/Resilience/Resilience.swift
+++ b/Sources/Swarm/Resilience/Resilience.swift
@@ -5,8 +5,10 @@
 // Includes:
 // - Retry policies with exponential backoff (see RetryPolicy.swift)
 // - Fallback chains for graceful degradation (see FallbackChain.swift)
-// - Circuit breaker pattern (to be implemented)
-// - Timeout handling (to be implemented)
+// - Circuit breaker pattern (see CircuitBreaker.swift)
+// - Rate limiting (see RateLimiter.swift)
+// - Agent.run wiring via ResilienceConfiguration (inference only; tools are not retried)
+
 
 // Re-export key resilience types
 @_exported import struct Foundation.TimeInterval

--- a/Sources/Swarm/Resilience/ResilienceConfiguration.swift
+++ b/Sources/Swarm/Resilience/ResilienceConfiguration.swift
@@ -1,0 +1,204 @@
+// ResilienceConfiguration.swift
+// Swarm Framework
+//
+// Agent-facing resilience settings for retry, circuit breaking, and rate limiting.
+
+import Foundation
+
+// MARK: - CircuitBreakerSettings
+
+/// Configuration for an agent-scoped inference circuit breaker.
+///
+/// When set on ``ResilienceConfiguration/circuitBreaker``, ``Agent`` creates a
+/// ``CircuitBreaker`` **once per agent instance** and reuses it across `run()` /
+/// `stream()` calls. Copies of the same `Agent` value share that breaker because
+/// it is an actor. Distinct `Agent` values do not share state.
+///
+/// Circuit breaking applies only to **provider inference** calls, never to tool
+/// execution.
+public struct CircuitBreakerSettings: Sendable, Equatable {
+    /// Consecutive inference failures before the breaker opens.
+    ///
+    /// Default: `5`.
+    public var failureThreshold: Int
+
+    /// Consecutive successes in half-open state required to close the breaker.
+    ///
+    /// Default: `2`.
+    public var successThreshold: Int
+
+    /// Seconds to wait after opening before probing half-open recovery.
+    ///
+    /// Default: `60`.
+    public var resetTimeout: TimeInterval
+
+    /// Maximum concurrent probes allowed while half-open.
+    ///
+    /// Default: `1`.
+    public var halfOpenMaxRequests: Int
+
+    /// Optional breaker name used in ``ResilienceError/circuitBreakerOpen(serviceName:)``.
+    ///
+    /// When `nil`, Swarm uses `agent:<configuration.name>:inference`.
+    public var name: String?
+
+    /// Creates circuit-breaker settings for agent inference.
+    ///
+    /// - Parameters:
+    ///   - failureThreshold: Consecutive failures before opening. Default: `5`
+    ///   - successThreshold: Consecutive half-open successes to close. Default: `2`
+    ///   - resetTimeout: Seconds before a half-open probe. Default: `60`
+    ///   - halfOpenMaxRequests: Concurrent half-open probes. Default: `1`
+    ///   - name: Optional breaker name. Default: `nil` (derived from the agent name)
+    public init(
+        failureThreshold: Int = 5,
+        successThreshold: Int = 2,
+        resetTimeout: TimeInterval = 60.0,
+        halfOpenMaxRequests: Int = 1,
+        name: String? = nil
+    ) {
+        self.failureThreshold = max(1, failureThreshold)
+        self.successThreshold = max(1, successThreshold)
+        self.resetTimeout = max(0, resetTimeout)
+        self.halfOpenMaxRequests = max(1, halfOpenMaxRequests)
+        self.name = name
+    }
+}
+
+// MARK: - RateLimitSettings
+
+/// Token-bucket settings for agent inference rate limiting.
+///
+/// When set on ``ResilienceConfiguration/rateLimit``, ``Agent`` creates a
+/// ``RateLimiter`` **once per agent instance** and reuses it across runs.
+/// Each logical provider inference call acquires one token **before** retries;
+/// retry attempts of that call do not acquire additional tokens.
+///
+/// Rate limiting applies only to **provider inference** calls, never to tool
+/// execution.
+public struct RateLimitSettings: Sendable, Equatable {
+    /// Maximum tokens the bucket can hold.
+    public var maxTokens: Int
+
+    /// Tokens added per second.
+    public var refillRatePerSecond: Double
+
+    /// Creates token-bucket settings.
+    ///
+    /// - Parameters:
+    ///   - maxTokens: Bucket capacity. Values below `1` are clamped to `1`.
+    ///   - refillRatePerSecond: Refill rate. Non-finite or non-positive values
+    ///     become `1.0`.
+    public init(maxTokens: Int, refillRatePerSecond: Double) {
+        self.maxTokens = max(1, maxTokens)
+        self.refillRatePerSecond = refillRatePerSecond.isFinite && refillRatePerSecond > 0
+            ? refillRatePerSecond
+            : 1.0
+    }
+
+    /// Creates settings equivalent to `maxRequestsPerMinute` sustained throughput.
+    ///
+    /// - Parameter maxRequestsPerMinute: Permitted inference calls per minute.
+    public init(maxRequestsPerMinute: Int) {
+        let normalized = max(1, maxRequestsPerMinute)
+        self.init(
+            maxTokens: normalized,
+            refillRatePerSecond: Double(normalized) / 60.0
+        )
+    }
+}
+
+// MARK: - ResilienceConfiguration
+
+/// Resilience policies applied to provider inference inside ``Agent/run(_:session:observer:)``.
+///
+/// Default ``disabled`` is a no-op: ``RetryPolicy/noRetry``, no circuit breaker,
+/// and no rate limiter. Unconfigured agents behave identically to Swarm before
+/// this API existed.
+///
+/// ## What is wrapped
+///
+/// Rate limiting, circuit breaking, and retry apply **only** to provider
+/// inference (`generate`, `generateWithToolCalls`, streaming inference, and
+/// Foundation Models native-session generation). Tool execution is never
+/// retried — tools can have side effects.
+///
+/// Provider fallback (``FallbackChain``) is **not** wired here. Compose
+/// providers yourself, or wait for a dedicated fallback API.
+///
+/// ## Timeout interaction
+///
+/// Retries consume the same remaining ``AgentConfiguration/timeout`` budget as
+/// the rest of the run. Backoff sleeps and subsequent attempts are cancelled
+/// when that deadline expires; a retry cannot outlive the run.
+///
+/// ## Retryability
+///
+/// ``Agent`` ignores a policy's `shouldRetry` closure for classification and
+/// instead uses ``InferenceRetryability/isRetryable(_:)``. Permanent failures
+/// (cancellation, guardrail rejection, schema/parse errors, tool failures) are
+/// never retried. See ``InferenceRetryability`` for the table.
+///
+/// ## Scoping
+///
+/// Circuit-breaker and rate-limiter actors are created per ``Agent`` instance
+/// and shared across that instance's runs. They are not shared globally or
+/// per provider type.
+///
+/// ## Example
+///
+/// ```swift
+/// let config = AgentConfiguration.default
+///     .resilience(ResilienceConfiguration(
+///         retryPolicy: .standard,
+///         circuitBreaker: CircuitBreakerSettings(failureThreshold: 5),
+///         rateLimit: RateLimitSettings(maxRequestsPerMinute: 60)
+///     ))
+///
+/// let agent = try Agent("Be concise.", configuration: config, inferenceProvider: provider)
+/// ```
+public struct ResilienceConfiguration: Sendable, Equatable {
+    /// Disabled resilience — no retries, breaker, or limiter.
+    ///
+    /// This is the default on ``AgentConfiguration`` and must remain
+    /// behavior-identical to an agent with no resilience field.
+    public static let disabled = ResilienceConfiguration()
+
+    /// Retry policy applied to each provider inference call.
+    ///
+    /// Default: ``RetryPolicy/noRetry``. Only ``RetryPolicy/maxAttempts`` and
+    /// ``RetryPolicy/backoff`` are honored by ``Agent``; retryability is
+    /// classified by ``InferenceRetryability``.
+    public var retryPolicy: RetryPolicy
+
+    /// Optional circuit-breaker settings for inference.
+    ///
+    /// `nil` (default) skips circuit breaking entirely.
+    public var circuitBreaker: CircuitBreakerSettings?
+
+    /// Optional token-bucket rate limit for inference.
+    ///
+    /// `nil` (default) skips rate limiting entirely.
+    public var rateLimit: RateLimitSettings?
+
+    /// Creates a resilience configuration.
+    ///
+    /// - Parameters:
+    ///   - retryPolicy: Retry policy. Default: ``RetryPolicy/noRetry``
+    ///   - circuitBreaker: Optional breaker settings. Default: `nil`
+    ///   - rateLimit: Optional rate-limit settings. Default: `nil`
+    public init(
+        retryPolicy: RetryPolicy = .noRetry,
+        circuitBreaker: CircuitBreakerSettings? = nil,
+        rateLimit: RateLimitSettings? = nil
+    ) {
+        self.retryPolicy = retryPolicy
+        self.circuitBreaker = circuitBreaker
+        self.rateLimit = rateLimit
+    }
+
+    /// Whether any policy would change inference execution relative to the default.
+    package var hasActivePolicies: Bool {
+        retryPolicy.maxAttempts > 0 || circuitBreaker != nil || rateLimit != nil
+    }
+}

--- a/Sources/Swarm/Resilience/ResilienceConfiguration.swift
+++ b/Sources/Swarm/Resilience/ResilienceConfiguration.swift
@@ -134,10 +134,12 @@ public struct RateLimitSettings: Sendable, Equatable {
 ///
 /// ## Retryability
 ///
-/// ``Agent`` ignores a policy's `shouldRetry` closure for classification and
-/// instead uses ``InferenceRetryability/isRetryable(_:)``. Permanent failures
+/// ``Agent`` retries only when **both** ``InferenceRetryability/isRetryable(_:)``
+/// and the policy's `shouldRetry` closure return `true`. Permanent failures
 /// (cancellation, guardrail rejection, schema/parse errors, tool failures) are
-/// never retried. See ``InferenceRetryability`` for the table.
+/// never retried, even if `shouldRetry` returns `true`. A custom `shouldRetry`
+/// may further restrict retries; it cannot expand them. See
+/// ``InferenceRetryability`` for the table.
 ///
 /// ## Scoping
 ///
@@ -166,9 +168,9 @@ public struct ResilienceConfiguration: Sendable, Equatable {
 
     /// Retry policy applied to each provider inference call.
     ///
-    /// Default: ``RetryPolicy/noRetry``. Only ``RetryPolicy/maxAttempts`` and
-    /// ``RetryPolicy/backoff`` are honored by ``Agent``; retryability is
-    /// classified by ``InferenceRetryability``.
+    /// Default: ``RetryPolicy/noRetry``. ``Agent`` honors ``RetryPolicy/maxAttempts``,
+    /// ``RetryPolicy/backoff``, ``RetryPolicy/shouldRetry``, and ``RetryPolicy/onRetry``.
+    /// Retryability is the conjunction of ``InferenceRetryability`` and `shouldRetry`.
     public var retryPolicy: RetryPolicy
 
     /// Optional circuit-breaker settings for inference.
@@ -200,5 +202,33 @@ public struct ResilienceConfiguration: Sendable, Equatable {
     /// Whether any policy would change inference execution relative to the default.
     package var hasActivePolicies: Bool {
         retryPolicy.maxAttempts > 0 || circuitBreaker != nil || rateLimit != nil
+    }
+
+    /// Builds the agent-scoped circuit breaker, or `nil` when breaker settings are absent.
+    package func makeCircuitBreaker(agentName: String) -> CircuitBreaker? {
+        guard let settings = circuitBreaker else { return nil }
+        let resolvedName: String
+        if let explicitName = settings.name, !explicitName.isEmpty {
+            resolvedName = explicitName
+        } else {
+            let trimmed = agentName.trimmingCharacters(in: .whitespacesAndNewlines)
+            resolvedName = "agent:\(trimmed.isEmpty ? "Agent" : trimmed):inference"
+        }
+        return CircuitBreaker(
+            name: resolvedName,
+            failureThreshold: settings.failureThreshold,
+            successThreshold: settings.successThreshold,
+            resetTimeout: settings.resetTimeout,
+            halfOpenMaxRequests: settings.halfOpenMaxRequests
+        )
+    }
+
+    /// Builds the agent-scoped rate limiter, or `nil` when rate-limit settings are absent.
+    package func makeRateLimiter() -> RateLimiter? {
+        guard let settings = rateLimit else { return nil }
+        return RateLimiter(
+            maxTokens: settings.maxTokens,
+            refillRatePerSecond: settings.refillRatePerSecond
+        )
     }
 }

--- a/Tests/SwarmTests/Agents/AgentResilienceWiringTests.swift
+++ b/Tests/SwarmTests/Agents/AgentResilienceWiringTests.swift
@@ -1,0 +1,200 @@
+// AgentResilienceWiringTests.swift
+// SwarmTests
+//
+// End-to-end proof that Agent.run honors ResilienceConfiguration.
+
+import Foundation
+@testable import Swarm
+import Testing
+
+@Suite("Agent resilience wiring")
+struct AgentResilienceWiringTests {
+    private static let transient = AgentError.generationFailed(reason: "transient 503")
+
+    @Test(".standard retries a transient failure; .noRetry does not")
+    func standardRetrySucceedsWhereNoRetryFails() async throws {
+        let noRetryProvider = MockInferenceProvider(responses: ["should not appear"])
+        await noRetryProvider.setErrorSequence([Self.transient])
+        let noRetryAgent = try Agent(
+            tools: [],
+            instructions: "Retry wiring",
+            configuration: AgentConfiguration.default
+                .enableStreaming(false)
+                .timeout(.seconds(15))
+                .resilience(ResilienceConfiguration(retryPolicy: .noRetry)),
+            inferenceProvider: noRetryProvider
+        )
+
+        await #expect(throws: AgentError.self) {
+            _ = try await noRetryAgent.run("hello")
+        }
+        #expect(await noRetryProvider.recordedInferenceCallCount == 1)
+
+        let retryProvider = MockInferenceProvider(responses: ["recovered"])
+        await retryProvider.setErrorSequence([Self.transient])
+        let retryObserver = RetryRecordingObserver()
+        let retryAgent = try Agent(
+            tools: [],
+            instructions: "Retry wiring",
+            configuration: AgentConfiguration.default
+                .enableStreaming(false)
+                .timeout(.seconds(15))
+                .resilience(ResilienceConfiguration(retryPolicy: .standard)),
+            inferenceProvider: retryProvider
+        )
+
+        let result = try await retryAgent.run("hello", observer: retryObserver)
+        #expect(result.output == "recovered")
+        #expect(await retryProvider.recordedInferenceCallCount == 2)
+        #expect(await retryObserver.retryAttempts == [1])
+    }
+
+    @Test("Circuit breaker short-circuits later runs after the failure threshold")
+    func circuitBreakerFailsFastOnSubsequentRuns() async throws {
+        let provider = MockInferenceProvider(responses: ["unused"])
+        await provider.setError(Self.transient)
+
+        let agent = try Agent(
+            tools: [],
+            instructions: "Breaker wiring",
+            configuration: AgentConfiguration.default
+                .enableStreaming(false)
+                .resilience(ResilienceConfiguration(
+                    retryPolicy: .noRetry,
+                    circuitBreaker: CircuitBreakerSettings(
+                        failureThreshold: 2,
+                        resetTimeout: 60,
+                        name: "test-breaker"
+                    )
+                )),
+            inferenceProvider: provider
+        )
+
+        await #expect(throws: AgentError.self) {
+            _ = try await agent.run("one")
+        }
+        await #expect(throws: AgentError.self) {
+            _ = try await agent.run("two")
+        }
+        #expect(await provider.recordedInferenceCallCount == 2)
+
+        do {
+            _ = try await agent.run("three")
+            Issue.record("Expected circuit breaker to short-circuit the third run")
+        } catch let error as ResilienceError {
+            #expect(error == .circuitBreakerOpen(serviceName: "test-breaker"))
+        } catch {
+            Issue.record("Expected ResilienceError.circuitBreakerOpen, got \(error)")
+        }
+
+        #expect(await provider.recordedInferenceCallCount == 2)
+    }
+
+    @Test("Rate limiter spaces successive inference calls")
+    func rateLimiterEnforcesFloorDuration() async throws {
+        let provider = MockInferenceProvider(responses: ["a", "b", "c"])
+        let agent = try Agent(
+            tools: [],
+            instructions: "Limiter wiring",
+            configuration: AgentConfiguration.default
+                .enableStreaming(false)
+                .resilience(ResilienceConfiguration(
+                    rateLimit: RateLimitSettings(maxTokens: 1, refillRatePerSecond: 20)
+                )),
+            inferenceProvider: provider
+        )
+
+        let start = ContinuousClock.now
+        _ = try await agent.run("one")
+        _ = try await agent.run("two")
+        _ = try await agent.run("three")
+        let elapsed = ContinuousClock.now - start
+
+        #expect(await provider.recordedInferenceCallCount == 3)
+        // Two refills at 50ms each (≥100ms). Lower bound is generous for clock slack;
+        // upper bound only guards against a hung limiter.
+        #expect(elapsed >= .milliseconds(40))
+        #expect(elapsed < .seconds(5))
+    }
+
+    @Test("Tool execution is not retried even with aggressive inference retry")
+    func toolExecutionIsNotRetried() async throws {
+        let tool = CountingFailingTool(name: "boom")
+        let provider = MockInferenceProvider()
+        await provider.configureToolCallingSequence(
+            toolCalls: [(name: "boom", args: [:])],
+            finalAnswer: "should not be reached"
+        )
+
+        let agent = try Agent(
+            tools: [tool],
+            instructions: "Do not retry tools",
+            configuration: AgentConfiguration.default
+                .enableStreaming(false)
+                .stopOnToolError(true)
+                .resilience(ResilienceConfiguration(retryPolicy: .aggressive)),
+            inferenceProvider: provider
+        )
+
+        await #expect(throws: AgentError.self) {
+            _ = try await agent.run("call the tool")
+        }
+
+        #expect(await tool.callCount == 1)
+        #expect(await provider.recordedInferenceCallCount == 1)
+    }
+
+    @Test("Default resilience configuration is a no-op")
+    func defaultResilienceIsDisabled() {
+        let config = AgentConfiguration.default
+        #expect(config.resilience == .disabled)
+        #expect(config.resilience.retryPolicy == .noRetry)
+        #expect(config.resilience.circuitBreaker == nil)
+        #expect(config.resilience.rateLimit == nil)
+        #expect(config.resilience.hasActivePolicies == false)
+    }
+
+    @Test("resilience builder is additive and does not mutate the original")
+    func resilienceBuilderIsAdditive() {
+        let original = AgentConfiguration.default
+        let modified = original.resilience(ResilienceConfiguration(retryPolicy: .standard))
+
+        #expect(original.resilience.retryPolicy == .noRetry)
+        #expect(modified.resilience.retryPolicy == .standard)
+        #expect(modified.maxIterations == original.maxIterations)
+    }
+}
+
+// MARK: - Helpers
+
+private actor RetryRecordingObserver: AgentObserver {
+    private(set) var retryAttempts: [Int] = []
+
+    func onInferenceRetry(
+        context _: AgentContext?,
+        agent _: any AgentRuntime,
+        attempt: Int,
+        error _: Error
+    ) async {
+        retryAttempts.append(attempt)
+    }
+}
+
+private actor CountingFailingTool: AnyJSONTool {
+    nonisolated let name: String
+    nonisolated let description = "A tool that fails once per call"
+    nonisolated let parameters: [ToolParameter] = []
+    nonisolated let inputGuardrails: [any ToolInputGuardrail] = []
+    nonisolated let outputGuardrails: [any ToolOutputGuardrail] = []
+
+    private(set) var callCount = 0
+
+    init(name: String) {
+        self.name = name
+    }
+
+    func execute(arguments _: [String: SendableValue]) async throws -> SendableValue {
+        callCount += 1
+        throw AgentError.toolExecutionFailed(toolName: name, underlyingError: "intentional")
+    }
+}

--- a/Tests/SwarmTests/Agents/AgentResilienceWiringTests.swift
+++ b/Tests/SwarmTests/Agents/AgentResilienceWiringTests.swift
@@ -163,6 +163,72 @@ struct AgentResilienceWiringTests {
         #expect(modified.resilience.retryPolicy == .standard)
         #expect(modified.maxIterations == original.maxIterations)
     }
+
+    @Test("Custom shouldRetry can restrict retries but cannot expand them")
+    func shouldRetryIsAndedWithClassification() async throws {
+        let provider = MockInferenceProvider(responses: ["should not appear"])
+        await provider.setErrorSequence([Self.transient])
+        let restrictive = RetryPolicy(
+            maxAttempts: 3,
+            backoff: .immediate,
+            shouldRetry: { _ in false }
+        )
+        let agent = try Agent(
+            tools: [],
+            instructions: "Restrict retries",
+            configuration: AgentConfiguration.default
+                .enableStreaming(false)
+                .timeout(.seconds(15))
+                .resilience(ResilienceConfiguration(retryPolicy: restrictive)),
+            inferenceProvider: provider
+        )
+
+        await #expect(throws: AgentError.self) {
+            _ = try await agent.run("hello")
+        }
+        #expect(await provider.recordedInferenceCallCount == 1)
+    }
+
+    @Test("Copies of the same Agent share the circuit breaker")
+    func agentCopiesShareCircuitBreaker() async throws {
+        let provider = MockInferenceProvider(responses: ["unused"])
+        await provider.setError(Self.transient)
+
+        let agent = try Agent(
+            tools: [],
+            instructions: "Shared breaker",
+            configuration: AgentConfiguration.default
+                .enableStreaming(false)
+                .resilience(ResilienceConfiguration(
+                    retryPolicy: .noRetry,
+                    circuitBreaker: CircuitBreakerSettings(
+                        failureThreshold: 2,
+                        resetTimeout: 60,
+                        name: "shared-breaker"
+                    )
+                )),
+            inferenceProvider: provider
+        )
+
+        await #expect(throws: AgentError.self) {
+            _ = try await agent.run("one")
+        }
+        await #expect(throws: AgentError.self) {
+            _ = try await agent.run("two")
+        }
+
+        let copy = agent
+        do {
+            _ = try await copy.run("three")
+            Issue.record("Expected the copied agent to share the open breaker")
+        } catch let error as ResilienceError {
+            #expect(error == .circuitBreakerOpen(serviceName: "shared-breaker"))
+        } catch {
+            Issue.record("Expected ResilienceError.circuitBreakerOpen, got \(error)")
+        }
+
+        #expect(await provider.recordedInferenceCallCount == 2)
+    }
 }
 
 // MARK: - Helpers

--- a/Tests/SwarmTests/Core/CoreTests.swift
+++ b/Tests/SwarmTests/Core/CoreTests.swift
@@ -138,6 +138,8 @@ struct AgentConfigurationTests {
         #expect(config.timeout == .seconds(60))
         #expect(config.temperature == 1.0)
         #expect(config.foundationModelsExecution == .capture)
+        #expect(config.resilience == .disabled)
+        #expect(config.resilience.retryPolicy == .noRetry)
     }
 
     @Test("Native session execution is opt-in and does not mutate capture default")

--- a/Tests/SwarmTests/Mocks/MockInferenceProvider.swift
+++ b/Tests/SwarmTests/Mocks/MockInferenceProvider.swift
@@ -42,6 +42,12 @@ public actor MockInferenceProvider: InferenceProvider,
     /// Error to throw on the next call. Set to nil to proceed normally.
     public var errorToThrow: Error?
 
+    /// Errors to throw in sequence before returning a successful response.
+    ///
+    /// Each inference call consumes one entry. After the sequence is exhausted,
+    /// the mock falls back to ``errorToThrow`` and then to configured responses.
+    public var errorSequence: [Error] = []
+
     /// Delay to simulate network latency.
     public var responseDelay: Duration = .zero
 
@@ -84,6 +90,17 @@ public actor MockInferenceProvider: InferenceProvider,
         generateCalls.last
     }
 
+    /// Combined count of prompt, message, and tool-call inference invocations.
+    ///
+    /// Streaming helpers record a stream call *and* then call `generate`, so this
+    /// count excludes `streamCalls` / `streamMessageCalls` to avoid double-counting.
+    public var recordedInferenceCallCount: Int {
+        generateCalls.count
+            + generateMessageCalls.count
+            + toolCallCalls.count
+            + toolCallMessageCalls.count
+    }
+
     // MARK: - Initialization
 
     /// Creates a new mock inference provider.
@@ -118,6 +135,12 @@ public actor MockInferenceProvider: InferenceProvider,
     /// Sets an error to throw on the next call.
     public func setError(_ error: Error?) {
         errorToThrow = error
+    }
+
+    /// Sets a finite sequence of errors to throw before succeeding.
+    public func setErrorSequence(_ errors: [Error]) {
+        errorSequence = errors
+        errorSequenceIndex = 0
     }
 
     /// Sets the response delay.
@@ -226,6 +249,8 @@ public actor MockInferenceProvider: InferenceProvider,
         tokenCountCalls = []
         toolCallResponses = []
         errorToThrow = nil
+        errorSequence = []
+        errorSequenceIndex = 0
     }
 
     /// Configures the mock for a simple tool calling sequence.
@@ -294,11 +319,27 @@ public actor MockInferenceProvider: InferenceProvider,
     /// Current index in the tool call responses array.
     private var toolCallResponseIndex = 0
 
-    private func nextTextResponse() async throws -> String {
-        if let error = errorToThrow {
+    /// Current index in the scripted error sequence.
+    private var errorSequenceIndex = 0
+
+    private func consumeScriptedError() throws {
+        if errorSequenceIndex < errorSequence.count {
+            let error = errorSequence[errorSequenceIndex]
+            errorSequenceIndex += 1
             throw error
         }
 
+        if let error = errorToThrow {
+            throw error
+        }
+    }
+
+    private func nextTextResponse() async throws -> String {
+        try consumeScriptedError()
+        return try await nextSuccessfulTextBody()
+    }
+
+    private func nextSuccessfulTextBody() async throws -> String {
         if responseDelay > .zero {
             try await Task.sleep(for: responseDelay)
         }
@@ -313,9 +354,7 @@ public actor MockInferenceProvider: InferenceProvider,
     }
 
     private func nextToolCallResponse() async throws -> InferenceResponse {
-        if let error = errorToThrow {
-            throw error
-        }
+        try consumeScriptedError()
 
         if responseDelay > .zero {
             try await Task.sleep(for: responseDelay)
@@ -327,7 +366,7 @@ public actor MockInferenceProvider: InferenceProvider,
             return response
         }
 
-        let content = try await nextTextResponse()
+        let content = try await nextSuccessfulTextBody()
         return InferenceResponse(content: content, finishReason: .completed)
     }
 

--- a/Tests/SwarmTests/Resilience/InferenceRetryabilityTests.swift
+++ b/Tests/SwarmTests/Resilience/InferenceRetryabilityTests.swift
@@ -1,0 +1,86 @@
+// InferenceRetryabilityTests.swift
+// SwarmTests
+//
+// Classification table for Agent inference retries.
+
+import Foundation
+@testable import Swarm
+import Testing
+
+@Suite("Inference retryability")
+struct InferenceRetryabilityTests {
+    @Test("Transient AgentError cases are retryable")
+    func transientAgentErrorsAreRetryable() {
+        let retryable: [AgentError] = [
+            .rateLimitExceeded(retryAfter: 1),
+            .inferenceProviderUnavailable(reason: "down"),
+            .generationFailed(reason: "503"),
+            .embeddingFailed(reason: "timeout")
+        ]
+
+        for error in retryable {
+            #expect(error.isRetryable, "expected \(error) to be retryable")
+            #expect(InferenceRetryability.isRetryable(error))
+        }
+    }
+
+    @Test("Permanent AgentError cases are not retryable")
+    func permanentAgentErrorsAreNotRetryable() {
+        let permanent: [AgentError] = [
+            .cancelled,
+            .timeout(duration: .seconds(1)),
+            .invalidInput(reason: "empty"),
+            .invalidLoop(reason: "bad"),
+            .maxIterationsExceeded(iterations: 3),
+            .guardrailViolation(reason: "blocked"),
+            .contentFiltered(reason: "safety"),
+            .invalidToolArguments(toolName: "x", reason: "parse"),
+            .toolExecutionFailed(toolName: "x", underlyingError: "boom"),
+            .toolNotFound(name: "x"),
+            .contextWindowExceeded(tokenCount: 10, limit: 8),
+            .unsupportedLanguage(language: "zz"),
+            .modelNotAvailable(model: "missing"),
+            .agentNotFound(name: "x"),
+            .internalError(reason: "bug"),
+            .toolCallingUnsupported
+        ]
+
+        for error in permanent {
+            #expect(!error.isRetryable, "expected \(error) not to be retryable")
+            #expect(!InferenceRetryability.isRetryable(error))
+        }
+    }
+
+    @Test("Cancellation, guardrails, and open breakers are not retryable")
+    func wrapperErrorsAreNotRetryable() {
+        #expect(!InferenceRetryability.isRetryable(CancellationError()))
+        #expect(!InferenceRetryability.isRetryable(
+            ResilienceError.circuitBreakerOpen(serviceName: "api")
+        ))
+        #expect(!InferenceRetryability.isRetryable(
+            ResilienceError.retriesExhausted(attempts: 3, lastError: "x")
+        ))
+        #expect(!InferenceRetryability.isRetryable(
+            GuardrailError.inputTripwireTriggered(
+                guardrailName: "test",
+                message: "no",
+                outputInfo: nil
+            )
+        ))
+    }
+
+    @Test("Network URLError codes are retryable; cancellation is not")
+    func urlErrors() {
+        #expect(InferenceRetryability.isRetryable(URLError(.timedOut)))
+        #expect(InferenceRetryability.isRetryable(URLError(.networkConnectionLost)))
+        #expect(InferenceRetryability.isRetryable(URLError(.cannotConnectToHost)))
+        #expect(!InferenceRetryability.isRetryable(URLError(.cancelled)))
+        #expect(!InferenceRetryability.isRetryable(URLError(.badURL)))
+    }
+
+    @Test("Unknown error types fail closed")
+    func unknownErrorsAreNotRetryable() {
+        struct Mystery: Error {}
+        #expect(!InferenceRetryability.isRetryable(Mystery()))
+    }
+}

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -391,6 +391,20 @@ let config = AgentConfiguration.default
     .foundationModelsExecution(.nativeSession)
 ```
 
+### Resilience (opt-in)
+
+By default agents do not retry inference. Attach policies through configuration:
+
+```swift
+let config = AgentConfiguration.default
+    .resilience(ResilienceConfiguration(
+        retryPolicy: .standard,
+        circuitBreaker: CircuitBreakerSettings(failureThreshold: 5)
+    ))
+```
+
+Retries wrap **provider calls only** (not tools), share the run's remaining timeout, and skip permanent failures such as guardrail rejection. See ``InferenceRetryability``.
+
 ### Structured output
 
 `runStructured` uses Foundation Models guided generation when the JSON Schema

--- a/docs/reference/api-catalog.md
+++ b/docs/reference/api-catalog.md
@@ -3,8 +3,8 @@
 Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for high-risk public rows on 2026-07-28 (Conduit hard-removed in 0.6).
 
 - Scope: all `.swift` files under `Sources/Swarm/`, excluding `Internal/GraphRuntime/`
-- Source files scanned: 162
-- Public/open symbols cataloged: 2436
+- Source files scanned: 165
+- Public/open symbols cataloged: 2464
 
 ## 1. Swarm (entry point)
 
@@ -91,7 +91,9 @@ Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for
 | 130 | case | public | FoundationModelsExecutionMode.capture | `public case capture` |
 | 139 | case | public | FoundationModelsExecutionMode.nativeSession | `public case nativeSession` |
 | 604 | var | public | AgentConfiguration.foundationModelsExecution | `public var foundationModelsExecution: FoundationModelsExecutionMode` |
-| 630 | func | public | AgentConfiguration.init(name:maxIterations:timeout:temperature:maxTokens:stopSequences:modelSettings:contextProfile:inferencePolicy:enableStreaming:includeToolCallDetails:stopOnToolError:includeReasoning:sessionHistoryLimit:contextMode:parallelToolCalls:previousResponseId:autoPreviousResponseId:defaultTracingEnabled:foundationModelsExecution:) | `public init(name: String = "Agent", maxIterations: Int = 10, timeout: Duration = .seconds(60), temperature: Double = 1.0, maxTokens: Int? = nil, stopSequences: [String] = [], modelSettings: ModelSettings? = nil, contextProfile: ContextProfile = .platformDefault, inferencePolicy: InferencePolicy? = nil, enableStreaming: Bool = true, includeToolCallDetails: Bool = true, stopOnToolError: Bool = false, includeReasoning: Bool = true, sessionHistoryLimit: Int? = 50, contextMode: ContextMode = .adaptive, parallelToolCalls: Bool = false, previousResponseId: String? = nil, autoPreviousResponseId: Bool = false, defaultTracingEnabled: Bool = true, foundationModelsExecution: FoundationModelsExecutionMode = .capture)` |
+| 608 | var | public | AgentConfiguration.resilience | `public var resilience: ResilienceConfiguration` |
+| 630 | func | public | AgentConfiguration.init(name:maxIterations:timeout:temperature:maxTokens:stopSequences:modelSettings:contextProfile:inferencePolicy:enableStreaming:includeToolCallDetails:stopOnToolError:includeReasoning:sessionHistoryLimit:contextMode:parallelToolCalls:previousResponseId:autoPreviousResponseId:defaultTracingEnabled:foundationModelsExecution:resilience:) | `public init(name: String = "Agent", maxIterations: Int = 10, timeout: Duration = .seconds(60), temperature: Double = 1.0, maxTokens: Int? = nil, stopSequences: [String] = [], modelSettings: ModelSettings? = nil, contextProfile: ContextProfile = .platformDefault, inferencePolicy: InferencePolicy? = nil, enableStreaming: Bool = true, includeToolCallDetails: Bool = true, stopOnToolError: Bool = false, includeReasoning: Bool = true, sessionHistoryLimit: Int? = 50, contextMode: ContextMode = .adaptive, parallelToolCalls: Bool = false, previousResponseId: String? = nil, autoPreviousResponseId: Bool = false, defaultTracingEnabled: Bool = true, foundationModelsExecution: FoundationModelsExecutionMode = .capture, resilience: ResilienceConfiguration = .disabled)` |
+| 108 | func | public | AgentConfiguration.resilience(_:) | `public @discardableResult func resilience(_ value: ResilienceConfiguration) -> AgentConfiguration` |
 | 345 | var | public | AgentConfiguration.description | `public var description: String { get }` |
 
 ### Core/AgentEnvironment.swift
@@ -2392,8 +2394,27 @@ Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for
 
 | Line | Kind | Access | Name | Signature |
 |------|------|--------|------|-----------|
-| 15 | typealias | public | Retry | `public typealias Retry = RetryPolicy` |
-| 16 | typealias | public | Fallback | `public typealias Fallback = FallbackChain` |
+| 17 | typealias | public | Retry | `public typealias Retry = RetryPolicy` |
+| 18 | typealias | public | Fallback | `public typealias Fallback = FallbackChain` |
+
+### Resilience/ResilienceConfiguration.swift
+
+| Line | Kind | Access | Name | Signature |
+|------|------|--------|------|-----------|
+| 20 | struct | public | CircuitBreakerSettings | `public struct CircuitBreakerSettings` |
+| 79 | struct | public | RateLimitSettings | `public struct RateLimitSettings` |
+| 160 | struct | public | ResilienceConfiguration | `public struct ResilienceConfiguration` |
+| 165 | var | public | ResilienceConfiguration.disabled | `public static let disabled: ResilienceConfiguration` |
+| 172 | var | public | ResilienceConfiguration.retryPolicy | `public var retryPolicy: RetryPolicy` |
+| 177 | var | public | ResilienceConfiguration.circuitBreaker | `public var circuitBreaker: CircuitBreakerSettings?` |
+| 182 | var | public | ResilienceConfiguration.rateLimit | `public var rateLimit: RateLimitSettings?` |
+
+### Resilience/InferenceRetryability.swift
+
+| Line | Kind | Access | Name | Signature |
+|------|------|--------|------|-----------|
+| 52 | enum | public | InferenceRetryability | `public enum InferenceRetryability` |
+| 57 | func | public | InferenceRetryability.isRetryable(_:) | `public static func isRetryable(_ error: Error) -> Bool` |
 
 ### Resilience/RetryPolicy.swift
 

--- a/docs/reference/front-facing-api.md
+++ b/docs/reference/front-facing-api.md
@@ -203,6 +203,23 @@ let agent = try Agent(
 | `handoffs` | `[AnyHandoffConfiguration]` | `[]` | Handoff targets for multi-agent orchestration |
 | `tools` | `@ToolBuilder () -> ToolCollection` | `{ .empty }` | Trailing closure producing the agent's tools |
 
+### Resilience (inference only)
+
+`AgentConfiguration.resilience` is additive and defaults to ``ResilienceConfiguration/disabled`` (``RetryPolicy/noRetry``, no breaker, no limiter). That default is a no-op.
+
+When configured, ``Agent/run`` applies **rate-limit acquire → circuit-breaker → retry** around **provider inference** only. Tool execution is never retried. Retries consume the remaining ``AgentConfiguration/timeout`` budget and cannot outlive the run. Circuit-breaker and rate-limiter actors are scoped **per Agent instance**, shared across that instance's runs.
+
+```swift
+let config = AgentConfiguration.default
+    .resilience(ResilienceConfiguration(
+        retryPolicy: .standard,
+        circuitBreaker: CircuitBreakerSettings(failureThreshold: 5),
+        rateLimit: RateLimitSettings(maxRequestsPerMinute: 60)
+    ))
+```
+
+Retryability is classified by ``InferenceRetryability/isRetryable(_:)`` (see that type's table). ``FallbackChain`` is not wired into `Agent` in this release.
+
 ### Runtime wrappers (on AgentRuntime)
 
 Core runtime wrappers are provided by `AgentRuntime` extensions:
@@ -590,6 +607,7 @@ public enum AgentEvent: Sendable {
         case memoryAccessed(operation: MemoryOperation, count: Int)
         case llmStarted(model: String?, promptTokens: Int?)
         case llmCompleted(model: String?, promptTokens: Int?, completionTokens: Int?, duration: TimeInterval)
+        case inferenceRetry(attempt: Int, message: String)
     }
 }
 

--- a/docs/reference/front-facing-api.md
+++ b/docs/reference/front-facing-api.md
@@ -218,7 +218,7 @@ let config = AgentConfiguration.default
     ))
 ```
 
-Retryability is classified by ``InferenceRetryability/isRetryable(_:)`` (see that type's table). ``FallbackChain`` is not wired into `Agent` in this release.
+Retryability is ``InferenceRetryability/isRetryable(_:)`` **and** the policy's `shouldRetry` (default: always). Permanent failures in that table are never retried. ``FallbackChain`` is not wired into `Agent` in this release.
 
 ### Runtime wrappers (on AgentRuntime)
 


### PR DESCRIPTION
## Summary

Chunk J of the Swarm remediation series. Chunk I is **merged** (`fix: native structured outputs + multi-call capture in FM provider` #128). This branch is from that `main`.

The resilience types (`RetryPolicy`, `CircuitBreaker`, `RateLimiter`) already existed and were used by the Hive/GraphRuntime bridge, but nothing user-facing reached them. This PR adds an additive config entry point and honors it in `Agent.run` **around provider inference only**.

### Config API

```swift
let config = AgentConfiguration.default
    .resilience(ResilienceConfiguration(
        retryPolicy: .standard,                           // default: .noRetry
        circuitBreaker: CircuitBreakerSettings(failureThreshold: 5),
        rateLimit: RateLimitSettings(maxRequestsPerMinute: 60)
    ))
```

- `ResilienceConfiguration.disabled` is the default on `AgentConfiguration` (`.noRetry`, no breaker, no limiter). Unconfigured agents are behavior-identical to today.
- Builder matches the existing `@discardableResult public func x(_ value:) -> AgentConfiguration` pattern: `.resilience(_:)`.
- **`FallbackChain` is not wired into Agent** — provider fallback is a larger design. Follow-up.

### Retryability classification

`Agent` classifies errors with `InferenceRetryability.isRetryable(_:)` / `AgentError.isRetryable`. A policy's `shouldRetry` closure is **not** used by `Agent.run`.

| Retryable (transient) | Not retryable (permanent) |
|---|---|
| `rateLimitExceeded` | `CancellationError` / `.cancelled` |
| `inferenceProviderUnavailable` | `.timeout` (**run deadline** — retries must not outlive it) |
| `generationFailed` (provider 5xx / internal) | `.invalidInput`, `.invalidLoop`, `.maxIterationsExceeded` |
| `embeddingFailed` | `.guardrailViolation`, `GuardrailError`, `.contentFiltered` |
| `URLError` network / timeout codes | `.invalidToolArguments`, `.toolExecutionFailed`, `.toolNotFound` |
| | `.contextWindowExceeded`, `.unsupportedLanguage`, `.modelNotAvailable` |
| | `.agentNotFound`, `.internalError`, `.toolCallingUnsupported` |
| | `ResilienceError.circuitBreakerOpen` / `.retriesExhausted` |
| | Unknown `Error` types (fail closed) |

Provider timeouts should surface as `generationFailed` or `URLError.timedOut` (retryable). `AgentError.timeout` is the run's remaining-time budget expiring.

**Timeout interaction:** retries consume the same remaining `AgentConfiguration.timeout`. Backoff sleeps and later attempts are cancelled when that deadline fires.

### Breaker / limiter scoping

**Per `Agent` instance, shared across its runs.** Circuit-breaker and rate-limiter actors live on the agent value (copies share them; distinct `Agent` values do not). Justification: one agent talking to one backend should trip/open together; global or per-provider-type sharing would couple unrelated agents and is harder to test.

Order per logical inference call: **rate-limit acquire → circuit-breaker → retry**. Acquire is once per call, not per retry attempt. Tool execution is never wrapped.

Native Foundation Models session turns that execute tools inside Apple's loop skip **retry** (limiter + breaker still apply) so those tools are not replayed.

Retries are visible: `AgentObserver.onInferenceRetry`, `.metric` traces (`metric_name=inference_retry`), stream `.observation(.inferenceRetry)`, and a warning log.

### Follow-up (not this chunk)

`AgentConfiguration.parallelToolCalls` is forwarded into `InferenceOptions` (provider hint via `AgentConfiguration+InferenceOptions`) but **Agent still executes tool calls sequentially** in `processToolCalls`. Concurrent tool execution remains unwired.

## Test plan

- [x] `bash scripts/ci/lean-build-test.sh` — **PASS** — `1809 tests in 235 suites` (Chunk I baseline: **1795 / 233**)
- [x] `swift test --no-parallel --traits Integrations` — **PASS** — `1953 tests in 258 suites` (Chunk I baseline: **1939 / 256**)
- [x] `swift run --traits Integrations SwarmCapabilityShowcase matrix` — all rows `passed`
- [x] E2E wiring (`AgentResilienceWiringTests`):
  - `.standard` recovers after one transient failure; `.noRetry` fails on the first (`callCount` 2 vs 1); `onInferenceRetry` fires
  - Circuit breaker: after `failureThreshold` 2, the next run throws `circuitBreakerOpen` with **unchanged** provider call count
  - Rate limiter: 3 calls with `maxTokens: 1, refillRatePerSecond: 20` take ≥ 40ms (generous lower bound)
  - Tool that fails once is executed **exactly once** even with `.aggressive` retry
  - Default config is `.disabled` (existing suite is the no-behavior-change evidence)
- [x] Classification table tests (`InferenceRetryabilityTests`)
- [x] SwiftFormat / SwiftLint `--strict` clean on changed files

Delta vs I is the new wiring + classification suites (~+14 tests / +2 suites). No regressions.

## Breaking changes

**Does this PR introduce breaking changes?**
- [x] No — additive `AgentConfiguration.resilience` defaulting to disabled.


Made with [Cursor](https://cursor.com)