### PR TITLE
feat: OTLP/HTTP export + W3C trace propagation for SwarmOpenTelemetry

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -148,6 +148,7 @@ var packageTargets: [Target] = [
         dependencies: [
             "Swarm",
             .product(name: "OpenTelemetryApi", package: "opentelemetry-swift-core"),
+            .product(name: "OpenTelemetrySdk", package: "opentelemetry-swift-core"),
         ],
         swiftSettings: swarmSwiftSettings
     ),

--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ The default Swarm graph is CI-tested on Ubuntu with Swift 6.2. Apple-only featur
 | | |
 |---|---|
 | [Getting Started](docs/guide/getting-started.md) | Installation, first agent, workflows |
-| [OpenTelemetry Tracing](docs/guide/opentelemetry-tracing.md) | Export agent and LLM spans, with optional trace header injection for provider HTTP requests |
+| [OpenTelemetry Tracing](docs/guide/opentelemetry-tracing.md) | OTLP/HTTP JSON export of agent and LLM spans, plus W3C `traceparent` on outbound HTTP |
 | [API Reference](docs/reference/api-catalog.md) | Every type, protocol, and API |
 | [Front-Facing API](docs/reference/front-facing-api.md) | Public API surface |
 | [Why Swarm?](docs/guide/why-swarm.md) | Design philosophy and architecture |

--- a/Sources/Swarm/Agents/Agent.swift
+++ b/Sources/Swarm/Agents/Agent.swift
@@ -187,6 +187,18 @@ public struct Agent: AgentRuntime, Sendable {
     /// See ``Tracer`` for the protocol definition and available implementations.
     public private(set) var tracer: (any Tracer)?
 
+    /// The auto-attached ``MetricsCollector``, when
+    /// ``AgentConfiguration/autoAttachMetricsCollector`` is `true`.
+    ///
+    /// `nil` when the configuration flag is off. When present, the collector
+    /// is composed into the tracer chain so execution metrics accumulate
+    /// without passing a tracer manually. Call ``MetricsCollector/snapshot()``
+    /// to read counters, durations, and token totals.
+    ///
+    /// - SeeAlso: ``AgentConfiguration/autoAttachMetricsCollector(_:)``,
+    ///   ``MetricsCollector``
+    public private(set) var metricsCollector: MetricsCollector?
+
     /// The configuration for the guardrail runner.
     ///
     /// This configuration controls how input and output guardrails are executed,
@@ -259,6 +271,9 @@ public struct Agent: AgentRuntime, Sendable {
         self.defaultMemory = try memory == nil ? Self.makeDefaultMemory() : nil
         self.inferenceProvider = inferenceProvider
         self.tracer = tracer
+        self.metricsCollector = configuration.autoAttachMetricsCollector
+            ? (tracer as? MetricsCollector ?? MetricsCollector())
+            : nil
         self.inputGuardrails = inputGuardrails
         self.outputGuardrails = outputGuardrails
         self.guardrailRunnerConfiguration = guardrailRunnerConfiguration
@@ -820,6 +835,26 @@ public struct Agent: AgentRuntime, Sendable {
         }
     }
 
+    private func resolvedActiveTracer() -> (any Tracer)? {
+        let configured = tracer ?? AgentEnvironmentValues.current.tracer
+        let fallback = configuration.defaultTracingEnabled
+            ? SwiftLogTracer(minimumLevel: .debug)
+            : nil
+        let base = configured ?? fallback
+
+        guard configuration.autoAttachMetricsCollector, let collector = metricsCollector else {
+            return base
+        }
+
+        if let base {
+            if let existing = base as? MetricsCollector, existing === collector {
+                return collector
+            }
+            return CompositeTracer(tracers: [base, collector])
+        }
+        return collector
+    }
+
     private func runInternal(
         _ input: String,
         session: (any Session)? = nil,
@@ -830,9 +865,7 @@ public struct Agent: AgentRuntime, Sendable {
             throw AgentError.invalidInput(reason: "Input cannot be empty")
         }
 
-        let activeTracer = tracer
-            ?? AgentEnvironmentValues.current.tracer
-            ?? (configuration.defaultTracingEnabled ? SwiftLogTracer(minimumLevel: .debug) : nil)
+        let activeTracer = resolvedActiveTracer()
         let activeMemory = resolvedMemory()
         let lifecycleMemory = activeMemory as? any MemorySessionLifecycle
         let trackedSessionMemory = activeMemory.flatMap(defaultSessionMemory)
@@ -3142,6 +3175,9 @@ public extension Agent {
     func withConfiguration(_ config: AgentConfiguration) -> Agent {
         var copy = self
         copy.configuration = config
+        if config.autoAttachMetricsCollector, copy.metricsCollector == nil {
+            copy.metricsCollector = copy.tracer as? MetricsCollector ?? MetricsCollector()
+        }
         return copy
     }
 

--- a/Sources/Swarm/Core/AgentConfiguration.swift
+++ b/Sources/Swarm/Core/AgentConfiguration.swift
@@ -195,6 +195,7 @@ public enum FoundationModelsExecutionMode: String, Sendable, Equatable {
 /// - ``previousResponseId(_:)`` - Set response continuation
 /// - ``autoPreviousResponseId(_:)`` - Set auto response tracking
 /// - ``defaultTracingEnabled(_:)`` - Set default tracing
+/// - ``autoAttachMetricsCollector(_:)`` - Auto-attach a ``MetricsCollector``
 /// - ``foundationModelsExecution(_:)`` - Set Foundation Models execution mode (experimental)
 /// - ``resilience(_:)`` - Set retry, circuit-breaker, and rate-limit policies for inference
 ///
@@ -589,6 +590,30 @@ public struct AgentConfiguration: Sendable, Equatable {
     ///   ``SwiftLogTracer``
     public var defaultTracingEnabled: Bool
 
+    /// Whether to auto-attach a ``MetricsCollector`` so execution metrics flow
+    /// without passing a tracer manually.
+    ///
+    /// When `true`, ``Agent`` creates a ``MetricsCollector`` at initialization
+    /// (or when this flag is enabled via ``Agent/withConfiguration(_:)``) and
+    /// composes it into the tracer chain. Read snapshots from
+    /// ``Agent/metricsCollector``.
+    ///
+    /// Default: `false` — metrics collection stays opt-in.
+    ///
+    /// ## Example
+    /// ```swift
+    /// let config = AgentConfiguration.default
+    ///     .autoAttachMetricsCollector(true)
+    /// let agent = try Agent("Be helpful.", configuration: config,
+    ///     inferenceProvider: provider)
+    /// _ = try await agent.run("Hello")
+    /// let snapshot = await agent.metricsCollector?.snapshot()
+    /// ```
+    ///
+    /// - SeeAlso: ``autoAttachMetricsCollector(_:)``, ``MetricsCollector``,
+    ///   ``Agent/metricsCollector``
+    public var autoAttachMetricsCollector: Bool
+
     // MARK: - Foundation Models Execution
 
     /// How Apple Foundation Models should execute tool-calling turns.
@@ -643,6 +668,7 @@ public struct AgentConfiguration: Sendable, Equatable {
     ///   - previousResponseId: Previous response ID for continuation. Default: nil
     ///   - autoPreviousResponseId: Enable auto response ID tracking. Default: false
     ///   - defaultTracingEnabled: Enable default tracing when no tracer configured. Default: true
+    ///   - autoAttachMetricsCollector: Auto-attach a ``MetricsCollector``. Default: false
     ///   - foundationModelsExecution: Foundation Models tool-loop mode. Default: ``FoundationModelsExecutionMode/capture``
     ///   - resilience: Retry / circuit-breaker / rate-limit policies for inference. Default: ``ResilienceConfiguration/disabled``
     public init(
@@ -665,6 +691,7 @@ public struct AgentConfiguration: Sendable, Equatable {
         previousResponseId: String? = nil,
         autoPreviousResponseId: Bool = false,
         defaultTracingEnabled: Bool = true,
+        autoAttachMetricsCollector: Bool = false,
         foundationModelsExecution: FoundationModelsExecutionMode = .capture,
         resilience: ResilienceConfiguration = .disabled
     ) {
@@ -697,6 +724,7 @@ public struct AgentConfiguration: Sendable, Equatable {
         self.previousResponseId = previousResponseId
         self.autoPreviousResponseId = autoPreviousResponseId
         self.defaultTracingEnabled = defaultTracingEnabled
+        self.autoAttachMetricsCollector = autoAttachMetricsCollector
         self.foundationModelsExecution = foundationModelsExecution
         self.resilience = resilience
     }
@@ -1198,6 +1226,27 @@ extension AgentConfiguration {
         return copy
     }
 
+    /// Sets whether to auto-attach a ``MetricsCollector`` to the tracer chain.
+    ///
+    /// When `true`, the agent records execution metrics without requiring you
+    /// to construct and pass a collector as `tracer`. Default: `false`.
+    ///
+    /// ## Example
+    /// ```swift
+    /// let config = AgentConfiguration.default
+    ///     .autoAttachMetricsCollector(true)
+    /// ```
+    ///
+    /// - Parameter value: `true` to auto-attach a metrics collector
+    /// - Returns: A new configuration with the updated setting
+    /// - SeeAlso: ``autoAttachMetricsCollector``, ``MetricsCollector``,
+    ///   ``Agent/metricsCollector``
+    @discardableResult public func autoAttachMetricsCollector(_ value: Bool) -> AgentConfiguration {
+        var copy = self
+        copy.autoAttachMetricsCollector = value
+        return copy
+    }
+
     // MARK: Foundation Models Execution
 
     /// Sets how Apple Foundation Models should execute tool-calling turns.
@@ -1278,6 +1327,7 @@ extension AgentConfiguration: CustomStringConvertible {
             previousResponseId: \(previousResponseId.map { "\"\($0)\"" } ?? "nil"),
             autoPreviousResponseId: \(autoPreviousResponseId),
             defaultTracingEnabled: \(defaultTracingEnabled),
+            autoAttachMetricsCollector: \(autoAttachMetricsCollector),
             foundationModelsExecution: \(foundationModelsExecution),
             resilience: \(String(describing: resilience))
         )

--- a/Sources/Swarm/Observability/TraceContextHeaders.swift
+++ b/Sources/Swarm/Observability/TraceContextHeaders.swift
@@ -1,0 +1,162 @@
+// TraceContextHeaders.swift
+// Swarm Framework
+//
+// W3C Trace Context headers for outbound HTTP requests.
+
+import Foundation
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// W3C Trace Context headers (`traceparent` and optional `tracestate`).
+///
+/// Use ``current`` / ``httpHeaders`` to inject the active span into outbound
+/// HTTP requests. Swarm's OpenTelemetry wrappers populate the current value
+/// for the duration of each agent and LLM span. Built-in Web tool requests
+/// apply these headers automatically. Custom providers should call
+/// ``applyCurrent(to:)`` before sending a request.
+///
+/// The `traceparent` format matches the W3C Trace Context spec exactly:
+/// `version-traceid-parentid-flags` (lowercase hex).
+///
+/// ```swift
+/// var request = URLRequest(url: endpoint)
+/// TraceContextHeaders.applyCurrent(to: &request)
+/// ```
+public struct TraceContextHeaders: Sendable, Hashable {
+    /// W3C `traceparent` header name.
+    public static let traceparentHeaderName = "traceparent"
+
+    /// W3C `tracestate` header name.
+    public static let tracestateHeaderName = "tracestate"
+
+    /// Regex for a valid W3C `traceparent` (`version-traceid-parentid-flags`).
+    public static let traceparentPattern = "^[0-9a-f]{2}-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$"
+
+    /// The current headers for this task, if a span is active.
+    public static var current: TraceContextHeaders? {
+        TraceContextHeadersStorage.current
+    }
+
+    /// W3C `traceparent` value (`00-{trace-id}-{span-id}-{flags}`).
+    public let traceparent: String
+
+    /// W3C `tracestate` value, when vendors have propagated extra state.
+    public let tracestate: String?
+
+    /// 32-character lowercase hex trace id parsed from ``traceparent``.
+    public var traceId: String {
+        components.traceId
+    }
+
+    /// 16-character lowercase hex span id parsed from ``traceparent``.
+    public var spanId: String {
+        components.spanId
+    }
+
+    /// 2-character lowercase hex flags parsed from ``traceparent``.
+    public var flags: String {
+        components.flags
+    }
+
+    /// Header name/value pairs suitable for an outbound `URLRequest`.
+    public var httpHeaders: [String: String] {
+        var headers = [Self.traceparentHeaderName: traceparent]
+        if let tracestate, !tracestate.isEmpty {
+            headers[Self.tracestateHeaderName] = tracestate
+        }
+        return headers
+    }
+
+    /// Creates headers from a fully formed W3C `traceparent` string.
+    ///
+    /// - Parameters:
+    ///   - traceparent: A `version-traceid-parentid-flags` value.
+    ///   - tracestate: Optional vendor `tracestate`.
+    /// - Returns: `nil` when `traceparent` is not a valid W3C value.
+    public init?(traceparent: String, tracestate: String? = nil) {
+        guard Self.isValidTraceparent(traceparent) else { return nil }
+        self.traceparent = traceparent
+        self.tracestate = tracestate.flatMap { $0.isEmpty ? nil : $0 }
+    }
+
+    /// Builds a W3C `traceparent` from hex identifiers.
+    ///
+    /// - Parameters:
+    ///   - traceId: 32-character hex trace id (case-insensitive; stored lowercase).
+    ///   - spanId: 16-character hex span id (case-insensitive; stored lowercase).
+    ///   - sampled: When `true`, flags are `01`; otherwise `00`.
+    ///   - tracestate: Optional vendor `tracestate`.
+    /// - Returns: `nil` when either identifier is the wrong length or not hex.
+    public init?(
+        traceId: String,
+        spanId: String,
+        sampled: Bool = true,
+        tracestate: String? = nil
+    ) {
+        let normalizedTraceId = traceId.lowercased()
+        let normalizedSpanId = spanId.lowercased()
+        guard Self.isHex(normalizedTraceId, count: 32),
+              Self.isHex(normalizedSpanId, count: 16)
+        else {
+            return nil
+        }
+        let flags = sampled ? "01" : "00"
+        self.traceparent = "00-\(normalizedTraceId)-\(normalizedSpanId)-\(flags)"
+        self.tracestate = tracestate.flatMap { $0.isEmpty ? nil : $0 }
+    }
+
+    /// Runs `operation` with ``current`` set to `headers`.
+    ///
+    /// OpenTelemetry wrappers use this so built-in HTTP clients and custom
+    /// providers see the active span. Prefer ``applyCurrent(to:)`` at call sites.
+    public static func withCurrent<T: Sendable>(
+        _ headers: TraceContextHeaders?,
+        operation: @Sendable () async throws -> T
+    ) async rethrows -> T {
+        try await TraceContextHeadersStorage.$current.withValue(headers) {
+            try await operation()
+        }
+    }
+
+    /// Applies ``current`` headers onto `request`. No-op when no span is active.
+    public static func applyCurrent(to request: inout URLRequest) {
+        current?.apply(to: &request)
+    }
+
+    /// Applies these headers onto `request`, overwriting any existing values.
+    public func apply(to request: inout URLRequest) {
+        request.setValue(traceparent, forHTTPHeaderField: Self.traceparentHeaderName)
+        if let tracestate {
+            request.setValue(tracestate, forHTTPHeaderField: Self.tracestateHeaderName)
+        }
+    }
+
+    /// Returns whether `value` is a spec-valid W3C `traceparent`.
+    public static func isValidTraceparent(_ value: String) -> Bool {
+        guard value.count == 55 else { return false }
+        let parts = value.split(separator: "-", omittingEmptySubsequences: false)
+        guard parts.count == 4 else { return false }
+        return isHex(String(parts[0]), count: 2)
+            && isHex(String(parts[1]), count: 32)
+            && isHex(String(parts[2]), count: 16)
+            && isHex(String(parts[3]), count: 2)
+    }
+
+    private var components: (traceId: String, spanId: String, flags: String) {
+        let parts = traceparent.split(separator: "-")
+        return (String(parts[1]), String(parts[2]), String(parts[3]))
+    }
+
+    private static func isHex(_ value: String, count: Int) -> Bool {
+        value.count == count && value.unicodeScalars.allSatisfy { scalar in
+            (48 ... 57).contains(scalar.value) || (97 ... 102).contains(scalar.value)
+        }
+    }
+}
+
+private enum TraceContextHeadersStorage {
+    @TaskLocal
+    static var current: TraceContextHeaders?
+}

--- a/Sources/Swarm/Tools/Web/WebSearchSupport.swift
+++ b/Sources/Swarm/Tools/Web/WebSearchSupport.swift
@@ -1234,6 +1234,7 @@ internal struct TavilySearchBackend: Sendable {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.timeoutInterval = configuration.fetchTimeout
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        TraceContextHeaders.applyCurrent(to: &request)
 
         let (data, response) = try await URLSession.shared.data(for: request)
         guard let http = response as? HTTPURLResponse else {
@@ -1288,6 +1289,7 @@ internal struct SafeWebFetcher: Sendable {
         request.timeoutInterval = configuration.fetchTimeout
         request.setValue(configuration.userAgent, forHTTPHeaderField: "User-Agent")
         request.setValue("gzip, deflate", forHTTPHeaderField: "Accept-Encoding")
+        TraceContextHeaders.applyCurrent(to: &request)
         if let conditionalEtag, !conditionalEtag.isEmpty {
             request.setValue(conditionalEtag, forHTTPHeaderField: "If-None-Match")
         }
@@ -1475,7 +1477,9 @@ private final class SafeWebFetchDelegate: NSObject, URLSessionDataDelegate, URLS
             completionHandler(nil)
             return
         }
-        completionHandler(request)
+        var redirected = request
+        TraceContextHeaders.applyCurrent(to: &redirected)
+        completionHandler(redirected)
     }
 }
 

--- a/Sources/SwarmOpenTelemetry/OTLPHTTPExporterConfiguration.swift
+++ b/Sources/SwarmOpenTelemetry/OTLPHTTPExporterConfiguration.swift
@@ -1,0 +1,145 @@
+// OTLPHTTPExporterConfiguration.swift
+// SwarmOpenTelemetry
+
+import Foundation
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Configuration for Swarm's in-house OTLP/HTTP JSON span exporter.
+///
+/// Posts completed spans to an OpenTelemetry Collector (or any OTLP/HTTP
+/// receiver) as `application/json`. There is no gRPC dependency.
+///
+/// ## Defaults
+///
+/// - Endpoint: `http://localhost:4318/v1/traces`
+/// - Batching: flush when ``maxBatchSize`` spans are queued, or every
+///   ``scheduleDelay``, whichever comes first
+/// - Retry: one retry with ``retryBackoff`` on 5xx and network failures;
+///   4xx responses are not retried
+///
+/// ```swift
+/// let exporter = OTLPHTTPTraceExporter(
+///     configuration: .default
+///         .endpoint(URL(string: "http://localhost:4318/v1/traces")!)
+///         .headers(["Authorization": "Bearer collector-token"])
+/// )
+/// ```
+public struct OTLPHTTPExporterConfiguration: Sendable, Equatable {
+    /// Default OTLP/HTTP traces path on a local collector.
+    public static let defaultEndpoint = URL(string: "http://localhost:4318/v1/traces")!
+
+    /// Configuration with collector defaults.
+    public static let `default` = OTLPHTTPExporterConfiguration()
+
+    /// OTLP/HTTP traces endpoint.
+    public var endpoint: URL
+
+    /// Extra headers sent with each export (collector auth, tenant keys).
+    public var headers: [String: String]
+
+    /// Resource attributes merged onto every exported batch.
+    ///
+    /// Default includes `service.name = swarm`. Span-level resource attributes
+    /// from the SDK are preserved; these values win on key collision.
+    public var resourceAttributes: [String: String]
+
+    /// Flush immediately once this many spans are queued. Default: `64`.
+    public var maxBatchSize: Int
+
+    /// Flush remaining spans on this interval. Default: 5 seconds.
+    public var scheduleDelay: Duration
+
+    /// Extra attempts after the first POST. Default: `1` (retry once).
+    public var maxRetries: Int
+
+    /// Delay before a retry. Default: 200 milliseconds.
+    public var retryBackoff: Duration
+
+    /// Creates an exporter configuration.
+    ///
+    /// - Parameters:
+    ///   - endpoint: OTLP/HTTP traces URL. Default: ``defaultEndpoint``
+    ///   - headers: Extra HTTP headers. Default: `[:]`
+    ///   - resourceAttributes: Resource attributes to merge. Default:
+    ///     `["service.name": "swarm"]`
+    ///   - maxBatchSize: Size-based flush threshold. Default: `64`
+    ///   - scheduleDelay: Timer-based flush interval. Default: 5 seconds
+    ///   - maxRetries: Retry count after the first attempt. Default: `1`
+    ///   - retryBackoff: Delay between retries. Default: 200 milliseconds
+    public init(
+        endpoint: URL = defaultEndpoint,
+        headers: [String: String] = [:],
+        resourceAttributes: [String: String] = ["service.name": "swarm"],
+        maxBatchSize: Int = 64,
+        scheduleDelay: Duration = .seconds(5),
+        maxRetries: Int = 1,
+        retryBackoff: Duration = .milliseconds(200)
+    ) {
+        self.endpoint = endpoint
+        self.headers = headers
+        self.resourceAttributes = resourceAttributes
+        self.maxBatchSize = max(1, maxBatchSize)
+        self.scheduleDelay = scheduleDelay > .zero ? scheduleDelay : .seconds(5)
+        self.maxRetries = max(0, maxRetries)
+        self.retryBackoff = retryBackoff >= .zero ? retryBackoff : .milliseconds(200)
+    }
+
+    /// Sets the OTLP/HTTP traces endpoint.
+    @discardableResult
+    public func endpoint(_ value: URL) -> OTLPHTTPExporterConfiguration {
+        var copy = self
+        copy.endpoint = value
+        return copy
+    }
+
+    /// Sets extra HTTP headers for collector authentication.
+    @discardableResult
+    public func headers(_ value: [String: String]) -> OTLPHTTPExporterConfiguration {
+        var copy = self
+        copy.headers = value
+        return copy
+    }
+
+    /// Sets resource attributes merged onto every batch.
+    @discardableResult
+    public func resourceAttributes(_ value: [String: String]) -> OTLPHTTPExporterConfiguration {
+        var copy = self
+        copy.resourceAttributes = value
+        return copy
+    }
+
+    /// Sets the size-based flush threshold.
+    @discardableResult
+    public func maxBatchSize(_ value: Int) -> OTLPHTTPExporterConfiguration {
+        var copy = self
+        copy.maxBatchSize = max(1, value)
+        return copy
+    }
+
+    /// Sets the timer-based flush interval.
+    @discardableResult
+    public func scheduleDelay(_ value: Duration) -> OTLPHTTPExporterConfiguration {
+        var copy = self
+        copy.scheduleDelay = value > .zero ? value : .seconds(5)
+        return copy
+    }
+
+    /// Sets how many times a failed POST is retried.
+    @discardableResult
+    public func maxRetries(_ value: Int) -> OTLPHTTPExporterConfiguration {
+        var copy = self
+        copy.maxRetries = max(0, value)
+        return copy
+    }
+
+    /// Sets the delay before a retry.
+    @discardableResult
+    public func retryBackoff(_ value: Duration) -> OTLPHTTPExporterConfiguration {
+        var copy = self
+        copy.retryBackoff = value >= .zero ? value : .milliseconds(200)
+        return copy
+    }
+}

--- a/Sources/SwarmOpenTelemetry/OTLPHTTPTraceExporter.swift
+++ b/Sources/SwarmOpenTelemetry/OTLPHTTPTraceExporter.swift
@@ -1,0 +1,247 @@
+// OTLPHTTPTraceExporter.swift
+// SwarmOpenTelemetry
+
+import Foundation
+import OpenTelemetryApi
+import OpenTelemetrySdk
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Minimal in-house OTLP/HTTP JSON ``SpanExporter``.
+///
+/// Posts completed spans to ``OTLPHTTPExporterConfiguration/endpoint`` as
+/// `application/json`. Batching is size- and timer-based. Transient failures
+/// (HTTP 5xx and network errors) retry once by default; HTTP 4xx does not.
+///
+/// This exporter does **not** pull gRPC or the first-party
+/// `OpenTelemetryProtocolExporterHTTP` package.
+///
+/// ```swift
+/// let exporter = OTLPHTTPTraceExporter()
+/// OpenTelemetry.registerTracerProvider(
+///     tracerProvider: TracerProviderBuilder()
+///         .add(spanProcessor: SimpleSpanProcessor(spanExporter: exporter))
+///         .build()
+/// )
+/// ```
+///
+/// Queue and timer state are guarded by `lock`. `@unchecked Sendable` is
+/// required because `SpanExporter` is invoked from the SDK's export queue.
+///
+/// - SeeAlso: ``OTLPHTTPExporterConfiguration``, ``OpenTelemetryTracing``
+public final class OTLPHTTPTraceExporter: SpanExporter, @unchecked Sendable {
+    /// The configuration used by this exporter.
+    public let configuration: OTLPHTTPExporterConfiguration
+
+    /// Creates an OTLP/HTTP JSON exporter.
+    ///
+    /// - Parameters:
+    ///   - configuration: Endpoint, headers, batching, and retry settings.
+    ///   - session: Session used for POST requests. Inject a `URLProtocol`
+    ///     stub in tests.
+    public init(
+        configuration: OTLPHTTPExporterConfiguration = .default,
+        session: URLSession = .shared
+    ) {
+        self.configuration = configuration
+        self.session = session
+        startTimer()
+    }
+
+    deinit {
+        flushTask?.cancel()
+    }
+
+    public func export(spans: [SpanData], explicitTimeout: TimeInterval?) -> SpanExporterResultCode {
+        enqueue(spans)
+        if pendingCount() >= configuration.maxBatchSize {
+            return flush(explicitTimeout: explicitTimeout)
+        }
+        return .success
+    }
+
+    public func export(spans: [SpanData], explicitTimeout: TimeInterval?) async -> SpanExporterResultCode {
+        enqueue(spans)
+        if pendingCount() >= configuration.maxBatchSize {
+            return await flush(explicitTimeout: explicitTimeout)
+        }
+        return .success
+    }
+
+    public func flush(explicitTimeout: TimeInterval?) -> SpanExporterResultCode {
+        let spans = drain()
+        guard !spans.isEmpty else { return .success }
+        return postSync(spans: spans, explicitTimeout: explicitTimeout)
+    }
+
+    public func flush(explicitTimeout: TimeInterval?) async -> SpanExporterResultCode {
+        let spans = drain()
+        guard !spans.isEmpty else { return .success }
+        return await post(spans: spans, explicitTimeout: explicitTimeout)
+    }
+
+    public func shutdown(explicitTimeout: TimeInterval?) {
+        flushTask?.cancel()
+        flushTask = nil
+        _ = flush(explicitTimeout: explicitTimeout)
+    }
+
+    public func shutdown(explicitTimeout: TimeInterval?) async {
+        flushTask?.cancel()
+        flushTask = nil
+        _ = await flush(explicitTimeout: explicitTimeout)
+    }
+
+    private let session: URLSession
+    private let lock = NSLock()
+    private var pending: [SpanData] = []
+    private var flushTask: Task<Void, Never>?
+
+    private func startTimer() {
+        let delay = configuration.scheduleDelay
+        flushTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: delay)
+                guard !Task.isCancelled else { break }
+                _ = await self?.flush(explicitTimeout: nil)
+            }
+        }
+    }
+
+    private func enqueue(_ spans: [SpanData]) {
+        lock.lock()
+        pending.append(contentsOf: spans)
+        lock.unlock()
+    }
+
+    private func pendingCount() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return pending.count
+    }
+
+    private func drain() -> [SpanData] {
+        lock.lock()
+        defer { lock.unlock() }
+        let spans = pending
+        pending = []
+        return spans
+    }
+
+    private func makeRequest(body: Data, timeout: TimeInterval?) -> URLRequest {
+        var request = URLRequest(url: configuration.endpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = body
+        if let timeout {
+            request.timeoutInterval = timeout
+        }
+        for (name, value) in configuration.headers {
+            request.setValue(value, forHTTPHeaderField: name)
+        }
+        return request
+    }
+
+    private func post(spans: [SpanData], explicitTimeout: TimeInterval?) async -> SpanExporterResultCode {
+        let body: Data
+        do {
+            body = try OTLPJSON.payload(
+                spans: spans,
+                resourceAttributes: configuration.resourceAttributes
+            )
+        } catch {
+            return .failure
+        }
+
+        let request = makeRequest(body: body, timeout: explicitTimeout)
+        let attempts = 1 + configuration.maxRetries
+        for attempt in 0 ..< attempts {
+            do {
+                let (_, response) = try await session.data(for: request)
+                switch classify(response: response, error: nil) {
+                case .success:
+                    return .success
+                case .permanentFailure:
+                    return .failure
+                case .transientFailure:
+                    if attempt + 1 < attempts {
+                        try? await Task.sleep(for: configuration.retryBackoff)
+                    }
+                }
+            } catch {
+                if attempt + 1 < attempts {
+                    try? await Task.sleep(for: configuration.retryBackoff)
+                } else {
+                    return .failure
+                }
+            }
+        }
+        return .failure
+    }
+
+    private func postSync(spans: [SpanData], explicitTimeout: TimeInterval?) -> SpanExporterResultCode {
+        let box = ExportResultBox()
+        let semaphore = DispatchSemaphore(value: 0)
+        Task {
+            box.value = await post(spans: spans, explicitTimeout: explicitTimeout)
+            semaphore.signal()
+        }
+        semaphore.wait()
+        return box.value
+    }
+
+    private func classify(response: URLResponse, error: Error?) -> ExportClassification {
+        if error != nil {
+            return .transientFailure
+        }
+        guard let http = response as? HTTPURLResponse else {
+            return .transientFailure
+        }
+        if (200 ..< 300).contains(http.statusCode) {
+            return .success
+        }
+        if (400 ..< 500).contains(http.statusCode) {
+            return .permanentFailure
+        }
+        return .transientFailure
+    }
+}
+
+private enum ExportClassification {
+    case success
+    case transientFailure
+    case permanentFailure
+}
+
+private final class ExportResultBox: @unchecked Sendable {
+    var value: SpanExporterResultCode = .failure
+}
+
+/// Registers a tracer provider that exports spans over OTLP/HTTP JSON.
+public enum OpenTelemetryTracing {
+    /// Installs ``OTLPHTTPTraceExporter`` as the process tracer provider.
+    ///
+    /// Uses ``SimpleSpanProcessor`` so the exporter owns batching. Call once
+    /// during app startup.
+    ///
+    /// - Parameters:
+    ///   - configuration: Endpoint, headers, batching, and retry settings.
+    ///   - session: Session used for export POSTs.
+    /// - Returns: The installed exporter (keep it if you need to ``SpanExporter/flush()``).
+    @discardableResult
+    public static func configureOTLPHTTPExport(
+        configuration: OTLPHTTPExporterConfiguration = .default,
+        session: URLSession = .shared
+    ) -> OTLPHTTPTraceExporter {
+        let exporter = OTLPHTTPTraceExporter(configuration: configuration, session: session)
+        let processor = SimpleSpanProcessor(spanExporter: exporter)
+        OpenTelemetry.registerTracerProvider(
+            tracerProvider: TracerProviderBuilder()
+                .add(spanProcessor: processor)
+                .build()
+        )
+        return exporter
+    }
+}

--- a/Sources/SwarmOpenTelemetry/OTLPJSON.swift
+++ b/Sources/SwarmOpenTelemetry/OTLPJSON.swift
@@ -1,0 +1,274 @@
+// OTLPJSON.swift
+// SwarmOpenTelemetry
+
+import Foundation
+import OpenTelemetryApi
+import OpenTelemetrySdk
+
+enum OTLPJSON {
+    static func payload(
+        spans: [SpanData],
+        resourceAttributes: [String: String]
+    ) throws -> Data {
+        let request = ExportRequest(
+            resourceSpans: group(spans: spans, resourceAttributes: resourceAttributes)
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return try encoder.encode(request)
+    }
+
+    private static func group(
+        spans: [SpanData],
+        resourceAttributes: [String: String]
+    ) -> [ResourceSpans] {
+        var buckets: [GroupKey: [SpanData]] = [:]
+        for span in spans {
+            let key = GroupKey(
+                resource: encodeAttributes(
+                    span.resource.attributes,
+                    overlay: resourceAttributes
+                ),
+                scopeName: span.instrumentationScope.name,
+                scopeVersion: span.instrumentationScope.version ?? ""
+            )
+            buckets[key, default: []].append(span)
+        }
+
+        return buckets.map { key, grouped in
+            ResourceSpans(
+                resource: Resource(attributes: key.resource),
+                scopeSpans: [
+                    ScopeSpans(
+                        scope: InstrumentationScope(
+                            name: key.scopeName,
+                            version: key.scopeVersion.isEmpty ? nil : key.scopeVersion
+                        ),
+                        spans: grouped.map(encodeSpan)
+                    )
+                ]
+            )
+        }
+    }
+
+    private static func encodeSpan(_ span: SpanData) -> Span {
+        Span(
+            traceId: span.traceId.hexString,
+            spanId: span.spanId.hexString,
+            parentSpanId: span.parentSpanId?.hexString,
+            name: span.name,
+            kind: otlpKind(span.kind),
+            startTimeUnixNano: unixNano(span.startTime),
+            endTimeUnixNano: unixNano(span.endTime),
+            attributes: encodeAttributes(span.attributes, overlay: [:]),
+            status: SpanStatus(
+                code: otlpStatus(span.status),
+                message: statusMessage(span.status)
+            )
+        )
+    }
+
+    private static func encodeAttributes(
+        _ attributes: [String: AttributeValue],
+        overlay: [String: String]
+    ) -> [KeyValue] {
+        var merged: [String: AnyValue] = [:]
+        for (key, value) in attributes {
+            merged[key] = anyValue(value)
+        }
+        for (key, value) in overlay {
+            merged[key] = AnyValue(stringValue: value)
+        }
+        return merged.keys.sorted().map { KeyValue(key: $0, value: merged[$0]!) }
+    }
+
+    private static func anyValue(_ value: AttributeValue) -> AnyValue {
+        switch value {
+        case let .string(string):
+            return AnyValue(stringValue: string)
+        case let .bool(bool):
+            return AnyValue(boolValue: bool)
+        case let .int(int):
+            return AnyValue(intValue: String(int))
+        case let .double(double):
+            return AnyValue(doubleValue: double)
+        case let .stringArray(values):
+            return AnyValue(stringValue: values.joined(separator: ","))
+        case let .boolArray(values):
+            return AnyValue(stringValue: values.map { $0 ? "true" : "false" }.joined(separator: ","))
+        case let .intArray(values):
+            return AnyValue(stringValue: values.map(String.init).joined(separator: ","))
+        case let .doubleArray(values):
+            return AnyValue(stringValue: values.map { String($0) }.joined(separator: ","))
+        case let .array(array):
+            return AnyValue(stringValue: array.description)
+        case let .set(set):
+            return AnyValue(stringValue: set.labels.description)
+        }
+    }
+
+    private static func otlpKind(_ kind: SpanKind) -> Int {
+        switch kind {
+        case .internal: return 1
+        case .server: return 2
+        case .client: return 3
+        case .producer: return 4
+        case .consumer: return 5
+        }
+    }
+
+    /// OTLP status codes (not the Swift SDK's `Status.code`, which swaps OK/UNSET).
+    private static func otlpStatus(_ status: OpenTelemetryApi.Status) -> Int {
+        switch status {
+        case .unset: return 0
+        case .ok: return 1
+        case .error: return 2
+        }
+    }
+
+    private static func statusMessage(_ status: OpenTelemetryApi.Status) -> String? {
+        if case let .error(description) = status, !description.isEmpty {
+            return description
+        }
+        return nil
+    }
+
+    private static func unixNano(_ date: Date) -> String {
+        let nanos = (date.timeIntervalSince1970 * 1_000_000_000).rounded()
+        return String(UInt64(max(0, nanos)))
+    }
+
+    private struct GroupKey: Hashable {
+        let resource: [KeyValue]
+        let scopeName: String
+        let scopeVersion: String
+    }
+
+    struct ExportRequest: Encodable {
+        var resourceSpans: [ResourceSpans]
+    }
+
+    struct ResourceSpans: Encodable {
+        var resource: Resource
+        var scopeSpans: [ScopeSpans]
+    }
+
+    struct Resource: Encodable {
+        var attributes: [KeyValue]
+    }
+
+    struct ScopeSpans: Encodable {
+        var scope: InstrumentationScope
+        var spans: [Span]
+    }
+
+    struct InstrumentationScope: Encodable {
+        var name: String
+        var version: String?
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(name, forKey: .name)
+            if let version {
+                try container.encode(version, forKey: .version)
+            }
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case name
+            case version
+        }
+    }
+
+    struct Span: Encodable {
+        var traceId: String
+        var spanId: String
+        var parentSpanId: String?
+        var name: String
+        var kind: Int
+        var startTimeUnixNano: String
+        var endTimeUnixNano: String
+        var attributes: [KeyValue]
+        var status: SpanStatus
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(traceId, forKey: .traceId)
+            try container.encode(spanId, forKey: .spanId)
+            if let parentSpanId {
+                try container.encode(parentSpanId, forKey: .parentSpanId)
+            }
+            try container.encode(name, forKey: .name)
+            try container.encode(kind, forKey: .kind)
+            try container.encode(startTimeUnixNano, forKey: .startTimeUnixNano)
+            try container.encode(endTimeUnixNano, forKey: .endTimeUnixNano)
+            try container.encode(attributes, forKey: .attributes)
+            try container.encode(status, forKey: .status)
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case traceId
+            case spanId
+            case parentSpanId
+            case name
+            case kind
+            case startTimeUnixNano
+            case endTimeUnixNano
+            case attributes
+            case status
+        }
+    }
+
+    struct SpanStatus: Encodable {
+        var code: Int
+        var message: String?
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(code, forKey: .code)
+            if let message {
+                try container.encode(message, forKey: .message)
+            }
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case code
+            case message
+        }
+    }
+
+    struct KeyValue: Encodable, Hashable {
+        var key: String
+        var value: AnyValue
+    }
+
+    struct AnyValue: Encodable, Hashable {
+        var stringValue: String?
+        var boolValue: Bool?
+        var intValue: String?
+        var doubleValue: Double?
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            if let stringValue {
+                try container.encode(stringValue, forKey: .stringValue)
+            }
+            if let boolValue {
+                try container.encode(boolValue, forKey: .boolValue)
+            }
+            if let intValue {
+                try container.encode(intValue, forKey: .intValue)
+            }
+            if let doubleValue {
+                try container.encode(doubleValue, forKey: .doubleValue)
+            }
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case stringValue
+            case boolValue
+            case intValue
+            case doubleValue
+        }
+    }
+}

--- a/Sources/SwarmOpenTelemetry/OpenTelemetryAgentRuntime.swift
+++ b/Sources/SwarmOpenTelemetry/OpenTelemetryAgentRuntime.swift
@@ -146,15 +146,17 @@ private extension OpenTelemetryAgentRuntime {
         builder.setAttribute(key: "swarm.request.input_length", value: input.count)
 
         return try await builder.withActiveSpan { span in
-            do {
-                let result = try await withInstrumentedProviderEnvironment {
-                    try await body(span)
+            try await OpenTelemetryTracePropagation.withCurrentSpan(span) {
+                do {
+                    let result = try await withInstrumentedProviderEnvironment {
+                        try await body(span)
+                    }
+                    span.status = .ok
+                    return result
+                } catch {
+                    OpenTelemetryAttributes.recordError(error, on: span)
+                    throw error
                 }
-                span.status = .ok
-                return result
-            } catch {
-                OpenTelemetryAttributes.recordError(error, on: span)
-                throw error
             }
         }
     }

--- a/Sources/SwarmOpenTelemetry/OpenTelemetryAnyInferenceProvider.swift
+++ b/Sources/SwarmOpenTelemetry/OpenTelemetryAnyInferenceProvider.swift
@@ -283,14 +283,16 @@ private final class OpenTelemetryAnyInferenceProviderCore: @unchecked Sendable {
     ) async throws -> T {
         let builder = makeSpanBuilder(operation: operation, inputLength: inputLength, options: options)
         return try await builder.withActiveSpan { span in
-            OpenTelemetryAttributes.applyMetadata(metadata, to: span)
-            do {
-                let result = try await body(span)
-                span.status = .ok
-                return result
-            } catch {
-                OpenTelemetryAttributes.recordError(error, on: span)
-                throw error
+            try await OpenTelemetryTracePropagation.withCurrentSpan(span) {
+                OpenTelemetryAttributes.applyMetadata(metadata, to: span)
+                do {
+                    let result = try await body(span)
+                    span.status = .ok
+                    return result
+                } catch {
+                    OpenTelemetryAttributes.recordError(error, on: span)
+                    throw error
+                }
             }
         }
     }

--- a/Sources/SwarmOpenTelemetry/OpenTelemetryInferenceProvider.swift
+++ b/Sources/SwarmOpenTelemetry/OpenTelemetryInferenceProvider.swift
@@ -196,14 +196,16 @@ private extension OpenTelemetryInferenceProvider {
     ) async throws -> T {
         let builder = makeSpanBuilder(operation: operation, inputLength: inputLength, options: options)
         return try await builder.withActiveSpan { span in
-            prepare(span: span)
-            do {
-                let result = try await body(span)
-                span.status = .ok
-                return result
-            } catch {
-                OpenTelemetryAttributes.recordError(error, on: span)
-                throw error
+            try await OpenTelemetryTracePropagation.withCurrentSpan(span) {
+                prepare(span: span)
+                do {
+                    let result = try await body(span)
+                    span.status = .ok
+                    return result
+                } catch {
+                    OpenTelemetryAttributes.recordError(error, on: span)
+                    throw error
+                }
             }
         }
     }

--- a/Sources/SwarmOpenTelemetry/OpenTelemetryTracePropagation.swift
+++ b/Sources/SwarmOpenTelemetry/OpenTelemetryTracePropagation.swift
@@ -1,0 +1,66 @@
+// OpenTelemetryTracePropagation.swift
+// SwarmOpenTelemetry
+
+import Foundation
+import OpenTelemetryApi
+import Swarm
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// W3C Trace Context helpers backed by the current OpenTelemetry span.
+///
+/// ``currentHeaders`` reads the active OTel span when one exists, otherwise
+/// ``TraceContextHeaders/current``. Custom inference providers should inject
+/// these headers on outbound HTTP:
+///
+/// ```swift
+/// var request = URLRequest(url: endpoint)
+/// OpenTelemetryTracePropagation.applyCurrent(to: &request)
+/// ```
+public enum OpenTelemetryTracePropagation {
+    /// W3C `traceparent` / `tracestate` for the current span, or `[:]` if none.
+    public static var currentHeaders: [String: String] {
+        current?.httpHeaders ?? [:]
+    }
+
+    /// The current W3C headers, or `nil` when no valid span is active.
+    public static var current: TraceContextHeaders? {
+        if let span = OpenTelemetry.instance.contextProvider.activeSpan,
+           span.context.isValid
+        {
+            return TraceContextHeaders(spanContext: span.context)
+        }
+        return TraceContextHeaders.current
+    }
+
+    /// Applies the current W3C headers onto `request`. No-op when no span is active.
+    public static func applyCurrent(to request: inout URLRequest) {
+        current?.apply(to: &request)
+    }
+
+    /// Runs `operation` with Swarm's ``TraceContextHeaders/current`` bound to `span`.
+    static func withCurrentSpan<T: Sendable>(
+        _ span: any SpanBase,
+        _ operation: @Sendable () async throws -> T
+    ) async rethrows -> T {
+        let headers = TraceContextHeaders(spanContext: span.context)
+        return try await TraceContextHeaders.withCurrent(headers, operation: operation)
+    }
+}
+
+extension TraceContextHeaders {
+    init?(spanContext: SpanContext) {
+        guard spanContext.isValid else { return nil }
+        let tracestate = spanContext.traceState.entries
+            .map { "\($0.key)=\($0.value)" }
+            .joined(separator: ",")
+        self.init(
+            traceId: spanContext.traceId.hexString,
+            spanId: spanContext.spanId.hexString,
+            sampled: spanContext.isSampled,
+            tracestate: tracestate.isEmpty ? nil : tracestate
+        )
+    }
+}

--- a/Tests/SwarmOpenTelemetryTests/OTLPHTTPTraceExporterTests.swift
+++ b/Tests/SwarmOpenTelemetryTests/OTLPHTTPTraceExporterTests.swift
@@ -1,0 +1,439 @@
+import Foundation
+import OpenTelemetryApi
+import OpenTelemetrySdk
+import Testing
+import Swarm
+@testable import SwarmOpenTelemetry
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+@Suite("OTLP/HTTP JSON exporter")
+struct OTLPHTTPTraceExporterTests {
+    @Test("Exports OTLP JSON with Swarm span attributes and resource overlay")
+    func exportsOTLPJSONPayloadShape() async throws {
+        let stub = OTLPRecordingURLProtocol.makeSession()
+        defer { OTLPRecordingURLProtocol.reset() }
+
+        let span = try await harvestSpan(
+            name: "swarm.agent.run support-agent",
+            attributes: [
+                "swarm.agent.name": .string("support-agent"),
+                "gen_ai.usage.input_tokens": .int(11),
+                "gen_ai.usage.output_tokens": .int(7),
+            ]
+        )
+
+        let exporter = OTLPHTTPTraceExporter(
+            configuration: .default
+                .endpoint(URL(string: "http://127.0.0.1:4318/v1/traces")!)
+                .maxBatchSize(1)
+                .scheduleDelay(.seconds(60))
+                .headers(["Authorization": "Bearer collector-token"])
+                .resourceAttributes(["service.name": "swarm-tests"]),
+            session: stub
+        )
+        defer { exporter.shutdown() }
+
+        OTLPRecordingURLProtocol.enqueue(status: 200)
+        let result = await exporter.export(spans: [span])
+        #expect(result == .success)
+
+        let request = try #require(OTLPRecordingURLProtocol.requests.first)
+        #expect(request.url?.absoluteString == "http://127.0.0.1:4318/v1/traces")
+        #expect(request.httpMethod == "POST")
+        #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/json")
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer collector-token")
+
+        let payload = try #require(OTLPRecordingURLProtocol.bodies.first)
+        let json = try #require(JSONSerialization.jsonObject(with: payload) as? [String: Any])
+        let resourceSpans = try #require(json["resourceSpans"] as? [[String: Any]])
+        #expect(resourceSpans.count == 1)
+
+        let resource = try #require(resourceSpans[0]["resource"] as? [String: Any])
+        let resourceAttrs = try #require(resource["attributes"] as? [[String: Any]])
+        #expect(attribute(resourceAttrs, key: "service.name") == "swarm-tests")
+
+        let scopeSpans = try #require(resourceSpans[0]["scopeSpans"] as? [[String: Any]])
+        let spans = try #require(scopeSpans[0]["spans"] as? [[String: Any]])
+        #expect(spans.count == 1)
+
+        let exported = spans[0]
+        #expect(exported["name"] as? String == "swarm.agent.run support-agent")
+        #expect(exported["kind"] as? Int == 1)
+        #expect((exported["traceId"] as? String)?.count == 32)
+        #expect((exported["spanId"] as? String)?.count == 16)
+        #expect(exported["startTimeUnixNano"] is String)
+        #expect(exported["endTimeUnixNano"] is String)
+
+        let status = try #require(exported["status"] as? [String: Any])
+        #expect(status["code"] as? Int == 1)
+
+        let attrs = try #require(exported["attributes"] as? [[String: Any]])
+        #expect(attribute(attrs, key: "swarm.agent.name") == "support-agent")
+        #expect(intAttribute(attrs, key: "gen_ai.usage.input_tokens") == "11")
+        #expect(intAttribute(attrs, key: "gen_ai.usage.output_tokens") == "7")
+    }
+
+    @Test("Flushes when the batch size is reached and not before")
+    func batchesBySize() async throws {
+        let stub = OTLPRecordingURLProtocol.makeSession()
+        defer { OTLPRecordingURLProtocol.reset() }
+
+        let first = try await harvestSpan(name: "one")
+        let second = try await harvestSpan(name: "two")
+
+        let exporter = OTLPHTTPTraceExporter(
+            configuration: .default
+                .maxBatchSize(2)
+                .scheduleDelay(.seconds(60)),
+            session: stub
+        )
+        defer { exporter.shutdown() }
+
+        OTLPRecordingURLProtocol.enqueue(status: 200)
+        _ = await exporter.export(spans: [first])
+        #expect(OTLPRecordingURLProtocol.requests.isEmpty)
+
+        _ = await exporter.export(spans: [second])
+        #expect(OTLPRecordingURLProtocol.requests.count == 1)
+
+        let payload = try #require(OTLPRecordingURLProtocol.bodies.first)
+        let names = try spanNames(in: payload)
+        #expect(Set(names) == ["one", "two"])
+    }
+
+    @Test("Retries once on HTTP 500 and succeeds")
+    func retriesOnceOn500() async throws {
+        let stub = OTLPRecordingURLProtocol.makeSession()
+        defer { OTLPRecordingURLProtocol.reset() }
+
+        let span = try await harvestSpan(name: "retry-me")
+        let exporter = OTLPHTTPTraceExporter(
+            configuration: .default
+                .maxBatchSize(1)
+                .scheduleDelay(.seconds(60))
+                .retryBackoff(.milliseconds(1)),
+            session: stub
+        )
+        defer { exporter.shutdown() }
+
+        OTLPRecordingURLProtocol.enqueue(status: 500)
+        OTLPRecordingURLProtocol.enqueue(status: 200)
+
+        let result = await exporter.export(spans: [span])
+        #expect(result == .success)
+        #expect(OTLPRecordingURLProtocol.requests.count == 2)
+    }
+
+    @Test("Does not retry on HTTP 400")
+    func doesNotRetryOn400() async throws {
+        let stub = OTLPRecordingURLProtocol.makeSession()
+        defer { OTLPRecordingURLProtocol.reset() }
+
+        let span = try await harvestSpan(name: "bad-request")
+        let exporter = OTLPHTTPTraceExporter(
+            configuration: .default
+                .maxBatchSize(1)
+                .scheduleDelay(.seconds(60))
+                .retryBackoff(.milliseconds(1)),
+            session: stub
+        )
+        defer { exporter.shutdown() }
+
+        OTLPRecordingURLProtocol.enqueue(status: 400)
+
+        let result = await exporter.export(spans: [span])
+        #expect(result == .failure)
+        #expect(OTLPRecordingURLProtocol.requests.count == 1)
+    }
+}
+
+@Test("W3C traceparent matches the current LLM span and shares the agent trace")
+func traceparentPropagatesAgentToOutboundHeaders() async throws {
+    let recorder = RecordingSpanExporter()
+    let tracerProvider = TracerProviderBuilder()
+        .add(
+            spanProcessor: SimpleSpanProcessor(spanExporter: recorder)
+                .reportingOnlySampled(sampled: false)
+        )
+        .build()
+
+    let capturing = HeaderCapturingProvider()
+    let agent = HeaderCapturingAgent(provider: capturing)
+        .instrumentedWithOpenTelemetry(
+            tracer: tracerProvider.get(instrumentationName: "test.agent"),
+            llmTracer: tracerProvider.get(instrumentationName: "test.llm")
+        )
+
+    _ = try await agent.run("hello")
+    tracerProvider.forceFlush()
+
+    let headers = try #require(capturing.headers())
+    #expect(TraceContextHeaders.isValidTraceparent(headers.traceparent))
+    #expect(headers.traceparent.wholeMatch(of: try Regex(TraceContextHeaders.traceparentPattern)) != nil)
+
+    let spans = recorder.spans
+    let agentSpan = try #require(spans.first { $0.name == "swarm.agent.run header-agent" })
+    let llmSpan = try #require(spans.first { $0.name == "chat llm" })
+
+    #expect(headers.traceId == agentSpan.traceId.hexString)
+    #expect(headers.traceId == llmSpan.traceId.hexString)
+    #expect(headers.spanId == llmSpan.spanId.hexString)
+    #expect(llmSpan.parentSpanId == agentSpan.spanId)
+}
+
+private func harvestSpan(
+    name: String,
+    attributes: [String: AttributeValue] = [:]
+) async throws -> SpanData {
+    let recorder = RecordingSpanExporter()
+    let provider = TracerProviderBuilder()
+        .add(
+            spanProcessor: SimpleSpanProcessor(spanExporter: recorder)
+                .reportingOnlySampled(sampled: false)
+        )
+        .build()
+    let tracer = provider.get(instrumentationName: "test.harvest")
+    let builder = tracer.spanBuilder(spanName: name)
+    builder.setSpanKind(spanKind: .internal)
+    for (key, value) in attributes {
+        builder.setAttribute(key: key, value: value)
+    }
+    builder.withActiveSpan { span in
+        span.status = .ok
+    }
+    provider.forceFlush()
+    return try #require(recorder.spans.first)
+}
+
+private func attribute(_ attributes: [[String: Any]], key: String) -> String? {
+    guard let match = attributes.first(where: { $0["key"] as? String == key }),
+          let value = match["value"] as? [String: Any]
+    else {
+        return nil
+    }
+    return value["stringValue"] as? String
+}
+
+private func intAttribute(_ attributes: [[String: Any]], key: String) -> String? {
+    guard let match = attributes.first(where: { $0["key"] as? String == key }),
+          let value = match["value"] as? [String: Any]
+    else {
+        return nil
+    }
+    return value["intValue"] as? String
+}
+
+private func spanNames(in payload: Data) throws -> [String] {
+    let json = try #require(JSONSerialization.jsonObject(with: payload) as? [String: Any])
+    let resourceSpans = try #require(json["resourceSpans"] as? [[String: Any]])
+    var names: [String] = []
+    for resource in resourceSpans {
+        let scopeSpans = try #require(resource["scopeSpans"] as? [[String: Any]])
+        for scope in scopeSpans {
+            let spans = try #require(scope["spans"] as? [[String: Any]])
+            names.append(contentsOf: spans.compactMap { $0["name"] as? String })
+        }
+    }
+    return names
+}
+
+private struct HeaderCapturingAgent: AgentRuntime {
+    let provider: any InferenceProvider
+
+    var tools: [any AnyJSONTool] { [] }
+    var instructions: String { "test" }
+    var configuration: AgentConfiguration { .default.name("header-agent") }
+    var inferenceProvider: (any InferenceProvider)? { provider }
+
+    func run(
+        _ input: String,
+        session: (any Session)?,
+        observer: (any AgentObserver)?
+    ) async throws -> AgentResult {
+        let provider = AgentEnvironmentValues.current.inferenceProviderTransform?(provider) ?? provider
+        _ = try await provider.generate(prompt: input, options: .default)
+        return AgentResult(output: "done", iterationCount: 1)
+    }
+
+    func stream(
+        _ input: String,
+        session: (any Session)?,
+        observer: (any AgentObserver)?
+    ) -> AsyncThrowingStream<AgentEvent, Error> {
+        AsyncThrowingStream { continuation in
+            continuation.finish()
+        }
+    }
+
+    func cancel() async {}
+}
+
+private final class HeaderCapturingProvider: InferenceProvider, @unchecked Sendable {
+    nonisolated(unsafe) private var captured: TraceContextHeaders?
+
+    func headers() -> TraceContextHeaders? {
+        captured
+    }
+
+    func generate(prompt: String, options: InferenceOptions) async throws -> String {
+        captured = TraceContextHeaders.current ?? OpenTelemetryTracePropagation.current
+        return prompt
+    }
+
+    func stream(prompt: String, options: InferenceOptions) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in
+            continuation.yield(prompt)
+            continuation.finish()
+        }
+    }
+
+    func generateWithToolCalls(
+        prompt: String,
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) async throws -> InferenceResponse {
+        InferenceResponse(content: prompt)
+    }
+}
+
+private final class RecordingSpanExporter: SpanExporter, @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [SpanData] = []
+
+    var spans: [SpanData] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+
+    func export(spans: [SpanData], explicitTimeout: TimeInterval?) -> SpanExporterResultCode {
+        lock.lock()
+        storage.append(contentsOf: spans)
+        lock.unlock()
+        return .success
+    }
+
+    func flush(explicitTimeout: TimeInterval?) -> SpanExporterResultCode {
+        .success
+    }
+
+    func shutdown(explicitTimeout: TimeInterval?) {}
+}
+
+private final class OTLPRecordingState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var recordedRequests: [URLRequest] = []
+    private var recordedBodies: [Data] = []
+    private var statuses: [Int] = []
+
+    var requests: [URLRequest] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedRequests
+    }
+
+    var bodies: [Data] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedBodies
+    }
+
+    func reset() {
+        lock.lock()
+        recordedRequests = []
+        recordedBodies = []
+        statuses = []
+        lock.unlock()
+    }
+
+    func enqueue(status: Int) {
+        lock.lock()
+        statuses.append(status)
+        lock.unlock()
+    }
+
+    func record(request: URLRequest, body: Data) -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        recordedRequests.append(request)
+        recordedBodies.append(body)
+        return statuses.isEmpty ? 200 : statuses.removeFirst()
+    }
+}
+
+private final class OTLPRecordingURLProtocol: URLProtocol, @unchecked Sendable {
+    private static let state = OTLPRecordingState()
+
+    static var requests: [URLRequest] {
+        state.requests
+    }
+
+    static var bodies: [Data] {
+        state.bodies
+    }
+
+    static func reset() {
+        state.reset()
+    }
+
+    static func enqueue(status: Int) {
+        state.enqueue(status: status)
+    }
+
+    static func makeSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [OTLPRecordingURLProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        let body = Self.requestBody(from: request)
+        let status = Self.state.record(request: request, body: body)
+
+        let response = HTTPURLResponse(
+            url: request.url ?? URL(string: "http://127.0.0.1/v1/traces")!,
+            statusCode: status,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data("{}".utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    private static func requestBody(from request: URLRequest) -> Data {
+        if let httpBody = request.httpBody {
+            return httpBody
+        }
+        guard let stream = request.httpBodyStream else {
+            return Data()
+        }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: 1024)
+        defer { buffer.deallocate() }
+        while stream.hasBytesAvailable {
+            let read = stream.read(buffer, maxLength: 1024)
+            if read > 0 {
+                data.append(buffer, count: read)
+            } else {
+                break
+            }
+        }
+        return data
+    }
+}

--- a/Tests/SwarmTests/Core/CoreTests.swift
+++ b/Tests/SwarmTests/Core/CoreTests.swift
@@ -140,6 +140,7 @@ struct AgentConfigurationTests {
         #expect(config.foundationModelsExecution == .capture)
         #expect(config.resilience == .disabled)
         #expect(config.resilience.retryPolicy == .noRetry)
+        #expect(config.autoAttachMetricsCollector == false)
     }
 
     @Test("Native session execution is opt-in and does not mutate capture default")

--- a/Tests/SwarmTests/Core/MetricsCollectorAutoAttachTests.swift
+++ b/Tests/SwarmTests/Core/MetricsCollectorAutoAttachTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+@testable import Swarm
+import Testing
+
+@Suite("MetricsCollector auto-attach")
+struct MetricsCollectorAutoAttachTests {
+    @Test("Default configuration does not auto-attach a collector")
+    func defaultIsOff() throws {
+        #expect(AgentConfiguration.default.autoAttachMetricsCollector == false)
+
+        let agent = try Agent(
+            "Be brief.",
+            configuration: .default.defaultTracingEnabled(false),
+            inferenceProvider: MockInferenceProvider(responses: ["ok"])
+        )
+        #expect(agent.metricsCollector == nil)
+    }
+
+    @Test("Configuration flag attaches a collector that records a successful run")
+    func autoAttachRecordsRun() async throws {
+        let config = AgentConfiguration.default
+            .autoAttachMetricsCollector(true)
+            .defaultTracingEnabled(false)
+        let provider = MockInferenceProvider(responses: ["hello"])
+        let agent = try Agent(
+            "Be brief.",
+            configuration: config,
+            inferenceProvider: provider
+        )
+
+        let collector = try #require(agent.metricsCollector)
+        let result = try await agent.run("Hi")
+        #expect(result.output == "hello")
+
+        let snapshot = await collector.snapshot()
+        #expect(snapshot.totalExecutions == 1)
+        #expect(snapshot.successfulExecutions == 1)
+        #expect(snapshot.failedExecutions == 0)
+    }
+
+    @Test("Builder method is additive and does not mutate the original")
+    func builderIsAdditive() {
+        let original = AgentConfiguration.default
+        let enabled = original.autoAttachMetricsCollector(true)
+
+        #expect(original.autoAttachMetricsCollector == false)
+        #expect(enabled.autoAttachMetricsCollector == true)
+        #expect(enabled.maxIterations == original.maxIterations)
+    }
+}

--- a/Tests/SwarmTests/Observability/TraceContextHeadersTests.swift
+++ b/Tests/SwarmTests/Observability/TraceContextHeadersTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+@testable import Swarm
+import Testing
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+@Suite("TraceContextHeaders")
+struct TraceContextHeadersTests {
+    @Test("Formats a spec-valid W3C traceparent")
+    func formatsValidTraceparent() throws {
+        let headers = try #require(
+            TraceContextHeaders(
+                traceId: "4bf92f3577b34da6a3ce929d0e0e4736",
+                spanId: "00f067aa0ba902b7",
+                sampled: true
+            )
+        )
+
+        #expect(headers.traceparent == "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+        #expect(TraceContextHeaders.isValidTraceparent(headers.traceparent))
+        #expect(headers.httpHeaders["traceparent"] == headers.traceparent)
+        #expect(headers.httpHeaders["tracestate"] == nil)
+    }
+
+    @Test("Includes tracestate when present")
+    func includesTracestate() throws {
+        let headers = try #require(
+            TraceContextHeaders(
+                traceId: "4bf92f3577b34da6a3ce929d0e0e4736",
+                spanId: "00f067aa0ba902b7",
+                sampled: false,
+                tracestate: "rojo=00f067aa0ba902b7"
+            )
+        )
+
+        #expect(headers.traceparent.hasSuffix("-00"))
+        #expect(headers.httpHeaders["tracestate"] == "rojo=00f067aa0ba902b7")
+    }
+
+    @Test("Rejects malformed identifiers")
+    func rejectsMalformedIdentifiers() {
+        #expect(TraceContextHeaders(traceId: "abc", spanId: "00f067aa0ba902b7") == nil)
+        #expect(TraceContextHeaders(traceparent: "not-a-traceparent") == nil)
+        #expect(TraceContextHeaders.isValidTraceparent("00-zzzz-00f067aa0ba902b7-01") == false)
+    }
+
+    @Test("applyCurrent injects headers onto a URLRequest")
+    func applyCurrentInjectsHeaders() async throws {
+        let headers = try #require(
+            TraceContextHeaders(
+                traceId: "4bf92f3577b34da6a3ce929d0e0e4736",
+                spanId: "00f067aa0ba902b7"
+            )
+        )
+
+        let request = await TraceContextHeaders.withCurrent(headers) {
+            var request = URLRequest(url: URL(string: "https://example.com/v1")!)
+            TraceContextHeaders.applyCurrent(to: &request)
+            return request
+        }
+
+        #expect(request.value(forHTTPHeaderField: "traceparent") == headers.traceparent)
+    }
+}

--- a/Tests/SwarmTests/Tools/WebSearchSupportTests.swift
+++ b/Tests/SwarmTests/Tools/WebSearchSupportTests.swift
@@ -171,6 +171,42 @@ struct WebSearchSupportTests {
         #expect(RedirectWebFetchURLProtocol.didLoadBody == false)
     }
 
+    @Test("Safe web fetcher injects current W3C traceparent")
+    func fetcherInjectsTraceparent() async throws {
+        TraceparentWebFetchURLProtocol.reset()
+        defer { TraceparentWebFetchURLProtocol.reset() }
+
+        let headers = try #require(
+            TraceContextHeaders(
+                traceId: "4bf92f3577b34da6a3ce929d0e0e4736",
+                spanId: "00f067aa0ba902b7",
+                tracestate: "rojo=00f067aa0ba902b7"
+            )
+        )
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("swarm-web-traceparent-tests", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root.deletingLastPathComponent()) }
+
+        let configuration = WebSearchTool.Configuration(
+            apiKey: nil,
+            persistFetchedArtifacts: false,
+            storeURL: root,
+            enabled: true
+        )
+        let sessionConfiguration = URLSessionConfiguration.ephemeral
+        sessionConfiguration.protocolClasses = [TraceparentWebFetchURLProtocol.self]
+        let fetcher = SafeWebFetcher(configuration: configuration, sessionConfiguration: sessionConfiguration)
+        let url = try #require(URL(string: "https://example.com/docs"))
+
+        _ = try await TraceContextHeaders.withCurrent(headers) {
+            try await fetcher.fetch(url: url, conditionalEtag: nil, conditionalLastModified: nil)
+        }
+
+        #expect(TraceparentWebFetchURLProtocol.traceparent == headers.traceparent)
+        #expect(TraceparentWebFetchURLProtocol.tracestate == "rojo=00f067aa0ba902b7")
+    }
+
     @Test("Safe web fetcher cancels URLSession task when caller cancels")
     func fetcherCancelsURLSessionTaskWhenCallerCancels() async throws {
         CancellableWebFetchURLProtocol.reset()
@@ -308,6 +344,66 @@ struct WebSearchSupportTests {
         let matches = try await store.searchSections(query: "updated instructions", topK: 10)
         #expect(matches.count == 1)
         #expect(matches.first?.section.text.contains("Updated instructions") == true)
+    }
+}
+
+private final class TraceparentWebFetchURLProtocol: URLProtocol {
+    private static let state = TraceHeaderState()
+
+    static var traceparent: String? { state.traceparent }
+    static var tracestate: String? { state.tracestate }
+
+    static func reset() {
+        state.reset()
+    }
+
+    override class func canInit(with _: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        Self.state.record(
+            traceparent: request.value(forHTTPHeaderField: "traceparent"),
+            tracestate: request.value(forHTTPHeaderField: "tracestate")
+        )
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "text/html"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data("<html><body>ok</body></html>".utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+private final class TraceHeaderState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var recordedTraceparent: String?
+    private var recordedTracestate: String?
+
+    var traceparent: String? { lock.withLock { recordedTraceparent } }
+    var tracestate: String? { lock.withLock { recordedTracestate } }
+
+    func record(traceparent: String?, tracestate: String?) {
+        lock.withLock {
+            recordedTraceparent = traceparent
+            recordedTracestate = tracestate
+        }
+    }
+
+    func reset() {
+        lock.withLock {
+            recordedTraceparent = nil
+            recordedTracestate = nil
+        }
     }
 }
 

--- a/docs/guide/opentelemetry-tracing.md
+++ b/docs/guide/opentelemetry-tracing.md
@@ -1,8 +1,8 @@
 # OpenTelemetry Tracing
 
 Swarm ships OpenTelemetry support as an optional product named `SwarmOpenTelemetry`.
-Use it when you want LLM requests and their underlying HTTP calls to show up in
-the same distributed trace as the rest of your app.
+Use it when you want agent turns and LLM calls to export as OTLP spans and to
+propagate W3C `traceparent` on outbound HTTP.
 
 Swarm's OpenTelemetry integration is scoped to agent turns and the LLM calls made
 inside those turns:
@@ -11,18 +11,21 @@ inside those turns:
   user-facing agent operation.
 - During that operation, Swarm automatically wraps the resolved
   `InferenceProvider` and emits child GenAI spans for LLM calls.
+- `OTLPHTTPTraceExporter` posts those spans to an OTLP/HTTP collector as JSON.
+  There is no gRPC dependency.
+- W3C `traceparent` (and `tracestate` when present) is injected from the current
+  span into built-in Web tool HTTP requests. Custom providers call
+  `TraceContextHeaders.applyCurrent(to:)` or
+  `OpenTelemetryTracePropagation.applyCurrent(to:)`.
 
-If you also want HTTP spans or `traceparent` header propagation for the
-underlying LLM network requests, install OpenTelemetry Swift's
-`URLSessionInstrumentation` in your application telemetry bootstrap. Swarm does
-not install it for you because URLSession instrumentation is process-wide.
+## Add the Package Product
 
-## Add the Package Products
-
-If your app already configures OpenTelemetry, add only `SwarmOpenTelemetry` to the
-target that creates agents:
+If your app already configures OpenTelemetry, add `SwarmOpenTelemetry` to the
+target that creates agents. Swarm `0.6.0` is the current published tag:
 
 ```swift
+.package(url: "https://github.com/christopherkarani/Swarm.git", from: "0.6.0")
+
 .target(
     name: "YourApp",
     dependencies: [
@@ -32,78 +35,99 @@ target that creates agents:
 )
 ```
 
-If the same target also configures an OTLP exporter, add the OpenTelemetry
-packages directly so SwiftPM lets the app import the SDK, exporter, and optional
-URLSession instrumentation modules:
+`SwarmOpenTelemetry` already depends on OpenTelemetry API + SDK
+(`opentelemetry-swift-core`). You do **not** need the first-party
+`OpenTelemetryProtocolExporterHTTP` package (that one pulls gRPC). Swarm's
+in-house exporter speaks OTLP/HTTP JSON over `URLSession`.
+
+## Configure export
+
+Register a tracer provider once during app startup. This example exports spans
+to a local OpenTelemetry Collector at the default OTLP/HTTP traces endpoint
+(`http://localhost:4318/v1/traces`):
 
 ```swift
-dependencies: [
-    .package(url: "https://github.com/christopherkarani/Swarm.git", from: "0.6.0"),
-    .package(url: "https://github.com/open-telemetry/opentelemetry-swift-core.git", from: "2.3.0"),
-    .package(url: "https://github.com/open-telemetry/opentelemetry-swift.git", from: "2.3.0"),
-],
-targets: [
-    .target(
-        name: "YourApp",
-        dependencies: [
-            .product(name: "Swarm", package: "Swarm"),
-            .product(name: "SwarmOpenTelemetry", package: "Swarm"),
-            .product(name: "OpenTelemetrySdk", package: "opentelemetry-swift-core"),
-            .product(name: "OpenTelemetryProtocolExporterHTTP", package: "opentelemetry-swift"),
-            .product(name: "URLSessionInstrumentation", package: "opentelemetry-swift"),
-        ]
-    )
-]
-```
-
-## Configure OpenTelemetry
-
-Register your tracer provider once during app startup. This example exports spans
-to a local OpenTelemetry Collector using OTLP/HTTP.
-
-```swift
-import Foundation
-import OpenTelemetryApi
-import OpenTelemetryProtocolExporterHttp
-import OpenTelemetrySdk
-import URLSessionInstrumentation
 import SwarmOpenTelemetry
 
-private var urlSessionInstrumentation: URLSessionInstrumentation?
-
 func configureTracing() {
-    let exporter = OtlpHttpTraceExporter(
-        endpoint: URL(string: "http://localhost:4318/v1/traces")!
-    )
-
-    let processor = SimpleSpanProcessor(spanExporter: exporter)
-
-    OpenTelemetry.registerTracerProvider(
-        tracerProvider: TracerProviderBuilder()
-            .add(spanProcessor: processor)
-            .build()
-    )
-
-    urlSessionInstrumentation = URLSessionInstrumentation(
-        configuration: URLSessionInstrumentationConfiguration(
-            shouldInstrument: { request in
-                guard let host = request.url?.host else { return false }
-                return host == "api.openai.com" || host == "api.anthropic.com"
-            },
-            shouldInjectTracingHeaders: { request in
-                guard let host = request.url?.host else { return false }
-                return host == "api.openai.com" || host == "api.anthropic.com"
-            }
-        )
+    OpenTelemetryTracing.configureOTLPHTTPExport(
+        configuration: .default
+            .headers(["Authorization": "Bearer collector-token"])
     )
 }
 ```
 
-Keep the `URLSessionInstrumentation` instance alive for as long as you want
-URLSession requests to be instrumented. The filtering closures are application
-policy: decide where HTTP spans and propagated trace headers are allowed.
+Or wire the exporter yourself if you already own the tracer provider:
 
-## Trace an Agent Run
+```swift
+import OpenTelemetryApi
+import OpenTelemetrySdk
+import SwarmOpenTelemetry
+
+func configureTracing() {
+    let exporter = OTLPHTTPTraceExporter(
+        configuration: .default
+            .endpoint(URL(string: "http://localhost:4318/v1/traces")!)
+            .headers(["Authorization": "Bearer collector-token"])
+            .maxBatchSize(64)
+            .scheduleDelay(.seconds(5))
+    )
+
+    OpenTelemetry.registerTracerProvider(
+        tracerProvider: TracerProviderBuilder()
+            .add(spanProcessor: SimpleSpanProcessor(spanExporter: exporter))
+            .build()
+    )
+}
+```
+
+### What exports
+
+Each finished agent and LLM span is POSTed as OTLP/JSON `resourceSpans`. Resource
+attributes include `service.name` (default `swarm`) plus any values you set on
+`OTLPHTTPExporterConfiguration.resourceAttributes`. Span attributes include the
+fields Swarm already records:
+
+- Agent: `swarm.operation.name`, `swarm.agent.name`, `swarm.request.input_length`,
+  `swarm.response.output_length`, `swarm.iterations.count`, tool-call counts,
+  and `gen_ai.usage.*` when the provider reports tokens.
+- LLM: `gen_ai.operation.name`, `gen_ai.request.*`, `gen_ai.provider.name`,
+  `gen_ai.request.model`, `server.address` / `url.full` when metadata is present,
+  and `error.type` on failure.
+
+Batching is size- and timer-based. Transient failures (HTTP 5xx and network
+errors) retry once by default; HTTP 4xx is not retried.
+
+## Local collector
+
+A minimal Collector config that accepts OTLP/HTTP JSON and prints spans:
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+processors:
+  batch: {}
+exporters:
+  debug:
+    verbosity: detailed
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]
+```
+
+```bash
+docker run --rm -p 4318:4318 \
+  -v "$(pwd)/otel-collector.yaml:/etc/otelcol/config.yaml" \
+  otel/opentelemetry-collector:latest
+```
+
+## Trace an agent run
 
 Wrap the agent once. Swarm will instrument whichever inference provider that
 agent resolves for the run.
@@ -129,39 +153,45 @@ print(result.output)
 This creates:
 
 - An agent parent span named like `swarm.agent.run support-agent`.
-- Inference child spans for provider calls.
-- URLSession HTTP spans for provider network requests, if your app installed URLSession instrumentation and the provider uses URLSession.
-- `traceparent` and `baggage` headers on instrumented URLSession requests, if your app enabled header injection.
+- Inference child spans for provider calls, sharing the agent trace.
+- An OTLP/HTTP JSON export of those spans to your collector.
+- `traceparent` (and `tracestate` when present) on built-in Web tool HTTP
+  requests made inside the active span.
 
-If one agent run makes multiple inference calls, those spans share the same
-trace as the agent span. With URLSession instrumentation enabled, provider HTTP
-requests made inside those spans inherit that same current trace context.
+## Propagate trace context
 
-## Control Header Injection
+Swarm injects W3C headers from the **current** span. The format is exactly
+`{version}-{trace-id}-{parent-id}-{flags}` (lowercase hex), for example
+`00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01`.
 
-URLSession instrumentation is global to the process, so configure it in the app
-instead of in Swarm. Restrict instrumentation and header injection to the hosts
-that should participate in distributed tracing:
+Built-in Web fetches and Tavily search apply `TraceContextHeaders.current`
+automatically. Custom providers — including a future remote OpenAI-compatible
+provider — should do the same:
 
 ```swift
-urlSessionInstrumentation = URLSessionInstrumentation(
-    configuration: URLSessionInstrumentationConfiguration(
-        shouldInstrument: { request in
-            guard let host = request.url?.host else { return false }
-            return host == "api.openai.com" || host == "api.anthropic.com"
-        },
-        shouldInjectTracingHeaders: { request in
-            guard let host = request.url?.host else { return false }
-            return host == "api.openai.com"
-        }
-    )
-)
+import Swarm
+
+var request = URLRequest(url: endpoint)
+TraceContextHeaders.applyCurrent(to: &request)
 ```
 
-Return `false` from `shouldInjectTracingHeaders` when you want local HTTP spans
-but do not want to propagate tracing headers to an upstream provider.
+If you already import `SwarmOpenTelemetry`, this is equivalent and also reads
+the active OTel span directly:
 
-## Capture Content
+```swift
+import SwarmOpenTelemetry
+
+var request = URLRequest(url: endpoint)
+OpenTelemetryTracePropagation.applyCurrent(to: &request)
+```
+
+Swarm does **not** install process-wide `URLSessionInstrumentation`. If you also
+want HTTP *spans* (not just header injection) for arbitrary `URLSession` traffic,
+add OpenTelemetry Swift's URLSession instrumentation in your app bootstrap and
+restrict it to the hosts you intend to trace. That module is optional and is
+not required for Swarm's own export or `traceparent` propagation.
+
+## Capture content
 
 LLM spans record request shape, provider metadata, token usage when the provider
 reports it (Foundation Models does not), output length,
@@ -180,10 +210,30 @@ let agent = try Agent(
 Keep prompt and response capture behind an explicit application-level policy
 before adding sensitive content to span attributes or events.
 
-## Platform Notes
+## Metrics without a manual tracer
 
-Agent and LLM span wrapping works anywhere the OpenTelemetry API and Swarm
-targets build.
-URLSession auto-instrumentation is available when the `URLSessionInstrumentation`
-module is importable by your application. On unsupported platforms, skip the
-URLSession instrumentation setup and keep only the Swarm agent wrapper.
+`MetricsCollector` can attach from configuration so execution counters flow
+without passing a tracer:
+
+```swift
+let config = AgentConfiguration.default
+    .autoAttachMetricsCollector(true)
+
+let agent = try Agent(
+    "Answer briefly.",
+    configuration: config,
+    inferenceProvider: .foundationModels()
+)
+
+_ = try await agent.run("Hello")
+let snapshot = await agent.metricsCollector?.snapshot()
+```
+
+The flag defaults to `false`.
+
+## Platform notes
+
+Agent and LLM span wrapping, OTLP/HTTP JSON export, and W3C header helpers work
+anywhere the OpenTelemetry API/SDK and Swarm targets build, including Linux.
+URLSession auto-instrumentation for extra HTTP spans remains an optional
+application concern and is not shipped by Swarm.

--- a/docs/reference/api-catalog.md
+++ b/docs/reference/api-catalog.md
@@ -3,8 +3,8 @@
 Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for high-risk public rows on 2026-07-28 (Conduit hard-removed in 0.6).
 
 - Scope: all `.swift` files under `Sources/Swarm/`, excluding `Internal/GraphRuntime/`
-- Source files scanned: 165
-- Public/open symbols cataloged: 2464
+- Source files scanned: 166
+- Public/open symbols cataloged: 2481
 
 ## 1. Swarm (entry point)
 
@@ -49,6 +49,7 @@ Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for
 | 108 | func | public | AgentConfiguration.autoPreviousResponseId(_:) | `public @discardableResult func autoPreviousResponseId(_ value: Bool) -> AgentConfiguration` |
 | 108 | func | public | AgentConfiguration.contextMode(_:) | `public @discardableResult func contextMode(_ value: ContextMode) -> AgentConfiguration` |
 | 108 | func | public | AgentConfiguration.contextProfile(_:) | `public @discardableResult func contextProfile(_ value: ContextProfile) -> AgentConfiguration` |
+| 108 | func | public | AgentConfiguration.autoAttachMetricsCollector(_:) | `public @discardableResult func autoAttachMetricsCollector(_ value: Bool) -> AgentConfiguration` |
 | 108 | func | public | AgentConfiguration.defaultTracingEnabled(_:) | `public @discardableResult func defaultTracingEnabled(_ value: Bool) -> AgentConfiguration` |
 | 108 | func | public | AgentConfiguration.enableStreaming(_:) | `public @discardableResult func enableStreaming(_ value: Bool) -> AgentConfiguration` |
 | 108 | func | public | AgentConfiguration.foundationModelsExecution(_:) | `public @discardableResult func foundationModelsExecution(_ value: FoundationModelsExecutionMode) -> AgentConfiguration` |
@@ -87,12 +88,13 @@ Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for
 | 245 | var | public | AgentConfiguration.previousResponseId | `public var previousResponseId: String?` |
 | 253 | var | public | AgentConfiguration.autoPreviousResponseId | `public var autoPreviousResponseId: Bool` |
 | 264 | var | public | AgentConfiguration.defaultTracingEnabled | `public var defaultTracingEnabled: Bool` |
+| 265 | var | public | AgentConfiguration.autoAttachMetricsCollector | `public var autoAttachMetricsCollector: Bool` |
 | 126 | enum | public | FoundationModelsExecutionMode | `public enum FoundationModelsExecutionMode` |
 | 130 | case | public | FoundationModelsExecutionMode.capture | `public case capture` |
 | 139 | case | public | FoundationModelsExecutionMode.nativeSession | `public case nativeSession` |
 | 604 | var | public | AgentConfiguration.foundationModelsExecution | `public var foundationModelsExecution: FoundationModelsExecutionMode` |
 | 608 | var | public | AgentConfiguration.resilience | `public var resilience: ResilienceConfiguration` |
-| 630 | func | public | AgentConfiguration.init(name:maxIterations:timeout:temperature:maxTokens:stopSequences:modelSettings:contextProfile:inferencePolicy:enableStreaming:includeToolCallDetails:stopOnToolError:includeReasoning:sessionHistoryLimit:contextMode:parallelToolCalls:previousResponseId:autoPreviousResponseId:defaultTracingEnabled:foundationModelsExecution:resilience:) | `public init(name: String = "Agent", maxIterations: Int = 10, timeout: Duration = .seconds(60), temperature: Double = 1.0, maxTokens: Int? = nil, stopSequences: [String] = [], modelSettings: ModelSettings? = nil, contextProfile: ContextProfile = .platformDefault, inferencePolicy: InferencePolicy? = nil, enableStreaming: Bool = true, includeToolCallDetails: Bool = true, stopOnToolError: Bool = false, includeReasoning: Bool = true, sessionHistoryLimit: Int? = 50, contextMode: ContextMode = .adaptive, parallelToolCalls: Bool = false, previousResponseId: String? = nil, autoPreviousResponseId: Bool = false, defaultTracingEnabled: Bool = true, foundationModelsExecution: FoundationModelsExecutionMode = .capture, resilience: ResilienceConfiguration = .disabled)` |
+| 630 | func | public | AgentConfiguration.init(name:maxIterations:timeout:temperature:maxTokens:stopSequences:modelSettings:contextProfile:inferencePolicy:enableStreaming:includeToolCallDetails:stopOnToolError:includeReasoning:sessionHistoryLimit:contextMode:parallelToolCalls:previousResponseId:autoPreviousResponseId:defaultTracingEnabled:autoAttachMetricsCollector:foundationModelsExecution:resilience:) | `public init(name: String = "Agent", maxIterations: Int = 10, timeout: Duration = .seconds(60), temperature: Double = 1.0, maxTokens: Int? = nil, stopSequences: [String] = [], modelSettings: ModelSettings? = nil, contextProfile: ContextProfile = .platformDefault, inferencePolicy: InferencePolicy? = nil, enableStreaming: Bool = true, includeToolCallDetails: Bool = true, stopOnToolError: Bool = false, includeReasoning: Bool = true, sessionHistoryLimit: Int? = 50, contextMode: ContextMode = .adaptive, parallelToolCalls: Bool = false, previousResponseId: String? = nil, autoPreviousResponseId: Bool = false, defaultTracingEnabled: Bool = true, autoAttachMetricsCollector: Bool = false, foundationModelsExecution: FoundationModelsExecutionMode = .capture, resilience: ResilienceConfiguration = .disabled)` |
 | 108 | func | public | AgentConfiguration.resilience(_:) | `public @discardableResult func resilience(_ value: ResilienceConfiguration) -> AgentConfiguration` |
 | 345 | var | public | AgentConfiguration.description | `public var description: String { get }` |
 
@@ -1078,7 +1080,8 @@ Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for
 | 54 | var | public | Agent.inferenceProvider | `public let inferenceProvider: (any InferenceProvider)?` |
 | 55 | var | public | Agent.inputGuardrails | `public let inputGuardrails: [any InputGuardrail]` |
 | 56 | var | public | Agent.outputGuardrails | `public let outputGuardrails: [any OutputGuardrail]` |
-| 57 | var | public | Agent.tracer | `public let tracer: (any Tracer)?` |
+| 57 | var | public | Agent.tracer | `public private(set) var tracer: (any Tracer)?` |
+| 200 | var | public | Agent.metricsCollector | `public private(set) var metricsCollector: MetricsCollector?` |
 | 58 | var | public | Agent.guardrailRunnerConfiguration | `public let guardrailRunnerConfiguration: GuardrailRunnerConfiguration` |
 | 61 | var | public | Agent.handoffs | `public var handoffs: [AnyHandoffConfiguration] { get }` |
 | 80 | func | public | Agent.init(tools:instructions:configuration:memory:inferenceProvider:tracer:inputGuardrails:outputGuardrails:guardrailRunnerConfiguration:handoffs:) | `public init(tools: [any AnyJSONTool] = [], instructions: String = "", configuration: AgentConfiguration = .default, memory: (any Memory)? = nil, inferenceProvider: (any InferenceProvider)? = nil, tracer: (any Tracer)? = nil, inputGuardrails: [any InputGuardrail] = [], outputGuardrails: [any OutputGuardrail] = [], guardrailRunnerConfiguration: GuardrailRunnerConfiguration = .default, handoffs: [AnyHandoffConfiguration] = []) throws` |
@@ -2170,6 +2173,25 @@ Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for
 | 240 | var | public | TraceContext.description | `public nonisolated var description: String { get }` |
 | 266 | func | public | TraceContext.withSpan(_:metadata:operation:) | `public func withSpan<T>(_ name: String, metadata: [String : SendableValue] = [:], operation: () async throws -> T) async rethrows -> T where T : Sendable` |
 
+### Observability/TraceContextHeaders.swift
+
+| Line | Kind | Access | Name | Signature |
+|------|------|--------|------|-----------|
+| 27 | struct | public | TraceContextHeaders | `public struct TraceContextHeaders` |
+| 29 | var | public | TraceContextHeaders.traceparentHeaderName | `public static let traceparentHeaderName: String` |
+| 32 | var | public | TraceContextHeaders.tracestateHeaderName | `public static let tracestateHeaderName: String` |
+| 35 | var | public | TraceContextHeaders.traceparentPattern | `public static let traceparentPattern: String` |
+| 38 | var | public | TraceContextHeaders.current | `public static var current: TraceContextHeaders? { get }` |
+| 43 | var | public | TraceContextHeaders.traceparent | `public let traceparent: String` |
+| 46 | var | public | TraceContextHeaders.tracestate | `public let tracestate: String?` |
+| 64 | var | public | TraceContextHeaders.httpHeaders | `public var httpHeaders: [String : String] { get }` |
+| 78 | func | public | TraceContextHeaders.init(traceparent:tracestate:) | `public init?(traceparent: String, tracestate: String? = nil)` |
+| 92 | func | public | TraceContextHeaders.init(traceId:spanId:sampled:tracestate:) | `public init?(traceId: String, spanId: String, sampled: Bool = true, tracestate: String? = nil)` |
+| 114 | func | public | TraceContextHeaders.withCurrent(_:operation:) | `public static func withCurrent<T>(_ headers: TraceContextHeaders?, operation: () async throws -> T) async rethrows -> T where T : Sendable` |
+| 124 | func | public | TraceContextHeaders.applyCurrent(to:) | `public static func applyCurrent(to request: inout URLRequest)` |
+| 129 | func | public | TraceContextHeaders.apply(to:) | `public func apply(to request: inout URLRequest)` |
+| 137 | func | public | TraceContextHeaders.isValidTraceparent(_:) | `public static func isValidTraceparent(_ value: String) -> Bool` |
+
 ### Observability/TraceEvent.swift
 
 | Line | Kind | Access | Name | Signature |
@@ -2905,6 +2927,33 @@ exports companion products with small public entry surfaces.
 | Line | Kind | Access | Name | Signature |
 |------|------|--------|------|-----------|
 | 210 | func | public | AgentRuntime.instrumentedWithOpenTelemetry(tracer:llmTracer:spanName:captureContent:) | `public func instrumentedWithOpenTelemetry(tracer: any OpenTelemetryApi.Tracer = OpenTelemetry.instance.tracerProvider.get(instrumentationName: "swarm.agent", instrumentationVersion: nil), llmTracer: any OpenTelemetryApi.Tracer = OpenTelemetry.instance.tracerProvider.get(instrumentationName: "swarm.llm", instrumentationVersion: nil), spanName: String? = nil, captureContent: Bool = false) -> some AgentRuntime` |
+
+#### Sources/SwarmOpenTelemetry/OTLPHTTPExporterConfiguration.swift
+
+| Line | Kind | Access | Name | Signature |
+|------|------|--------|------|-----------|
+| 30 | struct | public | OTLPHTTPExporterConfiguration | `public struct OTLPHTTPExporterConfiguration` |
+| 32 | var | public | OTLPHTTPExporterConfiguration.defaultEndpoint | `public static let defaultEndpoint: URL` |
+| 35 | var | public | OTLPHTTPExporterConfiguration.default | `public static let \`default\`: OTLPHTTPExporterConfiguration` |
+| 72 | func | public | OTLPHTTPExporterConfiguration.init(endpoint:headers:resourceAttributes:maxBatchSize:scheduleDelay:maxRetries:retryBackoff:) | `public init(endpoint: URL = defaultEndpoint, headers: [String : String] = [:], resourceAttributes: [String : String] = ["service.name": "swarm"], maxBatchSize: Int = 64, scheduleDelay: Duration = .seconds(5), maxRetries: Int = 1, retryBackoff: Duration = .milliseconds(200))` |
+
+#### Sources/SwarmOpenTelemetry/OTLPHTTPTraceExporter.swift
+
+| Line | Kind | Access | Name | Signature |
+|------|------|--------|------|-----------|
+| 30 | class | public | OTLPHTTPTraceExporter | `public final class OTLPHTTPTraceExporter` |
+| 40 | func | public | OTLPHTTPTraceExporter.init(configuration:session:) | `public init(configuration: OTLPHTTPExporterConfiguration = .default, session: URLSession = .shared)` |
+| 219 | enum | public | OpenTelemetryTracing | `public enum OpenTelemetryTracing` |
+| 230 | func | public | OpenTelemetryTracing.configureOTLPHTTPExport(configuration:session:) | `public static func configureOTLPHTTPExport(configuration: OTLPHTTPExporterConfiguration = .default, session: URLSession = .shared) -> OTLPHTTPTraceExporter` |
+
+#### Sources/SwarmOpenTelemetry/OpenTelemetryTracePropagation.swift
+
+| Line | Kind | Access | Name | Signature |
+|------|------|--------|------|-----------|
+| 22 | enum | public | OpenTelemetryTracePropagation | `public enum OpenTelemetryTracePropagation` |
+| 24 | var | public | OpenTelemetryTracePropagation.currentHeaders | `public static var currentHeaders: [String : String] { get }` |
+| 29 | var | public | OpenTelemetryTracePropagation.current | `public static var current: TraceContextHeaders? { get }` |
+| 39 | func | public | OpenTelemetryTracePropagation.applyCurrent(to:) | `public static func applyCurrent(to request: inout URLRequest)` |
 
 #### Sources/SwarmOpenTelemetry/SwarmTypeAliases.swift
 

--- a/docs/reference/front-facing-api.md
+++ b/docs/reference/front-facing-api.md
@@ -649,7 +649,7 @@ The package exports four public library products:
 | Product | Source surface | Public entry points |
 |---------|----------------|---------------------|
 | `Swarm` | `Sources/Swarm` | Agents, tools, workflows, memory, guardrails, providers, MCP client/bridge, workspace, resilience, observability, macros |
-| `SwarmOpenTelemetry` | `Sources/SwarmOpenTelemetry` | `OpenTelemetryInferenceProvider`, `InferenceProvider.instrumentedWithOpenTelemetry(...)`, `AgentRuntime.instrumentedWithOpenTelemetry(...)`, and `SwarmRuntimeTracer` |
+| `SwarmOpenTelemetry` | `Sources/SwarmOpenTelemetry` | `OpenTelemetryInferenceProvider`, `InferenceProvider.instrumentedWithOpenTelemetry(...)`, `AgentRuntime.instrumentedWithOpenTelemetry(...)`, `OTLPHTTPTraceExporter`, `OpenTelemetryTracing`, `OpenTelemetryTracePropagation`, and `SwarmRuntimeTracer` |
 | `SwarmMembrane` | `Sources/SwarmMembrane` | Re-export product for Swarm's Membrane integration. The target is `@_exported import Swarm`, so public Membrane symbols are the `MembraneEnvironment`, `MembraneFeatureConfiguration`, `MembraneAgentAdapter`, and `DefaultMembraneAgentAdapter` APIs cataloged under `Sources/Swarm/Integration/Membrane/`. |
 | `SwarmMCP` | `Sources/SwarmMCP` | `SwarmMCPServerService`, `SwarmMCPToolCatalog`, `SwarmMCPToolExecutor`, `SwarmMCPToolExecutionError`, and `SwarmMCPToolRegistryAdapter` |
 
@@ -659,16 +659,27 @@ The package exports four public library products:
 import Swarm
 import SwarmOpenTelemetry
 
+OpenTelemetryTracing.configureOTLPHTTPExport()
+
 let tracedAgent = try Agent(
     "Answer briefly.",
     inferenceProvider: .foundationModels()
 ).instrumentedWithOpenTelemetry()
 
 let tracedProvider = myCustomProvider.instrumentedWithOpenTelemetry()
+
+var request = URLRequest(url: endpoint)
+TraceContextHeaders.applyCurrent(to: &request)
 ```
 
-See [OpenTelemetry Tracing](../guide/opentelemetry-tracing.md) for SDK setup and
-URLSession instrumentation policy.
+`OTLPHTTPTraceExporter` posts OTLP/HTTP JSON to
+`http://localhost:4318/v1/traces` by default (no gRPC). Built-in Web tool
+requests inject W3C `traceparent` from the current span. See
+[OpenTelemetry Tracing](../guide/opentelemetry-tracing.md).
+
+`AgentConfiguration.autoAttachMetricsCollector(true)` attaches a
+`MetricsCollector` without passing a tracer; read
+`agent.metricsCollector?.snapshot()`. Default is off.
 
 ### MCP server adapter
 


### PR DESCRIPTION
## Summary

Chunk K of the Swarm remediation series. Chunk J is **merged** (`feat: wire resilience policies into Agent.run` #129). This branch is from current `main`.

Docs promised OTLP export and `traceparent` propagation; `Sources/SwarmOpenTelemetry/` only wrapped spans. This PR makes those promises true with a **minimal in-house OTLP/HTTP JSON exporter** (no gRPC, no new packages) and W3C header injection on outbound HTTP.

### Exporter config surface

```swift
OpenTelemetryTracing.configureOTLPHTTPExport(
    configuration: .default
        .endpoint(URL(string: "http://localhost:4318/v1/traces")!)
        .headers(["Authorization": "Bearer collector-token"])
        .maxBatchSize(64)
        .scheduleDelay(.seconds(5))
)
```

| Setting | Default |
|---|---|
| Endpoint | `http://localhost:4318/v1/traces` |
| Batching | size 64 **or** 5s timer |
| Retry | once, 200ms backoff, on 5xx / network only (not 4xx) |
| Resource | `service.name=swarm` (overridable) |
| Headers | `[:]` (collector auth) |

`OTLPHTTPTraceExporter` implements the OTel SDK `SpanExporter` over `URLSession`. `SwarmOpenTelemetry` now links `OpenTelemetrySdk` from the existing `opentelemetry-swift-core` pin. First-party `OpenTelemetryProtocolExporterHTTP` is **not** added.

### Propagation points wired

- **Public Swarm-core API** (Chunk P should use this; no OTel import): `TraceContextHeaders.current` / `.applyCurrent(to:)` / `.httpHeaders`. Format is exactly `version-traceid-parentid-flags` (lowercase hex).
- **OTel twin:** `OpenTelemetryTracePropagation.current` reads the active span, else the TaskLocal.
- Bound around agent/LLM spans in `OpenTelemetryAgentRuntime`, `OpenTelemetryInferenceProvider`, `OpenTelemetryAnyInferenceProvider`.
- Injected on built-in Web HTTP: Tavily POST, `SafeWebFetcher` GET, and redirects.

### MetricsCollector auto-attach

`AgentConfiguration.autoAttachMetricsCollector` (default **false**) + builder `.autoAttachMetricsCollector(true)`. When on, `Agent.metricsCollector` is composed into the tracer chain.

### Docs before / after

| | Before | After |
|---|---|---|
| Export | Guide implied OTLP / collector export; **zero** exporter code | In-house OTLP/HTTP JSON, endpoint + batch + retry, local Collector YAML |
| Headers | Guide implied trace context on HTTP | W3C `traceparent`/`tracestate` on Web tools + public helper for custom providers |
| URLSession auto-instrumentation | Could be read as shipped | Explicitly **not** installed; optional app-level extra |
| README tracing row | Generic OTel mention | OTLP/HTTP JSON export + W3C `traceparent` |

## Test plan

- [x] `bash scripts/ci/lean-build-test.sh` — **PASS** — `1823 tests in 238 suites`
- [x] `swift test --no-parallel --traits Integrations` — **PASS** — `1968 tests in 261 suites`
- [x] `swift run --traits Integrations SwarmCapabilityShowcase matrix` — all rows `passed`
- [x] Exporter (`OTLPHTTPTraceExporterTests`): OTLP JSON shape + Swarm attributes, flush-at-batch-size, retry-once-on-500, no-retry-on-400
- [x] `traceparent`: regex-valid format; agent trace id + LLM span id end-to-end; Web fetcher injects current headers
- [x] Metrics auto-attach via configuration (default off; builder additive)
- [x] SwiftFormat lint + SwiftLint `--strict` clean on changed files

### Baseline comparison

| Lane | Chunk A (#119 post-fix) | Chunk J (#129) | This PR |
|---|---|---|---|
| lean-build-test | **1719 / 220** | **1809 / 235** | **1823 / 238** |
| Integrations test | **1849 / 239** | **1953 / 258** | **1968 / 261** |
| Showcase matrix | 14/14 passed | all passed | all passed |

No regressions vs A or J. Delta vs J is the new exporter / propagation / metrics suites.

## Breaking changes

**Does this PR introduce breaking changes?**
- [x] No — additive public API; metrics auto-attach defaults off.


Made with [Cursor](https://cursor.com)