### PR TITLE
fix: durable hardening — checkpoint pruning, stable workflow signatures, chaos tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,11 @@ let workflow = Workflow()
 let resumed = try await workflow.durable.execute("watch", resumeFrom: "monitor-v1")
 ```
 
+A mid-step crash re-runs that whole step. File stores keep the newest 16
+checkpoints per run (configurable) and identify steps by kind, position, and
+optional `signature:` — not source line numbers. See
+[Durable Execution](docs/guide/durable-execution.md).
+
 #### Provider selection
 
 ```swift

--- a/Sources/Swarm/Workflow/Workflow+Durable.swift
+++ b/Sources/Swarm/Workflow/Workflow+Durable.swift
@@ -95,6 +95,8 @@ extension Workflow {
             }
         }
 
+        WorkflowDurableIdentity.warnIfUsingImplicitIdentity(self)
+
         let engine = WorkflowDurableEngine(
             workflow: self,
             checkpointing: checkpointing,
@@ -116,5 +118,59 @@ extension Workflow {
             try await executeDirect(input: input)
         }
         #endif
+    }
+}
+
+enum WorkflowDurableIdentity {
+    static let implicitIdentityWarning = """
+        Durable workflow uses implicit step identity (kind + position). \
+        Source fileID:line is no longer part of resume matching. Pass signature: \
+        on route, repeatUntil, and custom merge when those closures change.
+        """
+
+    static func warnIfUsingImplicitIdentity(_ workflow: Workflow) {
+        guard workflow.usesImplicitOpaqueIdentity else { return }
+        if WorkflowDurableIdentityRecorder.shared.record() {
+            Log.orchestration.warning("\(implicitIdentityWarning)")
+        }
+    }
+}
+
+enum WorkflowDurableIdentityTesting {
+    static var warningCount: Int {
+        WorkflowDurableIdentityRecorder.shared.count
+    }
+
+    static func reset() {
+        WorkflowDurableIdentityRecorder.shared.reset()
+    }
+}
+
+private final class WorkflowDurableIdentityRecorder: @unchecked Sendable {
+    static let shared = WorkflowDurableIdentityRecorder()
+    private let lock = NSLock()
+    private var didWarn = false
+    private var recordedCount = 0
+
+    var count: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedCount
+    }
+
+    func record() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !didWarn else { return false }
+        didWarn = true
+        recordedCount += 1
+        return true
+    }
+
+    func reset() {
+        lock.lock()
+        defer { lock.unlock() }
+        didWarn = false
+        recordedCount = 0
     }
 }

--- a/Sources/Swarm/Workflow/Workflow.swift
+++ b/Sources/Swarm/Workflow/Workflow.swift
@@ -89,15 +89,17 @@ import Foundation
 public struct Workflow: Sendable {
     struct OpaqueBehaviorSignature: Sendable, Equatable {
         let value: String
+        let usesImplicitIdentity: Bool
 
-        init(kind: String, explicit: String?, fileID: StaticString, line: UInt) {
+        init(kind: String, explicit: String?, position: String) {
             let trimmed = explicit?.trimmingCharacters(in: .whitespacesAndNewlines)
-            let identity = if let trimmed, !trimmed.isEmpty {
-                "explicit:\(workflowSignatureComponent(trimmed))"
+            if let trimmed, !trimmed.isEmpty {
+                value = "\(kind):explicit:\(workflowSignatureComponent(trimmed))"
+                usesImplicitIdentity = false
             } else {
-                "source:\(workflowSignatureComponent("\(fileID):\(line)"))"
+                value = "\(kind):stable:\(workflowSignatureComponent("\(kind)@\(position)"))"
+                usesImplicitIdentity = true
             }
-            value = "\(kind):\(identity)"
         }
     }
 
@@ -251,6 +253,8 @@ public struct Workflow: Sendable {
     ///   - agents: An array of agents to execute in parallel.
     ///   - merge: The strategy for combining results. Defaults to `.structured`.
     ///   - customMergeSignature: Optional stable durable identity to change when `.custom` merge behavior changes.
+    ///   - fileID: Retained for source compatibility; ignored for durable identity.
+    ///   - line: Retained for source compatibility; ignored for durable identity.
     /// - Returns: A new workflow with the added parallel step.
     ///
     /// ## Example
@@ -278,12 +282,12 @@ public struct Workflow: Sendable {
             mergeBehaviorSignature = OpaqueBehaviorSignature(
                 kind: "customMerge",
                 explicit: customMergeSignature,
-                fileID: fileID,
-                line: line
+                position: "\(copy.steps.count)"
             )
         } else {
             mergeBehaviorSignature = nil
         }
+        discardLegacySourceLocation(fileID, line)
         copy.steps.append(.parallel(
             agents,
             merge: merge,
@@ -300,6 +304,7 @@ public struct Workflow: Sendable {
     /// - Parameter condition: A closure that receives the current input string
     ///   and returns the agent to execute, or `nil` if routing fails.
     /// - Parameter signature: Optional stable durable identity to change when route behavior changes.
+    ///   When omitted, identity is the step kind plus position — not `fileID:line`.
     /// - Returns: A new workflow with the added routing step.
     ///
     /// ## Example
@@ -325,9 +330,10 @@ public struct Workflow: Sendable {
     ) -> Workflow {
         var copy = self
         copy.steps.append(.route(
-            OpaqueBehaviorSignature(kind: "route", explicit: signature, fileID: fileID, line: line),
+            OpaqueBehaviorSignature(kind: "route", explicit: signature, position: "\(copy.steps.count)"),
             condition
         ))
+        discardLegacySourceLocation(fileID, line)
         return copy
     }
 
@@ -353,6 +359,7 @@ public struct Workflow: Sendable {
     ///   - condition: A closure that receives the ``AgentResult`` from each
     ///     iteration and returns `true` when the workflow should stop.
     ///   - signature: Optional stable durable identity to change when repeat predicate behavior changes.
+    ///     When omitted, identity is the step kind plus a stable `repeat` position — not `fileID:line`.
     /// - Returns: A new workflow configured with the repeat condition.
     ///
     /// ## Example
@@ -379,9 +386,9 @@ public struct Workflow: Sendable {
         copy.repeatConditionSignature = OpaqueBehaviorSignature(
             kind: "repeat",
             explicit: signature,
-            fileID: fileID,
-            line: line
+            position: "repeat"
         )
+        discardLegacySourceLocation(fileID, line)
         copy.maxRepeatIterations = maxIterations
         return copy
     }
@@ -674,6 +681,49 @@ public struct Workflow: Sendable {
         }
         return (["workflowSignature:v2"] + parts + [repeatSignature]).joined(separator: "|")
     }
+
+    /// True when route, custom-merge, or repeat identity was derived from kind + position
+    /// instead of an explicit `signature:` / `customMergeSignature:`.
+    var usesImplicitOpaqueIdentity: Bool {
+        if repeatConditionSignature?.usesImplicitIdentity == true {
+            return true
+        }
+        return steps.contains { step in
+            switch step {
+            case .parallel(_, _, let mergeBehaviorSignature):
+                return mergeBehaviorSignature?.usesImplicitIdentity == true
+            case .route(let signature, _):
+                return signature.usesImplicitIdentity
+            case .single, .fallback:
+                return false
+            }
+        }
+    }
+}
+
+/// Compares a persisted durable signature with the current workflow definition.
+///
+/// Legacy checkpoints that still embed `fileID:line` (`:source:`) fail with a
+/// dedicated resume message rather than a generic mismatch.
+func workflowDurableSignatureMismatch(
+    checkpointSignature: String,
+    currentSignature: String
+) -> WorkflowError? {
+    guard checkpointSignature != currentSignature else {
+        return nil
+    }
+    if checkpointSignature.contains(":source:") {
+        return .resumeDefinitionMismatch(
+            reason: """
+            Checkpoint uses the legacy fileID:line workflow identity. Re-run this \
+            workflow from the start; Swarm now identifies steps by kind, position, \
+            and explicit signature: values, not source locations.
+            """
+        )
+    }
+    return .resumeDefinitionMismatch(
+        reason: "Workflow signature mismatch between checkpoint and current definition"
+    )
 }
 
 extension Workflow.MergeStrategy {
@@ -836,3 +886,7 @@ private func workflowOptionalTypeSignature(_ value: Any?) -> String {
 private func workflowSignatureComponent(_ value: String) -> String {
     "\(value.utf8.count)#\(value)"
 }
+
+/// `fileID` and `line` remain on the public builders for source compatibility.
+/// They are not part of durable identity.
+private func discardLegacySourceLocation(_: StaticString, _: UInt) {}

--- a/Sources/Swarm/Workflow/WorkflowCheckpointStore.swift
+++ b/Sources/Swarm/Workflow/WorkflowCheckpointStore.swift
@@ -46,14 +46,72 @@ actor WorkflowInMemoryCheckpointStore: WorkflowDurableCheckpointStore, HiveCheck
     }
 }
 
+protocol WorkflowCheckpointFileOperating: AnyObject, Sendable {
+    func contentsOfDirectory(at url: URL) throws -> [URL]
+    func fileExists(atPath path: String) -> Bool
+    func createDirectory(at url: URL) throws
+    func removeItem(at url: URL) throws
+    func read(from url: URL) throws -> Data
+    func write(_ data: Data, to url: URL) throws
+}
+
+/// FileManager is not Sendable; this operator is only used from the store actor.
+final class FoundationWorkflowCheckpointFileOperator: WorkflowCheckpointFileOperating, @unchecked Sendable {
+    private let fileManager = FileManager.default
+
+    func contentsOfDirectory(at url: URL) throws -> [URL] {
+        try fileManager.contentsOfDirectory(at: url, includingPropertiesForKeys: nil)
+    }
+
+    func fileExists(atPath path: String) -> Bool {
+        fileManager.fileExists(atPath: path)
+    }
+
+    func createDirectory(at url: URL) throws {
+        try fileManager.createDirectory(at: url, withIntermediateDirectories: true, attributes: nil)
+    }
+
+    func removeItem(at url: URL) throws {
+        try fileManager.removeItem(at: url)
+    }
+
+    func read(from url: URL) throws -> Data {
+        try Data(contentsOf: url)
+    }
+
+    func write(_ data: Data, to url: URL) throws {
+        try data.write(to: url, options: .atomic)
+    }
+}
+
+struct WorkflowCheckpointManifest: Codable, Sendable, Equatable {
+    var version: Int
+    var runs: [String: [WorkflowCheckpointManifestEntry]]
+}
+
+struct WorkflowCheckpointManifestEntry: Codable, Sendable, Equatable {
+    var checkpointID: String
+    var stepIndex: Int
+    var fileName: String
+}
+
 actor WorkflowFileCheckpointStore: WorkflowDurableCheckpointStore, HiveCheckpointStore {
     typealias Schema = WorkflowDurableSchema
 
-    private let directory: URL
-    private let fileManager = FileManager.default
+    static let manifestFileName = "workflow-checkpoints.manifest.json"
 
-    init(directory: URL) {
+    private let directory: URL
+    private let retention: WorkflowCheckpointRetention
+    private let files: any WorkflowCheckpointFileOperating
+
+    init(
+        directory: URL,
+        retention: WorkflowCheckpointRetention = .default,
+        files: any WorkflowCheckpointFileOperating = FoundationWorkflowCheckpointFileOperator()
+    ) {
         self.directory = directory
+        self.retention = retention
+        self.files = files
     }
 
     nonisolated var runtimeStore: AnyHiveCheckpointStore<WorkflowDurableSchema> {
@@ -66,51 +124,153 @@ actor WorkflowFileCheckpointStore: WorkflowDurableCheckpointStore, HiveCheckpoin
 
     func save(_ checkpoint: HiveCheckpoint<WorkflowDurableSchema>) async throws {
         try ensureDirectoryExists()
-        let data = try JSONEncoder().encode(checkpoint)
-        let url = checkpointFileURL(
+        let fileName = checkpointFileName(
             threadID: checkpoint.threadID,
             checkpointID: checkpoint.id
         )
-        try data.write(to: url, options: .atomic)
+        let url = directory.appendingPathComponent(fileName, isDirectory: false)
+        try files.write(JSONEncoder().encode(checkpoint), to: url)
+
+        var manifest = try loadManifestForWrite()
+        var entries = manifest.runs[checkpoint.threadID.rawValue, default: []]
+        entries.removeAll { $0.checkpointID == checkpoint.id.rawValue }
+        entries.append(
+            WorkflowCheckpointManifestEntry(
+                checkpointID: checkpoint.id.rawValue,
+                stepIndex: checkpoint.stepIndex,
+                fileName: fileName
+            )
+        )
+        entries.sort(by: Self.isOlderThan)
+        let pruned = prune(entries)
+        manifest.runs[checkpoint.threadID.rawValue] = pruned.kept
+        try writeManifest(manifest)
+        try deleteFiles(named: pruned.removed.map(\.fileName))
     }
 
     func loadLatest(threadID: HiveThreadID) async throws -> HiveCheckpoint<WorkflowDurableSchema>? {
         try ensureDirectoryExists()
-
-        let threadPrefix = filePrefix(for: threadID)
-        let files = try fileManager.contentsOfDirectory(
-            at: directory,
-            includingPropertiesForKeys: nil
-        )
-
-        let matching = files.filter { $0.lastPathComponent.hasPrefix(threadPrefix) }
-        guard matching.isEmpty == false else { return nil }
-
+        let manifest = try loadManifestForRead()
+        let entries = (manifest.runs[threadID.rawValue] ?? []).sorted(by: Self.isOlderThan)
         let decoder = JSONDecoder()
-        var latest: HiveCheckpoint<WorkflowDurableSchema>?
 
-        for fileURL in matching {
-            let data = try Data(contentsOf: fileURL)
-            let checkpoint = try decoder.decode(HiveCheckpoint<WorkflowDurableSchema>.self, from: data)
-            guard checkpoint.threadID == threadID else { continue }
-
-            if let existingLatest = latest {
-                let isNewer = checkpoint.stepIndex > existingLatest.stepIndex ||
-                    (checkpoint.stepIndex == existingLatest.stepIndex && checkpoint.id.rawValue > existingLatest.id.rawValue)
-                if isNewer {
-                    latest = checkpoint
-                }
-            } else {
-                latest = checkpoint
+        for entry in entries.reversed() {
+            let url = directory.appendingPathComponent(entry.fileName, isDirectory: false)
+            do {
+                let data = try files.read(from: url)
+                let checkpoint = try decoder.decode(HiveCheckpoint<WorkflowDurableSchema>.self, from: data)
+                guard checkpoint.threadID == threadID else { continue }
+                return checkpoint
+            } catch {
+                Log.orchestration.warning(
+                    "Skipping corrupt workflow checkpoint at \(entry.fileName): \(error)"
+                )
             }
         }
 
-        return latest
+        return nil
     }
 
-    private func checkpointFileURL(threadID: HiveThreadID, checkpointID: HiveCheckpointID) -> URL {
-        let name = "\(filePrefix(for: threadID))\(sanitize(checkpointID.rawValue)).json"
-        return directory.appendingPathComponent(name, isDirectory: false)
+    private func loadManifestForRead() throws -> WorkflowCheckpointManifest {
+        if let manifest = try readManifest() {
+            return manifest
+        }
+        let rebuilt = try rebuildManifest()
+        try writeManifest(rebuilt)
+        return rebuilt
+    }
+
+    private func loadManifestForWrite() throws -> WorkflowCheckpointManifest {
+        if let manifest = try readManifest() {
+            return manifest
+        }
+        return WorkflowCheckpointManifest(version: 1, runs: [:])
+    }
+
+    private func readManifest() throws -> WorkflowCheckpointManifest? {
+        let url = manifestURL
+        guard files.fileExists(atPath: url.path) else {
+            return nil
+        }
+        do {
+            let data = try files.read(from: url)
+            return try JSONDecoder().decode(WorkflowCheckpointManifest.self, from: data)
+        } catch {
+            Log.orchestration.warning("Skipping corrupt workflow checkpoint manifest: \(error)")
+            return nil
+        }
+    }
+
+    private func writeManifest(_ manifest: WorkflowCheckpointManifest) throws {
+        try files.write(JSONEncoder().encode(manifest), to: manifestURL)
+    }
+
+    private func rebuildManifest() throws -> WorkflowCheckpointManifest {
+        let urls = try files.contentsOfDirectory(at: directory)
+        var runs: [String: [WorkflowCheckpointManifestEntry]] = [:]
+        let decoder = JSONDecoder()
+
+        for fileURL in urls {
+            let name = fileURL.lastPathComponent
+            guard name.hasPrefix("workflow-"),
+                  name.hasSuffix(".json"),
+                  name != Self.manifestFileName
+            else {
+                continue
+            }
+            do {
+                let checkpoint = try decoder.decode(
+                    HiveCheckpoint<WorkflowDurableSchema>.self,
+                    from: files.read(from: fileURL)
+                )
+                runs[checkpoint.threadID.rawValue, default: []].append(
+                    WorkflowCheckpointManifestEntry(
+                        checkpointID: checkpoint.id.rawValue,
+                        stepIndex: checkpoint.stepIndex,
+                        fileName: name
+                    )
+                )
+            } catch {
+                Log.orchestration.warning("Skipping corrupt workflow checkpoint at \(name): \(error)")
+            }
+        }
+
+        for key in runs.keys {
+            runs[key]?.sort(by: Self.isOlderThan)
+        }
+        return WorkflowCheckpointManifest(version: 1, runs: runs)
+    }
+
+    private func prune(
+        _ entries: [WorkflowCheckpointManifestEntry]
+    ) -> (kept: [WorkflowCheckpointManifestEntry], removed: [WorkflowCheckpointManifestEntry]) {
+        let limit = retention.maxCheckpointsPerRun
+        guard entries.count > limit else {
+            return (entries, [])
+        }
+        let removed = Array(entries.prefix(entries.count - limit))
+        let kept = Array(entries.suffix(limit))
+        return (kept, removed)
+    }
+
+    private func deleteFiles(named names: [String]) throws {
+        for name in names {
+            let url = directory.appendingPathComponent(name, isDirectory: false)
+            guard files.fileExists(atPath: url.path) else { continue }
+            do {
+                try files.removeItem(at: url)
+            } catch {
+                Log.orchestration.warning("Failed to delete pruned workflow checkpoint \(name): \(error)")
+            }
+        }
+    }
+
+    private var manifestURL: URL {
+        directory.appendingPathComponent(Self.manifestFileName, isDirectory: false)
+    }
+
+    private func checkpointFileName(threadID: HiveThreadID, checkpointID: HiveCheckpointID) -> String {
+        "\(filePrefix(for: threadID))\(sanitize(checkpointID.rawValue)).json"
     }
 
     private func filePrefix(for threadID: HiveThreadID) -> String {
@@ -126,13 +286,19 @@ actor WorkflowFileCheckpointStore: WorkflowDurableCheckpointStore, HiveCheckpoin
     }
 
     private func ensureDirectoryExists() throws {
-        if !fileManager.fileExists(atPath: directory.path) {
-            try fileManager.createDirectory(
-                at: directory,
-                withIntermediateDirectories: true,
-                attributes: nil
-            )
+        if !files.fileExists(atPath: directory.path) {
+            try files.createDirectory(at: directory)
         }
+    }
+
+    private static func isOlderThan(
+        _ lhs: WorkflowCheckpointManifestEntry,
+        _ rhs: WorkflowCheckpointManifestEntry
+    ) -> Bool {
+        if lhs.stepIndex != rhs.stepIndex {
+            return lhs.stepIndex < rhs.stepIndex
+        }
+        return lhs.checkpointID < rhs.checkpointID
     }
 }
 #endif

--- a/Sources/Swarm/Workflow/WorkflowCheckpointing.swift
+++ b/Sources/Swarm/Workflow/WorkflowCheckpointing.swift
@@ -1,5 +1,28 @@
 import Foundation
 
+/// Retention policy for file-backed durable workflow checkpoints.
+///
+/// The file store keeps the newest `maxCheckpointsPerRun` checkpoints per
+/// durable run (checkpoint ID / Hive thread) and records them in a manifest so
+/// loads do not scan or decode the entire directory.
+public struct WorkflowCheckpointRetention: Sendable, Equatable {
+    /// Default policy: keep the 16 newest checkpoints per run.
+    public static let `default` = WorkflowCheckpointRetention(maxCheckpointsPerRun: 16)
+
+    /// Maximum number of checkpoints retained for a single durable run.
+    ///
+    /// Values below 1 are clamped to 1.
+    public var maxCheckpointsPerRun: Int
+
+    /// Creates a keep-latest-N retention policy.
+    ///
+    /// - Parameter maxCheckpointsPerRun: Number of newest checkpoints to keep
+    ///   per run. Defaults to 16.
+    public init(maxCheckpointsPerRun: Int = 16) {
+        self.maxCheckpointsPerRun = max(1, maxCheckpointsPerRun)
+    }
+}
+
 /// Checkpoint persistence configuration for advanced workflows.
 public struct WorkflowCheckpointing: Sendable {
     /// Whether durable checkpoint stores are linked in this build.
@@ -36,15 +59,45 @@ public struct WorkflowCheckpointing: Sendable {
     }
 
     /// File-system checkpoint persistence rooted at `directory`.
-    public static func fileSystem(directory: URL) -> WorkflowCheckpointing {
+    ///
+    /// Checkpoints are pruned to ``WorkflowCheckpointRetention/maxCheckpointsPerRun``
+    /// per durable run. Loads consult a directory manifest instead of decoding
+    /// every file.
+    ///
+    /// - Parameters:
+    ///   - directory: Directory that stores checkpoint JSON files and the manifest.
+    ///   - retention: Keep-latest-N policy. Defaults to 16 checkpoints per run.
+    public static func fileSystem(
+        directory: URL,
+        retention: WorkflowCheckpointRetention = .default
+    ) -> WorkflowCheckpointing {
         IntegrationsTrait.warnIfUnavailable(
             feature: "Durable workflow checkpointing",
             logger: Log.orchestration
         )
         #if SWARM_INTEGRATIONS
-        return WorkflowCheckpointing(backend: WorkflowFileCheckpointStore(directory: directory))
+        return WorkflowCheckpointing(
+            backend: WorkflowFileCheckpointStore(directory: directory, retention: retention)
+        )
         #else
         return WorkflowCheckpointing()
         #endif
     }
+
+    #if SWARM_INTEGRATIONS
+    /// Testing hook that injects a file operator for load/scan assertions.
+    static func fileSystem(
+        directory: URL,
+        retention: WorkflowCheckpointRetention = .default,
+        files: any WorkflowCheckpointFileOperating
+    ) -> WorkflowCheckpointing {
+        WorkflowCheckpointing(
+            backend: WorkflowFileCheckpointStore(
+                directory: directory,
+                retention: retention,
+                files: files
+            )
+        )
+    }
+    #endif
 }

--- a/Sources/Swarm/Workflow/WorkflowDurableEngine.swift
+++ b/Sources/Swarm/Workflow/WorkflowDurableEngine.swift
@@ -123,6 +123,9 @@ struct WorkflowDurableEngine: Sendable {
     let resume: Bool
 
     func run(startInput: String) async throws -> AgentResult {
+        if let controller = WorkflowDurableFaultInjection.controller {
+            await controller.beginAttempt()
+        }
         let graph = try makeGraph()
         let context = WorkflowDurableContext(
             workflow: workflow,
@@ -133,7 +136,7 @@ struct WorkflowDurableEngine: Sendable {
             context: context,
             clock: WorkflowDurableClock(),
             logger: WorkflowDurableLogger(),
-            checkpointStore: checkpointing.runtimeStore
+            checkpointStore: faultInjectingStore(wrapping: checkpointing.runtimeStore)
         )
 
         let runtime = try HiveRuntime(graph: graph, environment: environment)
@@ -168,6 +171,15 @@ struct WorkflowDurableEngine: Sendable {
         }
 
         return result
+    }
+
+    private func faultInjectingStore(
+        wrapping store: AnyHiveCheckpointStore<WorkflowDurableSchema>
+    ) -> AnyHiveCheckpointStore<WorkflowDurableSchema> {
+        guard WorkflowDurableFaultInjection.controller != nil else {
+            return store
+        }
+        return AnyHiveCheckpointStore(WorkflowFaultInjectingCheckpointStore(inner: store))
     }
 
     private func makeGraph() throws -> CompiledHiveGraph<WorkflowDurableSchema> {
@@ -249,10 +261,11 @@ private enum WorkflowNodeID {
 
 private func workflowNode(_ input: HiveNodeInput<WorkflowDurableSchema>) async throws -> HiveNodeOutput<WorkflowDurableSchema> {
     let checkpointSignature = try input.store.get(WorkflowDurableSchema.signatureKey)
-    if checkpointSignature != input.context.signature {
-        throw WorkflowError.resumeDefinitionMismatch(
-            reason: "Workflow signature mismatch between checkpoint and current definition"
-        )
+    if let mismatch = workflowDurableSignatureMismatch(
+        checkpointSignature: checkpointSignature,
+        currentSignature: input.context.signature
+    ) {
+        throw mismatch
     }
 
     let completed = try input.store.get(WorkflowDurableSchema.completedKey)
@@ -302,6 +315,9 @@ private func workflowNode(_ input: HiveNodeInput<WorkflowDurableSchema>) async t
     }
 
     let step = input.context.workflow.steps[stepCursor]
+    if let controller = WorkflowDurableFaultInjection.controller {
+        await controller.markWorkflowStepStarted()
+    }
     let result = try await input.context.workflow.execute(step: step, withInput: currentInput)
     let snapshot = WorkflowResultSnapshot(result)
 
@@ -328,5 +344,84 @@ private struct WorkflowDurableLogger: HiveLogger {
     func debug(_ message: String, metadata: [String: String]) {}
     func info(_ message: String, metadata: [String: String]) {}
     func error(_ message: String, metadata: [String: String]) {}
+}
+
+enum WorkflowDurableFaultPoint: Sendable, Equatable {
+    case beforeCheckpointWrite
+    case afterCheckpointWrite
+    case midStep
+}
+
+struct WorkflowDurableInjectedFault: Error, Sendable, Equatable {
+    let point: WorkflowDurableFaultPoint
+}
+
+enum WorkflowDurableFaultInjection {
+    @TaskLocal static var controller: WorkflowDurableFaultController?
+}
+
+actor WorkflowDurableFaultController {
+    private var queue: [WorkflowDurableFaultPoint]
+    private(set) var injected: [WorkflowDurableFaultPoint] = []
+    private var workflowStepStarted = false
+    private var injectedThisAttempt = false
+
+    init(queue: [WorkflowDurableFaultPoint]) {
+        self.queue = queue
+    }
+
+    func beginAttempt() {
+        workflowStepStarted = false
+        injectedThisAttempt = false
+    }
+
+    func markWorkflowStepStarted() {
+        workflowStepStarted = true
+    }
+
+    func consumeMidStep() throws {
+        try consume(.midStep, requireWorkflowStep: false)
+    }
+
+    func consumeBeforeWrite() throws {
+        try consume(.beforeCheckpointWrite, requireWorkflowStep: true)
+    }
+
+    func consumeAfterWrite() throws {
+        try consume(.afterCheckpointWrite, requireWorkflowStep: true)
+    }
+
+    private func consume(_ point: WorkflowDurableFaultPoint, requireWorkflowStep: Bool) throws {
+        guard !injectedThisAttempt, queue.first == point else { return }
+        if requireWorkflowStep, !workflowStepStarted { return }
+        queue.removeFirst()
+        injected.append(point)
+        injectedThisAttempt = true
+        throw WorkflowDurableInjectedFault(point: point)
+    }
+}
+
+actor WorkflowFaultInjectingCheckpointStore: HiveCheckpointStore {
+    typealias Schema = WorkflowDurableSchema
+
+    private let inner: AnyHiveCheckpointStore<WorkflowDurableSchema>
+
+    init(inner: AnyHiveCheckpointStore<WorkflowDurableSchema>) {
+        self.inner = inner
+    }
+
+    func save(_ checkpoint: HiveCheckpoint<WorkflowDurableSchema>) async throws {
+        if let controller = WorkflowDurableFaultInjection.controller {
+            try await controller.consumeBeforeWrite()
+        }
+        try await inner.save(checkpoint)
+        if let controller = WorkflowDurableFaultInjection.controller {
+            try await controller.consumeAfterWrite()
+        }
+    }
+
+    func loadLatest(threadID: HiveThreadID) async throws -> HiveCheckpoint<WorkflowDurableSchema>? {
+        try await inner.loadLatest(threadID: threadID)
+    }
 }
 #endif

--- a/Tests/SwarmTests/Workflow/WorkflowDurableChaosTests.swift
+++ b/Tests/SwarmTests/Workflow/WorkflowDurableChaosTests.swift
@@ -1,0 +1,159 @@
+#if SWARM_INTEGRATIONS
+import Foundation
+import HiveCore
+@testable import Swarm
+import Testing
+
+@Suite("Workflow durable chaos")
+struct WorkflowDurableChaosTests {
+    @Test("resume survives engineered kills and preserves step granularity")
+    func resumeSurvivesEngineeredKills() async throws {
+        for iteration in 0 ..< 3 {
+            try await runChaosScenario(iteration: iteration)
+        }
+    }
+}
+
+private func runChaosScenario(iteration: Int) async throws {
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent("swarm-chaos-\(iteration)-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let log = ExecutionLog()
+    let checkpointing = WorkflowCheckpointing.fileSystem(
+        directory: directory,
+        retention: WorkflowCheckpointRetention(maxCheckpointsPerRun: 8)
+    )
+    let checkpointID = "chaos-\(iteration)"
+    let faults: [WorkflowDurableFaultPoint] = [
+        .midStep,
+        .beforeCheckpointWrite,
+        .afterCheckpointWrite,
+        .midStep,
+        .beforeCheckpointWrite,
+        .afterCheckpointWrite,
+    ]
+    let controller = WorkflowDurableFaultController(queue: faults)
+
+    try await WorkflowDurableFaultInjection.$controller.withValue(controller) {
+        for index in faults.indices {
+            let resumeFrom = try await checkpointing.containsCheckpoint(for: checkpointID)
+                ? checkpointID
+                : nil
+            do {
+                _ = try await makeChaosWorkflow(
+                    log: log,
+                    checkpointing: checkpointing,
+                    checkpointID: checkpointID
+                ).durable.execute("start", resumeFrom: resumeFrom)
+                Issue.record("expected injected fault \(faults[index]) on attempt \(index)")
+            } catch let fault as WorkflowDurableInjectedFault {
+                #expect(fault.point == faults[index])
+            }
+        }
+    }
+
+    let result = try await makeChaosWorkflow(
+        log: log,
+        checkpointing: checkpointing,
+        checkpointID: checkpointID
+    ).durable.execute("ignored", resumeFrom: checkpointID)
+
+    #expect(result.output == "C")
+    let counts = await log.counts
+    #expect(counts["A"] == 3)
+    #expect(counts["B"] == 3)
+    #expect(counts["C"] == 1)
+    #expect(await controller.injected == faults)
+
+    try assertCheckpointsAreWellFormed(in: directory)
+}
+
+private func makeChaosWorkflow(
+    log: ExecutionLog,
+    checkpointing: WorkflowCheckpointing,
+    checkpointID: String
+) -> Workflow {
+    Workflow()
+        .step(ChaosAgent(label: "A", log: log))
+        .step(ChaosAgent(label: "B", log: log))
+        .step(ChaosAgent(label: "C", log: log))
+        .durable
+        .checkpoint(id: checkpointID, policy: .everyStep)
+        .durable
+        .checkpointing(checkpointing)
+}
+
+private func assertCheckpointsAreWellFormed(in directory: URL) throws {
+    let urls = try FileManager.default.contentsOfDirectory(
+        at: directory,
+        includingPropertiesForKeys: nil
+    )
+    let decoder = JSONDecoder()
+    var decodedCheckpoints = 0
+
+    for url in urls {
+        let name = url.lastPathComponent
+        let data = try Data(contentsOf: url)
+        if name == WorkflowFileCheckpointStore.manifestFileName {
+            let manifest = try decoder.decode(WorkflowCheckpointManifest.self, from: data)
+            #expect(manifest.version == 1)
+            continue
+        }
+        #expect(name.hasSuffix(".json"))
+        _ = try decoder.decode(HiveCheckpoint<WorkflowDurableSchema>.self, from: data)
+        decodedCheckpoints += 1
+    }
+
+    #expect(decodedCheckpoints > 0)
+}
+
+private actor ExecutionLog {
+    private var values: [String] = []
+
+    func record(_ label: String) {
+        values.append(label)
+    }
+
+    var counts: [String: Int] {
+        values.reduce(into: [:]) { $0[$1, default: 0] += 1 }
+    }
+}
+
+private actor ChaosAgent: AgentRuntime {
+    nonisolated let label: String
+    nonisolated let tools: [any AnyJSONTool] = []
+    nonisolated let instructions: String
+    nonisolated let configuration: AgentConfiguration
+    nonisolated let handoffs: [AnyHandoffConfiguration] = []
+    private let log: ExecutionLog
+
+    init(label: String, log: ExecutionLog) {
+        self.label = label
+        self.log = log
+        instructions = label
+        configuration = AgentConfiguration(name: label)
+    }
+
+    func run(_ input: String, session: (any Session)?, observer: (any AgentObserver)?) async throws -> AgentResult {
+        await log.record(label)
+        if let controller = WorkflowDurableFaultInjection.controller {
+            try await controller.consumeMidStep()
+        }
+        return AgentResult(output: label)
+    }
+
+    nonisolated func stream(
+        _ input: String,
+        session: (any Session)?,
+        observer: (any AgentObserver)?
+    ) -> AsyncThrowingStream<AgentEvent, Error> {
+        StreamHelper.makeTrackedStream { continuation in
+            continuation.finish(throwing: AgentError.internalError(reason: "chaos agent does not stream"))
+        }
+    }
+
+    func cancel() async {}
+}
+#endif

--- a/Tests/SwarmTests/Workflow/WorkflowDurableTests.swift
+++ b/Tests/SwarmTests/Workflow/WorkflowDurableTests.swift
@@ -119,7 +119,7 @@ struct WorkflowDurableTests {
 
         let original = Workflow()
             .step(MockAgentRuntime(response: "seed"))
-            .route { _ in nil as (any AgentRuntime)? }
+            .route({ _ in nil as (any AgentRuntime)? }, signature: "route-v1")
             .durable
             .checkpoint(id: "wf-route-closure-mismatch", policy: .everyStep)
             .durable
@@ -132,7 +132,7 @@ struct WorkflowDurableTests {
 
         let changed = Workflow()
             .step(MockAgentRuntime(response: "seed"))
-            .route { _ in MockAgentRuntime(response: "changed-route") }
+            .route({ _ in MockAgentRuntime(response: "changed-route") }, signature: "route-v2")
             .durable
             .checkpoint(id: "wf-route-closure-mismatch", policy: .everyStep)
             .durable
@@ -148,7 +148,11 @@ struct WorkflowDurableTests {
         let checkpointing = WorkflowCheckpointing.inMemory()
 
         let original = Workflow()
-            .parallel([MockAgentRuntime(response: "branch")], merge: .custom { _ in "original-merge" })
+            .parallel(
+                [MockAgentRuntime(response: "branch")],
+                merge: .custom { _ in "original-merge" },
+                customMergeSignature: "merge-v1"
+            )
             .durable
             .checkpoint(id: "wf-custom-merge-mismatch", policy: .everyStep)
             .durable
@@ -157,7 +161,11 @@ struct WorkflowDurableTests {
         _ = try await original.durable.execute("start")
 
         let changed = Workflow()
-            .parallel([MockAgentRuntime(response: "branch")], merge: .custom { _ in "changed-merge" })
+            .parallel(
+                [MockAgentRuntime(response: "branch")],
+                merge: .custom { _ in "changed-merge" },
+                customMergeSignature: "merge-v2"
+            )
             .durable
             .checkpoint(id: "wf-custom-merge-mismatch", policy: .everyStep)
             .durable
@@ -187,6 +195,25 @@ struct WorkflowDurableTests {
         await #expect(throws: WorkflowError.self) {
             _ = try await changed.durable.execute("resume", resumeFrom: "wf-repeat-closure-mismatch")
         }
+    }
+
+    @Test("durable execute warns once when implicit fileID:line identity would have been used")
+    func durableExecuteWarnsOnceForImplicitIdentity() async throws {
+        WorkflowDurableIdentityTesting.reset()
+        let checkpointing = WorkflowCheckpointing.inMemory()
+        let workflow = Workflow()
+            .step(MockAgentRuntime(response: "seed"))
+            .route { _ in MockAgentRuntime(response: "routed") }
+            .durable
+            .checkpoint(id: "wf-implicit-identity", policy: .everyStep)
+            .durable
+            .checkpointing(checkpointing)
+
+        _ = try await workflow.durable.execute("start")
+        #expect(WorkflowDurableIdentityTesting.warningCount == 1)
+
+        _ = try await workflow.durable.execute("again")
+        #expect(WorkflowDurableIdentityTesting.warningCount == 1)
     }
 
     @Test("durable fallback executes backup after retries exhausted")

--- a/Tests/SwarmTests/Workflow/WorkflowFileCheckpointStoreTests.swift
+++ b/Tests/SwarmTests/Workflow/WorkflowFileCheckpointStoreTests.swift
@@ -1,0 +1,211 @@
+#if SWARM_INTEGRATIONS
+import Foundation
+import HiveCore
+@testable import Swarm
+import Testing
+
+@Suite("Workflow file checkpoint store")
+struct WorkflowFileCheckpointStoreTests {
+    @Test("pruning keeps exactly N checkpoints per run")
+    func pruningKeepsExactlyNPerRun() async throws {
+        let directory = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let store = WorkflowFileCheckpointStore(
+            directory: directory,
+            retention: WorkflowCheckpointRetention(maxCheckpointsPerRun: 3)
+        )
+        let thread = HiveThreadID("run-prune")
+
+        for step in 0 ..< 7 {
+            try await store.save(makeCheckpoint(thread: thread, id: "cp-\(step)", step: step))
+        }
+
+        let names = try checkpointFileNames(in: directory)
+        #expect(names.count == 3)
+        #expect(names.contains("workflow-run-prune-cp-4.json"))
+        #expect(names.contains("workflow-run-prune-cp-5.json"))
+        #expect(names.contains("workflow-run-prune-cp-6.json"))
+        #expect(!names.contains("workflow-run-prune-cp-0.json"))
+
+        let latest = try await store.loadLatest(threadID: thread)
+        #expect(latest?.id.rawValue == "cp-6")
+        #expect(latest?.stepIndex == 6)
+    }
+
+    @Test("pruning is isolated per run")
+    func pruningIsIsolatedPerRun() async throws {
+        let directory = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let store = WorkflowFileCheckpointStore(
+            directory: directory,
+            retention: WorkflowCheckpointRetention(maxCheckpointsPerRun: 2)
+        )
+
+        for step in 0 ..< 4 {
+            try await store.save(makeCheckpoint(thread: HiveThreadID("alpha"), id: "a-\(step)", step: step))
+            try await store.save(makeCheckpoint(thread: HiveThreadID("beta"), id: "b-\(step)", step: step))
+        }
+
+        let names = try checkpointFileNames(in: directory)
+        #expect(names.filter { $0.contains("alpha") }.count == 2)
+        #expect(names.filter { $0.contains("beta") }.count == 2)
+    }
+
+    @Test("load reads the manifest instead of scanning the directory")
+    func loadReadsManifestNotDirectoryScan() async throws {
+        let directory = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let files = CountingWorkflowCheckpointFileOperator()
+        let store = WorkflowFileCheckpointStore(
+            directory: directory,
+            retention: WorkflowCheckpointRetention(maxCheckpointsPerRun: 4),
+            files: files
+        )
+        let thread = HiveThreadID("run-index")
+        try await store.save(makeCheckpoint(thread: thread, id: "cp-1", step: 1))
+        try await store.save(makeCheckpoint(thread: thread, id: "cp-2", step: 2))
+
+        files.resetCounts()
+        let latest = try await store.loadLatest(threadID: thread)
+
+        #expect(latest?.id.rawValue == "cp-2")
+        #expect(files.contentsOfDirectoryCount == 0)
+        #expect(files.readURLs.contains { $0.lastPathComponent == WorkflowFileCheckpointStore.manifestFileName })
+        #expect(files.readURLs.contains { $0.lastPathComponent == "workflow-run-index-cp-2.json" })
+        #expect(!files.readURLs.contains { $0.lastPathComponent == "workflow-run-index-cp-1.json" })
+    }
+
+    @Test("corrupt checkpoint files are skipped loudly and are not fatal")
+    func corruptCheckpointsAreSkipped() async throws {
+        let directory = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let store = WorkflowFileCheckpointStore(
+            directory: directory,
+            retention: WorkflowCheckpointRetention(maxCheckpointsPerRun: 8)
+        )
+        let thread = HiveThreadID("run-corrupt")
+        try await store.save(makeCheckpoint(thread: thread, id: "good", step: 1))
+        try await store.save(makeCheckpoint(thread: thread, id: "bad", step: 2))
+
+        let corruptURL = directory.appendingPathComponent("workflow-run-corrupt-bad.json")
+        try Data("{not-json".utf8).write(to: corruptURL, options: .atomic)
+
+        let latest = try await store.loadLatest(threadID: thread)
+        #expect(latest?.id.rawValue == "good")
+        #expect(latest?.stepIndex == 1)
+    }
+
+    @Test("all-corrupt entries return nil instead of throwing")
+    func allCorruptEntriesReturnNil() async throws {
+        let directory = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let store = WorkflowFileCheckpointStore(
+            directory: directory,
+            retention: .default
+        )
+        let thread = HiveThreadID("run-all-corrupt")
+        try await store.save(makeCheckpoint(thread: thread, id: "only", step: 1))
+        try Data("[]".utf8).write(
+            to: directory.appendingPathComponent("workflow-run-all-corrupt-only.json"),
+            options: .atomic
+        )
+
+        let latest = try await store.loadLatest(threadID: thread)
+        #expect(latest == nil)
+    }
+}
+
+private func makeDirectory() throws -> URL {
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent("swarm-checkpoint-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    return directory
+}
+
+private func checkpointFileNames(in directory: URL) throws -> [String] {
+    try FileManager.default.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)
+        .map(\.lastPathComponent)
+        .filter { $0.hasPrefix("workflow-") && $0.hasSuffix(".json") && $0 != WorkflowFileCheckpointStore.manifestFileName }
+        .sorted()
+}
+
+private func makeCheckpoint(
+    thread: HiveThreadID,
+    id: String,
+    step: Int
+) -> HiveCheckpoint<WorkflowDurableSchema> {
+    HiveCheckpoint(
+        id: HiveCheckpointID(id),
+        threadID: thread,
+        runID: HiveRunID(UUID()),
+        stepIndex: step,
+        schemaVersion: "1",
+        graphVersion: "1",
+        globalDataByChannelID: [:],
+        frontier: [],
+        joinBarrierSeenByJoinID: [:],
+        interruption: nil
+    )
+}
+
+private final class CountingWorkflowCheckpointFileOperator: WorkflowCheckpointFileOperating, @unchecked Sendable {
+    private let lock = NSLock()
+    private let foundation = FoundationWorkflowCheckpointFileOperator()
+    private var directoryCount = 0
+    private var reads: [URL] = []
+
+    var contentsOfDirectoryCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return directoryCount
+    }
+
+    var readURLs: [URL] {
+        lock.lock()
+        defer { lock.unlock() }
+        return reads
+    }
+
+    func resetCounts() {
+        lock.lock()
+        defer { lock.unlock() }
+        directoryCount = 0
+        reads = []
+    }
+
+    func contentsOfDirectory(at url: URL) throws -> [URL] {
+        lock.lock()
+        directoryCount += 1
+        lock.unlock()
+        return try foundation.contentsOfDirectory(at: url)
+    }
+
+    func fileExists(atPath path: String) -> Bool {
+        foundation.fileExists(atPath: path)
+    }
+
+    func createDirectory(at url: URL) throws {
+        try foundation.createDirectory(at: url)
+    }
+
+    func removeItem(at url: URL) throws {
+        try foundation.removeItem(at: url)
+    }
+
+    func read(from url: URL) throws -> Data {
+        lock.lock()
+        reads.append(url)
+        lock.unlock()
+        return try foundation.read(from: url)
+    }
+
+    func write(_ data: Data, to url: URL) throws {
+        try foundation.write(data, to: url)
+    }
+}
+#endif

--- a/Tests/SwarmTests/Workflow/WorkflowSignatureTests.swift
+++ b/Tests/SwarmTests/Workflow/WorkflowSignatureTests.swift
@@ -1,0 +1,113 @@
+import Foundation
+@testable import Swarm
+import Testing
+
+@Suite("Workflow signatures")
+struct WorkflowSignatureTests {
+    @Test("shifted line numbers produce the same signature")
+    func shiftedLineNumbersProduceTheSameSignature() {
+        let first = Workflow()
+            .step(namedAgent("Writer"))
+            .route({ _ in namedAgent("Router") }, fileID: "First.swift", line: 10)
+            .repeatUntil(maxIterations: 2, { _ in true }, fileID: "First.swift", line: 20)
+            .parallel(
+                [namedAgent("Branch")],
+                merge: .custom { $0.map(\.output).joined() },
+                fileID: "First.swift",
+                line: 30
+            )
+
+        let second = Workflow()
+            .step(namedAgent("Writer"))
+            .route({ _ in namedAgent("Router") }, fileID: "Second.swift", line: 410)
+            .repeatUntil(maxIterations: 2, { _ in true }, fileID: "Second.swift", line: 880)
+            .parallel(
+                [namedAgent("Branch")],
+                merge: .custom { $0.map(\.output).joined() },
+                fileID: "Second.swift",
+                line: 990
+            )
+
+        #expect(first.workflowSignature == second.workflowSignature)
+        #expect(first.workflowSignature.contains("stable:"))
+        #expect(!first.workflowSignature.contains("source:"))
+    }
+
+    @Test("different workflows produce different signatures")
+    func differentWorkflowsProduceDifferentSignatures() {
+        let sequential = Workflow()
+            .step(namedAgent("Alpha"))
+        let routed = Workflow()
+            .route { _ in namedAgent("Alpha") }
+        let otherAgent = Workflow()
+            .step(namedAgent("Beta"))
+        let extraStep = Workflow()
+            .step(namedAgent("Alpha"))
+            .step(namedAgent("Beta"))
+
+        #expect(sequential.workflowSignature != routed.workflowSignature)
+        #expect(sequential.workflowSignature != otherAgent.workflowSignature)
+        #expect(sequential.workflowSignature != extraStep.workflowSignature)
+    }
+
+    @Test("explicit signature is used unchanged and still distinguishes behavior")
+    func explicitSignatureIsUsedUnchanged() {
+        let first = Workflow()
+            .route({ _ in namedAgent("Router") }, signature: "route-v1", fileID: "A.swift", line: 1)
+        let second = Workflow()
+            .route({ _ in namedAgent("Router") }, signature: "route-v2", fileID: "A.swift", line: 1)
+        let same = Workflow()
+            .route({ _ in namedAgent("Router") }, signature: "route-v1", fileID: "B.swift", line: 99)
+
+        #expect(first.workflowSignature != second.workflowSignature)
+        #expect(first.workflowSignature == same.workflowSignature)
+        #expect(first.workflowSignature.contains("explicit:"))
+        #expect(!first.usesImplicitOpaqueIdentity)
+        #expect(Workflow().route { _ in namedAgent("Router") }.usesImplicitOpaqueIdentity)
+    }
+
+    @Test("legacy fileID:line checkpoints fail with a dedicated resume message")
+    func legacySourceIdentityFailsWithClearMessage() {
+        let current = Workflow()
+            .route { _ in namedAgent("Router") }
+            .workflowSignature
+        let legacy = current.replacingOccurrences(of: ":stable:", with: ":source:")
+        #expect(legacy.contains(":source:"))
+        #expect(legacy != current)
+
+        let error = workflowDurableSignatureMismatch(
+            checkpointSignature: legacy,
+            currentSignature: current
+        )
+
+        guard let error else {
+            Issue.record("expected a resume mismatch for legacy source identity")
+            return
+        }
+        #expect(error == .resumeDefinitionMismatch(
+            reason: """
+            Checkpoint uses the legacy fileID:line workflow identity. Re-run this \
+            workflow from the start; Swarm now identifies steps by kind, position, \
+            and explicit signature: values, not source locations.
+            """
+        ))
+    }
+
+    @Test("matching signatures produce no mismatch")
+    func matchingSignaturesProduceNoMismatch() {
+        let signature = Workflow().step(namedAgent("Solo")).workflowSignature
+        #expect(
+            workflowDurableSignatureMismatch(
+                checkpointSignature: signature,
+                currentSignature: signature
+            ) == nil
+        )
+    }
+}
+
+private func namedAgent(_ name: String) -> MockAgentRuntime {
+    MockAgentRuntime(
+        response: name,
+        configuration: AgentConfiguration(name: name)
+    )
+}

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -70,6 +70,7 @@ export default defineConfig({
           text: 'Introduction',
           items: [
             { text: 'Getting Started', link: '/guide/getting-started' },
+            { text: 'Durable Execution', link: '/guide/durable-execution' },
             { text: 'Foundation Models', link: '/guide/foundation-models' },
             { text: 'Capability Showcase', link: '/guide/capability-showcase' },
             { text: 'Agent Workspace', link: '/guide/agent-workspace' },

--- a/docs/guide/durable-execution.md
+++ b/docs/guide/durable-execution.md
@@ -1,0 +1,116 @@
+# Durable Execution
+
+Durable workflows persist progress to a checkpoint store and resume from a
+checkpoint ID after a crash, process restart, or explicit `resumeFrom`.
+Checkpoint/resume requires the **`Integrations`** SwiftPM trait
+(`--traits Integrations` or `.package(..., traits: ["Integrations"])`).
+
+```swift
+let result = try await Workflow()
+    .step(fetchAgent)
+    .step(analyzeAgent)
+    .durable
+    .checkpoint(id: "weekly-report", policy: .everyStep)
+    .durable
+    .checkpointing(.fileSystem(directory: checkpointsURL))
+    .durable
+    .execute("Create this week's report", resumeFrom: nil)
+```
+
+This page is the contract for what resume does — and what it does not do.
+
+## Step-granularity semantics
+
+A durable checkpoint is written **after a workflow step completes**, not in the
+middle of that step.
+
+- If the process dies **mid-step**, resume re-runs the **entire** step from its
+  original input. Partial side effects from the failed attempt are not rolled
+  back.
+- If the process dies **after** the checkpoint write, resume continues at the
+  next step. The completed step is not re-executed.
+- If the process dies **after** the step finishes but **before** the checkpoint
+  is persisted, resume treats the step as incomplete and re-runs it.
+
+Side effects inside a step (HTTP calls, file writes, tool invocations) must be
+**idempotent** or **externalized** behind an idempotency key. Swarm does not
+checkpoint agent session state or memory this quarter — only workflow cursor,
+last step result, and the workflow signature.
+
+`.everyStep` records progress after each step. `.onCompletion` records a single
+checkpoint when the workflow finishes.
+
+## Signature stability
+
+Resume matches the saved workflow against the current definition. The signature
+is derived from:
+
+1. Step **kind** and **position** (`single`, `parallel`, `route`, `fallback`,
+   `repeat`)
+2. Stable agent identifiers (type, name, instructions, configuration, tools)
+3. An explicit `signature:` / `customMergeSignature:` when you provide one
+
+`#fileID` and `#line` are **not** part of identity. Editing source so a builder
+moves to a different line does not break resume.
+
+```swift
+// Same signature at any line number:
+.route { input in input.contains("risk") ? riskAgent : summaryAgent }
+
+// Bump this when the closure behavior changes, or resume will keep matching:
+.route({ input in input.contains("risk") ? riskAgent : summaryAgent }, signature: "risk-router-v2")
+```
+
+| Builder | Implicit identity (no `signature:`) | When to pass `signature:` |
+|---|---|---|
+| `.step` | Agent configuration | You change the agent’s name, instructions, tools, or config |
+| `.parallel` + built-in merge | Agents + merge kind | You change the agent set or merge strategy |
+| `.parallel` + `.custom` | Kind + position | The merge closure behavior changes |
+| `.route` | Kind + position | The routing closure behavior changes |
+| `.repeatUntil` | Kind + `repeat` position | The stop predicate changes |
+
+Durable execute emits a **one-time** warning when a workflow relies on implicit
+identity for route / custom merge / repeat. The warning is informational —
+resume still works — but you should add an explicit signature before changing
+those closures.
+
+### Migration from fileID:line identity
+
+Older checkpoints stored opaque-step identity as `fileID:line` (`:source:` in
+the signature string). Those checkpoints **do not** load best-effort.
+
+Resume throws `WorkflowError.resumeDefinitionMismatch` with a message that names
+the legacy identity and tells you to start a new run. Sequential-only workflows
+that never used route / custom merge / implicit repeat keep matching, because
+their signature never included a source location.
+
+## Pruning and indexed loads
+
+`WorkflowCheckpointing.fileSystem(directory:retention:)` writes one JSON file
+per checkpoint plus a directory manifest
+(`workflow-checkpoints.manifest.json`).
+
+- **Policy:** keep the newest `N` checkpoints **per durable run** (the
+  checkpoint ID / thread). Default `N` is **16**.
+- **Deletion:** the manifest is updated first, then pruned files are removed.
+  A crash between those steps can leave an orphan file; it is not loaded.
+- **Loads:** `loadLatest` reads the manifest and decodes the newest readable
+  file. It does not scan or decode the whole directory.
+- **Corruption:** a checkpoint file that fails to decode is skipped with a
+  warning. Load continues to the previous entry. If every entry is corrupt,
+  load returns `nil` instead of throwing.
+
+```swift
+let checkpointing = WorkflowCheckpointing.fileSystem(
+    directory: checkpointsURL,
+    retention: WorkflowCheckpointRetention(maxCheckpointsPerRun: 8)
+)
+```
+
+In-memory stores are unbounded and intended for tests.
+
+## What is not checkpointed
+
+Agent session history, memory backends, and in-flight tool calls are **not**
+part of a workflow checkpoint. Rebuild those independently, or keep step bodies
+idempotent so a re-run is safe.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -373,6 +373,10 @@ let result = try await Workflow()
     .execute("Summarize the WWDC session", resumeFrom: nil)
 ```
 
+See [Durable Execution](./durable-execution.md) for step-granularity semantics
+(a mid-step crash re-runs the whole step), signature stability rules, and
+file-store pruning (keep-latest-16 per run by default).
+
 ## Choosing a Provider
 
 Built-in inference is **Apple Foundation Models only**. Pass a provider via the

--- a/docs/guide/why-swarm.md
+++ b/docs/guide/why-swarm.md
@@ -38,6 +38,10 @@ let result = try await Workflow()
     .execute("Create this week report")
 ```
 
+A mid-step crash re-runs that whole step; side effects must be idempotent.
+See [Durable Execution](./durable-execution.md) for signature stability and
+checkpoint pruning.
+
 ## Workflow Is Fluent
 
 Compose sequential, parallel, and routed flows with a small default API:

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ features:
   - icon: "\U0001F4BE"
     title: Workflows Survive Crashes
     details: Advanced workflows can checkpoint and resume with explicit checkpoint stores and deterministic IDs.
-    link: /reference/overview
+    link: /guide/durable-execution
     linkText: Explore checkpointing
 
   - icon: "\U0001F9E0"

--- a/docs/reference/api-catalog.md
+++ b/docs/reference/api-catalog.md
@@ -2492,23 +2492,27 @@ Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for
 | 202 | case | public | Workflow.MergeStrategy.custom(_:) | `public case custom(@Sendable ([AgentResult]) -> String)` |
 | 218 | func | public | Workflow.init() | `public init()` |
 | 238 | func | public | Workflow.step(_:) | `public func step(_ agent: some AgentRuntime) -> Workflow` |
-| 268 | func | public | Workflow.parallel(_:merge:customMergeSignature:fileID:line:) | `public func parallel(_ agents: [any AgentRuntime], merge: Workflow.MergeStrategy = .structured, customMergeSignature: String? = nil, fileID: StaticString = #fileID, line: UInt = #line) -> Workflow` |
-| 320 | func | public | Workflow.route(_:signature:fileID:line:) | `public func route(_ condition: @escaping @Sendable (String) -> (any AgentRuntime)?, signature: String? = nil, fileID: StaticString = #fileID, line: UInt = #line) -> Workflow` |
-| 335 | func | public | Workflow.route(signature:fileID:line:_:) | `public func route(signature: String, fileID: StaticString = #fileID, line: UInt = #line, _ condition: @escaping @Sendable (String) -> (any AgentRuntime)?) -> Workflow` |
-| 370 | func | public | Workflow.repeatUntil(maxIterations:_:signature:fileID:line:) | `public func repeatUntil(maxIterations: Int = 100, _ condition: @escaping @Sendable (AgentResult) -> Bool, signature: String? = nil, fileID: StaticString = #fileID, line: UInt = #line) -> Workflow` |
-| 390 | func | public | Workflow.repeatUntil(maxIterations:signature:fileID:line:_:) | `public func repeatUntil(maxIterations: Int = 100, signature: String, fileID: StaticString = #fileID, line: UInt = #line, _ condition: @escaping @Sendable (AgentResult) -> Bool) -> Workflow` |
-| 416 | func | public | Workflow.timeout(_:) | `public func timeout(_ duration: Duration) -> Workflow` |
-| 442 | func | public | Workflow.observed(by:) | `public func observed(by observer: some AgentObserver) -> Workflow` |
-| 469 | func | public | Workflow.run(_:) | `public func run(_ input: String) async throws -> AgentResult` |
-| 504 | func | public | Workflow.stream(_:) | `public func stream(_ input: String) -> AsyncThrowingStream<AgentEvent, Error>` |
+| 272 | func | public | Workflow.parallel(_:merge:customMergeSignature:fileID:line:) | `public func parallel(_ agents: [any AgentRuntime], merge: Workflow.MergeStrategy = .structured, customMergeSignature: String? = nil, fileID: StaticString = #fileID, line: UInt = #line) -> Workflow` |
+| 325 | func | public | Workflow.route(_:signature:fileID:line:) | `public func route(_ condition: @escaping @Sendable (String) -> (any AgentRuntime)?, signature: String? = nil, fileID: StaticString = #fileID, line: UInt = #line) -> Workflow` |
+| 341 | func | public | Workflow.route(signature:fileID:line:_:) | `public func route(signature: String, fileID: StaticString = #fileID, line: UInt = #line, _ condition: @escaping @Sendable (String) -> (any AgentRuntime)?) -> Workflow` |
+| 377 | func | public | Workflow.repeatUntil(maxIterations:_:signature:fileID:line:) | `public func repeatUntil(maxIterations: Int = 100, _ condition: @escaping @Sendable (AgentResult) -> Bool, signature: String? = nil, fileID: StaticString = #fileID, line: UInt = #line) -> Workflow` |
+| 397 | func | public | Workflow.repeatUntil(maxIterations:signature:fileID:line:_:) | `public func repeatUntil(maxIterations: Int = 100, signature: String, fileID: StaticString = #fileID, line: UInt = #line, _ condition: @escaping @Sendable (AgentResult) -> Bool) -> Workflow` |
+| 423 | func | public | Workflow.timeout(_:) | `public func timeout(_ duration: Duration) -> Workflow` |
+| 449 | func | public | Workflow.observed(by:) | `public func observed(by observer: some AgentObserver) -> Workflow` |
+| 476 | func | public | Workflow.run(_:) | `public func run(_ input: String) async throws -> AgentResult` |
+| 511 | func | public | Workflow.stream(_:) | `public func stream(_ input: String) -> AsyncThrowingStream<AgentEvent, Error>` |
 
 ### Workflow/WorkflowCheckpointing.swift
 
 | Line | Kind | Access | Name | Signature |
 |------|------|--------|------|-----------|
-| 5 | struct | public | WorkflowCheckpointing | `public struct WorkflowCheckpointing` |
-| 13 | func | public | WorkflowCheckpointing.inMemory() | `public static func inMemory() -> WorkflowCheckpointing` |
-| 19 | func | public | WorkflowCheckpointing.fileSystem(directory:) | `public static func fileSystem(directory: URL) -> WorkflowCheckpointing` |
+| 8 | struct | public | WorkflowCheckpointRetention | `public struct WorkflowCheckpointRetention` |
+| 10 | var | public | WorkflowCheckpointRetention.default | `public static let \`default\`: WorkflowCheckpointRetention` |
+| 15 | var | public | WorkflowCheckpointRetention.maxCheckpointsPerRun | `public var maxCheckpointsPerRun: Int` |
+| 21 | func | public | WorkflowCheckpointRetention.init(maxCheckpointsPerRun:) | `public init(maxCheckpointsPerRun: Int = 16)` |
+| 27 | struct | public | WorkflowCheckpointing | `public struct WorkflowCheckpointing` |
+| 49 | func | public | WorkflowCheckpointing.inMemory() | `public static func inMemory() -> WorkflowCheckpointing` |
+| 70 | func | public | WorkflowCheckpointing.fileSystem(directory:retention:) | `public static func fileSystem(directory: URL, retention: WorkflowCheckpointRetention = .default) -> WorkflowCheckpointing` |
 
 ## 10. MCP
 

--- a/docs/reference/front-facing-api.md
+++ b/docs/reference/front-facing-api.md
@@ -405,8 +405,13 @@ public extension Workflow {
 // Durable engine requires Integrations at execute.
 WorkflowCheckpointing.isAvailable
 WorkflowCheckpointing.inMemory()
-WorkflowCheckpointing.fileSystem(directory: URL)
+WorkflowCheckpointing.fileSystem(directory: URL, retention: WorkflowCheckpointRetention = .default)
+WorkflowCheckpointRetention.default // keep-latest 16 per run
 ```
+
+File-backed stores prune to keep-latest-N per run and load through a directory
+manifest. Resume identity is step kind + position + explicit `signature:` —
+not `fileID:line`. See [Durable Execution](/guide/durable-execution).
 
 ## 8) InputGuard and OutputGuard
 

--- a/docs/reference/overview.md
+++ b/docs/reference/overview.md
@@ -9,6 +9,7 @@ The current API reference covers the supported public surface for Swarm 0.6.0. P
 | [Agents](/reference/front-facing-api) | Agent types, configuration, and the canonical initializer |
 | [Tools](/reference/front-facing-api) | `@Tool` macro, `FunctionTool`, and `ToolCollection` |
 | [Workflow](/guide/getting-started) | Fluent workflow composition and execution |
+| [Durable execution](/guide/durable-execution) | Checkpoint/resume, signatures, pruning |
 | [Handoffs](/reference/front-facing-api) | Agent handoffs and routing between runtime agents |
 | [Memory](/reference/front-facing-api) | Conversation, Vector, Summary, SwiftData backends |
 | [Streaming](/reference/front-facing-api) | `AgentEvent` streaming and text output |


### PR DESCRIPTION
## Summary

Chunk O of the remediation series. Durable workflows now survive reality: bounded checkpoint storage, identity that does not break when you edit source, and a chaos test that proves resume.

**Based on `origin/main` after Chunk N merged** ([#133](https://github.com/christopherkarani/Swarm/pull/133)).

## Pruning policy + defaults

`WorkflowCheckpointing.fileSystem(directory:retention:)` keeps the **newest N checkpoints per durable run** (checkpoint ID / thread).

| Setting | Value |
|---|---|
| Default N | **16** (`WorkflowCheckpointRetention.default`) |
| Index | `workflow-checkpoints.manifest.json` — loads read this, not a directory scan |
| Deletion | Manifest is rewritten first, then pruned files are removed |
| Corruption | Decode failures are skipped with a warning; load continues to the previous entry. All-corrupt → `nil`, not a throw |

A counting file operator asserts `loadLatest` does not call `contentsOfDirectory` after a manifest exists.

In-memory stores stay unbounded (tests).

## Signature scheme + migration

| Case | Identity |
|---|---|
| Explicit `signature:` / `customMergeSignature:` | Unchanged (`explicit:`) |
| Implicit route / custom merge / repeat | Step **kind + position** (`stable:`) — **not** `fileID:line` |
| Sequential steps | Agent configuration (type, name, instructions, tools, …) as before |

`#fileID` / `#line` remain on the public builders for source compatibility and are ignored for resume matching. Same workflow at shifted line numbers produces the **same** signature.

Durable execute emits a **one-time** warning when a workflow relies on implicit opaque identity.

**Migration: fail loud, not best-effort.** Checkpoints that still embed `:source:` (legacy fileID:line) throw `WorkflowError.resumeDefinitionMismatch` telling the caller to start a new run. Sequential-only v2 checkpoints that never contained a source location still match.

## Chaos test evidence

`WorkflowDurableChaosTests` injects faults in the engine (not process death):

| Kill | Point | Re-executes that step? |
|---|---|---|
| 1 | mid-step A | yes |
| 2 | before checkpoint write (A) | yes |
| 3 | after checkpoint write (A) | no |
| 4 | mid-step B | yes |
| 5 | before checkpoint write (B) | yes |
| 6 | after checkpoint write (B) | no |

**N = 6 kills, all resumed.** Final output `C`. Execution counts: A=3, B=3, C=1 — matches step-granularity (mid-step crash = the whole step re-runs). Remaining checkpoint JSON + manifest all decode. Scenario looped **3× inside the test** and **5 extra local runs** — no flakes.

## Docs deltas

- New: [`docs/guide/durable-execution.md`](docs/guide/durable-execution.md) — step granularity, signature rules, pruning, “not checkpointed this quarter” (session/memory).
- Linked from getting-started, why-swarm, README, overview, front-facing-api, vitepress sidebar, homepage.

## Test plan

- [x] `bash scripts/ci/lean-build-test.sh` — **1843 tests in 243 suites PASS** (Macros-disabled fixture PASS)
- [x] `swift test --no-parallel --traits Integrations` — **1996 tests in 269 suites PASS**
- [x] `swift run --traits Integrations SwarmCapabilityShowcase matrix` — **14/14 passed**
- [x] Chaos test 5 extra local repeats — all green
- [x] SwiftFormat `--lint` clean on changed Swift files

### Baseline comparison

| Lane | Chunk A | Chunk N (#133) | This PR (O) |
|---|---|---|---|
| Lean | 1719 / 220 | 1838 / 242 | **1843 / 243** |
| Integrations | 1849 / 239 | 1984 / 266 | **1996 / 269** |
| Showcase | — | 14/14 | **14/14** |

Delta vs N is signature tests (+5 lean), plus file-store / chaos / implicit-identity warning on the Integrations lane. No regressions vs Chunk A.

## Breaking changes

**Does this PR introduce breaking changes?**

- [x] Yes (resume identity only — documented)

Legacy durable checkpoints whose signature contains `:source:` (fileID:line on route / custom merge / implicit repeat) will not resume. Start a new run. Sequential-only checkpoints are unaffected. `fileID` / `line` parameters are not removed.


Made with [Cursor](https://cursor.com)