### PR TITLE
build: default-on Macros trait, relaxed pins, orphan dependency removal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ Swarm/
 │   │   ├── Guardrails/            # Input/Output/Tool guardrail specs + runner
 │   │   ├── Resilience/            # Retry, circuit breaker, fallback, rate limit
 │   │   ├── Observability/         # AgentTracer, SwiftLog/OSLog tracers, metrics
-│   │   ├── MCP/                   # MCPClient, MCPServer, ToolBridge, capabilities
+│   │   ├── MCP/                   # MCPClient, MCPServerConnection, stdio/HTTP transports, ToolBridge
 │   │   ├── Workspace/             # AgentWorkspace (AGENTS.md, .swarm/ skills)
 │   │   ├── Macros/                # Public macro declarations
 │   │   ├── Integration/           # Membrane and Wax integrations

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,8 @@ Integrations is on. ContextCore / full Membrane session stack are Apple-only
 Wax remains a remote package + trait-gated product; MetalANNS stays remote for
 the ContextCore chain. Lean resolve must not pull package identities `hive`,
 `membrane`, `contextcore`, or `conduit`, and must not pin Wax/MetalANNS/GRDB/
-crypto/mutex/SwiftSoup (trait-gated product edges). Always-on: swift-syntax,
+crypto/mutex/SwiftSoup (trait-gated product edges). Default-on: swift-syntax
+(via the Macros trait; disable with `traits: []`),
 swift-log, MCP sdk, OTel (+ NIO transitives; `swift-collections` via NIO is
 OK). CI: `scripts/ci/lean-build-test.sh` (cold resolve + product-scoped lean
 build + `SWARM_OMIT_INTEGRATION_TARGETS=1` tests) and

--- a/Fixtures/MacrosDisabledConsumer/Package.swift
+++ b/Fixtures/MacrosDisabledConsumer/Package.swift
@@ -1,0 +1,38 @@
+// swift-tools-version: 6.2
+import PackageDescription
+
+let package = Package(
+    name: "MacrosDisabledConsumer",
+    platforms: [
+        .macOS(.v26),
+        .iOS(.v26),
+    ],
+    products: [
+        .library(name: "MacrosDisabledConsumer", targets: ["MacrosDisabledConsumer"]),
+    ],
+    dependencies: [
+        // Empty traits disable default-on Macros and must resolve without swift-syntax.
+        .package(name: "Swarm", path: "../..", traits: []),
+    ],
+    targets: [
+        .target(
+            name: "MacrosDisabledConsumer",
+            dependencies: [
+                .product(name: "Swarm", package: "Swarm"),
+            ],
+            swiftSettings: [
+                .enableExperimentalFeature("StrictConcurrency"),
+            ]
+        ),
+        .testTarget(
+            name: "MacrosDisabledConsumerTests",
+            dependencies: [
+                "MacrosDisabledConsumer",
+                .product(name: "Swarm", package: "Swarm"),
+            ],
+            swiftSettings: [
+                .enableExperimentalFeature("StrictConcurrency"),
+            ]
+        ),
+    ]
+)

--- a/Fixtures/MacrosDisabledConsumer/Sources/MacrosDisabledConsumer/MacrosDisabledConsumer.swift
+++ b/Fixtures/MacrosDisabledConsumer/Sources/MacrosDisabledConsumer/MacrosDisabledConsumer.swift
@@ -1,0 +1,25 @@
+import Swarm
+
+/// Macro-free consumer surface used by the CI fixture.
+///
+/// This module depends on Swarm with `traits: []` (Macros disabled) and must
+/// compile using ``FunctionTool`` instead of `@Tool` / `@Parameter`.
+public enum MacrosDisabledConsumer {
+    /// Builds a `FunctionTool` echo helper for the fixture smoke test.
+    public static func makeEchoTool() -> FunctionTool {
+        FunctionTool(
+            name: "echo",
+            description: "Echoes a message",
+            parameters: [
+                ToolParameter(
+                    name: "message",
+                    description: "Text to echo",
+                    type: .string
+                ),
+            ]
+        ) { args in
+            let message = try args.require("message", as: String.self)
+            return .string("echo:\(message)")
+        }
+    }
+}

--- a/Fixtures/MacrosDisabledConsumer/Tests/MacrosDisabledConsumerTests/FunctionToolSmokeTests.swift
+++ b/Fixtures/MacrosDisabledConsumer/Tests/MacrosDisabledConsumerTests/FunctionToolSmokeTests.swift
@@ -1,0 +1,13 @@
+import Swarm
+import Testing
+@testable import MacrosDisabledConsumer
+
+@Suite("Macros-disabled consumer")
+struct FunctionToolSmokeTests {
+    @Test("FunctionTool executes without @Tool macros")
+    func functionToolEchoesMessage() async throws {
+        let tool = MacrosDisabledConsumer.makeEchoTool()
+        let result = try await tool.execute(arguments: ["message": .string("hi")])
+        #expect(result.stringValue == "echo:hi")
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -38,6 +38,7 @@ var packageDependencies: [Package.Dependency] = [
     // on toolchains/prebuilts that work with Swift 6.2 / Xcode 26.
     // Only SwarmMacros (+ SwiftSyntaxMacrosTestSupport in tests) depends on
     // swift-syntax. Upper bound stays <603 for package-graph stability.
+    // Product edges are Macros-trait-gated so consumers can drop the pin.
     .package(url: "https://github.com/swiftlang/swift-syntax.git", "601.0.0"..<"603.0.0"),
     .package(url: "https://github.com/apple/swift-log.git", from: "1.12.0"),
     .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.12.1"),
@@ -53,6 +54,7 @@ var packageDependencies: [Package.Dependency] = [
 // Accelerate). They are trait-linked only on Apple platforms so Linux
 // Integrations can still build Hive + MembraneCore + web helpers without
 // compiling the GPU memory stack.
+let macrosTrait = "Macros"
 let integrationTrait = "Integrations"
 let appleIntegrationPlatforms: [Platform] = [.macOS, .iOS, .tvOS, .visionOS]
 if enableIntegrationModules {
@@ -63,8 +65,12 @@ if enableIntegrationModules {
         // collections/MetalANNS). With Integrations off, SPM does not pin them.
         // SWARM_CORE_ONLY=1 or SWARM_OMIT_INTEGRATION_TARGETS=1 drops this block.
         .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.13.5"),
-        .package(url: "https://github.com/christopherkarani/Wax.git", exact: "0.1.23"),
-        .package(url: "https://github.com/christopherkarani/MetalANNS.git", exact: "0.1.3"),
+        // Floor at the previously exact pin. 0.1.24 fails to clone (broken
+        // homebrew-wax submodule ref). 0.1.25 makes FrameStore.close()/frames()
+        // throwing and breaks WaxMemory + WaxMembraneStorage. Revisit after
+        // adapting to the throwing API.
+        .package(url: "https://github.com/christopherkarani/Wax.git", "0.1.23"..<"0.1.24"),
+        .package(url: "https://github.com/christopherkarani/MetalANNS.git", from: "0.1.3"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "3.7.0"),
         .package(url: "https://github.com/swhitty/swift-mutex.git", from: "0.0.6"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),
@@ -72,7 +78,7 @@ if enableIntegrationModules {
 }
 
 var swarmDependencies: [Target.Dependency] = [
-    "SwarmMacros",
+    .target(name: "SwarmMacros", condition: .when(traits: [macrosTrait])),
     .product(name: "Logging", package: "swift-log"),
 ]
 
@@ -106,6 +112,8 @@ if enableIntegrationModules {
     swarmSwiftSettings.append(.define("SWARM_INTEGRATIONS", .when(traits: [integrationTrait])))
 }
 
+swarmSwiftSettings.append(.define("SWARM_MACROS", .when(traits: [macrosTrait])))
+
 let swarmCoreOnlyExcludes = [
     "Integration/Wax",
     "Integration/Membrane/SessionMembraneAgentAdapter.swift",
@@ -124,12 +132,28 @@ var packageTargets: [Target] = [
     .macro(
         name: "SwarmMacros",
         dependencies: [
-            .product(name: "SwiftSyntax", package: "swift-syntax"),
-            .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
-            .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
-            .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
-            .product(name: "SwiftDiagnostics", package: "swift-syntax"),
-            .product(name: "SwiftParser", package: "swift-syntax")
+            .product(name: "SwiftSyntax", package: "swift-syntax", condition: .when(traits: [macrosTrait])),
+            .product(
+                name: "SwiftSyntaxMacros",
+                package: "swift-syntax",
+                condition: .when(traits: [macrosTrait])
+            ),
+            .product(
+                name: "SwiftCompilerPlugin",
+                package: "swift-syntax",
+                condition: .when(traits: [macrosTrait])
+            ),
+            .product(
+                name: "SwiftSyntaxBuilder",
+                package: "swift-syntax",
+                condition: .when(traits: [macrosTrait])
+            ),
+            .product(
+                name: "SwiftDiagnostics",
+                package: "swift-syntax",
+                condition: .when(traits: [macrosTrait])
+            ),
+            .product(name: "SwiftParser", package: "swift-syntax", condition: .when(traits: [macrosTrait])),
         ],
         swiftSettings: [
             .enableExperimentalFeature("StrictConcurrency")
@@ -217,8 +241,12 @@ var packageTargets: [Target] = [
         name: "SwarmMacrosTests",
         dependencies: [
             "Swarm",
-            "SwarmMacros",
-            .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax")
+            .target(name: "SwarmMacros", condition: .when(traits: [macrosTrait])),
+            .product(
+                name: "SwiftSyntaxMacrosTestSupport",
+                package: "swift-syntax",
+                condition: .when(traits: [macrosTrait])
+            ),
         ],
         swiftSettings: [
             .enableExperimentalFeature("StrictConcurrency")
@@ -333,11 +361,6 @@ if enableIntegrationModules {
             dependencies: [
                 "ContextCoreShaders",
                 "ContextCoreTypes",
-                .product(
-                    name: "MetalANNS",
-                    package: "MetalANNS",
-                    condition: integrationsAppleRemoteDepsActive
-                ),
             ],
             path: "Sources/ContextCoreEngine",
             swiftSettings: integrationsTargetSwiftSettings,
@@ -414,8 +437,19 @@ let package = Package(
     ],
     products: packageProducts,
     traits: [
-        // Lean default: core Swarm + Foundation Models only. Opt in for full graph.
-        .default(enabledTraits: []),
+        // Macros on by default (SE-0450). Consumers disable with `traits: []` to
+        // drop swift-syntax; FunctionTool is the macro-free tool path.
+        // Integrations enables Macros so existing `traits: ["Integrations"]`
+        // consumers keep @Tool (specifying traits replaces defaults).
+        .default(enabledTraits: [macrosTrait]),
+        .trait(
+            name: macrosTrait,
+            description: """
+            Enable Swarm compiler macros (@Tool, @Parameter, #Prompt, @Traceable, \
+            and related plugins). On by default. Disable to drop the swift-syntax \
+            dependency; use FunctionTool for the macro-free tool path.
+            """
+        ),
         .trait(
             name: integrationTrait,
             description: """
@@ -424,8 +458,9 @@ let package = Package(
             ContextCore are native in-tree Sources/ targets (internal; not separate products). \
             ContextCore / full Membrane session stack require Apple platforms (Metal/CoreML); \
             Linux Integrations still gets Hive + MembraneCore + web helpers. \
-            Wax remains an external package for now.
-            """
+            Wax remains an external package for now. Enabling Integrations also enables Macros.
+            """,
+            enabledTraits: [macrosTrait]
         ),
     ],
     dependencies: packageDependencies,

--- a/Package.swift
+++ b/Package.swift
@@ -209,6 +209,7 @@ var packageTargets: [Target] = [
             }
             return dependencies
         }(),
+        exclude: ["MCP/Fixtures"],
         resources: [],
         swiftSettings: swarmSwiftSettings
     ),

--- a/README.md
+++ b/README.md
@@ -30,21 +30,43 @@ Two agents, one pipeline, compiled to a DAG. Crash recovery is opt-in — enable
 
 Default **link** is **lean**: core Swarm + on-device Foundation Models. Graph/memory/web/Hive paths are trait-gated (off by default) and are not linked into Swarm unless you enable Integrations.
 
-HiveCore, Membrane, and ContextCore are **native in-tree** `Sources/` targets (internal modules — not separate library products). Enabling Integrations **links** those modules plus Wax (still remote) and SwiftSoup; omitting the trait does not link them into Swarm. Lean resolve never pulls Hive/Membrane/ContextCore/Conduit **package identities**, and (with trait-gated product edges) also does **not** pin Wax, MetalANNS→GRDB, swift-crypto, swift-mutex, or SwiftSoup. Always-on remotes remain (swift-syntax, swift-log, MCP sdk, OTel, plus NIO transitives — including `swift-collections` via NIO). `SWARM_CORE_ONLY=1` drops the integration package block entirely. ContextCore / full Membrane session stack require Apple platforms (Metal/CoreML); Linux Integrations still builds Hive + MembraneCore + web helpers. DefaultAgentMemory uses a CoreML MiniLM model that is **not** bundled — call `SemanticEmbeddingAvailability.ensureModelAvailable()` to download it on demand. Without the model, ContextCore falls back to deterministic pseudo-embeddings, logs a once-per-process warning naming that API, and `DefaultAgentMemory.isSemanticMemoryAvailable` reports `false`.
+HiveCore, Membrane, and ContextCore are **native in-tree** `Sources/` targets (internal modules — not separate library products). Enabling Integrations **links** those modules plus Wax (still remote) and SwiftSoup; omitting the trait does not link them into Swarm. Lean resolve never pulls Hive/Membrane/ContextCore/Conduit **package identities**, and (with trait-gated product edges) also does **not** pin Wax, MetalANNS→GRDB, swift-crypto, swift-mutex, or SwiftSoup. Default remotes remain (swift-syntax via the default-on **Macros** trait, swift-log, MCP sdk, OTel, plus NIO transitives — including `swift-collections` via NIO). Disable Macros with `traits: []` to drop swift-syntax; use `FunctionTool` instead of `@Tool`. `SWARM_CORE_ONLY=1` drops the integration package block entirely. ContextCore / full Membrane session stack require Apple platforms (Metal/CoreML); Linux Integrations still builds Hive + MembraneCore + web helpers. DefaultAgentMemory uses a CoreML MiniLM model that is **not** bundled — call `SemanticEmbeddingAvailability.ensureModelAvailable()` to download it on demand. Without the model, ContextCore falls back to deterministic pseudo-embeddings, logs a once-per-process warning naming that API, and `DefaultAgentMemory.isSemanticMemoryAvailable` reports `false`.
 
 **Root-package note:** bare `swift build` / `swift test` on this repo compile every registered target, so integration modules need either `--traits Integrations` or the lean CI helper (`scripts/ci/lean-build-test.sh`). App consumers only build reachable targets and stay lean without that helper.
 
 ```swift
-// Lean default link (recommended for most apps)
+// Lean default link (recommended for most apps). Macros are on by default.
 .package(url: "https://github.com/christopherkarani/Swarm.git", from: "0.6.0")
 
 // Full integrations: durable Hive workflows, ContextCore+Wax default memory,
-// Membrane adapters, and web helpers
+// Membrane adapters, and web helpers. Integrations also enables Macros.
 .package(
     url: "https://github.com/christopherkarani/Swarm.git",
     from: "0.6.0",
     traits: ["Integrations"]
 )
+
+// Macro-free lean: drops swift-syntax. You lose @Tool, @Parameter, #Prompt,
+// and @Traceable — use FunctionTool instead.
+.package(
+    url: "https://github.com/christopherkarani/Swarm.git",
+    from: "0.6.0",
+    traits: []
+)
+```
+
+```swift
+// FunctionTool compiles without the Macros trait
+let echo = FunctionTool(
+    name: "echo",
+    description: "Echoes a message",
+    parameters: [
+        ToolParameter(name: "message", description: "Text to echo", type: .string)
+    ]
+) { args in
+    let message = try args.require("message", as: String.self)
+    return .string(message)
+}
 ```
 
 From a checkout of this package:

--- a/Sources/Swarm/Core/AgentRuntime.swift
+++ b/Sources/Swarm/Core/AgentRuntime.swift
@@ -262,7 +262,6 @@ public protocol InferenceProvider: Sendable {
 ///     .maxTokens(2000)
 ///     .stopSequences("END", "STOP")
 /// ```
-@Builder
 public struct InferenceOptions: Sendable, Equatable {
     /// Default inference options.
     public static let `default` = InferenceOptions()
@@ -402,6 +401,120 @@ public struct InferenceOptions: Sendable, Equatable {
         self.previousResponseId = previousResponseId
         self.structuredOutput = structuredOutput
         self.reasoning = reasoning
+    }
+
+    // MARK: - Fluent Builders
+
+    @discardableResult
+    public func temperature(_ value: Double) -> Self {
+        var copy = self
+        copy.temperature = value
+        return copy
+    }
+
+    @discardableResult
+    public func maxTokens(_ value: Int?) -> Self {
+        var copy = self
+        copy.maxTokens = value
+        return copy
+    }
+
+    @discardableResult
+    public func stopSequences(_ value: [String]) -> Self {
+        var copy = self
+        copy.stopSequences = value
+        return copy
+    }
+
+    @discardableResult
+    public func topP(_ value: Double?) -> Self {
+        var copy = self
+        copy.topP = value
+        return copy
+    }
+
+    @discardableResult
+    public func topK(_ value: Int?) -> Self {
+        var copy = self
+        copy.topK = value
+        return copy
+    }
+
+    @discardableResult
+    public func presencePenalty(_ value: Double?) -> Self {
+        var copy = self
+        copy.presencePenalty = value
+        return copy
+    }
+
+    @discardableResult
+    public func frequencyPenalty(_ value: Double?) -> Self {
+        var copy = self
+        copy.frequencyPenalty = value
+        return copy
+    }
+
+    @discardableResult
+    public func toolChoice(_ value: ToolChoice?) -> Self {
+        var copy = self
+        copy.toolChoice = value
+        return copy
+    }
+
+    @discardableResult
+    public func seed(_ value: Int?) -> Self {
+        var copy = self
+        copy.seed = value
+        return copy
+    }
+
+    @discardableResult
+    public func parallelToolCalls(_ value: Bool?) -> Self {
+        var copy = self
+        copy.parallelToolCalls = value
+        return copy
+    }
+
+    @discardableResult
+    public func truncation(_ value: TruncationStrategy?) -> Self {
+        var copy = self
+        copy.truncation = value
+        return copy
+    }
+
+    @discardableResult
+    public func verbosity(_ value: Verbosity?) -> Self {
+        var copy = self
+        copy.verbosity = value
+        return copy
+    }
+
+    @discardableResult
+    public func providerSettings(_ value: [String: SendableValue]?) -> Self {
+        var copy = self
+        copy.providerSettings = value
+        return copy
+    }
+
+    @discardableResult
+    public func previousResponseId(_ value: String?) -> Self {
+        var copy = self
+        copy.previousResponseId = value
+        return copy
+    }
+
+    @discardableResult
+    public func structuredOutput(_ value: StructuredOutputRequest?) -> Self {
+        var copy = self
+        copy.structuredOutput = value
+        return copy
+    }
+
+    @discardableResult
+    public func reasoning(_ value: ReasoningConfig?) -> Self {
+        var copy = self
+        copy.reasoning = value
+        return copy
     }
 
     // MARK: - Special Builder Methods

--- a/Sources/Swarm/Core/ModelSettings.swift
+++ b/Sources/Swarm/Core/ModelSettings.swift
@@ -38,7 +38,6 @@ import Foundation
 /// let merged = base.merged(with: override)
 /// // Result: temperature 0.7, maxTokens 2048
 /// ```
-@Builder
 public struct ModelSettings: Sendable, Equatable {
     // MARK: - Sampling Parameters
 
@@ -205,6 +204,129 @@ public struct ModelSettings: Sendable, Equatable {
         self.minP = minP
         self.providerSettings = providerSettings
         self.reasoning = reasoning
+    }
+}
+
+// MARK: - Fluent Builders
+
+public extension ModelSettings {
+    @discardableResult
+    func temperature(_ value: Double?) -> Self {
+        var copy = self
+        copy.temperature = value
+        return copy
+    }
+
+    @discardableResult
+    func topP(_ value: Double?) -> Self {
+        var copy = self
+        copy.topP = value
+        return copy
+    }
+
+    @discardableResult
+    func topK(_ value: Int?) -> Self {
+        var copy = self
+        copy.topK = value
+        return copy
+    }
+
+    @discardableResult
+    func maxTokens(_ value: Int?) -> Self {
+        var copy = self
+        copy.maxTokens = value
+        return copy
+    }
+
+    @discardableResult
+    func frequencyPenalty(_ value: Double?) -> Self {
+        var copy = self
+        copy.frequencyPenalty = value
+        return copy
+    }
+
+    @discardableResult
+    func presencePenalty(_ value: Double?) -> Self {
+        var copy = self
+        copy.presencePenalty = value
+        return copy
+    }
+
+    @discardableResult
+    func stopSequences(_ value: [String]?) -> Self {
+        var copy = self
+        copy.stopSequences = value
+        return copy
+    }
+
+    @discardableResult
+    func seed(_ value: Int?) -> Self {
+        var copy = self
+        copy.seed = value
+        return copy
+    }
+
+    @discardableResult
+    func toolChoice(_ value: ToolChoice?) -> Self {
+        var copy = self
+        copy.toolChoice = value
+        return copy
+    }
+
+    @discardableResult
+    func parallelToolCalls(_ value: Bool?) -> Self {
+        var copy = self
+        copy.parallelToolCalls = value
+        return copy
+    }
+
+    @discardableResult
+    func truncation(_ value: TruncationStrategy?) -> Self {
+        var copy = self
+        copy.truncation = value
+        return copy
+    }
+
+    @discardableResult
+    func verbosity(_ value: Verbosity?) -> Self {
+        var copy = self
+        copy.verbosity = value
+        return copy
+    }
+
+    @discardableResult
+    func promptCacheRetention(_ value: CacheRetention?) -> Self {
+        var copy = self
+        copy.promptCacheRetention = value
+        return copy
+    }
+
+    @discardableResult
+    func repetitionPenalty(_ value: Double?) -> Self {
+        var copy = self
+        copy.repetitionPenalty = value
+        return copy
+    }
+
+    @discardableResult
+    func minP(_ value: Double?) -> Self {
+        var copy = self
+        copy.minP = value
+        return copy
+    }
+
+    @discardableResult
+    func providerSettings(_ value: [String: SendableValue]?) -> Self {
+        var copy = self
+        copy.providerSettings = value
+        return copy
+    }
+
+    @discardableResult
+    func reasoning(_ value: ReasoningConfig?) -> Self {
+        var copy = self
+        copy.reasoning = value
+        return copy
     }
 }
 

--- a/Sources/Swarm/MCP/HTTPMCPServer.swift
+++ b/Sources/Swarm/MCP/HTTPMCPServer.swift
@@ -12,9 +12,11 @@ import Foundation
 
 /// An HTTP-based client for Model Context Protocol (MCP) servers.
 ///
-/// HTTPMCPServer provides a stateless HTTP transport for communicating with
-/// MCP-compliant servers. It handles JSON-RPC 2.0 request/response encoding,
-/// automatic retries with exponential backoff, and capability negotiation.
+/// HTTPMCPServer speaks the streamable HTTP transport: JSON-RPC over POST
+/// with `Accept: application/json, text/event-stream`, `MCP-Protocol-Version`,
+/// and `MCP-Session-Id` when the server assigns one. Responses may be a
+/// JSON body or an SSE `data:` event. The client negotiates protocol version
+/// on initialize and fails loudly on unsupported servers.
 ///
 /// ## Example Usage
 ///
@@ -47,7 +49,7 @@ import Foundation
 ///
 /// HTTPMCPServer is implemented as an actor, ensuring thread-safe access
 /// to mutable state such as cached capabilities.
-public actor HTTPMCPServer: MCPServer {
+public actor HTTPMCPServer: MCPServerConnection {
     // MARK: Public
 
     // MARK: - Public Properties
@@ -61,6 +63,18 @@ public actor HTTPMCPServer: MCPServer {
     /// Call `initialize()` to populate capabilities from the server.
     public var capabilities: MCPCapabilities {
         cachedCapabilities ?? MCPCapabilities()
+    }
+
+    /// The protocol version negotiated during ``initialize()``.
+    ///
+    /// `nil` until initialize succeeds.
+    public var negotiatedProtocolVersion: String? {
+        cachedProtocolVersion
+    }
+
+    /// The session identifier assigned by a streamable HTTP server, if any.
+    public var sessionID: String? {
+        cachedSessionID
     }
 
     // MARK: - Initialization
@@ -101,26 +115,18 @@ public actor HTTPMCPServer: MCPServer {
         decoder = JSONDecoder()
     }
 
-    // MARK: - MCPServer Protocol Implementation
+    // MARK: - MCPServerConnection Protocol Implementation
 
     /// Initializes the connection to the MCP server and negotiates capabilities.
     ///
-    /// Sends an "initialize" request with protocol version and client information,
-    /// then parses and caches the server's capabilities.
+    /// Sends an "initialize" request offering ``MCPProtocolVersion/current``,
+    /// accepts any version in ``MCPProtocolVersion/supported``, and throws
+    /// ``MCPError/unsupportedProtocolVersion(_:)`` otherwise.
     ///
     /// - Returns: The capabilities supported by this server.
-    /// - Throws: `MCPError` if initialization fails.
+    /// - Throws: `MCPError` if initialization or version negotiation fails.
     public func initialize() async throws -> MCPCapabilities {
-        let params: [String: SendableValue] = [
-            "protocolVersion": .string("2024-11-05"),
-            "capabilities": .dictionary([:]),
-            "clientInfo": .dictionary([
-                "name": .string("Swarm"),
-                "version": .string("1.0.0")
-            ])
-        ]
-
-        let request = try MCPRequest(method: "initialize", params: params)
+        let request = try MCPRequest(method: "initialize", params: MCPWireCodec.initializeParameters())
         let response = try await sendRequest(request)
 
         if let error = response.error {
@@ -131,8 +137,10 @@ public actor HTTPMCPServer: MCPServer {
             throw MCPError.internalError("No result in initialize response")
         }
 
-        let capabilities = try parseCapabilities(from: result)
+        let version = try MCPWireCodec.negotiatedVersion(from: result)
+        let capabilities = try MCPWireCodec.parseCapabilities(from: result)
         try await sendNotification(try MCPNotification(method: "notifications/initialized"))
+        cachedProtocolVersion = version
         cachedCapabilities = capabilities
         return capabilities
     }
@@ -153,35 +161,34 @@ public actor HTTPMCPServer: MCPServer {
             throw MCPError.internalError("No result in tools/list response")
         }
 
-        return try parseTools(from: result)
+        return try MCPWireCodec.parseTools(from: result)
     }
 
-    /// Calls a tool on the MCP server with the specified arguments.
+    /// Calls a tool and returns unwrapped content blocks.
+    ///
+    /// A single MCP `text` content block becomes a `.string`. Use
+    /// ``callToolRaw(name:arguments:)`` to keep the protocol envelope.
     ///
     /// - Parameters:
     ///   - name: The name of the tool to call.
     ///   - arguments: A dictionary of argument names to values.
-    /// - Returns: The result of the tool execution.
-    /// - Throws: `MCPError` if the request fails.
+    /// - Returns: The unwrapped tool result.
+    /// - Throws: `MCPError` if the name is empty, the request fails, or the
+    ///   tool reports `isError`.
     public func callTool(name: String, arguments: [String: SendableValue]) async throws -> SendableValue {
-        let params: [String: SendableValue] = [
-            "name": .string(name),
-            "arguments": .dictionary(arguments)
-        ]
+        try await invokeTool(name: name, arguments: arguments, style: .unwrappedContent)
+    }
 
-        let request = try MCPRequest(method: "tools/call", params: params)
-        let response = try await sendRequest(request)
-
-        if let error = response.error {
-            throw MCPError(code: error.code, message: error.message, data: error.data)
-        }
-
-        guard let result = response.result else {
-            throw MCPError.internalError("No result in tools/call response")
-        }
-
-        try validateToolCallResult(result, toolName: name)
-        return result
+    /// Calls a tool and returns the raw `tools/call` envelope.
+    ///
+    /// - Parameters:
+    ///   - name: The name of the tool to call.
+    ///   - arguments: A dictionary of argument names to values.
+    /// - Returns: The raw result object (`content`, `isError`, …).
+    /// - Throws: `MCPError` if the name is empty, the request fails, or the
+    ///   tool reports `isError`.
+    public func callToolRaw(name: String, arguments: [String: SendableValue]) async throws -> SendableValue {
+        try await invokeTool(name: name, arguments: arguments, style: .rawEnvelope)
     }
 
     /// Lists all resources available from this MCP server.
@@ -200,7 +207,7 @@ public actor HTTPMCPServer: MCPServer {
             throw MCPError.internalError("No result in resources/list response")
         }
 
-        return try parseResources(from: result)
+        return try MCPWireCodec.parseResources(from: result)
     }
 
     /// Reads the content of a resource from the MCP server.
@@ -252,15 +259,17 @@ public actor HTTPMCPServer: MCPServer {
             throw MCPError.internalError("No result in resources/read response")
         }
 
-        return try parseResourceContent(from: result)
+        return try MCPWireCodec.parseResourceContent(from: result)
     }
 
     /// Closes the connection to the MCP server.
     ///
-    /// For HTTP, this simply clears the cached capabilities since the
-    /// transport is stateless. It is safe to call multiple times.
+    /// Clears cached capabilities, the negotiated version, and the session
+    /// id. It is safe to call multiple times.
     public func close() async throws {
         cachedCapabilities = nil
+        cachedProtocolVersion = nil
+        cachedSessionID = nil
     }
 
     // MARK: Private
@@ -284,6 +293,12 @@ public actor HTTPMCPServer: MCPServer {
 
     /// Cached capabilities from the server.
     private var cachedCapabilities: MCPCapabilities?
+
+    /// Protocol version accepted during initialize.
+    private var cachedProtocolVersion: String?
+
+    /// Streamable HTTP session identifier, when the server assigned one.
+    private var cachedSessionID: String?
 
     /// JSON encoder for requests.
     private let encoder: JSONEncoder
@@ -383,27 +398,17 @@ public actor HTTPMCPServer: MCPServer {
     /// - Returns: The MCP response from the server.
     /// - Throws: `MCPError` if the request fails.
     private func performRequest(_ mcpRequest: MCPRequest) async throws -> MCPResponse {
-        var urlRequest = URLRequest(url: baseURL)
-        urlRequest.httpMethod = "POST"
-        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        urlRequest.timeoutInterval = timeout
-
-        if let apiKey {
-            urlRequest.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
-        }
-
-        urlRequest.httpBody = try encoder.encode(mcpRequest)
-
+        let urlRequest = try makeStreamableRequest(body: encoder.encode(mcpRequest))
         let (data, response) = try await session.data(for: urlRequest)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw MCPError.internalError("Invalid response type")
         }
 
-        // Check for HTTP errors
+        captureSessionID(from: httpResponse)
+
         let statusCode = httpResponse.statusCode
         guard (200 ... 299).contains(statusCode) else {
-            // Try to decode error message from response body
             let errorMessage = if let bodyString = String(data: data, encoding: .utf8), !bodyString.isEmpty {
                 "HTTP \(statusCode): \(bodyString)"
             } else {
@@ -413,7 +418,8 @@ public actor HTTPMCPServer: MCPServer {
             throw MCPError(code: statusCode, message: errorMessage)
         }
 
-        return try decoder.decode(MCPResponse.self, from: data)
+        let payload = try decodeHTTPBody(data, response: httpResponse)
+        return try decoder.decode(MCPResponse.self, from: payload)
     }
 
     /// Performs a single HTTP notification request to the MCP server.
@@ -421,22 +427,14 @@ public actor HTTPMCPServer: MCPServer {
     /// - Parameter notification: The JSON-RPC notification to send.
     /// - Throws: `MCPError` if the request fails.
     private func performNotification(_ notification: MCPNotification) async throws {
-        var urlRequest = URLRequest(url: baseURL)
-        urlRequest.httpMethod = "POST"
-        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        urlRequest.timeoutInterval = timeout
-
-        if let apiKey {
-            urlRequest.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
-        }
-
-        urlRequest.httpBody = try encoder.encode(notification)
-
+        let urlRequest = try makeStreamableRequest(body: encoder.encode(notification))
         let (data, response) = try await session.data(for: urlRequest)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw MCPError.internalError("Invalid response type")
         }
+
+        captureSessionID(from: httpResponse)
 
         let statusCode = httpResponse.statusCode
         guard (200 ... 299).contains(statusCode) else {
@@ -450,263 +448,71 @@ public actor HTTPMCPServer: MCPServer {
         }
     }
 
-    // MARK: - Parsing Helpers
+    private func invokeTool(
+        name: String,
+        arguments: [String: SendableValue],
+        style: MCPToolResultStyle
+    ) async throws -> SendableValue {
+        try MCPWireCodec.requireToolName(name)
 
-    /// Parses capabilities from an initialize response.
-    ///
-    /// - Parameter value: The result value from the initialize response.
-    /// - Returns: The parsed MCPCapabilities.
-    /// - Throws: `MCPError` if parsing fails.
-    private func parseCapabilities(from value: SendableValue) throws -> MCPCapabilities {
-        guard let dict = value.dictionaryValue else {
-            throw MCPError.parseError("Expected dictionary in initialize result")
+        let params: [String: SendableValue] = [
+            "name": .string(name),
+            "arguments": .dictionary(arguments)
+        ]
+
+        let request = try MCPRequest(method: "tools/call", params: params)
+        let response = try await sendRequest(request)
+
+        if let error = response.error {
+            throw MCPError(code: error.code, message: error.message, data: error.data)
         }
 
-        let capabilitiesDict = dict["capabilities"]?.dictionaryValue ?? [:]
+        guard let result = response.result else {
+            throw MCPError.internalError("No result in tools/call response")
+        }
 
-        let hasTools = capabilitiesDict["tools"] != nil
-        let hasResources = capabilitiesDict["resources"] != nil
-        let hasPrompts = capabilitiesDict["prompts"] != nil
-        let hasSampling = capabilitiesDict["sampling"] != nil
+        return try MCPWireCodec.toolCallResult(result, toolName: name, style: style)
+    }
 
-        return MCPCapabilities(
-            tools: hasTools,
-            resources: hasResources,
-            prompts: hasPrompts,
-            sampling: hasSampling
+    private func makeStreamableRequest(body: Data) -> URLRequest {
+        var urlRequest = URLRequest(url: baseURL)
+        urlRequest.httpMethod = "POST"
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        urlRequest.setValue("application/json, text/event-stream", forHTTPHeaderField: "Accept")
+        urlRequest.setValue(
+            cachedProtocolVersion ?? MCPProtocolVersion.current,
+            forHTTPHeaderField: "MCP-Protocol-Version"
         )
+        urlRequest.timeoutInterval = timeout
+
+        if let cachedSessionID {
+            urlRequest.setValue(cachedSessionID, forHTTPHeaderField: "MCP-Session-Id")
+        }
+
+        if let apiKey {
+            urlRequest.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        }
+
+        urlRequest.httpBody = body
+        return urlRequest
     }
 
-    /// Parses tool schemas from a tools/list response.
-    ///
-    /// - Parameter value: The result value from the tools/list response.
-    /// - Returns: An array of ToolSchema objects.
-    /// - Throws: `MCPError` if parsing fails.
-    private func parseTools(from value: SendableValue) throws -> [ToolSchema] {
-        guard let dict = value.dictionaryValue,
-              let toolsArray = dict["tools"]?.arrayValue else {
-            throw MCPError.parseError("Expected dictionary with 'tools' array in tools/list result")
-        }
-
-        var tools: [ToolSchema] = []
-
-        for toolValue in toolsArray {
-            guard let toolDict = toolValue.dictionaryValue,
-                  let name = extractString(toolDict["name"]) else {
-                continue
-            }
-
-            let description = extractString(toolDict["description"]) ?? ""
-            let parameters = parseParameters(from: toolDict["inputSchema"])
-
-            tools.append(ToolSchema(name: name, description: description, parameters: parameters))
-        }
-
-        return tools
-    }
-
-    /// Parses parameters from a JSON Schema inputSchema.
-    ///
-    /// - Parameter schema: The inputSchema value.
-    /// - Returns: An array of ToolParameter objects.
-    private func parseParameters(from schema: SendableValue?) -> [ToolParameter] {
-        guard let schemaDict = schema?.dictionaryValue else {
-            return []
-        }
-
-        return parseObjectProperties(from: schemaDict)
-    }
-
-    private func parseObjectProperties(from schemaDict: [String: SendableValue]) -> [ToolParameter] {
-        guard let properties = schemaDict["properties"]?.dictionaryValue else {
-            return []
-        }
-
-        let requiredSet = Set(schemaDict["required"]?.arrayValue?.compactMap(\.stringValue) ?? [])
-        var parameters: [ToolParameter] = []
-
-        for (name, propValue) in properties {
-            guard let propDict = propValue.dictionaryValue else { continue }
-
-            let description = extractString(propDict["description"]) ?? ""
-            let paramType = parseParameterType(from: propDict)
-            let isRequired = requiredSet.contains(name)
-
-            parameters.append(ToolParameter(
-                name: name,
-                description: description,
-                type: paramType,
-                isRequired: isRequired,
-                defaultValue: propDict["default"]
-            ))
-        }
-
-        return parameters
-    }
-
-    /// Maps a JSON Schema node to a ToolParameter.ParameterType.
-    ///
-    /// - Parameter schemaDict: The JSON Schema node dictionary.
-    /// - Returns: The corresponding ParameterType.
-    private func parseParameterType(from schemaDict: [String: SendableValue]) -> ToolParameter.ParameterType {
-        if let options = parseStringOptions(from: schemaDict), !options.isEmpty {
-            return .oneOf(options)
-        }
-
-        let typeString = extractString(schemaDict["type"]) ?? inferredTypeString(from: schemaDict)
-
-        switch typeString.lowercased() {
-        case "string":
-            return .string
-        case "integer":
-            return .int
-        case "number":
-            return .double
-        case "boolean":
-            return .bool
-        case "array":
-            if let itemsDict = schemaDict["items"]?.dictionaryValue {
-                return .array(elementType: parseParameterType(from: itemsDict))
-            } else {
-                return .array(elementType: .any)
-            }
-        case "object":
-            return .object(properties: parseObjectProperties(from: schemaDict))
-        default:
-            return .any
+    private func captureSessionID(from response: HTTPURLResponse) {
+        if let session = response.value(forHTTPHeaderField: "MCP-Session-Id"), !session.isEmpty {
+            cachedSessionID = session
         }
     }
 
-    private func inferredTypeString(from schemaDict: [String: SendableValue]) -> String {
-        if schemaDict["properties"]?.dictionaryValue != nil {
-            return "object"
+    private func decodeHTTPBody(_ data: Data, response: HTTPURLResponse) throws -> Data {
+        let contentType = response.value(forHTTPHeaderField: "Content-Type") ?? ""
+        if contentType.lowercased().contains("text/event-stream") {
+            return try MCPWireCodec.jsonRPCPayload(fromSSE: data)
         }
-        if schemaDict["items"]?.dictionaryValue != nil {
-            return "array"
-        }
-        return "any"
-    }
-
-    private func parseStringOptions(from schemaDict: [String: SendableValue]) -> [String]? {
-        if let values = schemaDict["enum"]?.arrayValue?.compactMap(\.stringValue), !values.isEmpty {
-            return values
-        }
-
-        guard let oneOf = schemaDict["oneOf"]?.arrayValue else {
-            return nil
-        }
-
-        let values = oneOf.flatMap { option -> [String] in
-            guard let optionDict = option.dictionaryValue else {
-                return []
-            }
-            if let constValue = optionDict["const"]?.stringValue {
-                return [constValue]
-            }
-            return optionDict["enum"]?.arrayValue?.compactMap(\.stringValue) ?? []
-        }
-        return values.isEmpty ? nil : values
-    }
-
-    /// Parses resources from a resources/list response.
-    ///
-    /// - Parameter value: The result value from the resources/list response.
-    /// - Returns: An array of MCPResource objects.
-    /// - Throws: `MCPError` if parsing fails.
-    private func parseResources(from value: SendableValue) throws -> [MCPResource] {
-        guard let dict = value.dictionaryValue,
-              let resourcesArray = dict["resources"]?.arrayValue else {
-            throw MCPError.parseError("Expected dictionary with 'resources' array in resources/list result")
-        }
-
-        var resources: [MCPResource] = []
-
-        for resourceValue in resourcesArray {
-            guard let resourceDict = resourceValue.dictionaryValue,
-                  let uri = extractString(resourceDict["uri"]),
-                  let name = extractString(resourceDict["name"]) else {
-                continue
-            }
-
-            let description = extractString(resourceDict["description"])
-            let mimeType = extractString(resourceDict["mimeType"])
-
-            resources.append(MCPResource(
-                uri: uri,
-                name: name,
-                description: description,
-                mimeType: mimeType
-            ))
-        }
-
-        return resources
-    }
-
-    /// Parses resource content from a resources/read response.
-    ///
-    /// - Parameter value: The result value from the resources/read response.
-    /// - Returns: The parsed MCPResourceContent.
-    /// - Throws: `MCPError` if parsing fails.
-    private func parseResourceContent(from value: SendableValue) throws -> MCPResourceContent {
-        guard let dict = value.dictionaryValue,
-              let contentsArray = dict["contents"]?.arrayValue,
-              let firstContent = contentsArray.first,
-              let contentDict = firstContent.dictionaryValue else {
-            throw MCPError.parseError("Expected dictionary with 'contents' array in resources/read result")
-        }
-
-        let uri = extractString(contentDict["uri"]) ?? ""
-        let mimeType = extractString(contentDict["mimeType"])
-        let text = extractString(contentDict["text"])
-        let blob = extractString(contentDict["blob"])
-
-        return try MCPResourceContent(
-            uri: uri,
-            mimeType: mimeType,
-            text: text,
-            blob: blob
-        )
-    }
-
-    private func validateToolCallResult(_ result: SendableValue, toolName: String) throws {
-        guard let resultDict = result.dictionaryValue,
-              resultDict["isError"]?.boolValue == true else {
-            return
-        }
-
-        let detail = toolCallErrorMessage(from: resultDict)
-        throw MCPError(
-            code: MCPError.internalErrorCode,
-            message: "Remote MCP tool '\(toolName)' failed: \(detail)",
-            data: result
-        )
-    }
-
-    private func toolCallErrorMessage(from resultDict: [String: SendableValue]) -> String {
-        guard let content = resultDict["content"]?.arrayValue else {
-            return "tool returned isError"
-        }
-
-        let textParts = content.compactMap { item -> String? in
-            guard let itemDict = item.dictionaryValue else {
-                return nil
-            }
-            return itemDict["text"]?.stringValue
-        }
-
-        return textParts.isEmpty ? "tool returned isError" : textParts.joined(separator: "\n")
-    }
-
-    /// Extracts a string from a SendableValue.
-    ///
-    /// - Parameter value: The value to extract from.
-    /// - Returns: The string value, or nil if not a string.
-    private func extractString(_ value: SendableValue?) -> String? {
-        value?.stringValue
+        return data
     }
 }
 
-private struct MCPNotification: Sendable, Encodable, Equatable {
+package struct MCPNotification: Sendable, Encodable, Equatable {
     let jsonrpc: String
     let method: String
     let params: [String: SendableValue]?

--- a/Sources/Swarm/MCP/MCPCapabilities.swift
+++ b/Sources/Swarm/MCP/MCPCapabilities.swift
@@ -44,16 +44,19 @@ public struct MCPCapabilities: Sendable, Codable, Equatable {
     /// such as files, databases, or external data sources.
     public let resources: Bool
 
-    /// Whether the server supports prompt templates.
+    /// Whether the remote server advertised prompt templates.
     ///
-    /// When `true`, the server can provide and manage
-    /// reusable prompt templates.
+    /// Swarm's client does not implement `prompts/list` or `prompts/get`.
+    /// Connection types always report `false` so this flag cannot be used
+    /// as a feature-detection signal for Swarm APIs. The stored property
+    /// remains for source compatibility.
     public let prompts: Bool
 
-    /// Whether the server supports sampling.
+    /// Whether the remote server advertised sampling.
     ///
-    /// When `true`, the server can perform sampling operations
-    /// for model generation.
+    /// Swarm's client does not implement sampling (a server-initiated
+    /// request that needs an inference provider). Connection types always
+    /// report `false`. The stored property remains for source compatibility.
     public let sampling: Bool
 
     // MARK: - Initialization
@@ -63,8 +66,10 @@ public struct MCPCapabilities: Sendable, Codable, Equatable {
     /// - Parameters:
     ///   - tools: Whether tool discovery and execution is supported. Default: `false`
     ///   - resources: Whether resource access is supported. Default: `false`
-    ///   - prompts: Whether prompt templates are supported. Default: `false`
-    ///   - sampling: Whether sampling is supported. Default: `false`
+    ///   - prompts: Unused by Swarm's client. Default: `false`. Prefer omitting
+    ///     this argument; the value is retained for source compatibility.
+    ///   - sampling: Unused by Swarm's client. Default: `false`. Prefer omitting
+    ///     this argument; the value is retained for source compatibility.
     public init(
         tools: Bool = false,
         resources: Bool = false,

--- a/Sources/Swarm/MCP/MCPClient.swift
+++ b/Sources/Swarm/MCP/MCPClient.swift
@@ -96,7 +96,7 @@ public actor MCPClient {
     /// ## Note
     /// Adding a server with the same name as an existing server will replace
     /// the existing server after closing it.
-    public func addServer(_ server: any MCPServer) async throws {
+    public func addServer(_ server: any MCPServerConnection) async throws {
         // Close existing server with same name if present
         if let existing = servers[server.name] {
             try? await existing.close()
@@ -612,7 +612,7 @@ public actor MCPClient {
     // MARK: Private
 
     /// Registry of connected MCP servers, keyed by server name.
-    private var servers: [String: any MCPServer] = [:]
+    private var servers: [String: any MCPServerConnection] = [:]
 
     /// Cache of tools from all connected servers, keyed by client-visible tool name.
     private var toolCache: [String: any AnyJSONTool] = [:]
@@ -699,7 +699,7 @@ public actor MCPClient {
     private struct DiscoveredTool {
         let serverName: String
         let schema: ToolSchema
-        let server: any MCPServer
+        let server: any MCPServerConnection
     }
 
     private func reserveUniqueToolName(

--- a/Sources/Swarm/MCP/MCPError.swift
+++ b/Sources/Swarm/MCP/MCPError.swift
@@ -142,6 +142,23 @@ public extension MCPError {
             message: details ?? "Internal error: Internal JSON-RPC error"
         )
     }
+
+    /// Creates an invalid-request error for an unsupported MCP protocol version.
+    ///
+    /// Swarm never silently assumes compatibility with an unknown server
+    /// revision. The message lists every version this client will accept.
+    ///
+    /// - Parameter version: The version string reported by the server, or
+    ///   empty when the initialize result omitted `protocolVersion`.
+    /// - Returns: An MCPError with code -32600.
+    static func unsupportedProtocolVersion(_ version: String) -> MCPError {
+        let reported = version.isEmpty ? "<missing>" : version
+        let supported = MCPProtocolVersion.supported.sorted().joined(separator: ", ")
+        return MCPError(
+            code: invalidRequestCode,
+            message: "Unsupported MCP protocol version '\(reported)'. Swarm supports: \(supported)."
+        )
+    }
 }
 
 // MARK: LocalizedError

--- a/Sources/Swarm/MCP/MCPProtocol.swift
+++ b/Sources/Swarm/MCP/MCPProtocol.swift
@@ -258,7 +258,19 @@ package struct MCPResponse: Sendable, Codable, Equatable {
                 )
             )
         }
-        let id = try container.decode(String.self, forKey: .id)
+        let id: String
+        if let stringId = try? container.decode(String.self, forKey: .id) {
+            id = stringId
+        } else if let intId = try? container.decode(Int.self, forKey: .id) {
+            id = String(intId)
+        } else {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: [CodingKeys.id],
+                    debugDescription: "Response ID must be a string or number"
+                )
+            )
+        }
         guard !id.isEmpty else {
             throw DecodingError.dataCorrupted(
                 DecodingError.Context(
@@ -333,11 +345,11 @@ package extension MCPResponse {
     ///   - result: The result value to include in the response.
     /// - Returns: An MCPResponse with the result set and error as `nil`.
     ///
-    /// - Precondition: `id` must be non-empty. Passing an empty string is a
-    ///   programming error and will terminate the process in both debug and
-    ///   release builds via `precondition`.
-    static func success(id: String, result: SendableValue) -> MCPResponse {
-        precondition(!id.isEmpty, "MCPResponse.success requires a non-empty id")
+    /// - Throws: `MCPError.invalidRequest` when `id` is empty.
+    static func success(id: String, result: SendableValue) throws -> MCPResponse {
+        guard !id.isEmpty else {
+            throw MCPError.invalidRequest("MCPResponse.success requires a non-empty id")
+        }
         return MCPResponse(
             id: id,
             result: result,
@@ -352,11 +364,11 @@ package extension MCPResponse {
     ///   - error: The error object describing what went wrong.
     /// - Returns: An MCPResponse with the error set and result as `nil`.
     ///
-    /// - Precondition: `id` must be non-empty. Passing an empty string is a
-    ///   programming error and will terminate the process in both debug and
-    ///   release builds via `precondition`.
-    static func failure(id: String, error: MCPErrorObject) -> MCPResponse {
-        precondition(!id.isEmpty, "MCPResponse.failure requires a non-empty id")
+    /// - Throws: `MCPError.invalidRequest` when `id` is empty.
+    static func failure(id: String, error: MCPErrorObject) throws -> MCPResponse {
+        guard !id.isEmpty else {
+            throw MCPError.invalidRequest("MCPResponse.failure requires a non-empty id")
+        }
         return MCPResponse(
             id: id,
             result: nil,

--- a/Sources/Swarm/MCP/MCPProtocolVersion.swift
+++ b/Sources/Swarm/MCP/MCPProtocolVersion.swift
@@ -1,0 +1,68 @@
+// MCPProtocolVersion.swift
+// Swarm Framework
+//
+// MCP protocol version identifiers and client-side negotiation.
+
+import Foundation
+
+// MARK: - MCPProtocolVersion
+
+/// Protocol versions understood by Swarm's MCP client.
+///
+/// MCP versions are date strings (`YYYY-MM-DD`) naming the last
+/// backwards-incompatible revision. Swarm speaks the current specification
+/// and remains compatible with the original `2024-11-05` revision used by
+/// many deployed servers.
+///
+/// - SeeAlso: https://modelcontextprotocol.io/specification/2025-11-25/
+public enum MCPProtocolVersion: Sendable {
+    /// The original MCP revision (`2024-11-05`).
+    public static let legacy = "2024-11-05"
+
+    /// The latest MCP revision Swarm's client requests during initialize.
+    public static let current = "2025-11-25"
+
+    /// Every protocol version this client will accept from a server.
+    ///
+    /// Unknown versions fail loudly — Swarm never silently assumes
+    /// compatibility with an unsupported server.
+    public static let supported: Set<String> = [
+        "2024-11-05",
+        "2025-03-26",
+        "2025-06-18",
+        "2025-11-25"
+    ]
+
+    /// Negotiates the session version from the server's initialize result.
+    ///
+    /// - Parameter serverReported: The `protocolVersion` string returned by
+    ///   the server. `nil` or empty is treated as unsupported.
+    /// - Returns: The server-reported version when it is in ``supported``.
+    /// - Throws: ``MCPError/unsupportedProtocolVersion(_:)`` when the server
+    ///   speaks a version Swarm does not implement.
+    public static func negotiate(serverReported: String?) throws -> String {
+        guard let serverReported, !serverReported.isEmpty else {
+            throw MCPError.unsupportedProtocolVersion(serverReported ?? "")
+        }
+        guard supported.contains(serverReported) else {
+            throw MCPError.unsupportedProtocolVersion(serverReported)
+        }
+        return serverReported
+    }
+}
+
+// MARK: - MCPToolResultStyle
+
+/// How ``MCPServerConnection/callTool(name:arguments:)`` presents a
+/// successful `tools/call` result.
+public enum MCPToolResultStyle: Sendable, Equatable {
+    /// Unwrap MCP content blocks (the default).
+    ///
+    /// A single `text` content block becomes a `.string`. Multiple blocks
+    /// become a `.array` of the original content objects. Results that are
+    /// not MCP envelopes are returned unchanged.
+    case unwrappedContent
+
+    /// Return the raw `tools/call` result object (`content`, `isError`, …).
+    case rawEnvelope
+}

--- a/Sources/Swarm/MCP/MCPServer.swift
+++ b/Sources/Swarm/MCP/MCPServer.swift
@@ -1,18 +1,21 @@
 // MCPServer.swift
 // Swarm Framework
 //
-// Protocol defining the interface for Model Context Protocol (MCP) servers.
+// Protocol defining the interface for Model Context Protocol (MCP) server connections.
 
 import Foundation
 
-// MARK: - MCPServer
+// MARK: - MCPServerConnection
 
-/// A protocol defining the interface for Model Context Protocol (MCP) servers.
+/// A client-side connection to a Model Context Protocol (MCP) server.
 ///
-/// MCPServer provides a standardized interface for communicating with MCP-compliant
-/// servers that expose tools, resources, and other capabilities to agents. The protocol
-/// follows a lifecycle pattern where servers must be initialized before use and
-/// properly closed when no longer needed.
+/// `MCPServerConnection` is the interface Swarm uses to talk to a remote MCP
+/// process or HTTP endpoint. Implementations include ``HTTPMCPServer`` and
+/// ``StdioMCPServer``. The historical name `MCPServer` was easy to confuse
+/// with an actual server; it remains available as a deprecated typealias.
+///
+/// The protocol follows a lifecycle pattern where connections must be
+/// initialized before use and properly closed when no longer needed.
 ///
 /// ## Server Lifecycle
 ///
@@ -77,7 +80,7 @@ import Foundation
 ///
 /// ## Thread Safety
 ///
-/// Implementations of `MCPServer` must be `Sendable` to support concurrent access
+/// Implementations of `MCPServerConnection` must be `Sendable` to support concurrent access
 /// from multiple async contexts. Use actors or other synchronization primitives
 /// to protect mutable state.
 ///
@@ -86,7 +89,7 @@ import Foundation
 /// All methods throw `MCPError` for protocol-level errors. Implementations should
 /// map transport-specific errors to appropriate `MCPError` instances using the
 /// standard JSON-RPC 2.0 error codes.
-public protocol MCPServer: Sendable {
+public protocol MCPServerConnection: Sendable {
     /// The name of this MCP server.
     ///
     /// This name is used for identification and logging purposes.
@@ -185,12 +188,18 @@ public protocol MCPServer: Sendable {
     /// Executes the named tool with the provided arguments and returns the result.
     /// The tool must exist in the list returned by `listTools()`.
     ///
+    /// Built-in transports unwrap MCP `content` blocks by default (a single
+    /// text block becomes a `.string`). Use ``HTTPMCPServer/callToolRaw(name:arguments:)``
+    /// or ``StdioMCPServer/callToolRaw(name:arguments:)`` for the raw envelope.
+    /// An empty tool name throws ``MCPError/invalidParams(_:)`` instead of
+    /// trapping.
+    ///
     /// - Parameters:
     ///   - name: The name of the tool to call, as returned by `listTools()`.
     ///   - arguments: A dictionary of argument names to values. The arguments must
     ///                match the tool's parameter definitions.
     ///
-    /// - Returns: The result of the tool execution as a `SendableValue`.
+    /// - Returns: The unwrapped tool result as a `SendableValue`.
     ///
     /// - Throws: `MCPError.methodNotFound` if the tool does not exist.
     ///           `MCPError.invalidParams` if the arguments are invalid or missing.
@@ -264,9 +273,9 @@ public protocol MCPServer: Sendable {
     func readResource(uri: String) async throws -> MCPResourceContent
 }
 
-// MARK: - MCPServer Default Implementations
+// MARK: - MCPServerConnection Default Implementations
 
-public extension MCPServer {
+public extension MCPServerConnection {
     /// Checks whether tools are supported and throws if not.
     ///
     /// Helper method to validate tool capability before operations.
@@ -291,6 +300,14 @@ public extension MCPServer {
         }
     }
 }
+
+/// Deprecated name for ``MCPServerConnection``.
+///
+/// The historical `MCPServer` name described a *client* connection and was
+/// easy to confuse with an MCP server process. New code should conform to
+/// and refer to ``MCPServerConnection``.
+@available(*, deprecated, renamed: "MCPServerConnection")
+public typealias MCPServer = MCPServerConnection
 
 // MARK: - MCPServerState
 

--- a/Sources/Swarm/MCP/MCPToolBridge.swift
+++ b/Sources/Swarm/MCP/MCPToolBridge.swift
@@ -41,7 +41,7 @@ public actor MCPToolBridge {
     /// Creates a new MCP tool bridge for the given server.
     ///
     /// - Parameter server: The MCP server to bridge tools from.
-    public init(server: any MCPServer) {
+    public init(server: any MCPServerConnection) {
         self.server = server
     }
 
@@ -76,7 +76,7 @@ public actor MCPToolBridge {
     // MARK: Private
 
     /// The MCP server providing the tools.
-    private let server: any MCPServer
+    private let server: any MCPServerConnection
 }
 
 // MARK: - MCPBridgedTool
@@ -91,12 +91,12 @@ public actor MCPToolBridge {
 ///
 /// MCPBridgedTool is `Sendable` and can be safely shared across async contexts.
 /// The underlying MCP server must also be `Sendable` (as required by the
-/// `MCPServer` protocol).
+/// `MCPServerConnection` protocol).
 ///
 /// ### Actor Isolation Contract
 ///
-/// This struct stores an existential reference (`any MCPServer`) to an actor-isolated
-/// server. While Swift's type system allows this because `MCPServer` requires `Sendable`
+/// This struct stores an existential reference (`any MCPServerConnection`) to an actor-isolated
+/// server. While Swift's type system allows this because `MCPServerConnection` requires `Sendable`
 /// conformance, the following guarantees apply:
 ///
 /// - **Execution Serialization**: All calls to `execute()` are automatically serialized
@@ -122,7 +122,7 @@ struct MCPBridgedTool: AnyJSONTool, Sendable {
     let schema: ToolSchema
 
     /// The MCP server to delegate execution to.
-    let server: any MCPServer
+    let server: any MCPServerConnection
 
     /// Optional display name used when this tool must be disambiguated.
     let displayNameOverride: String?
@@ -132,7 +132,7 @@ struct MCPBridgedTool: AnyJSONTool, Sendable {
 
     init(
         schema: ToolSchema,
-        server: any MCPServer,
+        server: any MCPServerConnection,
         displayName: String? = nil,
         serverToolName: String? = nil
     ) {

--- a/Sources/Swarm/MCP/MCPWireCodec.swift
+++ b/Sources/Swarm/MCP/MCPWireCodec.swift
@@ -1,0 +1,289 @@
+// MCPWireCodec.swift
+// Swarm Framework
+//
+// Shared JSON-RPC parsing and MCP result shaping for HTTP and stdio clients.
+
+import Foundation
+
+// MARK: - MCPWireCodec
+
+/// Package helpers shared by ``HTTPMCPServer`` and ``StdioMCPServer``.
+enum MCPWireCodec {
+    // MARK: Internal
+
+    static func requireToolName(_ name: String) throws {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw MCPError.invalidParams("Tool name must be non-empty")
+        }
+    }
+
+    static func parseCapabilities(from value: SendableValue) throws -> MCPCapabilities {
+        guard let dict = value.dictionaryValue else {
+            throw MCPError.parseError("Expected dictionary in initialize result")
+        }
+
+        let capabilitiesDict = dict["capabilities"]?.dictionaryValue ?? [:]
+        return MCPCapabilities(
+            tools: capabilitiesDict["tools"] != nil,
+            resources: capabilitiesDict["resources"] != nil,
+            prompts: false,
+            sampling: false
+        )
+    }
+
+    static func negotiatedVersion(from value: SendableValue) throws -> String {
+        guard let dict = value.dictionaryValue else {
+            throw MCPError.parseError("Expected dictionary in initialize result")
+        }
+        return try MCPProtocolVersion.negotiate(serverReported: extractString(dict["protocolVersion"]))
+    }
+
+    static func parseTools(from value: SendableValue) throws -> [ToolSchema] {
+        guard let dict = value.dictionaryValue,
+              let toolsArray = dict["tools"]?.arrayValue else {
+            throw MCPError.parseError("Expected dictionary with 'tools' array in tools/list result")
+        }
+
+        var tools: [ToolSchema] = []
+
+        for toolValue in toolsArray {
+            guard let toolDict = toolValue.dictionaryValue,
+                  let name = extractString(toolDict["name"]) else {
+                continue
+            }
+
+            let description = extractString(toolDict["description"]) ?? ""
+            let parameters = parseParameters(from: toolDict["inputSchema"])
+
+            tools.append(ToolSchema(name: name, description: description, parameters: parameters))
+        }
+
+        return tools
+    }
+
+    static func parseResources(from value: SendableValue) throws -> [MCPResource] {
+        guard let dict = value.dictionaryValue,
+              let resourcesArray = dict["resources"]?.arrayValue else {
+            throw MCPError.parseError("Expected dictionary with 'resources' array in resources/list result")
+        }
+
+        var resources: [MCPResource] = []
+
+        for resourceValue in resourcesArray {
+            guard let resourceDict = resourceValue.dictionaryValue,
+                  let uri = extractString(resourceDict["uri"]),
+                  let name = extractString(resourceDict["name"]) else {
+                continue
+            }
+
+            resources.append(MCPResource(
+                uri: uri,
+                name: name,
+                description: extractString(resourceDict["description"]),
+                mimeType: extractString(resourceDict["mimeType"])
+            ))
+        }
+
+        return resources
+    }
+
+    static func parseResourceContent(from value: SendableValue) throws -> MCPResourceContent {
+        guard let dict = value.dictionaryValue,
+              let contentsArray = dict["contents"]?.arrayValue,
+              let firstContent = contentsArray.first,
+              let contentDict = firstContent.dictionaryValue else {
+            throw MCPError.parseError("Expected dictionary with 'contents' array in resources/read result")
+        }
+
+        return try MCPResourceContent(
+            uri: extractString(contentDict["uri"]) ?? "",
+            mimeType: extractString(contentDict["mimeType"]),
+            text: extractString(contentDict["text"]),
+            blob: extractString(contentDict["blob"])
+        )
+    }
+
+    static func toolCallResult(
+        _ result: SendableValue,
+        toolName: String,
+        style: MCPToolResultStyle
+    ) throws -> SendableValue {
+        guard let resultDict = result.dictionaryValue,
+              resultDict["content"] != nil || resultDict["isError"] != nil else {
+            return result
+        }
+
+        if resultDict["isError"]?.boolValue == true {
+            let detail = toolCallErrorMessage(from: resultDict)
+            throw MCPError(
+                code: MCPError.internalErrorCode,
+                message: "Remote MCP tool '\(toolName)' failed: \(detail)",
+                data: result
+            )
+        }
+
+        switch style {
+        case .rawEnvelope:
+            return result
+        case .unwrappedContent:
+            return unwrapContent(resultDict["content"])
+        }
+    }
+
+    static func jsonRPCPayload(fromSSE data: Data) throws -> Data {
+        guard let text = String(data: data, encoding: .utf8) else {
+            throw MCPError.parseError("SSE payload was not valid UTF-8")
+        }
+
+        var payloadLines: [String] = []
+        for rawLine in text.split(whereSeparator: \.isNewline) {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            if line.hasPrefix("data:") {
+                payloadLines.append(String(line.dropFirst(5)).trimmingCharacters(in: .whitespaces))
+            }
+        }
+
+        let joined = payloadLines.filter { !$0.isEmpty }.joined(separator: "\n")
+        guard !joined.isEmpty, let payload = joined.data(using: .utf8) else {
+            throw MCPError.parseError("SSE stream did not contain a JSON-RPC data event")
+        }
+        return payload
+    }
+
+    static func initializeParameters() -> [String: SendableValue] {
+        [
+            "protocolVersion": .string(MCPProtocolVersion.current),
+            "capabilities": .dictionary([:]),
+            "clientInfo": .dictionary([
+                "name": .string("Swarm"),
+                "version": .string(Swarm.version)
+            ])
+        ]
+    }
+
+    // MARK: Private
+
+    private static func parseParameters(from schema: SendableValue?) -> [ToolParameter] {
+        guard let schemaDict = schema?.dictionaryValue else {
+            return []
+        }
+        return parseObjectProperties(from: schemaDict)
+    }
+
+    private static func parseObjectProperties(from schemaDict: [String: SendableValue]) -> [ToolParameter] {
+        guard let properties = schemaDict["properties"]?.dictionaryValue else {
+            return []
+        }
+
+        let requiredSet = Set(schemaDict["required"]?.arrayValue?.compactMap(\.stringValue) ?? [])
+        var parameters: [ToolParameter] = []
+
+        for (name, propValue) in properties {
+            guard let propDict = propValue.dictionaryValue else { continue }
+
+            parameters.append(ToolParameter(
+                name: name,
+                description: extractString(propDict["description"]) ?? "",
+                type: parseParameterType(from: propDict),
+                isRequired: requiredSet.contains(name),
+                defaultValue: propDict["default"]
+            ))
+        }
+
+        return parameters
+    }
+
+    private static func parseParameterType(from schemaDict: [String: SendableValue]) -> ToolParameter.ParameterType {
+        if let options = parseStringOptions(from: schemaDict), !options.isEmpty {
+            return .oneOf(options)
+        }
+
+        let typeString = extractString(schemaDict["type"]) ?? inferredTypeString(from: schemaDict)
+
+        switch typeString.lowercased() {
+        case "string":
+            return .string
+        case "integer":
+            return .int
+        case "number":
+            return .double
+        case "boolean":
+            return .bool
+        case "array":
+            if let itemsDict = schemaDict["items"]?.dictionaryValue {
+                return .array(elementType: parseParameterType(from: itemsDict))
+            }
+            return .array(elementType: .any)
+        case "object":
+            return .object(properties: parseObjectProperties(from: schemaDict))
+        default:
+            return .any
+        }
+    }
+
+    private static func inferredTypeString(from schemaDict: [String: SendableValue]) -> String {
+        if schemaDict["properties"]?.dictionaryValue != nil {
+            return "object"
+        }
+        if schemaDict["items"]?.dictionaryValue != nil {
+            return "array"
+        }
+        return "any"
+    }
+
+    private static func parseStringOptions(from schemaDict: [String: SendableValue]) -> [String]? {
+        if let values = schemaDict["enum"]?.arrayValue?.compactMap(\.stringValue), !values.isEmpty {
+            return values
+        }
+
+        guard let oneOf = schemaDict["oneOf"]?.arrayValue else {
+            return nil
+        }
+
+        let values = oneOf.flatMap { option -> [String] in
+            guard let optionDict = option.dictionaryValue else {
+                return []
+            }
+            if let constValue = optionDict["const"]?.stringValue {
+                return [constValue]
+            }
+            return optionDict["enum"]?.arrayValue?.compactMap(\.stringValue) ?? []
+        }
+        return values.isEmpty ? nil : values
+    }
+
+    private static func unwrapContent(_ content: SendableValue?) -> SendableValue {
+        guard let items = content?.arrayValue else {
+            return content ?? .null
+        }
+
+        if items.count == 1, let only = items.first {
+            if let text = only.dictionaryValue?["text"]?.stringValue {
+                let type = only.dictionaryValue?["type"]?.stringValue
+                if type == nil || type == "text" {
+                    return .string(text)
+                }
+            }
+            return only
+        }
+
+        return .array(items)
+    }
+
+    private static func toolCallErrorMessage(from resultDict: [String: SendableValue]) -> String {
+        guard let content = resultDict["content"]?.arrayValue else {
+            return "tool returned isError"
+        }
+
+        let textParts = content.compactMap { item -> String? in
+            item.dictionaryValue?["text"]?.stringValue
+        }
+
+        return textParts.isEmpty ? "tool returned isError" : textParts.joined(separator: "\n")
+    }
+
+    private static func extractString(_ value: SendableValue?) -> String? {
+        value?.stringValue
+    }
+}

--- a/Sources/Swarm/MCP/StdioMCPServer.swift
+++ b/Sources/Swarm/MCP/StdioMCPServer.swift
@@ -1,0 +1,422 @@
+// StdioMCPServer.swift
+// Swarm Framework
+//
+// Stdio client transport: launch a child MCP server and speak newline-delimited JSON-RPC.
+
+import Foundation
+#if canImport(Darwin)
+    import Darwin
+#elseif canImport(Glibc)
+    import Glibc
+#endif
+
+// MARK: - StdioMCPServer
+
+/// A stdio client for Model Context Protocol (MCP) servers.
+///
+/// `StdioMCPServer` launches a child process and speaks newline-delimited
+/// JSON-RPC over the child's stdin/stdout — the deployment used by most
+/// filesystem, git, and local MCP servers. Stderr is captured for
+/// diagnostics. The process is terminated on ``close()`` and unexpected
+/// exits fail in-flight requests.
+///
+/// ## Example
+///
+/// ```swift
+/// let server = StdioMCPServer(
+///     command: "npx",
+///     arguments: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+///     name: "filesystem"
+/// )
+/// let capabilities = try await server.initialize()
+/// let tools = try await server.listTools()
+/// try await server.close()
+/// ```
+///
+/// ## Thread Safety
+///
+/// `StdioMCPServer` is an actor. All process and pipe state is isolated.
+public actor StdioMCPServer: MCPServerConnection {
+    // MARK: Public
+
+    /// The name of this MCP server connection.
+    public let name: String
+
+    /// Capabilities cached after a successful ``initialize()``.
+    public var capabilities: MCPCapabilities {
+        cachedCapabilities ?? MCPCapabilities()
+    }
+
+    /// The protocol version negotiated during ``initialize()``.
+    public var negotiatedProtocolVersion: String? {
+        cachedProtocolVersion
+    }
+
+    /// Captured stderr from the child process, newest content last.
+    ///
+    /// Useful when initialize or a request fails and the server logged
+    /// a diagnostic to stderr.
+    public var stderrLog: String {
+        String(data: stderrBuffer, encoding: .utf8) ?? ""
+    }
+
+    /// Creates a stdio MCP client that will launch `command` on initialize.
+    ///
+    /// - Parameters:
+    ///   - command: The executable to launch. Looked up on `PATH` unless it
+    ///     contains a path separator.
+    ///   - arguments: Arguments passed to the executable.
+    ///   - environment: Optional environment overlay. When `nil`, the child
+    ///     inherits the current process environment.
+    ///   - workingDirectory: Optional working directory for the child.
+    ///   - name: A name for this connection (used for identification).
+    ///   - timeout: Per-request timeout in seconds. Default: 30.0
+    public init(
+        command: String,
+        arguments: [String] = [],
+        environment: [String: String]? = nil,
+        workingDirectory: URL? = nil,
+        name: String,
+        timeout: TimeInterval = 30.0
+    ) {
+        self.command = command
+        self.arguments = arguments
+        self.environment = environment
+        self.workingDirectory = workingDirectory
+        self.name = name
+        self.timeout = timeout
+        encoder = JSONEncoder()
+        decoder = JSONDecoder()
+    }
+
+    // MARK: - MCPServerConnection
+
+    /// Launches the child process (if needed), sends `initialize`, and
+    /// negotiates the protocol version.
+    ///
+    /// - Returns: The capabilities advertised by the server.
+    /// - Throws: `MCPError` if the process cannot be started, the handshake
+    ///   fails, or the server speaks an unsupported protocol version.
+    public func initialize() async throws -> MCPCapabilities {
+        try startProcessIfNeeded()
+
+        let request = try MCPRequest(method: "initialize", params: MCPWireCodec.initializeParameters())
+        let response = try await sendRequest(request)
+        let result = try requireResult(response, context: "initialize")
+        let version = try MCPWireCodec.negotiatedVersion(from: result)
+        let capabilities = try MCPWireCodec.parseCapabilities(from: result)
+
+        try await sendNotification(try MCPNotification(method: "notifications/initialized"))
+        cachedProtocolVersion = version
+        cachedCapabilities = capabilities
+        return capabilities
+    }
+
+    public func listTools() async throws -> [ToolSchema] {
+        let response = try await sendRequest(try MCPRequest(method: "tools/list"))
+        return try MCPWireCodec.parseTools(from: requireResult(response, context: "tools/list"))
+    }
+
+    /// Calls a tool and returns unwrapped content blocks.
+    public func callTool(name: String, arguments: [String: SendableValue]) async throws -> SendableValue {
+        try await invokeTool(name: name, arguments: arguments, style: .unwrappedContent)
+    }
+
+    /// Calls a tool and returns the raw `tools/call` envelope.
+    public func callToolRaw(name: String, arguments: [String: SendableValue]) async throws -> SendableValue {
+        try await invokeTool(name: name, arguments: arguments, style: .rawEnvelope)
+    }
+
+    public func listResources() async throws -> [MCPResource] {
+        let response = try await sendRequest(try MCPRequest(method: "resources/list"))
+        return try MCPWireCodec.parseResources(from: requireResult(response, context: "resources/list"))
+    }
+
+    public func readResource(uri: String) async throws -> MCPResourceContent {
+        let response = try await sendRequest(
+            try MCPRequest(method: "resources/read", params: ["uri": .string(uri)])
+        )
+        return try MCPWireCodec.parseResourceContent(from: requireResult(response, context: "resources/read"))
+    }
+
+    /// Terminates the child process and fails any in-flight requests.
+    ///
+    /// Sends SIGTERM, waits briefly, then SIGKILL if the process is still
+    /// alive. Safe to call multiple times.
+    public func close() async throws {
+        failPending(MCPError.internalError("Stdio MCP connection closed"))
+        readerTask?.cancel()
+        readerTask = nil
+        stderrTask?.cancel()
+        stderrTask = nil
+
+        stdinHandle?.closeFile()
+        stdinHandle = nil
+        stdoutHandle?.readabilityHandler = nil
+        stdoutHandle?.closeFile()
+        stdoutHandle = nil
+        stderrHandle?.readabilityHandler = nil
+        stderrHandle?.closeFile()
+        stderrHandle = nil
+
+        if let process, process.isRunning {
+            process.terminate()
+            let deadline = Date().addingTimeInterval(2)
+            while process.isRunning, Date() < deadline {
+                try await Task.sleep(for: .milliseconds(50))
+            }
+            if process.isRunning {
+                killProcess(process)
+            }
+        }
+
+        process = nil
+        cachedCapabilities = nil
+        cachedProtocolVersion = nil
+        stdoutBuffer.removeAll()
+    }
+
+    // MARK: Private
+
+    private let command: String
+    private let arguments: [String]
+    private let environment: [String: String]?
+    private let workingDirectory: URL?
+    private let timeout: TimeInterval
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    private var process: Process?
+    private var stdinHandle: FileHandle?
+    private var stdoutHandle: FileHandle?
+    private var stderrHandle: FileHandle?
+    private var readerTask: Task<Void, Never>?
+    private var stderrTask: Task<Void, Never>?
+    private var pending: [String: CheckedContinuation<MCPResponse, Error>] = [:]
+    private var stdoutBuffer = Data()
+    private var stderrBuffer = Data()
+    private var cachedCapabilities: MCPCapabilities?
+    private var cachedProtocolVersion: String?
+
+    private func startProcessIfNeeded() throws {
+        if let process, process.isRunning {
+            return
+        }
+
+        let child = Process()
+        if command.contains("/") {
+            child.executableURL = URL(fileURLWithPath: command)
+            child.arguments = arguments
+        } else {
+            child.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+            child.arguments = [command] + arguments
+        }
+        if let environment {
+            var merged = ProcessInfo.processInfo.environment
+            for (key, value) in environment {
+                merged[key] = value
+            }
+            child.environment = merged
+        }
+        if let workingDirectory {
+            child.currentDirectoryURL = workingDirectory
+        }
+
+        let stdin = Pipe()
+        let stdout = Pipe()
+        let stderr = Pipe()
+        child.standardInput = stdin
+        child.standardOutput = stdout
+        child.standardError = stderr
+
+        child.terminationHandler = { [weak self] finished in
+            let status = finished.terminationStatus
+            Task { [weak self] in
+                await self?.handleProcessExit(status: status)
+            }
+        }
+
+        do {
+            try child.run()
+        } catch {
+            throw MCPError.internalError("Failed to launch MCP stdio server '\(command)': \(error.localizedDescription)")
+        }
+
+        process = child
+        stdinHandle = stdin.fileHandleForWriting
+        stdoutHandle = stdout.fileHandleForReading
+        stderrHandle = stderr.fileHandleForReading
+
+        let stdoutStream = makeDataStream(from: stdout.fileHandleForReading)
+        readerTask = Task { [weak self] in
+            for await chunk in stdoutStream {
+                await self?.consumeStdout(chunk)
+            }
+        }
+
+        let stderrStream = makeDataStream(from: stderr.fileHandleForReading)
+        stderrTask = Task { [weak self] in
+            for await chunk in stderrStream {
+                await self?.consumeStderr(chunk)
+            }
+        }
+    }
+
+    private func makeDataStream(from handle: FileHandle) -> AsyncStream<Data> {
+        AsyncStream { continuation in
+            handle.readabilityHandler = { fileHandle in
+                let data = fileHandle.availableData
+                if data.isEmpty {
+                    continuation.finish()
+                    fileHandle.readabilityHandler = nil
+                } else {
+                    continuation.yield(data)
+                }
+            }
+            continuation.onTermination = { _ in
+                handle.readabilityHandler = nil
+            }
+        }
+    }
+
+    private func consumeStdout(_ chunk: Data) {
+        stdoutBuffer.append(chunk)
+        while let newline = stdoutBuffer.firstIndex(of: UInt8(ascii: "\n")) {
+            let line = stdoutBuffer[..<newline]
+            stdoutBuffer.removeSubrange(...newline)
+            guard !line.isEmpty else { continue }
+            handleMessage(Data(line))
+        }
+    }
+
+    private func consumeStderr(_ chunk: Data) {
+        stderrBuffer.append(chunk)
+        if stderrBuffer.count > 16_384 {
+            stderrBuffer = stderrBuffer.suffix(16_384)
+        }
+    }
+
+    private func handleMessage(_ data: Data) {
+        do {
+            let response = try decoder.decode(MCPResponse.self, from: data)
+            if let continuation = pending.removeValue(forKey: response.id) {
+                continuation.resume(returning: response)
+            }
+        } catch {
+            // Notifications or malformed lines are ignored at the session layer.
+        }
+    }
+
+    private func handleProcessExit(status: Int32) {
+        let detail = stderrLog.isEmpty
+            ? "exit status \(status)"
+            : "exit status \(status); stderr: \(stderrLog)"
+        failPending(MCPError.internalError("MCP stdio server '\(name)' exited unexpectedly (\(detail))"))
+        process = nil
+    }
+
+    private func failPending(_ error: MCPError) {
+        let waiting = pending
+        pending.removeAll()
+        for (_, continuation) in waiting {
+            continuation.resume(throwing: error)
+        }
+    }
+
+    private func sendRequest(_ request: MCPRequest) async throws -> MCPResponse {
+        try await withThrowingTaskGroup(of: MCPResponse.self) { group in
+            group.addTask {
+                try await self.performSend(request)
+            }
+            group.addTask {
+                try await Task.sleep(for: .seconds(self.timeout))
+                await self.cancelPending(
+                    id: request.id,
+                    error: MCPError.internalError(
+                        "Timed out waiting for MCP stdio response to '\(request.method)'"
+                    )
+                )
+                throw MCPError.internalError("Timed out waiting for MCP stdio response to '\(request.method)'")
+            }
+            let result = try await group.next()!
+            group.cancelAll()
+            return result
+        }
+    }
+
+    private func performSend(_ request: MCPRequest) async throws -> MCPResponse {
+        try await withCheckedThrowingContinuation { continuation in
+            if process?.isRunning != true {
+                continuation.resume(
+                    throwing: MCPError.internalError("MCP stdio server '\(name)' is not running")
+                )
+                return
+            }
+            pending[request.id] = continuation
+            do {
+                try writeLine(encoder.encode(request))
+            } catch {
+                pending.removeValue(forKey: request.id)
+                continuation.resume(throwing: error)
+            }
+        }
+    }
+
+    private func cancelPending(id: String, error: MCPError) {
+        if let continuation = pending.removeValue(forKey: id) {
+            continuation.resume(throwing: error)
+        }
+    }
+
+    private func sendNotification(_ notification: MCPNotification) async throws {
+        try writeLine(encoder.encode(notification))
+    }
+
+    private func writeLine(_ data: Data) throws {
+        guard let stdinHandle, process?.isRunning == true else {
+            throw MCPError.internalError("MCP stdio server '\(name)' is not running")
+        }
+        var payload = data
+        payload.append(UInt8(ascii: "\n"))
+        do {
+            stdinHandle.write(payload)
+        } catch {
+            throw MCPError.internalError("Failed to write to MCP stdio server '\(name)': \(error.localizedDescription)")
+        }
+    }
+
+    private func invokeTool(
+        name: String,
+        arguments: [String: SendableValue],
+        style: MCPToolResultStyle
+    ) async throws -> SendableValue {
+        try MCPWireCodec.requireToolName(name)
+        let response = try await sendRequest(
+            try MCPRequest(
+                method: "tools/call",
+                params: [
+                    "name": .string(name),
+                    "arguments": .dictionary(arguments)
+                ]
+            )
+        )
+        let result = try requireResult(response, context: "tools/call")
+        return try MCPWireCodec.toolCallResult(result, toolName: name, style: style)
+    }
+
+    private func requireResult(_ response: MCPResponse, context: String) throws -> SendableValue {
+        if let error = response.error {
+            throw MCPError(code: error.code, message: error.message, data: error.data)
+        }
+        guard let result = response.result else {
+            throw MCPError.internalError("No result in \(context) response")
+        }
+        return result
+    }
+
+    private func killProcess(_ process: Process) {
+        let pid = process.processIdentifier
+        guard pid > 0 else { return }
+        _ = kill(pid, SIGKILL)
+    }
+}

--- a/Sources/Swarm/Macros/MacroDeclarations.swift
+++ b/Sources/Swarm/Macros/MacroDeclarations.swift
@@ -4,6 +4,8 @@
 // Public macro declarations for Swarm.
 // These macros significantly reduce boilerplate when creating tools and agents.
 
+#if SWARM_MACROS
+
 // MARK: - @Tool Macro
 
 /// A macro that generates Tool protocol conformance for a struct.
@@ -322,6 +324,8 @@ public macro Prompt(_ content: String) -> PromptString = #externalMacro(
     type: "PromptMacro"
 )
 
+#endif
+
 // MARK: - PromptString
 
 /// A validated prompt string created by the #Prompt macro.
@@ -357,6 +361,8 @@ public struct PromptString: Sendable, ExpressibleByStringLiteral, ExpressibleByS
         interpolations = []
     }
 }
+
+#if SWARM_MACROS
 
 // MARK: - #Tool Macro (Inline Tool)
 
@@ -475,6 +481,7 @@ public macro Tool(
 @attached(member, names: arbitrary)
 public macro Builder() = #externalMacro(module: "SwarmMacros", type: "BuilderMacro")
 
+#endif
 
 // MARK: - PromptString String Interpolation
 

--- a/Sources/Swarm/Tools/BuiltInTools.swift
+++ b/Sources/Swarm/Tools/BuiltInTools.swift
@@ -381,7 +381,7 @@ public enum BuiltInTools {
     /// - Apple platforms: calculator, dateTime, string, semanticCompactor
     /// - Linux: dateTime, string, semanticCompactor
     public static var all: [any AnyJSONTool] {
-        var tools: [any AnyJSONTool] = [dateTime, string, bridgeToolToAnyJSON(SemanticCompactorTool())]
+        var tools: [any AnyJSONTool] = [dateTime, string, semanticCompactor]
         #if canImport(Darwin)
         tools.append(calculator)
         #endif

--- a/Sources/Swarm/Tools/SemanticCompactorTool.swift
+++ b/Sources/Swarm/Tools/SemanticCompactorTool.swift
@@ -14,41 +14,63 @@ import Foundation
 ///
 /// On supported Apple devices (iOS 18+ / macOS 15+), it runs entirely on-device,
 /// ensuring privacy and low latency.
-@Tool("Compacts or summarizes a piece of text to its essential information.")
-public struct SemanticCompactorTool {
-    // MARK: - Parameters
-    
-    @Parameter("The long text or content to compact")
-    var text: String
-    
-    @Parameter("The compaction strategy: 'summary' (concise paragraph), 'key_points' (bullet list), or 'semantic_core' (most minimal version).", default: "summary")
-    var strategy: String = "summary"
-    
-    @Parameter("The maximum length of the output in characters (approximate).", default: 500)
-    var maxLength: Int = 500
-    
-    // MARK: - Properties
-    
+///
+/// Implemented as ``AnyJSONTool`` so it compiles without the Macros trait.
+/// Prefer ``FunctionTool`` or `@Tool` in application code.
+public struct SemanticCompactorTool: AnyJSONTool, Sendable {
+    public let name = "semantic_compactor"
+    public let description = "Compacts or summarizes a piece of text to its essential information."
+    public let parameters: [ToolParameter] = [
+        ToolParameter(
+            name: "text",
+            description: "The long text or content to compact",
+            type: .string
+        ),
+        ToolParameter(
+            name: "strategy",
+            description: """
+            The compaction strategy: 'summary' (concise paragraph), \
+            'key_points' (bullet list), or 'semantic_core' (most minimal version).
+            """,
+            type: .string,
+            isRequired: false,
+            defaultValue: .string("summary")
+        ),
+        ToolParameter(
+            name: "maxLength",
+            description: "The maximum length of the output in characters (approximate).",
+            type: .int,
+            isRequired: false,
+            defaultValue: .int(500)
+        ),
+    ]
+
+    /// The long text or content to compact.
+    public var text: String = ""
+
+    /// The compaction strategy: `summary`, `key_points`, or `semantic_core`.
+    public var strategy: String = "summary"
+
+    /// The maximum length of the output in characters (approximate).
+    public var maxLength: Int = 500
+
     private let summarizer: any Summarizer
-    
-    // MARK: - Initialization
-    
+
     /// Creates a new semantic compactor tool.
     ///
-    /// - Parameter summarizer: The summarization engine to use. 
+    /// - Parameter summarizer: The summarization engine to use.
     ///   Defaults to a fallback chain that tries Foundation Models first, then truncates.
     public init(summarizer: (any Summarizer)? = nil) {
-        // Initialize @Parameter properties with defaults
         self.text = ""
         self.strategy = "summary"
         self.maxLength = 500
-        
+
         if let summarizer {
             self.summarizer = summarizer
         } else {
             #if canImport(FoundationModels)
             if #available(macOS 26.0, iOS 26.0, *) {
-                 self.summarizer = FallbackSummarizer(
+                self.summarizer = FallbackSummarizer(
                     primary: FoundationModelsSummarizer(),
                     fallback: TruncatingSummarizer.shared
                 )
@@ -60,45 +82,58 @@ public struct SemanticCompactorTool {
             #endif
         }
     }
-    
-    // MARK: - Execution
-    
+
     public func execute() async throws -> String {
         guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             return "No text provided to compact."
         }
-        
-        // Adjust prompt based on strategy
+
         let prompt: String
         switch strategy.lowercased() {
         case "key_points", "bullets":
-            prompt = "Extract the key points from the following text as a bulleted list. Be concise and factual.\n\nText:\n\(text)\n\nKey Points:"
+            prompt = """
+            Extract the key points from the following text as a bulleted list. Be concise and factual.
+
+            Text:
+            \(text)
+
+            Key Points:
+            """
         case "semantic_core", "compact":
-            prompt = "Condense the following text to its absolute semantic core. Remove all filler words while preserving all names, dates, figures, and critical facts. Use as few words as possible.\n\nText:\n\(text)\n\nCore Info:"
+            prompt = """
+            Condense the following text to its absolute semantic core. \
+            Remove all filler words while preserving all names, dates, figures, and critical facts. \
+            Use as few words as possible.
+
+            Text:
+            \(text)
+
+            Core Info:
+            """
         default:
-            // Standard summary
             prompt = text
         }
-        
-        // Use the summarizer
-        // Since the current Summarizer protocol in the codebase handles its own internal prompts 
-        // for FoundationModelsSummarizer, we pass the text. 
-        // If it's a specialized strategy, we wrap the text in a prompt if the summarizer is just a 
-        // generic LLM wrapper, but FoundationModelsSummarizer has its own internal conversational 
-        // prompt. 
-        
-        // For the sake of this tool's flexibility, we'll try to use the summarizer 
-        // but respect the maxTokens (approx characters / 4)
+
         let maxTokens = maxLength / 4
-        
+
         do {
-            // Note: In a real implementation we might pass the 'prompt' instead of 'text' 
-            // if the summarizer supports arbitrary prompts, but the current protocol 
-            // is designed for memory summarization.
             return try await summarizer.summarize(prompt, maxTokens: maxTokens)
         } catch {
-            // Fallback to basic truncation if the summarizer fails
             return try await TruncatingSummarizer.shared.summarize(text, maxTokens: maxTokens)
         }
+    }
+
+    public func execute(arguments: [String: SendableValue]) async throws -> SendableValue {
+        guard let text = arguments["text"]?.stringValue else {
+            throw AgentError.invalidToolArguments(
+                toolName: name,
+                reason: "Missing required parameter 'text'"
+            )
+        }
+        var copy = self
+        copy.text = text
+        copy.strategy = arguments["strategy"]?.stringValue ?? "summary"
+        copy.maxLength = arguments["maxLength"]?.intValue ?? 500
+        return .string(try await copy.execute())
     }
 }

--- a/Sources/Swarm/Tools/ZoniSearchTool.swift
+++ b/Sources/Swarm/Tools/ZoniSearchTool.swift
@@ -26,8 +26,10 @@ public struct ZoniSearchDocument: Sendable, Equatable {
 ///
 /// This tool allows an agent to query a knowledge base (PDFs, Markdown, Web pages)
 /// that has been indexed using Zoni's technical pipeline.
-@Tool("Searches a private knowledge base of documents to find specific, factual information.")
-public struct ZoniSearchTool {
+///
+/// Implemented as ``AnyJSONTool`` so it compiles without the Macros trait.
+/// Prefer ``FunctionTool`` or `@Tool` in application code.
+public struct ZoniSearchTool: AnyJSONTool, Sendable {
     public enum Error: Swift.Error, LocalizedError, Sendable {
         case pipelineNotConfigured
 
@@ -38,12 +40,29 @@ public struct ZoniSearchTool {
             }
         }
     }
-    
-    @Parameter("The specific question or information to look up in the documents")
-    var query: String
-    
-    @Parameter("Optional category or collection to limit the search to", default: nil)
-    var collection: String?
+
+    public let name = "zoni_search"
+    public let description =
+        "Searches a private knowledge base of documents to find specific, factual information."
+    public let parameters: [ToolParameter] = [
+        ToolParameter(
+            name: "query",
+            description: "The specific question or information to look up in the documents",
+            type: .string
+        ),
+        ToolParameter(
+            name: "collection",
+            description: "Optional category or collection to limit the search to",
+            type: .string,
+            isRequired: false
+        ),
+    ]
+
+    /// The specific question or information to look up in the documents.
+    public var query: String = ""
+
+    /// Optional category or collection to limit the search to.
+    public var collection: String?
 
     private let search: @Sendable (String, String?) async throws -> String
 
@@ -62,9 +81,22 @@ public struct ZoniSearchTool {
         self.collection = nil
         self.search = search
     }
-    
+
     public func execute() async throws -> String {
         try await search(query, collection)
+    }
+
+    public func execute(arguments: [String: SendableValue]) async throws -> SendableValue {
+        guard let query = arguments["query"]?.stringValue else {
+            throw AgentError.invalidToolArguments(
+                toolName: name,
+                reason: "Missing required parameter 'query'"
+            )
+        }
+        var copy = self
+        copy.query = query
+        copy.collection = arguments["collection"]?.stringValue
+        return .string(try await copy.execute())
     }
 
     private static func searchDocuments(

--- a/Sources/SwarmCapabilityShowcaseSupport/CapabilityShowcase.swift
+++ b/Sources/SwarmCapabilityShowcaseSupport/CapabilityShowcase.swift
@@ -1118,7 +1118,7 @@ private actor AttemptCounter {
     }
 }
 
-private actor ShowcaseMCPServer: MCPServer {
+private actor ShowcaseMCPServer: MCPServerConnection {
     let name: String
     private var schemas: [ToolSchema] = []
     private var serverCapabilities: MCPCapabilities

--- a/Tests/SwarmTests/Integration/MCPIntegrationTests.swift
+++ b/Tests/SwarmTests/Integration/MCPIntegrationTests.swift
@@ -10,7 +10,7 @@ import Testing
 // MARK: - IntegrationTestMCPServer
 
 /// A mock MCP server for integration testing.
-actor IntegrationTestMCPServer: MCPServer {
+actor IntegrationTestMCPServer: MCPServerConnection {
     // MARK: Internal
 
     let name: String

--- a/Tests/SwarmTests/MCP/Fixtures/mcp_fixture_server.py
+++ b/Tests/SwarmTests/MCP/Fixtures/mcp_fixture_server.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Reference MCP server fixture for Swarm wire-protocol interop tests.
+
+Speaks JSON-RPC 2.0 over newline-delimited stdio (default) or streamable HTTP
+(`--http`). Implements initialize, tools/list, tools/call, and
+notifications/initialized. Not a mock of Swarm types — a real MCP peer.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+SUPPORTED_VERSIONS = {
+    "2024-11-05",
+    "2025-03-26",
+    "2025-06-18",
+    "2025-11-25",
+}
+CURRENT_VERSION = "2025-11-25"
+SESSION_ID = "swarm-fixture-session"
+
+
+def handle_rpc(message: dict[str, Any]) -> dict[str, Any] | None:
+    method = message.get("method")
+    rpc_id = message.get("id")
+    params = message.get("params") or {}
+
+    if method == "notifications/initialized" or (method or "").startswith("notifications/"):
+        return None
+
+    if method == "initialize":
+        requested = params.get("protocolVersion") or CURRENT_VERSION
+        version = requested if requested in SUPPORTED_VERSIONS else CURRENT_VERSION
+        return _result(
+            rpc_id,
+            {
+                "protocolVersion": version,
+                "capabilities": {"tools": {"listChanged": False}},
+                "serverInfo": {"name": "swarm-mcp-fixture", "version": "1.0.0"},
+            },
+        )
+
+    if method == "tools/list":
+        return _result(
+            rpc_id,
+            {
+                "tools": [
+                    {
+                        "name": "echo",
+                        "description": "Echoes the text argument",
+                        "inputSchema": {
+                            "type": "object",
+                            "required": ["text"],
+                            "properties": {
+                                "text": {"type": "string", "description": "Text to echo"}
+                            },
+                        },
+                    }
+                ]
+            },
+        )
+
+    if method == "tools/call":
+        name = params.get("name") or ""
+        arguments = params.get("arguments") or {}
+        if not name:
+            return _error(rpc_id, -32602, "Tool name must be non-empty")
+        if name != "echo":
+            return _error(rpc_id, -32601, f"Unknown tool '{name}'")
+        text = arguments.get("text", "")
+        return _result(
+            rpc_id,
+            {
+                "content": [{"type": "text", "text": str(text)}],
+                "isError": False,
+            },
+        )
+
+    return _error(rpc_id, -32601, f"Method not found: {method}")
+
+
+def _result(rpc_id: Any, result: dict[str, Any]) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": rpc_id, "result": result}
+
+
+def _error(rpc_id: Any, code: int, message: str) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": rpc_id, "error": {"code": code, "message": message}}
+
+
+def run_stdio() -> None:
+    for raw in sys.stdin:
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            message = json.loads(line)
+        except json.JSONDecodeError as exc:
+            sys.stderr.write(f"invalid json: {exc}\n")
+            sys.stderr.flush()
+            continue
+        response = handle_rpc(message)
+        if response is None:
+            continue
+        sys.stdout.write(json.dumps(response, separators=(",", ":")) + "\n")
+        sys.stdout.flush()
+
+
+class MCPHTTPHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, fmt: str, *args: Any) -> None:
+        sys.stderr.write("http: " + (fmt % args) + "\n")
+
+    def do_POST(self) -> None:  # noqa: N802
+        length = int(self.headers.get("Content-Length") or "0")
+        body = self.rfile.read(length) if length else b""
+        if not body:
+            self._send(202, b"")
+            return
+        try:
+            message = json.loads(body.decode("utf-8"))
+        except json.JSONDecodeError:
+            self._send(400, b'{"error":"invalid json"}')
+            return
+
+        response = handle_rpc(message)
+        if response is None:
+            self._send(202, b"", content_type="application/json")
+            return
+        payload = json.dumps(response, separators=(",", ":")).encode("utf-8")
+        self._send(200, payload, content_type="application/json")
+
+    def _send(self, status: int, body: bytes, content_type: str = "application/json") -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("MCP-Session-Id", SESSION_ID)
+        self.end_headers()
+        if body:
+            self.wfile.write(body)
+
+
+def run_http(port: int, port_file: str | None) -> None:
+    server = ThreadingHTTPServer(("127.0.0.1", port), MCPHTTPHandler)
+    chosen = server.server_address[1]
+    if port_file:
+        with open(port_file, "w", encoding="utf-8") as handle:
+            handle.write(str(chosen))
+    sys.stderr.write(f"MCP_FIXTURE_PORT={chosen}\n")
+    sys.stderr.flush()
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    thread.join()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Swarm MCP interop fixture")
+    parser.add_argument("--http", type=int, nargs="?", const=0, default=None)
+    parser.add_argument("--port-file", default=None)
+    args = parser.parse_args()
+    if args.http is None:
+        run_stdio()
+    else:
+        run_http(args.http, args.port_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/Tests/SwarmTests/MCP/HTTPMCPServerModernizationTests.swift
+++ b/Tests/SwarmTests/MCP/HTTPMCPServerModernizationTests.swift
@@ -1,0 +1,291 @@
+// HTTPMCPServerModernizationTests.swift
+// SwarmTests
+//
+// Version negotiation, envelope unwrap, empty tool names, and streamable HTTP.
+
+import Foundation
+@testable import Swarm
+import Testing
+
+@Suite("HTTPMCPServer Modernization Tests", .serialized)
+struct HTTPMCPServerModernizationTests {
+    @Test("Unsupported protocol version fails loudly")
+    func unsupportedProtocolVersionFails() async throws {
+        let session = try makeSession { _, body in
+            let request = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            let id = request["id"] as? String ?? "1"
+            return try jsonResponse(
+                id: id,
+                result: [
+                    "protocolVersion": "1999-01-01",
+                    "capabilities": ["tools": [:]]
+                ]
+            )
+        }
+        defer { ModernizationURLProtocol.reset() }
+
+        let server = try HTTPMCPServer(
+            url: URL(string: "https://mcp.example.com/api")!,
+            name: "version-test",
+            maxRetries: 0,
+            session: session
+        )
+
+        do {
+            _ = try await server.initialize()
+            Issue.record("Expected unsupported protocol version to throw")
+        } catch let error as MCPError {
+            #expect(error.code == MCPError.invalidRequestCode)
+            #expect(error.message.contains("1999-01-01"))
+            #expect(error.message.contains("2024-11-05"))
+        }
+    }
+
+    @Test("callTool unwraps a single text content block")
+    func callToolUnwrapsTextContent() async throws {
+        let session = try makeSession { _, body in
+            let request = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            let id = request["id"] as? String ?? "1"
+            return try jsonResponse(
+                id: id,
+                result: [
+                    "content": [
+                        ["type": "text", "text": "hello from envelope"]
+                    ],
+                    "isError": false
+                ]
+            )
+        }
+        defer { ModernizationURLProtocol.reset() }
+
+        let server = try HTTPMCPServer(
+            url: URL(string: "https://mcp.example.com/api")!,
+            name: "unwrap-test",
+            maxRetries: 0,
+            session: session
+        )
+
+        let unwrapped = try await server.callTool(name: "echo", arguments: [:])
+        #expect(unwrapped == .string("hello from envelope"))
+
+        let raw = try await server.callToolRaw(name: "echo", arguments: [:])
+        #expect(raw.dictionaryValue?["isError"]?.boolValue == false)
+        #expect(raw.dictionaryValue?["content"]?.arrayValue?.isEmpty == false)
+    }
+
+    @Test("Empty tool name returns an error instead of trapping")
+    func emptyToolNameReturnsError() async throws {
+        let server = try HTTPMCPServer(
+            url: URL(string: "https://mcp.example.com/api")!,
+            name: "empty-name",
+            maxRetries: 0
+        )
+
+        do {
+            _ = try await server.callTool(name: "   ", arguments: [:])
+            Issue.record("Expected empty tool name to throw")
+        } catch let error as MCPError {
+            #expect(error.code == MCPError.invalidParamsCode)
+            #expect(error.message.contains("non-empty"))
+        }
+    }
+
+    @Test("Prompts and sampling advertised by the server are not surfaced")
+    func promptsAndSamplingAreDeadvertised() async throws {
+        let session = try makeSession { _, body in
+            let request = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            let id = request["id"] as? String ?? "1"
+            if request["method"] as? String == "notifications/initialized" {
+                return emptyAccepted()
+            }
+            return try jsonResponse(
+                id: id,
+                result: [
+                    "protocolVersion": MCPProtocolVersion.current,
+                    "capabilities": [
+                        "tools": [:],
+                        "prompts": [:],
+                        "sampling": [:]
+                    ]
+                ]
+            )
+        }
+        defer { ModernizationURLProtocol.reset() }
+
+        let server = try HTTPMCPServer(
+            url: URL(string: "https://mcp.example.com/api")!,
+            name: "caps-test",
+            maxRetries: 0,
+            session: session
+        )
+
+        let capabilities = try await server.initialize()
+        #expect(capabilities.tools)
+        #expect(!capabilities.prompts)
+        #expect(!capabilities.sampling)
+    }
+
+    @Test("Session id from initialize is forwarded on the next request")
+    func sessionIDIsForwarded() async throws {
+        let session = try makeSession { request, body in
+            let object = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            let method = object["method"] as? String
+            let id = object["id"] as? String ?? "1"
+            if method == "initialize" {
+                return try jsonResponse(
+                    id: id,
+                    result: [
+                        "protocolVersion": MCPProtocolVersion.legacy,
+                        "capabilities": ["tools": [:]]
+                    ],
+                    headers: ["MCP-Session-Id": "abc-session"]
+                )
+            }
+            if method == "notifications/initialized" {
+                return emptyAccepted()
+            }
+            #expect(request.value(forHTTPHeaderField: "MCP-Session-Id") == "abc-session")
+            return try jsonResponse(id: id, result: ["tools": []])
+        }
+        defer { ModernizationURLProtocol.reset() }
+
+        let server = try HTTPMCPServer(
+            url: URL(string: "https://mcp.example.com/api")!,
+            name: "session-test",
+            maxRetries: 0,
+            session: session
+        )
+
+        _ = try await server.initialize()
+        #expect(await server.sessionID == "abc-session")
+        _ = try await server.listTools()
+    }
+
+    @Test("SSE JSON-RPC responses are decoded")
+    func sseResponsesAreDecoded() async throws {
+        let session = try makeSession { _, body in
+            let request = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            let id = request["id"] as? String ?? "1"
+            let payload = """
+            event: message
+            data: {"jsonrpc":"2.0","id":"\(id)","result":{"tools":[]}}
+
+            """
+            let response = HTTPURLResponse(
+                url: URL(string: "https://mcp.example.com/api")!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "text/event-stream"]
+            )!
+            return (response, Data(payload.utf8))
+        }
+        defer { ModernizationURLProtocol.reset() }
+
+        let server = try HTTPMCPServer(
+            url: URL(string: "https://mcp.example.com/api")!,
+            name: "sse-test",
+            maxRetries: 0,
+            session: session
+        )
+
+        let tools = try await server.listTools()
+        #expect(tools.isEmpty)
+    }
+
+    private func makeSession(
+        _ handler: @escaping @Sendable (URLRequest, Data) throws -> (HTTPURLResponse, Data)
+    ) throws -> URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [ModernizationURLProtocol.self]
+        ModernizationURLProtocol.reset()
+        ModernizationURLProtocol.handler = handler
+        return URLSession(configuration: config)
+    }
+
+    private func jsonResponse(
+        id: String,
+        result: [String: Any],
+        headers: [String: String] = [:]
+    ) throws -> (HTTPURLResponse, Data) {
+        var headerFields = headers
+        headerFields["Content-Type"] = "application/json"
+        let response = HTTPURLResponse(
+            url: URL(string: "https://mcp.example.com/api")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: headerFields
+        )!
+        let body: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": result
+        ]
+        return (response, try JSONSerialization.data(withJSONObject: body))
+    }
+
+    private func emptyAccepted() -> (HTTPURLResponse, Data) {
+        let response = HTTPURLResponse(
+            url: URL(string: "https://mcp.example.com/api")!,
+            statusCode: 202,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        return (response, Data())
+    }
+}
+
+private final class ModernizationURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var handler: (@Sendable (URLRequest, Data) throws -> (HTTPURLResponse, Data))?
+
+    static func reset() {
+        handler = nil
+    }
+
+    override class func canInit(with _: URLRequest) -> Bool { true }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = Self.handler else {
+            fatalError("ModernizationURLProtocol.handler not set")
+        }
+        do {
+            let body = try bodyData(from: request)
+            let (response, data) = try handler(request, body)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+
+    private func bodyData(from request: URLRequest) throws -> Data {
+        if let body = request.httpBody {
+            return body
+        }
+
+        guard let stream = request.httpBodyStream else {
+            return Data()
+        }
+
+        stream.open()
+        defer { stream.close() }
+
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while stream.hasBytesAvailable {
+            let read = stream.read(&buffer, maxLength: buffer.count)
+            if read < 0 {
+                throw stream.streamError ?? MCPError.internalError("Failed to read HTTP body stream")
+            }
+            if read == 0 {
+                break
+            }
+            data.append(buffer, count: read)
+        }
+        return data
+    }
+}

--- a/Tests/SwarmTests/MCP/HTTPMCPServerTests.swift
+++ b/Tests/SwarmTests/MCP/HTTPMCPServerTests.swift
@@ -152,9 +152,19 @@ struct HTTPMCPServerLifecycleTests {
         #expect(methods == ["initialize", "notifications/initialized"])
 
         let initializeParams = try #require(requestObjects[0]["params"] as? [String: Any])
+        #expect(initializeParams["protocolVersion"] as? String == MCPProtocolVersion.current)
         #expect(initializeParams["capabilities"] != nil)
         let clientInfo = try #require(initializeParams["clientInfo"] as? [String: Any])
         #expect(clientInfo["name"] as? String == "Swarm")
+        #expect(clientInfo["version"] as? String == Swarm.version)
+
+        let firstHeaders = try #require(HTTPMCPRecordingURLProtocol.requestHeaders.first)
+        #expect(firstHeaders["Accept"]?.contains("application/json") == true)
+        #expect(firstHeaders["Accept"]?.contains("text/event-stream") == true)
+        #expect(firstHeaders["MCP-Protocol-Version"] == MCPProtocolVersion.current)
+
+        #expect(await server.negotiatedProtocolVersion == "2024-11-05")
+        #expect(await server.sessionID == nil)
 
         if requestObjects.count > 1 {
             #expect(requestObjects[1]["id"] == nil)
@@ -211,8 +221,11 @@ private final class HTTPMCPRecordingURLProtocol: URLProtocol {
     nonisolated(unsafe) static var requestBodies: [Data] = []
     nonisolated(unsafe) static var handler: ((URLRequest, Data) throws -> (HTTPURLResponse, Data))?
 
+    nonisolated(unsafe) static var requestHeaders: [[String: String]] = []
+
     static func reset() {
         requestBodies = []
+        requestHeaders = []
         handler = nil
     }
 
@@ -232,6 +245,17 @@ private final class HTTPMCPRecordingURLProtocol: URLProtocol {
         do {
             let body = try bodyData(from: request)
             Self.requestBodies.append(body)
+            var headers: [String: String] = [:]
+            if let accept = request.value(forHTTPHeaderField: "Accept") {
+                headers["Accept"] = accept
+            }
+            if let version = request.value(forHTTPHeaderField: "MCP-Protocol-Version") {
+                headers["MCP-Protocol-Version"] = version
+            }
+            if let session = request.value(forHTTPHeaderField: "MCP-Session-Id") {
+                headers["MCP-Session-Id"] = session
+            }
+            Self.requestHeaders.append(headers)
             let (response, data) = try handler(request, body)
             client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
             client?.urlProtocol(self, didLoad: data)

--- a/Tests/SwarmTests/MCP/MCPClientTests+Mocks.swift
+++ b/Tests/SwarmTests/MCP/MCPClientTests+Mocks.swift
@@ -9,7 +9,7 @@ import Foundation
 // MARK: - MockMCPServer
 
 /// A mock MCP server for testing MCPClient behavior.
-actor MockMCPServer: MCPServer {
+actor MockMCPServer: MCPServerConnection {
     let name: String
     var capabilitiesToReturn: MCPCapabilities
     var toolsToReturn: [ToolSchema]

--- a/Tests/SwarmTests/MCP/MCPFixtureSupport.swift
+++ b/Tests/SwarmTests/MCP/MCPFixtureSupport.swift
@@ -1,0 +1,65 @@
+// MCPFixtureSupport.swift
+// SwarmTests
+//
+// Locates the reference MCP fixture script and python3 for interop tests.
+
+import Foundation
+import Testing
+
+enum MCPFixtureSupport {
+    static var scriptURL: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .appendingPathComponent("Fixtures/mcp_fixture_server.py")
+    }
+
+    static func requirePython3() throws -> String {
+        let candidates = ["/usr/bin/python3", "/opt/homebrew/bin/python3", "/usr/local/bin/python3"]
+        for path in candidates where FileManager.default.isExecutableFile(atPath: path) {
+            return path
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["which", "python3"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = Pipe()
+        try process.run()
+        process.waitUntilExit()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let path = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if process.terminationStatus == 0, !path.isEmpty {
+            return path
+        }
+
+        throw MCPFixtureError.python3Unavailable
+    }
+
+    static func waitForPortFile(_ url: URL, timeout: TimeInterval = 5) throws -> Int {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if let text = try? String(contentsOf: url, encoding: .utf8),
+               let port = Int(text.trimmingCharacters(in: .whitespacesAndNewlines)),
+               port > 0 {
+                return port
+            }
+            Thread.sleep(forTimeInterval: 0.05)
+        }
+        throw MCPFixtureError.portFileTimeout
+    }
+}
+
+enum MCPFixtureError: Error, CustomStringConvertible {
+    case python3Unavailable
+    case portFileTimeout
+
+    var description: String {
+        switch self {
+        case .python3Unavailable:
+            "python3 is required for MCP interop tests"
+        case .portFileTimeout:
+            "MCP HTTP fixture did not write its port file in time"
+        }
+    }
+}

--- a/Tests/SwarmTests/MCP/MCPInteropTests.swift
+++ b/Tests/SwarmTests/MCP/MCPInteropTests.swift
@@ -1,0 +1,116 @@
+// MCPInteropTests.swift
+// SwarmTests
+//
+// Wire-protocol tests against a real MCP server fixture over stdio and HTTP.
+
+import Foundation
+@testable import Swarm
+import Testing
+
+@Suite("MCP Interop Tests", .serialized)
+struct MCPInteropTests {
+    @Test("Stdio transport completes initialize, tools/list, and tools/call")
+    func stdioHandshakeListAndCall() async throws {
+        let python = try MCPFixtureSupport.requirePython3()
+        let script = MCPFixtureSupport.scriptURL
+        #expect(FileManager.default.fileExists(atPath: script.path))
+
+        let server = StdioMCPServer(
+            command: python,
+            arguments: [script.path],
+            name: "stdio-interop",
+            timeout: 10
+        )
+        defer {
+            Task { try? await server.close() }
+        }
+
+        let capabilities = try await server.initialize()
+        #expect(capabilities.tools)
+        #expect(!capabilities.prompts)
+        #expect(!capabilities.sampling)
+        #expect(await server.negotiatedProtocolVersion == MCPProtocolVersion.current)
+
+        let tools = try await server.listTools()
+        #expect(tools.map(\.name) == ["echo"])
+
+        let result = try await server.callTool(
+            name: "echo",
+            arguments: ["text": .string("stdio-wire")]
+        )
+        #expect(result == .string("stdio-wire"))
+
+        let raw = try await server.callToolRaw(
+            name: "echo",
+            arguments: ["text": .string("raw")]
+        )
+        #expect(raw.dictionaryValue?["content"] != nil)
+    }
+
+    @Test("HTTP transport completes initialize, tools/list, and tools/call")
+    func httpHandshakeListAndCall() async throws {
+        let python = try MCPFixtureSupport.requirePython3()
+        let script = MCPFixtureSupport.scriptURL
+        let portFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("swarm-mcp-http-\(UUID().uuidString).port")
+        defer { try? FileManager.default.removeItem(at: portFile) }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: python)
+        process.arguments = [script.path, "--http", "0", "--port-file", portFile.path]
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+        try process.run()
+        defer {
+            process.terminate()
+            process.waitUntilExit()
+        }
+
+        let port = try MCPFixtureSupport.waitForPortFile(portFile)
+        let url = try #require(URL(string: "http://127.0.0.1:\(port)/"))
+        let server = try HTTPMCPServer(
+            url: url,
+            name: "http-interop",
+            maxRetries: 0
+        )
+        defer {
+            Task { try? await server.close() }
+        }
+
+        let capabilities = try await server.initialize()
+        #expect(capabilities.tools)
+        #expect(await server.negotiatedProtocolVersion == MCPProtocolVersion.current)
+        #expect(await server.sessionID == "swarm-fixture-session")
+
+        let tools = try await server.listTools()
+        #expect(tools.map(\.name) == ["echo"])
+
+        let result = try await server.callTool(
+            name: "echo",
+            arguments: ["text": .string("http-wire")]
+        )
+        #expect(result == .string("http-wire"))
+    }
+
+    @Test("Stdio empty tool name returns an error")
+    func stdioEmptyToolName() async throws {
+        let python = try MCPFixtureSupport.requirePython3()
+        let server = StdioMCPServer(
+            command: python,
+            arguments: [MCPFixtureSupport.scriptURL.path],
+            name: "stdio-empty-name",
+            timeout: 10
+        )
+        defer {
+            Task { try? await server.close() }
+        }
+
+        _ = try await server.initialize()
+        do {
+            _ = try await server.callTool(name: "", arguments: [:])
+            Issue.record("Expected empty tool name to throw")
+        } catch let error as MCPError {
+            #expect(error.code == MCPError.invalidParamsCode)
+        }
+    }
+}

--- a/Tests/SwarmTests/MCP/MCPProtocolTests.swift
+++ b/Tests/SwarmTests/MCP/MCPProtocolTests.swift
@@ -87,7 +87,7 @@ struct MCPResponseTests {
         // This test verifies the Swift API works correctly with properly encoded values.
 
         // Create response using factory method (proper internal API)
-        let response = MCPResponse.success(id: "resp-1", result: .dictionary(["tools": .array([])]))
+        let response = try MCPResponse.success(id: "resp-1", result: .dictionary(["tools": .array([])]))
 
         #expect(response.jsonrpc == "2.0")
         #expect(response.id == "resp-1")
@@ -129,7 +129,7 @@ struct MCPResponseTests {
 
     @Test("success factory creates valid response")
     func successFactory() throws {
-        let response = MCPResponse.success(id: "success-1", result: .string("done"))
+        let response = try MCPResponse.success(id: "success-1", result: .string("done"))
 
         #expect(response.jsonrpc == "2.0")
         #expect(response.id == "success-1")
@@ -140,7 +140,7 @@ struct MCPResponseTests {
     @Test("failure factory creates valid error response")
     func failureFactory() throws {
         let errorObj = MCPErrorObject(code: -32600, message: "Invalid request")
-        let response = MCPResponse.failure(id: "fail-1", error: errorObj)
+        let response = try MCPResponse.failure(id: "fail-1", error: errorObj)
 
         #expect(response.jsonrpc == "2.0")
         #expect(response.id == "fail-1")
@@ -176,6 +176,61 @@ struct MCPResponseTests {
         let data = jsonString.data(using: .utf8)!
         #expect(throws: DecodingError.self) {
             _ = try JSONDecoder().decode(MCPResponse.self, from: data)
+        }
+    }
+
+    @Test("response decodes numeric JSON-RPC id")
+    func responseDecodesNumericID() throws {
+        let jsonString = """
+        {
+            "jsonrpc": "2.0",
+            "id": 7,
+            "result": "ok"
+        }
+        """
+        let data = jsonString.data(using: .utf8)!
+        let response = try JSONDecoder().decode(MCPResponse.self, from: data)
+        #expect(response.id == "7")
+        #expect(response.result == .string("ok"))
+    }
+
+    @Test("success factory rejects empty id")
+    func successFactoryRejectsEmptyID() {
+        #expect(throws: MCPError.self) {
+            _ = try MCPResponse.success(id: "", result: .string("ok"))
+        }
+    }
+
+    @Test("failure factory rejects empty id")
+    func failureFactoryRejectsEmptyID() {
+        #expect(throws: MCPError.self) {
+            _ = try MCPResponse.failure(
+                id: "",
+                error: MCPErrorObject(code: -32600, message: "invalid")
+            )
+        }
+    }
+}
+
+@Suite("MCPProtocolVersion Tests")
+struct MCPProtocolVersionTests {
+    @Test("negotiates supported current and legacy versions")
+    func negotiatesSupportedVersions() throws {
+        #expect(try MCPProtocolVersion.negotiate(serverReported: MCPProtocolVersion.current) == "2025-11-25")
+        #expect(try MCPProtocolVersion.negotiate(serverReported: MCPProtocolVersion.legacy) == "2024-11-05")
+        #expect(try MCPProtocolVersion.negotiate(serverReported: "2025-06-18") == "2025-06-18")
+    }
+
+    @Test("unsupported or missing versions fail loudly")
+    func unsupportedVersionsFail() {
+        #expect(throws: MCPError.self) {
+            _ = try MCPProtocolVersion.negotiate(serverReported: "1999-01-01")
+        }
+        #expect(throws: MCPError.self) {
+            _ = try MCPProtocolVersion.negotiate(serverReported: nil)
+        }
+        #expect(throws: MCPError.self) {
+            _ = try MCPProtocolVersion.negotiate(serverReported: "")
         }
     }
 }

--- a/Tests/SwarmTests/Regression/FrameworkDXRegressionTests.swift
+++ b/Tests/SwarmTests/Regression/FrameworkDXRegressionTests.swift
@@ -305,7 +305,7 @@ private struct OrderedWorkflowAgent: AgentRuntime {
     func cancel() async {}
 }
 
-private actor BlockingToolListServer: MCPServer {
+private actor BlockingToolListServer: MCPServerConnection {
     let name: String
     private var tools: [ToolSchema]
     private var blockedContinuation: CheckedContinuation<Void, Never>?
@@ -374,7 +374,7 @@ private actor BlockingToolListServer: MCPServer {
     }
 }
 
-private actor BlockingResourceListServer: MCPServer {
+private actor BlockingResourceListServer: MCPServerConnection {
     let name: String
     private var resources: [MCPResource]
     private var blockedContinuation: CheckedContinuation<Void, Never>?

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -46,9 +46,10 @@ package and is linked only with Integrations. Omitting the trait does **not**
 link Integrations modules into your app. Lean resolve never pulls
 Hive/Membrane/ContextCore/Conduit **package identities**, and trait-gated
 product edges also keep Wax, MetalANNS→GRDB, swift-crypto, swift-mutex, and
-SwiftSoup off the lean pin list. Always-on remotes remain (swift-syntax,
-swift-log, MCP sdk, OTel, plus NIO transitives — including `swift-collections`
-via NIO). `SWARM_CORE_ONLY=1` drops the integration package block entirely.
+SwiftSoup off the lean pin list. Default remotes remain (swift-syntax via the
+default-on **Macros** trait, swift-log, MCP sdk, OTel, plus NIO transitives —
+including `swift-collections` via NIO). Disable Macros with `traits: []` to
+drop swift-syntax. `SWARM_CORE_ONLY=1` drops the integration package block entirely.
 
 **Platform note:** ContextCore and the full Membrane session stack need Apple
 frameworks (Metal/CoreML/Accelerate). On Linux, Integrations still enables Hive
@@ -65,6 +66,46 @@ pseudo-embeddings, logs a once-per-process warning naming that API, and
 to auto-download (default `off`). A failed auto-download logs a warning and
 starts the session with fallback embeddings; call `ensureModelAvailable()` to
 retry. Simulator uses CoreML CPU inference; it is not a special-case fallback.
+
+### Disabling the Macros trait
+
+The **`Macros`** SwiftPM trait is **on by default**. It pulls `swift-syntax` so
+`@Tool`, `@Parameter`, `#Prompt`, and `@Traceable` work. Specifying traits on
+the package dependency replaces defaults, so `traits: ["Integrations"]` still
+keeps macros (Integrations enables Macros). To drop `swift-syntax` entirely:
+
+```swift
+.package(
+    url: "https://github.com/christopherkarani/Swarm.git",
+    from: "0.6.0",
+    traits: []
+)
+```
+
+You lose `@Tool`, `@Parameter`, `#Prompt`, and `@Traceable`. Everything else
+stays: agents, workflows, memory, and ``FunctionTool``.
+
+```swift
+import Swarm
+
+let echo = FunctionTool(
+    name: "echo",
+    description: "Echoes a message",
+    parameters: [
+        ToolParameter(name: "message", description: "Text to echo", type: .string)
+    ]
+) { args in
+    let message = try args.require("message", as: String.self)
+    return .string(message)
+}
+
+let agent = try Agent(
+    "Repeat the user's text.",
+    inferenceProvider: .foundationModels()
+) {
+    echo
+}
+```
 
 ### Xcode
 

--- a/docs/reference/api-catalog.md
+++ b/docs/reference/api-catalog.md
@@ -1,10 +1,10 @@
 # Swarm Public API Catalog
 
-Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for high-risk public rows on 2026-07-28 (Conduit hard-removed in 0.6).
+Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for high-risk public rows on 2026-07-28 (Conduit hard-removed in 0.6). MCP client rows refreshed 2026-08-14.
 
 - Scope: all `.swift` files under `Sources/Swarm/`, excluding `Internal/GraphRuntime/`
-- Source files scanned: 166
-- Public/open symbols cataloged: 2481
+- Source files scanned: 169
+- Public/open symbols cataloged: 2495
 
 ## 1. Swarm (entry point)
 
@@ -2520,12 +2520,23 @@ Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for
 | 56 | var | public | HTTPMCPServer.name | `public let name: String` |
 | 62 | var | public | HTTPMCPServer.capabilities | `public var capabilities: MCPCapabilities { get }` |
 | 77 | func | public | HTTPMCPServer.init(url:name:apiKey:timeout:maxRetries:session:) | `public init(url: URL, name: String, apiKey: String? = nil, timeout: TimeInterval = 30.0, maxRetries: Int = 3, session: URLSession = .shared) throws` |
+| 70 | var | public | HTTPMCPServer.negotiatedProtocolVersion | `public var negotiatedProtocolVersion: String? { get }` |
+| 76 | var | public | HTTPMCPServer.sessionID | `public var sessionID: String? { get }` |
 | 113 | func | public | HTTPMCPServer.initialize() | `public func initialize() async throws -> MCPCapabilities` |
 | 142 | func | public | HTTPMCPServer.listTools() | `public func listTools() async throws -> [ToolSchema]` |
 | 164 | func | public | HTTPMCPServer.callTool(name:arguments:) | `public func callTool(name: String, arguments: [String : SendableValue]) async throws -> SendableValue` |
+| 180 | func | public | HTTPMCPServer.callToolRaw(name:arguments:) | `public func callToolRaw(name: String, arguments: [String : SendableValue]) async throws -> SendableValue` |
 | 188 | func | public | HTTPMCPServer.listResources() | `public func listResources() async throws -> [MCPResource]` |
 | 208 | func | public | HTTPMCPServer.readResource(uri:) | `public func readResource(uri: String) async throws -> MCPResourceContent` |
 | 259 | func | public | HTTPMCPServer.close() | `public func close() async throws` |
+
+### MCP/StdioMCPServer.swift
+
+| Line | Kind | Access | Name | Signature |
+|------|------|--------|------|-----------|
+| — | class | public | StdioMCPServer | `public actor StdioMCPServer` |
+| — | func | public | StdioMCPServer.init(command:arguments:environment:workingDirectory:name:timeout:) | `public init(command: String, arguments: [String] = [], environment: [String: String]? = nil, workingDirectory: URL? = nil, name: String, timeout: TimeInterval = 30.0)` |
+| — | func | public | StdioMCPServer.callToolRaw(name:arguments:) | `public func callToolRaw(name: String, arguments: [String : SendableValue]) async throws -> SendableValue` |
 
 ### MCP/MCPCapabilities.swift
 
@@ -2547,7 +2558,7 @@ Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for
 | 56 | class | public | MCPClient | `public actor MCPClient` |
 | 68 | var | public | MCPClient.connectedServers | `public var connectedServers: [String] { get }` |
 | 77 | func | public | MCPClient.init() | `public init()` |
-| 99 | func | public | MCPClient.addServer(_:) | `public func addServer(_ server: any MCPServer) async throws` |
+| 99 | func | public | MCPClient.addServer(_:) | `public func addServer(_ server: any MCPServerConnection) async throws` |
 | 135 | func | public | MCPClient.removeServer(named:) | `public func removeServer(named name: String) async throws` |
 | 174 | func | public | MCPClient.getAllTools() | `public func getAllTools() async throws -> [any AnyJSONTool]` |
 | 279 | func | public | MCPClient.refreshTools() | `public func refreshTools() async throws -> [any AnyJSONTool]` |
@@ -2578,6 +2589,7 @@ Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for
 | 115 | func | public | MCPError.methodNotFound(_:) | `public static func methodNotFound(_ method: String? = nil) -> MCPError` |
 | 128 | func | public | MCPError.invalidParams(_:) | `public static func invalidParams(_ details: String? = nil) -> MCPError` |
 | 139 | func | public | MCPError.internalError(_:) | `public static func internalError(_ details: String? = nil) -> MCPError` |
+| — | func | public | MCPError.unsupportedProtocolVersion(_:) | `public static func unsupportedProtocolVersion(_ version: String) -> MCPError` |
 | 150 | var | public | MCPError.errorDescription | `public var errorDescription: String? { get }` |
 | 162 | var | public | MCPError.debugDescription | `public var debugDescription: String { get }` |
 | 176 | func | public | MCPError.init(from:) | `public init(from decoder: any Decoder) throws` |
@@ -2603,8 +2615,8 @@ Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for
 | 224 | func | public | MCPResponse.init(jsonrpc:id:result:error:) | `public init(jsonrpc: String = "2.0", id: String, result: SendableValue? = nil, error: MCPErrorObject? = nil) throws` |
 | 249 | func | public | MCPResponse.init(from:) | `public init(from decoder: any Decoder) throws` |
 | 291 | func | public | MCPResponse.encode(to:) | `public func encode(to encoder: any Encoder) throws` |
-| 339 | func | public | MCPResponse.success(id:result:) | `public static func success(id: String, result: SendableValue) -> MCPResponse` |
-| 358 | func | public | MCPResponse.failure(id:error:) | `public static func failure(id: String, error: MCPErrorObject) -> MCPResponse` |
+| 339 | func | public | MCPResponse.success(id:result:) | `public static func success(id: String, result: SendableValue) throws -> MCPResponse` |
+| 358 | func | public | MCPResponse.failure(id:error:) | `public static func failure(id: String, error: MCPErrorObject) throws -> MCPResponse` |
 | 399 | struct | public | MCPErrorObject | `public struct MCPErrorObject` |
 | 405 | var | public | MCPErrorObject.code | `public let code: Int` |
 | 411 | var | public | MCPErrorObject.message | `public let message: String` |
@@ -2639,17 +2651,18 @@ Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for
 
 | Line | Kind | Access | Name | Signature |
 |------|------|--------|------|-----------|
-| 90 | protocol | public | MCPServer | `public protocol MCPServer : Sendable` |
-| 95 | var | public | MCPServer.name | `public var name: String { get }` |
-| 112 | var | public | MCPServer.capabilities | `public var capabilities: MCPCapabilities { get async }` |
-| 138 | func | public | MCPServer.initialize() | `public func initialize() async throws -> MCPCapabilities` |
-| 159 | func | public | MCPServer.close() | `public func close() async throws` |
-| 182 | func | public | MCPServer.listTools() | `public func listTools() async throws -> [ToolSchema]` |
-| 216 | func | public | MCPServer.callTool(name:arguments:) | `public func callTool(name: String, arguments: [String : SendableValue]) async throws -> SendableValue` |
-| 239 | func | public | MCPServer.listResources() | `public func listResources() async throws -> [MCPResource]` |
-| 265 | func | public | MCPServer.readResource(uri:) | `public func readResource(uri: String) async throws -> MCPResourceContent` |
-| 276 | func | public | MCPServer.requireToolsCapability() | `public func requireToolsCapability() async throws` |
-| 288 | func | public | MCPServer.requireResourcesCapability() | `public func requireResourcesCapability() async throws` |
+| 90 | protocol | public | MCPServerConnection | `public protocol MCPServerConnection : Sendable` |
+| 95 | var | public | MCPServerConnection.name | `public var name: String { get }` |
+| 112 | var | public | MCPServerConnection.capabilities | `public var capabilities: MCPCapabilities { get async }` |
+| 138 | func | public | MCPServerConnection.initialize() | `public func initialize() async throws -> MCPCapabilities` |
+| 159 | func | public | MCPServerConnection.close() | `public func close() async throws` |
+| 182 | func | public | MCPServerConnection.listTools() | `public func listTools() async throws -> [ToolSchema]` |
+| 216 | func | public | MCPServerConnection.callTool(name:arguments:) | `public func callTool(name: String, arguments: [String : SendableValue]) async throws -> SendableValue` |
+| 239 | func | public | MCPServerConnection.listResources() | `public func listResources() async throws -> [MCPResource]` |
+| 265 | func | public | MCPServerConnection.readResource(uri:) | `public func readResource(uri: String) async throws -> MCPResourceContent` |
+| 276 | func | public | MCPServerConnection.requireToolsCapability() | `public func requireToolsCapability() async throws` |
+| 288 | func | public | MCPServerConnection.requireResourcesCapability() | `public func requireResourcesCapability() async throws` |
+| — | typealias | public | MCPServer | `@available(*, deprecated, renamed: "MCPServerConnection") public typealias MCPServer = MCPServerConnection` |
 | 301 | enum | public | MCPServerState | `public enum MCPServerState` |
 | 305 | var | public | MCPServerState.isReady | `public var isReady: Bool { get }` |
 | 310 | var | public | MCPServerState.isTerminated | `public var isTerminated: Bool { get }` |
@@ -2665,7 +2678,7 @@ Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for
 | Line | Kind | Access | Name | Signature |
 |------|------|--------|------|-----------|
 | 36 | class | public | MCPToolBridge | `public actor MCPToolBridge` |
-| 44 | func | public | MCPToolBridge.init(server:) | `public init(server: any MCPServer)` |
+| 44 | func | public | MCPToolBridge.init(server:) | `public init(server: any MCPServerConnection)` |
 | 69 | func | public | MCPToolBridge.bridgeTools() | `public func bridgeTools() async throws -> [any AnyJSONTool]` |
 
 ## 11. Providers

--- a/docs/reference/front-facing-api.md
+++ b/docs/reference/front-facing-api.md
@@ -683,26 +683,38 @@ requests inject W3C `traceparent` from the current span. See
 
 ### MCP server adapter
 
-The core `Swarm` product includes MCP client-side primitives:
+The core `Swarm` product includes MCP client-side primitives. The client
+connection protocol is `MCPServerConnection` (`MCPServer` remains as a
+deprecated typealias). Built-in transports are streamable HTTP and stdio:
 
 ```swift
-let server = try HTTPMCPServer(
+let http = try HTTPMCPServer(
     url: URL(string: "https://mcp.example.com/api")!,
     name: "example-server",
     apiKey: "sk-..."
 )
+let stdio = StdioMCPServer(
+    command: "npx",
+    arguments: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+    name: "filesystem"
+)
 
 let client = MCPClient()
-try await client.addServer(server)
+try await client.addServer(http)
+try await client.addServer(stdio)
 let tools = try await client.getAllTools()
 
-let bridge = MCPToolBridge(server: server)
+let bridge = MCPToolBridge(server: http)
 let bridgedTools = try await bridge.bridgeTools()
 ```
 
-`HTTPMCPServer(url:name:apiKey:timeout:maxRetries:session:)` is the remote HTTP
-client. `MCPClient` aggregates multiple MCP servers and `MCPToolBridge` exposes
-remote MCP tools as Swarm JSON tools.
+`HTTPMCPServer` speaks streamable HTTP (JSON or SSE responses, session id,
+`MCP-Protocol-Version`) and negotiates `2024-11-05` through `2025-11-25`.
+`StdioMCPServer` launches a child process and uses newline-delimited JSON-RPC.
+`callTool` unwraps MCP content blocks; `callToolRaw` returns the envelope.
+Swarm does not implement prompts or sampling — those capability flags stay
+`false` on connections. `MCPClient` aggregates multiple connections and
+`MCPToolBridge` exposes remote MCP tools as Swarm JSON tools.
 
 `SwarmMCPServerService` exposes a `SwarmMCPToolCatalog` and
 `SwarmMCPToolExecutor` over the MCP Swift SDK transport. For a Swarm

--- a/docs/reference/front-facing-api.md
+++ b/docs/reference/front-facing-api.md
@@ -28,8 +28,10 @@ HiveCore, Membrane, and ContextCore are native in-tree `Sources/` targets
 Wax remains a remote package + trait-gated product. Lean resolve never pulls
 Hive/Membrane/ContextCore/Conduit package identities, and trait-gated product
 edges also keep Wax, MetalANNS→GRDB, swift-crypto, swift-mutex, and SwiftSoup
-off the lean pin list. Always-on remotes remain (swift-syntax, swift-log, MCP
-sdk, OTel, plus NIO transitives including `swift-collections`).
+off the lean pin list. Default remotes remain (swift-syntax via the default-on
+**Macros** trait, swift-log, MCP sdk, OTel, plus NIO transitives including
+`swift-collections`). Disable Macros with `traits: []` to drop swift-syntax
+and use ``FunctionTool`` instead of `@Tool`.
 `SWARM_CORE_ONLY=1` drops the integration package block. ContextCore / full
 Membrane session stack are Apple-only (Metal/CoreML); Linux Integrations keeps
 Hive + MembraneCore + web helpers. `DefaultAgentMemory` (ContextCore + Wax)

--- a/scripts/ci/lean-build-test.sh
+++ b/scripts/ci/lean-build-test.sh
@@ -37,4 +37,7 @@ SWARM_OMIT_INTEGRATION_TARGETS=1 swift package resolve
 SWARM_OMIT_INTEGRATION_TARGETS=1 bash scripts/ci/verify-lean-resolve.sh
 SWARM_OMIT_INTEGRATION_TARGETS=1 swift test --no-parallel
 
+echo "lean-build-test: phase 3 — Macros-disabled consumer (zero swift-syntax)"
+bash scripts/ci/verify-macros-disabled-consumer.sh
+
 echo "lean-build-test: PASS"

--- a/scripts/ci/verify-lean-resolve.sh
+++ b/scripts/ci/verify-lean-resolve.sh
@@ -6,9 +6,11 @@
 # Forbidden = hive | membrane | contextcore | conduit (and matching
 # christopherkarani/* remote URLs). In-tree Sources/ modules are fine.
 #
-# Lean residual (Integrations off): always-on syntax/log/MCP/OTel (+ NIO
-# transitives including swift-collections). Must NOT pin Wax, MetalANNS→GRDB,
-# swift-crypto, swift-mutex, or SwiftSoup.
+# Lean residual (Integrations off, Macros on by default): syntax/log/MCP/OTel
+# (+ NIO transitives including swift-collections). Must NOT pin Wax,
+# MetalANNS→GRDB, swift-crypto, swift-mutex, or SwiftSoup.
+# Disable Macros (`traits: []`) to drop swift-syntax — see
+# scripts/ci/verify-macros-disabled-consumer.sh.
 #
 # Usage (after resolve):
 #   swift package resolve

--- a/scripts/ci/verify-macros-disabled-consumer.sh
+++ b/scripts/ci/verify-macros-disabled-consumer.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Prove a consumer can depend on Swarm with Macros disabled and resolve
+# a graph that contains zero swift-syntax. Also builds and tests the fixture.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+FIXTURE_DIR="$ROOT_DIR/Fixtures/MacrosDisabledConsumer"
+
+if [[ ! -f "$FIXTURE_DIR/Package.swift" ]]; then
+  echo "verify-macros-disabled-consumer: fixture missing at $FIXTURE_DIR" >&2
+  exit 2
+fi
+
+cd "$FIXTURE_DIR"
+rm -rf .build Package.resolved
+
+echo "verify-macros-disabled-consumer: resolve with Macros disabled (traits: [])"
+swift package resolve
+
+echo "verify-macros-disabled-consumer: show-dependencies"
+DEPS="$(swift package show-dependencies)"
+echo "$DEPS"
+
+if echo "$DEPS" | grep -Eiq 'swift-syntax'; then
+  echo "FAIL: swift-syntax is present in the Macros-disabled consumer graph" >&2
+  exit 1
+fi
+
+if [[ -f Package.resolved ]]; then
+  if grep -Eiq 'swift-syntax' Package.resolved; then
+    echo "FAIL: swift-syntax is pinned in the Macros-disabled Package.resolved" >&2
+    exit 1
+  fi
+fi
+
+echo "verify-macros-disabled-consumer: build + FunctionTool smoke test"
+swift test --no-parallel
+
+echo "PASS: Macros-disabled consumer resolves without swift-syntax and tests pass"


### PR DESCRIPTION
# Pull Request

## Thank you for contributing to Swarm! 🎉

We appreciate your effort to improve the framework. This template helps ensure high-quality contributions that align with the project's standards.

---

## Description

### What does this PR do?

Makes swift-syntax optional via a default-on `Macros` SwiftPM trait, relaxes rigid Wax/MetalANNS exact pins, and removes the unused MetalANNS dependency edge on `ContextCoreEngine`. A CI fixture proves a consumer with Macros disabled resolves **zero** swift-syntax and still builds with `FunctionTool`.

**Based on unmerged Chunk L** ([#131](https://github.com/christopherkarani/Swarm/pull/131) / `feat/mcp-modernization`). Packaging commit is `0dd593ae`; the MCP commit is L's and should land with #131 first.

### Motivation and Context

Consumers that do not use `@Tool` / `@Parameter` / `#Prompt` / `@Traceable` were forced to pin swift-syntax. Exact Wax `0.1.23` and MetalANNS `0.1.3` pins fought any consumer that pinned differently. One of the two MetalANNS target edges (`ContextCoreEngine`) provided no symbols.

Fixes # (issue)

---

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 **Bug fix** (non-breaking change which fixes an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔨 **Refactoring** (code improvement without functional changes)
- [x] 📚 **Documentation** (updates to README, inline docs, or examples)
- [ ] ⚠️ **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [x] 🧪 **Test improvement** (adding missing tests or improving existing ones)
- [x] 🔧 **Build/CI** (changes to build process, dependencies, or CI configuration)

---

## Changes Made

### Implementation Details

- Default-on **Macros** trait (SE-0450). Gates the Swarm→SwarmMacros edge and every swift-syntax product edge. Public macro declarations compile out under `#if SWARM_MACROS`.
- Integrations **enables Macros** so existing `traits: ["Integrations"]` keeps `@Tool` (specifying traits replaces defaults).
- Disable Macros with `traits: []`. Consumer fixture `Fixtures/MacrosDisabledConsumer` resolves zero swift-syntax and runs a FunctionTool smoke test (`scripts/ci/verify-macros-disabled-consumer.sh`, lean-build-test phase 3).
- Swarm sources no longer depend on macros (`ZoniSearchTool` / `SemanticCompactorTool` → `AnyJSONTool`; `@Builder` on `ModelSettings` / `InferenceOptions` → handwritten setters) so a Macros-off consumer still compiles the library.
- MetalANNS `exact: "0.1.3"` → `from: "0.1.3"` (resolved 0.1.3, no API drift).
- Wax could not stay open-ended: `from: "0.1.23"` resolved 0.1.25, which makes `FrameStore.close()` / `frames()` throwing and breaks `WaxMemory` + `WaxMembraneStorage`. 0.1.24 fails to clone (broken `homebrew-wax` submodule ref). Ceiling is `"0.1.23"..<"0.1.24"`.
- Orphan MetalANNS edge removed from `ContextCoreEngine` (no `import MetalANNS`). `ContextCore` still links it.

### Before / after dependency graphs

| Graph | Before | After |
|---|---|---|
| Exact pins | Wax `exact: 0.1.23`, MetalANNS `exact: 0.1.3` (**2**) | **0** exact. MetalANNS `from: 0.1.3`. Wax `"0.1.23"..<"0.1.24"` |
| MetalANNS target edges | ContextCoreEngine + ContextCore | ContextCore only |
| Lean default resolve | 9 pins including swift-syntax 602.0.0 | **unchanged 9** (Macros still default-on) |
| Macros disabled (`traits: []`) | n/a (swift-syntax always pinned) | swift-log + MCP sdk + OTel + NIO transitives. **No swift-syntax** |

### Files Changed

- `Package.swift` — Macros trait, gated swift-syntax edges, relaxed pins, orphan MetalANNS edge removed
- `Sources/Swarm/Macros/MacroDeclarations.swift` — compile out macros when Macros is off
- `Sources/Swarm/Tools/ZoniSearchTool.swift` / `SemanticCompactorTool.swift` / `BuiltInTools.swift` — macro-free `AnyJSONTool` implementations
- `Sources/Swarm/Core/ModelSettings.swift` / `AgentRuntime.swift` — handwritten fluent builders replacing `@Builder`
- `Fixtures/MacrosDisabledConsumer/` — consumer package with `traits: []` + FunctionTool smoke test
- `scripts/ci/verify-macros-disabled-consumer.sh` / `lean-build-test.sh` / `verify-lean-resolve.sh` — CI proof
- `README.md` / `docs/guide/getting-started.md` / `docs/reference/front-facing-api.md` / `CLAUDE.md` — how to disable Macros and the FunctionTool path

### API Changes (if applicable)

No removed public types. `@Tool` / `@Parameter` / `#Prompt` / `@Traceable` are unavailable when Macros is disabled; `FunctionTool` remains. `PromptString` stays available. Default consumers are unchanged.

---

## Testing

### Test Coverage

- [x] I have followed **Test-Driven Development (TDD)** practices (wrote tests first, then implementation)
- [x] All new code is covered by unit tests
- [x] I have added tests for edge cases and error conditions
- [ ] I have used mock protocols for external dependencies (LLM providers, network, etc.)

### Test Results

```bash
# Lean (includes Macros-disabled fixture)
bash scripts/ci/lean-build-test.sh
# 1837 tests in 241 suites PASS
# fixture: zero swift-syntax + FunctionTool smoke PASS

# Integrations
swift test --no-parallel --traits Integrations
# 1982 tests in 264 suites PASS

# Showcase
swift run --traits Integrations SwarmCapabilityShowcase matrix
# 14/14 passed
```

Chunk A baseline: lean 1719 / 220, Integrations 1849 / 239. Chunk L / this PR: lean 1837 / 241, Integrations 1982 / 264 (no regression).

### Manual Testing

Resolved both lanes; confirmed lean deny-list still excludes wax/metalanns/grdb/crypto/mutex/swiftsoup. Confirmed ContextCoreEngine links without MetalANNS. Confirmed Wax 0.1.25 API drift and 0.1.24 submodule failure before applying the ceiling.

---

## Breaking Changes

**Does this PR introduce breaking changes?**
- [ ] Yes (please describe below)
- [x] No

### Breaking Change Details

Not source-breaking for default consumers. To drop swift-syntax:

```swift
.package(url: "https://github.com/christopherkarani/Swarm.git", from: "0.6.0", traits: [])
```

Use `FunctionTool` instead of `@Tool`. Integrations consumers keep macros without changing their trait list.

---

## Pre-Submission Checklist

### Code Quality
- [x] My code follows the Swift 6.2 standards and project conventions
- [x] I have performed a self-review of my own code
- [x] I have run `swift build` and ensured no compilation errors
- [x] I have run `swift test` and all tests pass
- [x] I have run SwiftFormat: `swiftformat Sources Tests --lint --config .swiftformat`
- [x] I have run SwiftLint and fixed any warnings: `swiftlint lint`

### Concurrency & Safety
- [x] All public types conform to `Sendable` where appropriate
- [x] I have used `async/await` and structured concurrency correctly
- [x] I have properly applied `@MainActor`, `actor`, or `nonisolated` annotations
- [x] My code is free from data races and concurrency issues

### Documentation
- [x] I have added/updated documentation comments for public APIs
- [x] I have updated the README.md if needed
- [ ] I have added examples to `Sources/Swarm/Examples/` if introducing new features
- [x] My code does not use `print()` statements (uses `swift-log` instead)

### Testing (TDD Required)
- [x] I wrote tests **before** writing the implementation (Red phase)
- [x] I wrote minimal code to make tests pass (Green phase)
- [x] I refactored while keeping tests green (Refactor phase)
- [ ] Mock protocols are used for external dependencies

### Version Compatibility
- [x] My code supports the minimum requirements: iOS 26+, macOS 26+, tvOS 26+, Swift 6.2
- [x] I have not introduced dependencies that break compatibility

---

## Additional Context

### Related Issues/PRs

- Depends on #131 (Chunk L — MCP modernization; this branch is based on `feat/mcp-modernization`)
- Blocks Chunk N (merge completion: SwarmMembrane deprecation, config unify, unreachable internals)

### Questions or Concerns

Wax ceiling is `"0.1.23"..<"0.1.24"` until Swarm adapts to the 0.1.25 throwing `FrameStore` API. MetalANNS `from: "0.1.3"` resolved 0.1.3 with no drift.

---

## Reviewer Checklist (for maintainers)

- [ ] Code follows project architecture and patterns
- [ ] Tests are comprehensive and follow TDD principles
- [ ] Documentation is clear and complete
- [ ] No security vulnerabilities introduced (SQL injection, XSS, command injection, etc.)
- [ ] Performance implications are acceptable
- [ ] Breaking changes are properly documented
- [ ] CI/CD checks pass

---

**Thank you again for your contribution!** Your efforts help make Swarm better for the entire Swift community. If you have any questions, feel free to ask in the comments below.