### PR TITLE
feat: MCP modernization — stdio transport, version negotiation, envelope unwrap

### DIFF
--- a/Sources/Swarm/MCP/HTTPMCPServer.swift
+++ b/Sources/Swarm/MCP/HTTPMCPServer.swift
@@ -139,8 +139,8 @@ public actor HTTPMCPServer: MCPServerConnection {
 
         let version = try MCPWireCodec.negotiatedVersion(from: result)
         let capabilities = try MCPWireCodec.parseCapabilities(from: result)
-        try await sendNotification(try MCPNotification(method: "notifications/initialized"))
         cachedProtocolVersion = version
+        try await sendNotification(try MCPNotification(method: "notifications/initialized"))
         cachedCapabilities = capabilities
         return capabilities
     }
@@ -184,9 +184,9 @@ public actor HTTPMCPServer: MCPServerConnection {
     /// - Parameters:
     ///   - name: The name of the tool to call.
     ///   - arguments: A dictionary of argument names to values.
-    /// - Returns: The raw result object (`content`, `isError`, …).
-    /// - Throws: `MCPError` if the name is empty, the request fails, or the
-    ///   tool reports `isError`.
+    /// - Returns: The raw result object (`content`, `isError`, …), including
+    ///   envelopes where `isError` is `true`.
+    /// - Throws: `MCPError` if the name is empty or the request fails.
     public func callToolRaw(name: String, arguments: [String: SendableValue]) async throws -> SendableValue {
         try await invokeTool(name: name, arguments: arguments, style: .rawEnvelope)
     }

--- a/Sources/Swarm/MCP/MCPWireCodec.swift
+++ b/Sources/Swarm/MCP/MCPWireCodec.swift
@@ -114,19 +114,18 @@ enum MCPWireCodec {
             return result
         }
 
-        if resultDict["isError"]?.boolValue == true {
-            let detail = toolCallErrorMessage(from: resultDict)
-            throw MCPError(
-                code: MCPError.internalErrorCode,
-                message: "Remote MCP tool '\(toolName)' failed: \(detail)",
-                data: result
-            )
-        }
-
         switch style {
         case .rawEnvelope:
             return result
         case .unwrappedContent:
+            if resultDict["isError"]?.boolValue == true {
+                let detail = toolCallErrorMessage(from: resultDict)
+                throw MCPError(
+                    code: MCPError.internalErrorCode,
+                    message: "Remote MCP tool '\(toolName)' failed: \(detail)",
+                    data: result
+                )
+            }
             return unwrapContent(resultDict["content"])
         }
     }

--- a/Sources/Swarm/MCP/StdioMCPServer.swift
+++ b/Sources/Swarm/MCP/StdioMCPServer.swift
@@ -106,8 +106,8 @@ public actor StdioMCPServer: MCPServerConnection {
         let version = try MCPWireCodec.negotiatedVersion(from: result)
         let capabilities = try MCPWireCodec.parseCapabilities(from: result)
 
-        try await sendNotification(try MCPNotification(method: "notifications/initialized"))
         cachedProtocolVersion = version
+        try await sendNotification(try MCPNotification(method: "notifications/initialized"))
         cachedCapabilities = capabilities
         return capabilities
     }
@@ -338,7 +338,9 @@ public actor StdioMCPServer: MCPServerConnection {
                 )
                 throw MCPError.internalError("Timed out waiting for MCP stdio response to '\(request.method)'")
             }
-            let result = try await group.next()!
+            guard let result = try await group.next() else {
+                throw MCPError.internalError("MCP stdio request produced no response")
+            }
             group.cancelAll()
             return result
         }

--- a/Tests/SwarmTests/MCP/HTTPMCPServerModernizationTests.swift
+++ b/Tests/SwarmTests/MCP/HTTPMCPServerModernizationTests.swift
@@ -73,6 +73,69 @@ struct HTTPMCPServerModernizationTests {
         #expect(raw.dictionaryValue?["content"]?.arrayValue?.isEmpty == false)
     }
 
+    @Test("callToolRaw returns an isError envelope instead of throwing")
+    func callToolRawReturnsIsErrorEnvelope() async throws {
+        let session = try makeSession { _, body in
+            let request = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            let id = request["id"] as? String ?? "1"
+            return try jsonResponse(
+                id: id,
+                result: [
+                    "content": [
+                        ["type": "text", "text": "remote tool failed"]
+                    ],
+                    "isError": true
+                ]
+            )
+        }
+        defer { ModernizationURLProtocol.reset() }
+
+        let server = try HTTPMCPServer(
+            url: URL(string: "https://mcp.example.com/api")!,
+            name: "raw-error-test",
+            maxRetries: 0,
+            session: session
+        )
+
+        let raw = try await server.callToolRaw(name: "explode", arguments: [:])
+        #expect(raw.dictionaryValue?["isError"]?.boolValue == true)
+        #expect(raw.dictionaryValue?["content"]?.arrayValue?.isEmpty == false)
+    }
+
+    @Test("Initialized notification uses the negotiated protocol version")
+    func initializedNotificationUsesNegotiatedVersion() async throws {
+        let session = try makeSession { request, body in
+            let object = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            let method = object["method"] as? String
+            let id = object["id"] as? String ?? "1"
+            if method == "initialize" {
+                return try jsonResponse(
+                    id: id,
+                    result: [
+                        "protocolVersion": MCPProtocolVersion.legacy,
+                        "capabilities": ["tools": [:]]
+                    ]
+                )
+            }
+            if method == "notifications/initialized" {
+                #expect(request.value(forHTTPHeaderField: "MCP-Protocol-Version") == MCPProtocolVersion.legacy)
+                return emptyAccepted()
+            }
+            return try jsonResponse(id: id, result: ["tools": []])
+        }
+        defer { ModernizationURLProtocol.reset() }
+
+        let server = try HTTPMCPServer(
+            url: URL(string: "https://mcp.example.com/api")!,
+            name: "version-header-test",
+            maxRetries: 0,
+            session: session
+        )
+
+        _ = try await server.initialize()
+        #expect(await server.negotiatedProtocolVersion == MCPProtocolVersion.legacy)
+    }
+
     @Test("Empty tool name returns an error instead of trapping")
     func emptyToolNameReturnsError() async throws {
         let server = try HTTPMCPServer(

--- a/Tests/SwarmTests/MCP/MCPProtocolTests.swift
+++ b/Tests/SwarmTests/MCP/MCPProtocolTests.swift
@@ -400,3 +400,29 @@ struct MCPResourceTests {
         }
     }
 }
+
+@Suite("MCPWireCodec Tests")
+struct MCPWireCodecTests {
+    @Test("unwrapped isError envelopes throw")
+    func unwrappedIsErrorThrows() {
+        let envelope: SendableValue = .dictionary([
+            "content": .array([.dictionary(["type": .string("text"), "text": .string("boom")])]),
+            "isError": .bool(true)
+        ])
+
+        #expect(throws: MCPError.self) {
+            _ = try MCPWireCodec.toolCallResult(envelope, toolName: "explode", style: .unwrappedContent)
+        }
+    }
+
+    @Test("rawEnvelope returns isError envelopes")
+    func rawEnvelopeReturnsIsError() throws {
+        let envelope: SendableValue = .dictionary([
+            "content": .array([.dictionary(["type": .string("text"), "text": .string("boom")])]),
+            "isError": .bool(true)
+        ])
+
+        let raw = try MCPWireCodec.toolCallResult(envelope, toolName: "explode", style: .rawEnvelope)
+        #expect(raw == envelope)
+    }
+}


### PR DESCRIPTION
## Summary

Chunk L of the Swarm remediation series. Independent of Chunk K (already merged as #130). Branched from current `origin/main`.

Swarm's MCP client now speaks the protocol the ecosystem actually uses: **stdio** (the common filesystem/git deployment), **streamable HTTP** with version negotiation, and **unwrapped tool results**.

### Task 5 — official SDK: KEEP the custom stack

Timeboxed evaluation of `modelcontextprotocol/swift-sdk` (already a dependency, used by `SwarmMCP` server). **Not adopted as the client.** Concrete blockers:

1. Official `StdioTransport` talks to *this* process's stdin/stdout. It does not spawn a child. Swarm needs a client that launches servers.
2. Type mismatch: `MCP.Value` / `MCP.MCPError` / `CallTool.Result` vs Swarm's public `SendableValue` / `MCPError` / `ToolSchema`. Adoption would leak official types or need a large mapping layer.
3. `MCPClient` is a multi-server aggregator (cache, TTL, name collision) — not provided by official `Client`.
4. Official `HTTPClientTransport` SSE is `#if !os(Linux)` (EventSource). Linux CI would lose streaming HTTP.
5. `MCP.MCPError` name-collides with Swarm's `MCPError` if core imports the SDK.

Official SDK remains the **server** implementation in the `SwarmMCP` product. The custom client is hardened instead.

### Transport matrix

| Transport | Type | Version negotiation | Session | Result shape |
|---|---|---|---|---|
| `StdioMCPServer` | Child process, NDJSON on stdin/stdout | Offers `2025-11-25`; accepts `2024-11-05`…`2025-11-25` | Process lifecycle (stderr capture, SIGTERM→SIGKILL) | Unwrapped by default |
| `HTTPMCPServer` | Streamable HTTP POST | Same; `MCP-Protocol-Version` header | `MCP-Session-Id` captured and forwarded | Unwrapped by default; SSE `data:` accepted |

Unsupported server versions throw `MCPError.unsupportedProtocolVersion` — never silently assumed.

### Envelope unwrap + capabilities honesty

- `callTool` unwraps MCP content blocks (single `text` → `.string`).
- `callToolRaw` is the explicit opt-in for the raw envelope (`content`, `isError`, …).
- **prompts/sampling: de-advertised, not implemented.** Sampling is server-initiated and needs an inference provider; prompts are unused by Swarm agents. Connection types always report `false`. Fields kept for source compatibility.
- Empty tool name and empty `MCPResponse` factory ids throw `MCPError` instead of `precondition`.

### Naming

`MCPServer` (a *client* connection) → `MCPServerConnection`. Deprecated typealias kept. In-repo conformances/usages updated (Sources, Tests, showcase).

### Interop tests (exit gate)

Real MCP peer: `Tests/SwarmTests/MCP/Fixtures/mcp_fixture_server.py` (not a Swarm-type mock).

```
Suite "MCP Interop Tests" passed after 1.013 seconds.
  Stdio transport completes initialize, tools/list, and tools/call  passed
  HTTP transport completes initialize, tools/list, and tools/call   passed
  Stdio empty tool name returns an error                            passed
```

python3 is required on CI images (macOS + Linux). Fixture is excluded from the SwarmTests target and located via `#filePath`.

## Test plan

- [x] `bash scripts/ci/lean-build-test.sh` — **PASS** — `1837 tests in 241 suites`
- [x] `swift test --no-parallel --traits Integrations` — **PASS** — `1982 tests in 264 suites`
- [x] `swift run --traits Integrations SwarmCapabilityShowcase matrix` — all rows `passed` (including `mcp`)
- [x] Interop: initialize + `tools/list` + `tools/call` over **both** transports
- [x] Version negotiation: current + legacy accepted; unknown version fails loudly
- [x] Envelope unwrap + `callToolRaw`; empty tool name returns `invalidParams`
- [x] SwiftFormat lint + SwiftLint `--strict` clean on changed MCP files

### Baseline comparison

| Lane | Chunk A (#119) | Chunk K (#130) | This PR |
|---|---|---|---|
| lean-build-test | **1719 / 220** | **1823 / 238** | **1837 / 241** |
| Integrations test | **1849 / 239** | **1968 / 261** | **1982 / 264** |
| Showcase matrix | 14/14 passed | all passed | all passed |

No regressions vs A or K. Delta is the new MCP modernization / interop suites.

## Deprecation notes

- `MCPServer` → `MCPServerConnection` (`@available(*, deprecated, renamed:)`).
- `MCPCapabilities.prompts` / `.sampling` remain but are unused by Swarm's client (always `false` on built-in connections).
- `callTool` **behavior change**: returns unwrapped content instead of the raw envelope. Use `callToolRaw` to keep the old shape. Mocks that already returned a string are unchanged.

## Breaking changes

**Does this PR introduce breaking changes?**
- [x] Behavior change (non-source-breaking): `callTool` unwraps envelopes. Migrate envelope consumers to `callToolRaw`.
- [ ] Source-breaking removals — no; `MCPServer` typealias kept.

## Checkpoint history

Completed in one session. Handoff for Chunk M is in local `docs/plans/chunk-m-brief.md` (git-ignored, not staged).


Made with [Cursor](https://cursor.com)