### PR TITLE
feat: OpenAI-compatible remote provider (streaming, tools, structured outputs)

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -104,6 +104,9 @@ jobs:
       - name: Run tests with Integrations trait
         run: swift test --no-parallel --traits Integrations
 
+      - name: Linux OpenAI-compatible provider proof
+        run: swift test --no-parallel --filter OpenAICompatible
+
   # Code Quality (macOS only - SwiftLint/SwiftFormat)
   code-quality:
     name: Code Quality

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ That is a working agent with type-safe tool calling. Swarm also supports **AGENT
 - **Swift concurrency is part of the surface.** Swift 6.2 `StrictConcurrency` is enabled across the package.
 - **Tools stay type-safe.** The `@Tool` macro generates JSON schemas from Swift structs.
 - **Workflows can survive crashes.** Durable checkpointing (Integrations trait) lets you resume from an explicit checkpoint ID.
-- **Built-in inference is on-device Foundation Models.** Inject any `InferenceProvider` for custom backends; the agent loop stays the same.
+- **Built-in inference is on-device Foundation Models, plus an OpenAI-compatible remote provider.** Linux and machines without Apple Intelligence use `.openAICompatible(...)`; the agent loop stays the same.
 - **It is written in Swift all the way down.** `AsyncThrowingStream`, actors, result builders, and macros are first-class here.
 
 ## Examples
@@ -202,7 +202,37 @@ Notes that matter in production:
 - **Streaming tool calls**: not advertised as token-level tool streaming; `Agent.stream` observes the same `run` loop via `AgentEvent` (lifecycle, tools, and `.output(.token)` chunks). Foundation Models yields incremental text deltas; providers without a streaming API emit the full response as a single chunk.
 - **Structured outputs**: `runStructured` uses Foundation Models guided generation when the JSON Schema maps onto `GenerationSchema` (`source: .providerNative`); otherwise it is prompt instruction + parse (`source: .promptFallback`). `.jsonObject` always uses the fallback path.
 - **Dynamic profiles**: `.foundationModels(profile:)` re-resolves instructions/tools/history every turn (WWDC 2026–aligned Swarm API).
-- **Linux / CI**: Foundation Models is compile-time gated; inject a mock or custom `InferenceProvider`, or use the deterministic `--demo` modes in `Examples/`.
+- **Linux / CI**: Foundation Models is compile-time gated. Use `.openAICompatible(.ollama(model:))` (or any OpenAI-compatible host), inject a mock, or use the deterministic `--demo` modes in `Examples/`.
+
+### OpenAI-compatible remote provider
+
+No Apple Intelligence required. Same agent loop, `URLSession` only:
+
+```swift
+// Local (Ollama). Data stays on loopback HTTP — not on-device Foundation Models.
+let local = try Agent(
+    "Be helpful.",
+    inferenceProvider: .openAICompatible(.ollama(model: "llama3.2"))
+)
+
+// Cloud. Prompt content leaves the device.
+let cloud = try Agent(
+    "Be helpful.",
+    inferenceProvider: .openAICompatible(
+        .openAI(apiKey: "sk-...", model: "gpt-4o")
+    )
+)
+```
+
+| Host | Factory | Leaves the device? |
+|---|---|---|
+| OpenAI | `.openAI(apiKey:model:)` | Yes — to OpenAI |
+| Azure OpenAI | `.azureOpenAI(resource:deployment:apiKey:)` | Yes — to Azure |
+| OpenRouter | `.openRouter(apiKey:model:)` | Yes — to OpenRouter |
+| Ollama | `.ollama(model:)` | Yes — to `localhost` HTTP |
+| LM Studio | `.lmStudio(model:)` | Yes — to `localhost` HTTP |
+
+See [Remote Providers](docs/guide/remote-providers.md) for full snippets, structured-output honesty, and live Ollama test setup.
 
 ### Multi-agent pipeline
 
@@ -324,6 +354,12 @@ optional `signature:` — not source line numbers. See
 // Built-in: on-device Foundation Models (no API key)
 let local = try Agent("Be helpful.", inferenceProvider: .foundationModels())
 
+// Built-in: OpenAI-compatible remote / local HTTP (Linux-friendly)
+let remote = try Agent(
+    "Be helpful.",
+    inferenceProvider: .openAICompatible(.ollama(model: "llama3.2"))
+)
+
 // Custom backend: any type conforming to InferenceProvider
 let custom = try Agent("Be helpful.", inferenceProvider: myCustomProvider)
 
@@ -372,7 +408,7 @@ for message in await conversation.messages {
 | **Resilience** | 7 backoff strategies, circuit breaker, fallback chains, rate limiting |
 | **Observability** | `AgentObserver`, `Tracer`, `SwiftLogTracer`, per-agent token metrics when the provider reports usage (Foundation Models does not) |
 | **MCP** | Model Context Protocol client and server support |
-| **Providers** | Built-in Apple Foundation Models (on-device); inject any `InferenceProvider` for custom backends |
+| **Providers** | Built-in Apple Foundation Models (on-device) and `OpenAICompatibleProvider` (OpenAI / Azure / OpenRouter / Ollama / LM Studio); inject any `InferenceProvider` for other backends |
 | **Macros** | `@Tool`, `@Parameter`, `@Traceable`, `#Prompt` |
 
 ## Architecture
@@ -395,7 +431,7 @@ for message in await conversation.messages {
 │   Workflow Graph  ·  Checkpointing  ·  Deterministic retry │
 ├─────────────────────────────────────────────────────────────┤
 │              InferenceProvider (pluggable)                   │
-│ Foundation Models (built-in) · custom InferenceProvider     │
+│ Foundation Models · OpenAI-compatible · custom provider     │
 └─────────────────────────────────────────────────────────────┘
 ```
 
@@ -409,13 +445,14 @@ for message in await conversation.messages {
 | tvOS     | 26.0+   |
 | Linux    | Ubuntu 22.04+ with Swift 6.2 |
 
-The default Swarm graph is CI-tested on Ubuntu with Swift 6.2. Apple-only features such as Foundation Models, SwiftData, OSLog, and some built-in tool behavior are unavailable or different on Linux; inject a mock or custom `InferenceProvider` there.
+The default Swarm graph is CI-tested on Ubuntu with Swift 6.2. Apple-only features such as Foundation Models, SwiftData, OSLog, and some built-in tool behavior are unavailable or different on Linux; use ``OpenAICompatibleProvider`` (stubbed in CI, live against Ollama when `SWARM_OLLAMA_LIVE_TESTS=1`) or inject a mock.
 
 ## Documentation
 
 | | |
 |---|---|
 | [Getting Started](docs/guide/getting-started.md) | Installation, first agent, workflows |
+| [Remote Providers](docs/guide/remote-providers.md) | OpenAI-compatible provider (OpenAI, Azure, OpenRouter, Ollama, LM Studio) |
 | [OpenTelemetry Tracing](docs/guide/opentelemetry-tracing.md) | OTLP/HTTP JSON export of agent and LLM spans, plus W3C `traceparent` on outbound HTTP |
 | [API Reference](docs/reference/api-catalog.md) | Every type, protocol, and API |
 | [Front-Facing API](docs/reference/front-facing-api.md) | Public API surface |

--- a/Sources/Swarm/Providers/DefaultInferenceProviderFactory.swift
+++ b/Sources/Swarm/Providers/DefaultInferenceProviderFactory.swift
@@ -10,7 +10,9 @@ import Foundation
 enum DefaultInferenceProviderFactory {
     /// Returns an on-device Foundation Models provider when the system model is available.
     ///
-    /// This is the only built-in inference backend. Custom backends inject
+    /// Built-in default on Apple platforms. ``OpenAICompatibleProvider`` is the
+    /// remote alternative when Foundation Models is unavailable (Linux, CI,
+    /// or no Apple Intelligence). Custom backends still inject
     /// ``InferenceProvider`` explicitly or via `Swarm.configure(provider:)`.
     static func makeFoundationModelsProviderIfAvailable() -> (any InferenceProvider)? {
         #if canImport(FoundationModels)

--- a/Sources/Swarm/Providers/OpenAICompatible/OpenAICompatibleCodec.swift
+++ b/Sources/Swarm/Providers/OpenAICompatible/OpenAICompatibleCodec.swift
@@ -1,0 +1,425 @@
+// OpenAICompatibleCodec.swift
+// Swarm Framework
+//
+// InferenceMessage / ToolSchema ↔ OpenAI chat-completions JSON.
+
+import Foundation
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+enum OpenAICompatibleCodec: Sendable {
+    static func chatCompletionsURL(for configuration: OpenAICompatibleProviderConfiguration) throws -> URL {
+        var components = URLComponents(url: configuration.baseURL, resolvingAgainstBaseURL: false)
+        guard var components else {
+            throw AgentError.invalidInput(reason: "OpenAI-compatible baseURL is not a valid URL")
+        }
+
+        let path = components.path
+        if !path.hasSuffix("/chat/completions") && !path.hasSuffix("/chat/completions/") {
+            if path.hasSuffix("/") {
+                components.path = path + "chat/completions"
+            } else if path.isEmpty {
+                components.path = "/chat/completions"
+            } else {
+                components.path = path + "/chat/completions"
+            }
+        }
+
+        var items = components.queryItems ?? []
+        for (name, value) in configuration.queryItems.sorted(by: { $0.key < $1.key }) {
+            items.append(URLQueryItem(name: name, value: value))
+        }
+        components.queryItems = items.isEmpty ? nil : items
+
+        guard let url = components.url else {
+            throw AgentError.invalidInput(reason: "OpenAI-compatible endpoint could not be constructed")
+        }
+        return url
+    }
+
+    static func makeRequest(
+        configuration: OpenAICompatibleProviderConfiguration,
+        messages: [InferenceMessage],
+        tools: [ToolSchema],
+        options: InferenceOptions,
+        stream: Bool,
+        structuredOutput: StructuredOutputRequest?
+    ) throws -> URLRequest {
+        let url = try chatCompletionsURL(for: configuration)
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(stream ? "text/event-stream" : "application/json", forHTTPHeaderField: "Accept")
+
+        for (name, value) in configuration.httpHeaders {
+            request.setValue(value, forHTTPHeaderField: name)
+        }
+
+        let hasAuthHeader = configuration.httpHeaders.keys.contains { key in
+            key.caseInsensitiveCompare("Authorization") == .orderedSame
+                || key.caseInsensitiveCompare("api-key") == .orderedSame
+        }
+        if !hasAuthHeader, let apiKey = configuration.apiKey, !apiKey.isEmpty {
+            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        }
+
+        TraceContextHeaders.applyCurrent(to: &request)
+
+        let body = try requestBody(
+            configuration: configuration,
+            messages: messages,
+            tools: tools,
+            options: options,
+            stream: stream,
+            structuredOutput: structuredOutput
+        )
+        request.httpBody = try JSONSerialization.data(withJSONObject: body, options: [.sortedKeys])
+        return request
+    }
+
+    static func requestBody(
+        configuration: OpenAICompatibleProviderConfiguration,
+        messages: [InferenceMessage],
+        tools: [ToolSchema],
+        options: InferenceOptions,
+        stream: Bool,
+        structuredOutput: StructuredOutputRequest?
+    ) throws -> [String: Any] {
+        var body: [String: Any] = [
+            "model": configuration.model,
+            "messages": messages.map(encodeMessage),
+            "temperature": options.temperature,
+        ]
+
+        if let maxTokens = options.maxTokens {
+            body["max_tokens"] = maxTokens
+        }
+        if !options.stopSequences.isEmpty {
+            body["stop"] = options.stopSequences
+        }
+        if let topP = options.topP {
+            body["top_p"] = topP
+        }
+        if let presencePenalty = options.presencePenalty {
+            body["presence_penalty"] = presencePenalty
+        }
+        if let frequencyPenalty = options.frequencyPenalty {
+            body["frequency_penalty"] = frequencyPenalty
+        }
+        if let seed = options.seed {
+            body["seed"] = seed
+        }
+        if let parallel = options.parallelToolCalls {
+            body["parallel_tool_calls"] = parallel
+        }
+        if !tools.isEmpty {
+            body["tools"] = tools.map(encodeTool)
+            if let toolChoice = options.toolChoice {
+                body["tool_choice"] = encodeToolChoice(toolChoice)
+            }
+        }
+        if stream {
+            body["stream"] = true
+            body["stream_options"] = ["include_usage": true]
+        }
+        if let structuredOutput,
+           configuration.structuredOutputMode == .nativeJSONSchema
+        {
+            body["response_format"] = try encodeResponseFormat(structuredOutput)
+        }
+
+        return body
+    }
+
+    static func encodeMessage(_ message: InferenceMessage) -> [String: Any] {
+        var object: [String: Any] = [
+            "role": message.role.rawValue,
+            "content": message.content,
+        ]
+        if let name = message.name, message.role != .tool {
+            object["name"] = name
+        }
+        if message.role == .tool {
+            object["tool_call_id"] = message.toolCallID ?? message.name ?? "tool_call"
+        }
+        if !message.toolCalls.isEmpty {
+            object["tool_calls"] = message.toolCalls.enumerated().map { index, call in
+                encodeToolCall(call, index: index)
+            }
+        }
+        return object
+    }
+
+    static func encodeTool(_ schema: ToolSchema) -> [String: Any] {
+        [
+            "type": "function",
+            "function": [
+                "name": schema.name,
+                "description": schema.description,
+                "parameters": parametersSchema(for: schema),
+            ] as [String: Any],
+        ]
+    }
+
+    static func encodeToolChoice(_ choice: ToolChoice) -> Any {
+        switch choice {
+        case .auto:
+            return "auto"
+        case .none:
+            return "none"
+        case .required:
+            return "required"
+        case let .specific(toolName):
+            return [
+                "type": "function",
+                "function": ["name": toolName],
+            ] as [String: Any]
+        }
+    }
+
+    static func encodeResponseFormat(_ request: StructuredOutputRequest) throws -> [String: Any] {
+        switch request.format {
+        case .jsonObject:
+            return ["type": "json_object"]
+        case let .jsonSchema(name, schemaJSON):
+            guard let data = schemaJSON.data(using: .utf8),
+                  let schema = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+            else {
+                throw AgentError.invalidInput(
+                    reason: "Structured output JSON schema is not a JSON object"
+                )
+            }
+            return [
+                "type": "json_schema",
+                "json_schema": [
+                    "name": sanitizeSchemaName(name),
+                    "schema": schema,
+                    "strict": true,
+                ] as [String: Any],
+            ]
+        }
+    }
+
+    static func inferenceResponse(from chunk: OpenAICompatibleChatChunk) throws -> InferenceResponse {
+        let choice = chunk.choices.first
+        let message = choice?.message ?? choice?.delta
+        let toolCalls = (message?.toolCalls ?? []).map(parsedToolCall)
+        let finishReason = finishReason(from: choice?.finishReason, hasToolCalls: !toolCalls.isEmpty)
+
+        if finishReason == .contentFilter {
+            throw AgentError.contentFiltered(
+                reason: message?.content ?? "OpenAI-compatible content filter"
+            )
+        }
+
+        let content = message?.content.flatMap { $0.isEmpty ? nil : $0 }
+        return InferenceResponse(
+            content: content,
+            toolCalls: toolCalls,
+            finishReason: finishReason,
+            usage: chunk.usage
+        )
+    }
+
+    static func parsedToolCall(_ delta: OpenAICompatibleChatChunk.ToolCallDelta) -> InferenceResponse.ParsedToolCall {
+        InferenceResponse.ParsedToolCall(
+            id: delta.id,
+            name: delta.name ?? "",
+            arguments: decodeArguments(delta.arguments)
+        )
+    }
+
+    static func decodeArguments(_ json: String) -> [String: SendableValue] {
+        let trimmed = json.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              let data = trimmed.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data)
+        else {
+            return [:]
+        }
+        if case let .dictionary(dictionary) = SendableValue.fromJSONValue(object) {
+            return dictionary
+        }
+        return [:]
+    }
+
+    static func finishReason(from raw: String?, hasToolCalls: Bool) -> InferenceResponse.FinishReason {
+        switch raw {
+        case "tool_calls", "function_call":
+            return .toolCall
+        case "length":
+            return .maxTokens
+        case "content_filter":
+            return .contentFilter
+        case "cancelled", "cancelled_by_user":
+            return .cancelled
+        default:
+            return hasToolCalls ? .toolCall : .completed
+        }
+    }
+
+    static func parametersSchema(for schema: ToolSchema) -> [String: Any] {
+        parametersSchema(name: schema.name, parameters: schema.parameters)
+    }
+
+    private static func parametersSchema(name: String, parameters: [ToolParameter]) -> [String: Any] {
+        var properties: [String: Any] = [:]
+        var required: [String] = []
+
+        for parameter in parameters {
+            var schema = jsonSchema(for: parameter.type)
+            schema["description"] = parameter.description
+            if let defaultValue = parameter.defaultValue {
+                schema["default"] = defaultValue.toJSONObject()
+            }
+            properties[parameter.name] = schema
+            if parameter.isRequired, parameter.defaultValue == nil {
+                required.append(parameter.name)
+            }
+        }
+
+        required.sort { $0.utf8.lexicographicallyPrecedes($1.utf8) }
+
+        var root: [String: Any] = [
+            "type": "object",
+            "properties": properties,
+            "additionalProperties": false,
+        ]
+        if !required.isEmpty {
+            root["required"] = required
+        }
+        if properties.isEmpty {
+            root["description"] = "Tool parameters for \(name)"
+        }
+        return root
+    }
+
+    private static func jsonSchema(for type: ToolParameter.ParameterType) -> [String: Any] {
+        switch type {
+        case .string:
+            return ["type": "string"]
+        case .int:
+            return ["type": "integer"]
+        case .double:
+            return ["type": "number"]
+        case .bool:
+            return ["type": "boolean"]
+        case let .array(elementType):
+            return [
+                "type": "array",
+                "items": jsonSchema(for: elementType),
+            ]
+        case let .object(properties):
+            return parametersSchema(name: "object", parameters: properties)
+        case let .oneOf(options):
+            return [
+                "type": "string",
+                "enum": options,
+            ]
+        case .any:
+            return [:]
+        }
+    }
+
+    private static func encodeToolCall(_ call: InferenceMessage.ToolCall, index: Int) -> [String: Any] {
+        let argumentsObject = SendableValue.dictionary(call.arguments).toJSONObject()
+        let argumentsData = (try? JSONSerialization.data(withJSONObject: argumentsObject, options: [.sortedKeys]))
+            ?? Data("{}".utf8)
+        let arguments = String(data: argumentsData, encoding: .utf8) ?? "{}"
+        return [
+            "id": call.id ?? "call_\(index)",
+            "type": "function",
+            "function": [
+                "name": call.name,
+                "arguments": arguments,
+            ] as [String: Any],
+        ]
+    }
+
+    private static func sanitizeSchemaName(_ name: String) -> String {
+        let filtered = name.map { character -> Character in
+            character.isLetter || character.isNumber || character == "_" || character == "-"
+                ? character
+                : "_"
+        }
+        let sanitized = String(filtered)
+        return sanitized.isEmpty ? "response" : sanitized
+    }
+}
+
+/// Accumulates streamed tool-call deltas into ``InferenceStreamUpdate`` values.
+struct OpenAICompatibleStreamAccumulator: Sendable {
+    private var toolCalls: [Int: AccumulatedToolCall] = [:]
+    private var emittedCompleted = false
+
+    mutating func consume(_ chunk: OpenAICompatibleChatChunk) -> [InferenceStreamUpdate] {
+        var updates: [InferenceStreamUpdate] = []
+
+        for choice in chunk.choices {
+            if let content = choice.delta?.content, !content.isEmpty {
+                updates.append(.outputChunk(content))
+            }
+            for delta in choice.delta?.toolCalls ?? [] {
+                var accumulated = toolCalls[delta.index] ?? AccumulatedToolCall(index: delta.index)
+                if let id = delta.id, !id.isEmpty {
+                    accumulated.id = id
+                }
+                if let name = delta.name, !name.isEmpty {
+                    accumulated.name = name
+                }
+                accumulated.arguments += delta.arguments
+                toolCalls[delta.index] = accumulated
+                updates.append(
+                    .toolCallPartial(
+                        PartialToolCallUpdate(
+                            providerCallId: accumulated.id,
+                            toolName: accumulated.name,
+                            index: accumulated.index,
+                            argumentsFragment: accumulated.arguments
+                        )
+                    )
+                )
+            }
+            if let finish = choice.finishReason,
+               finish == "tool_calls" || finish == "function_call"
+            {
+                updates.append(contentsOf: completeToolCalls())
+            }
+        }
+
+        if let usage = chunk.usage {
+            updates.append(.usage(usage))
+        }
+
+        return updates
+    }
+
+    mutating func finish() -> [InferenceStreamUpdate] {
+        completeToolCalls()
+    }
+
+    private mutating func completeToolCalls() -> [InferenceStreamUpdate] {
+        guard !emittedCompleted, !toolCalls.isEmpty else {
+            return []
+        }
+        emittedCompleted = true
+        let parsed = toolCalls.keys.sorted().compactMap { index -> InferenceResponse.ParsedToolCall? in
+            guard let call = toolCalls[index] else { return nil }
+            return InferenceResponse.ParsedToolCall(
+                id: call.id.isEmpty ? nil : call.id,
+                name: call.name,
+                arguments: OpenAICompatibleCodec.decodeArguments(call.arguments)
+            )
+        }
+        return parsed.isEmpty ? [] : [.toolCallsCompleted(parsed)]
+    }
+}
+
+private struct AccumulatedToolCall: Sendable {
+    var index: Int
+    var id: String = ""
+    var name: String = ""
+    var arguments: String = ""
+}

--- a/Sources/Swarm/Providers/OpenAICompatible/OpenAICompatibleCodec.swift
+++ b/Sources/Swarm/Providers/OpenAICompatible/OpenAICompatibleCodec.swift
@@ -89,7 +89,7 @@ enum OpenAICompatibleCodec: Sendable {
     ) throws -> [String: Any] {
         var body: [String: Any] = [
             "model": configuration.model,
-            "messages": messages.map(encodeMessage),
+            "messages": encodeMessages(messages),
             "temperature": options.temperature,
         ]
 
@@ -124,8 +124,12 @@ enum OpenAICompatibleCodec: Sendable {
             body["stream"] = true
             body["stream_options"] = ["include_usage": true]
         }
+        // Many OpenAI-compatible hosts reject `tools` + `response_format` on
+        // the same call. Native structured output is only advertised when this
+        // request is not also a tool-calling turn.
         if let structuredOutput,
-           configuration.structuredOutputMode == .nativeJSONSchema
+           configuration.structuredOutputMode == .nativeJSONSchema,
+           tools.isEmpty
         {
             body["response_format"] = try encodeResponseFormat(structuredOutput)
         }
@@ -133,7 +137,37 @@ enum OpenAICompatibleCodec: Sendable {
         return body
     }
 
-    static func encodeMessage(_ message: InferenceMessage) -> [String: Any] {
+    static func encodeMessages(_ messages: [InferenceMessage]) -> [[String: Any]] {
+        var pendingCallIDs: [String] = []
+        var pendingCallNames: [String] = []
+        var nextUnused = 0
+
+        return messages.map { message in
+            if message.role == .assistant, !message.toolCalls.isEmpty {
+                pendingCallIDs = message.toolCalls.enumerated().map { index, call in
+                    synthesizedToolCallID(call.id, index: index)
+                }
+                pendingCallNames = message.toolCalls.map(\.name)
+                nextUnused = 0
+            }
+
+            let toolCallID: String?
+            if message.role == .tool {
+                toolCallID = resolvedToolCallID(
+                    for: message,
+                    pendingIDs: pendingCallIDs,
+                    pendingNames: pendingCallNames,
+                    nextUnused: &nextUnused
+                )
+            } else {
+                toolCallID = message.toolCallID
+            }
+
+            return encodeMessage(message, toolCallID: toolCallID)
+        }
+    }
+
+    static func encodeMessage(_ message: InferenceMessage, toolCallID: String? = nil) -> [String: Any] {
         var object: [String: Any] = [
             "role": message.role.rawValue,
             "content": message.content,
@@ -142,7 +176,9 @@ enum OpenAICompatibleCodec: Sendable {
             object["name"] = name
         }
         if message.role == .tool {
-            object["tool_call_id"] = message.toolCallID ?? message.name ?? "tool_call"
+            if let toolCallID, !toolCallID.isEmpty {
+                object["tool_call_id"] = toolCallID
+            }
         }
         if !message.toolCalls.isEmpty {
             object["tool_calls"] = message.toolCalls.enumerated().map { index, call in
@@ -323,13 +359,48 @@ enum OpenAICompatibleCodec: Sendable {
         }
     }
 
+    static func synthesizedToolCallID(_ id: String?, index: Int) -> String {
+        let trimmed = id?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? "call_\(index)" : trimmed
+    }
+
+    private static func resolvedToolCallID(
+        for message: InferenceMessage,
+        pendingIDs: [String],
+        pendingNames: [String],
+        nextUnused: inout Int
+    ) -> String? {
+        if let explicit = message.toolCallID?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !explicit.isEmpty
+        {
+            return explicit
+        }
+
+        if let name = message.name,
+           let match = pendingNames.enumerated().first(where: { index, callName in
+               index >= nextUnused && callName == name
+           })
+        {
+            nextUnused = match.offset + 1
+            return pendingIDs[match.offset]
+        }
+
+        if nextUnused < pendingIDs.count {
+            let id = pendingIDs[nextUnused]
+            nextUnused += 1
+            return id
+        }
+
+        return nil
+    }
+
     private static func encodeToolCall(_ call: InferenceMessage.ToolCall, index: Int) -> [String: Any] {
         let argumentsObject = SendableValue.dictionary(call.arguments).toJSONObject()
         let argumentsData = (try? JSONSerialization.data(withJSONObject: argumentsObject, options: [.sortedKeys]))
             ?? Data("{}".utf8)
         let arguments = String(data: argumentsData, encoding: .utf8) ?? "{}"
         return [
-            "id": call.id ?? "call_\(index)",
+            "id": synthesizedToolCallID(call.id, index: index),
             "type": "function",
             "function": [
                 "name": call.name,
@@ -382,11 +453,9 @@ struct OpenAICompatibleStreamAccumulator: Sendable {
                     )
                 )
             }
-            if let finish = choice.finishReason,
-               finish == "tool_calls" || finish == "function_call"
-            {
-                updates.append(contentsOf: completeToolCalls())
-            }
+            // Defer `.toolCallsCompleted` until `finish()` so a later usage
+            // chunk is still consumed. ``Agent`` stops the stream on completed
+            // calls.
         }
 
         if let usage = chunk.usage {

--- a/Sources/Swarm/Providers/OpenAICompatible/OpenAICompatibleConfiguration.swift
+++ b/Sources/Swarm/Providers/OpenAICompatible/OpenAICompatibleConfiguration.swift
@@ -1,0 +1,197 @@
+// OpenAICompatibleConfiguration.swift
+// Swarm Framework
+//
+// Configuration for the OpenAI-compatible remote inference provider.
+
+import Foundation
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// How ``OpenAICompatibleProvider`` produces structured JSON.
+///
+/// Matches the Chunk I honesty rule: only claim
+/// ``StructuredOutputResult/Source/providerNative`` when the request actually
+/// used a provider constraint (`response_format`).
+public enum OpenAICompatibleStructuredOutputMode: String, Sendable, Equatable, Codable {
+    /// Send `response_format` (`json_schema` or `json_object`) and label the
+    /// result ``StructuredOutputResult/Source/providerNative``.
+    ///
+    /// Use for OpenAI, Azure OpenAI, and OpenRouter. Local servers that ignore
+    /// `response_format` should use ``promptFallback`` instead.
+    case nativeJSONSchema
+
+    /// Append JSON instructions and parse the reply. Label
+    /// ``StructuredOutputResult/Source/promptFallback``.
+    ///
+    /// Default for Ollama and LM Studio, which do not reliably constrain
+    /// generation via `response_format`.
+    case promptFallback
+}
+
+/// Configuration for ``OpenAICompatibleProvider``.
+///
+/// Every supported host is `baseURL` + optional `apiKey` + `model` + extra
+/// headers. Convenience factories fill those fields for OpenAI, Azure OpenAI,
+/// OpenRouter, Ollama, and LM Studio.
+///
+/// ## Privacy
+///
+/// Prompt content, tool schemas, and tool results are sent to `baseURL`.
+/// Contrast with ``FoundationModelsInferenceProvider``, which stays on-device.
+///
+/// ```swift
+/// let cloud = OpenAICompatibleProviderConfiguration.openAI(
+///     apiKey: ProcessInfo.processInfo.environment["OPENAI_API_KEY"] ?? "",
+///     model: "gpt-4o"
+/// )
+/// let local = OpenAICompatibleProviderConfiguration.ollama(model: "llama3.2")
+/// ```
+public struct OpenAICompatibleProviderConfiguration: Sendable, Equatable {
+    /// API root. `/chat/completions` is appended unless `baseURL` already ends
+    /// with that path.
+    public var baseURL: URL
+
+    /// Bearer token. Omit for local servers that do not require auth.
+    ///
+    /// Not sent when `httpHeaders` already contains `Authorization` or `api-key`
+    /// (Azure).
+    public var apiKey: String?
+
+    /// Model or deployment identifier placed in the request `model` field.
+    public var model: String
+
+    /// Extra headers merged onto every request (for example Azure `api-key`,
+    /// OpenRouter `HTTP-Referer`).
+    public var httpHeaders: [String: String]
+
+    /// Query items appended to the chat-completions URL (Azure `api-version`).
+    public var queryItems: [String: String]
+
+    /// Whether structured outputs use native `response_format` or prompt-parse.
+    public var structuredOutputMode: OpenAICompatibleStructuredOutputMode
+
+    /// Stable provider name for ``InferenceProviderMetadata`` (`openai`,
+    /// `ollama`, `azure-openai`, …).
+    public var providerName: String
+
+    /// Creates a configuration.
+    ///
+    /// - Parameters:
+    ///   - baseURL: API root. `/chat/completions` is appended when missing.
+    ///   - apiKey: Optional Bearer token. Default: `nil`.
+    ///   - model: Model or deployment identifier.
+    ///   - httpHeaders: Extra headers. Default: `[:]`.
+    ///   - queryItems: Extra query items. Default: `[:]`.
+    ///   - structuredOutputMode: Native `response_format` vs prompt-parse.
+    ///     Default: ``OpenAICompatibleStructuredOutputMode/nativeJSONSchema``.
+    ///   - providerName: Metadata name. Default: `openai-compatible`.
+    public init(
+        baseURL: URL,
+        apiKey: String? = nil,
+        model: String,
+        httpHeaders: [String: String] = [:],
+        queryItems: [String: String] = [:],
+        structuredOutputMode: OpenAICompatibleStructuredOutputMode = .nativeJSONSchema,
+        providerName: String = "openai-compatible"
+    ) {
+        self.baseURL = baseURL
+        self.apiKey = apiKey
+        self.model = model
+        self.httpHeaders = httpHeaders
+        self.queryItems = queryItems
+        self.structuredOutputMode = structuredOutputMode
+        self.providerName = providerName
+    }
+
+    /// OpenAI Chat Completions (`https://api.openai.com/v1`).
+    public static func openAI(
+        apiKey: String,
+        model: String = "gpt-4o"
+    ) -> OpenAICompatibleProviderConfiguration {
+        OpenAICompatibleProviderConfiguration(
+            baseURL: URL(string: "https://api.openai.com/v1")!,
+            apiKey: apiKey,
+            model: model,
+            structuredOutputMode: .nativeJSONSchema,
+            providerName: "openai"
+        )
+    }
+
+    /// Azure OpenAI chat completions.
+    ///
+    /// Uses `api-key` auth and `api-version` on
+    /// `https://{resource}.openai.azure.com/openai/deployments/{deployment}`.
+    public static func azureOpenAI(
+        resource: String,
+        deployment: String,
+        apiKey: String,
+        apiVersion: String = "2024-10-21",
+        model: String? = nil
+    ) -> OpenAICompatibleProviderConfiguration {
+        let url = URL(
+            string: "https://\(resource).openai.azure.com/openai/deployments/\(deployment)"
+        )!
+        return OpenAICompatibleProviderConfiguration(
+            baseURL: url,
+            apiKey: nil,
+            model: model ?? deployment,
+            httpHeaders: ["api-key": apiKey],
+            queryItems: ["api-version": apiVersion],
+            structuredOutputMode: .nativeJSONSchema,
+            providerName: "azure-openai"
+        )
+    }
+
+    /// OpenRouter (`https://openrouter.ai/api/v1`).
+    public static func openRouter(
+        apiKey: String,
+        model: String,
+        httpHeaders: [String: String] = [:]
+    ) -> OpenAICompatibleProviderConfiguration {
+        OpenAICompatibleProviderConfiguration(
+            baseURL: URL(string: "https://openrouter.ai/api/v1")!,
+            apiKey: apiKey,
+            model: model,
+            httpHeaders: httpHeaders,
+            structuredOutputMode: .nativeJSONSchema,
+            providerName: "openrouter"
+        )
+    }
+
+    /// Ollama's OpenAI-compatible endpoint (default `http://127.0.0.1:11434/v1`).
+    ///
+    /// Structured outputs use prompt-parse fallback — Ollama does not reliably
+    /// honor `response_format.json_schema`.
+    public static func ollama(
+        model: String,
+        baseURL: URL = URL(string: "http://127.0.0.1:11434/v1")!
+    ) -> OpenAICompatibleProviderConfiguration {
+        OpenAICompatibleProviderConfiguration(
+            baseURL: baseURL,
+            apiKey: nil,
+            model: model,
+            structuredOutputMode: .promptFallback,
+            providerName: "ollama"
+        )
+    }
+
+    /// LM Studio's OpenAI-compatible endpoint (default `http://127.0.0.1:1234/v1`).
+    ///
+    /// Structured outputs use prompt-parse fallback unless you opt into
+    /// ``OpenAICompatibleStructuredOutputMode/nativeJSONSchema``.
+    public static func lmStudio(
+        model: String,
+        baseURL: URL = URL(string: "http://127.0.0.1:1234/v1")!,
+        apiKey: String? = nil
+    ) -> OpenAICompatibleProviderConfiguration {
+        OpenAICompatibleProviderConfiguration(
+            baseURL: baseURL,
+            apiKey: apiKey,
+            model: model,
+            structuredOutputMode: .promptFallback,
+            providerName: "lmstudio"
+        )
+    }
+}

--- a/Sources/Swarm/Providers/OpenAICompatible/OpenAICompatibleErrorMapper.swift
+++ b/Sources/Swarm/Providers/OpenAICompatible/OpenAICompatibleErrorMapper.swift
@@ -1,0 +1,123 @@
+// OpenAICompatibleErrorMapper.swift
+// Swarm Framework
+//
+// HTTP status + error body → AgentError with Chunk J retryability.
+
+import Foundation
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Maps OpenAI-compatible HTTP failures onto ``AgentError`` so
+/// ``InferenceRetryability`` matches Chunk J's table:
+/// 429 / 5xx / network are retryable; 400 / 401 / 403 are not.
+enum OpenAICompatibleErrorMapper: Sendable {
+    static func map(
+        statusCode: Int,
+        body: Data,
+        headers: [AnyHashable: Any],
+        model: String
+    ) -> AgentError {
+        let message = extractMessage(from: body)
+        let code = extractErrorCode(from: body)
+
+        if code == "context_length_exceeded" || message.localizedCaseInsensitiveContains("context length") {
+            return .contextWindowExceeded(tokenCount: 0, limit: 0)
+        }
+
+        if code == "content_filter" || statusCode == 451 {
+            return .contentFiltered(reason: message)
+        }
+
+        switch statusCode {
+        case 429:
+            return .rateLimitExceeded(retryAfter: parseRetryAfter(headers))
+        case 400:
+            return .invalidInput(reason: "OpenAI-compatible request rejected (400): \(message)")
+        case 401:
+            return .invalidInput(reason: "OpenAI-compatible authentication failed (401): \(message)")
+        case 403:
+            return .invalidInput(reason: "OpenAI-compatible request forbidden (403): \(message)")
+        case 404:
+            return .modelNotAvailable(model: model)
+        case 408:
+            return .generationFailed(reason: "OpenAI-compatible request timed out (408): \(message)")
+        case 413:
+            return .invalidInput(reason: "OpenAI-compatible payload too large (413): \(message)")
+        case 500 ... 599:
+            return .generationFailed(reason: "OpenAI-compatible server error (\(statusCode)): \(message)")
+        default:
+            if (400 ..< 500).contains(statusCode) {
+                return .invalidInput(reason: "OpenAI-compatible client error (\(statusCode)): \(message)")
+            }
+            return .generationFailed(reason: "OpenAI-compatible HTTP \(statusCode): \(message)")
+        }
+    }
+
+    static func mapTransport(_ error: Error) -> Error {
+        if error is AgentError {
+            return error
+        }
+        if error is CancellationError {
+            return AgentError.cancelled
+        }
+        if error is URLError {
+            return error
+        }
+        return AgentError.generationFailed(reason: String(describing: error))
+    }
+
+    static func extractMessage(from body: Data) -> String {
+        guard !body.isEmpty else {
+            return "empty error body"
+        }
+        if let object = try? JSONSerialization.jsonObject(with: body) as? [String: Any] {
+            if let error = object["error"] as? [String: Any] {
+                if let message = error["message"] as? String, !message.isEmpty {
+                    return message
+                }
+            }
+            if let message = object["message"] as? String, !message.isEmpty {
+                return message
+            }
+        }
+        return String(data: body, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .nilIfEmpty ?? "unreadable error body"
+    }
+
+    private static func extractErrorCode(from body: Data) -> String? {
+        guard let object = try? JSONSerialization.jsonObject(with: body) as? [String: Any],
+              let error = object["error"] as? [String: Any]
+        else {
+            return nil
+        }
+        if let code = error["code"] as? String {
+            return code
+        }
+        if let type = error["type"] as? String {
+            return type
+        }
+        return nil
+    }
+
+    private static func parseRetryAfter(_ headers: [AnyHashable: Any]) -> TimeInterval? {
+        let value = headers.first { key, _ in
+            String(describing: key).caseInsensitiveCompare("Retry-After") == .orderedSame
+        }?.value
+        guard let raw = value as? String ?? (value as? NSNumber).map(String.init(describing:)) else {
+            return nil
+        }
+        if let seconds = TimeInterval(raw) {
+            return seconds
+        }
+        return nil
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? {
+        isEmpty ? nil : self
+    }
+}

--- a/Sources/Swarm/Providers/OpenAICompatible/OpenAICompatibleProvider.swift
+++ b/Sources/Swarm/Providers/OpenAICompatible/OpenAICompatibleProvider.swift
@@ -1,0 +1,431 @@
+// OpenAICompatibleProvider.swift
+// Swarm Framework
+//
+// OpenAI-compatible remote inference provider (URLSession only).
+
+import Foundation
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Remote inference provider for OpenAI-compatible Chat Completions APIs.
+///
+/// Talks to OpenAI, Azure OpenAI, OpenRouter, Ollama, LM Studio, and any other
+/// host that implements `/v1/chat/completions`. Uses `URLSession` only — no
+/// extra package dependencies.
+///
+/// ## What is sent
+///
+/// Prompt text, tool schemas, tool results, and structured-output schemas leave
+/// the device. Contrast with ``FoundationModelsInferenceProvider``, which stays
+/// on-device when Apple Intelligence is available.
+///
+/// ## Capabilities
+///
+/// - Structured ``InferenceMessage`` history (roles, `tool_calls`, `tool_call_id`)
+/// - Function calling via ``ToolSchema``
+/// - SSE streaming, including incremental tool-call argument deltas
+/// - Token usage from `usage.prompt_tokens` / `usage.completion_tokens`
+///   (`stream_options.include_usage` is requested when streaming)
+/// - Structured outputs: native `response_format` when
+///   ``OpenAICompatibleStructuredOutputMode/nativeJSONSchema`` is set;
+///   otherwise labeled prompt-parse fallback
+/// - W3C `traceparent` / `tracestate` via ``TraceContextHeaders/applyCurrent(to:)``
+///
+/// ```swift
+/// let agent = try Agent(
+///     "Be helpful.",
+///     inferenceProvider: .openAICompatible(.ollama(model: "llama3.2"))
+/// )
+/// ```
+///
+/// Inject a `URLSession` with a `URLProtocol` stub in tests.
+public struct OpenAICompatibleProvider: InferenceProvider,
+    ConversationInferenceProvider,
+    StreamingConversationInferenceProvider,
+    ToolCallStreamingConversationInferenceProvider,
+    ToolCallStreamingInferenceProvider,
+    StructuredOutputInferenceProvider,
+    StructuredOutputConversationInferenceProvider,
+    CapabilityReportingInferenceProvider,
+    InferenceProviderMetadata
+{
+    /// Provider configuration (endpoint, model, auth, structured-output mode).
+    public let configuration: OpenAICompatibleProviderConfiguration
+
+    /// `URLSession` is thread-safe. swift-corelibs-foundation does not mark it
+    /// `Sendable`, so the session is stored in this box.
+    private let sessionBox: SessionBox
+
+    /// Creates a provider.
+    ///
+    /// - Parameters:
+    ///   - configuration: Endpoint, model, and auth.
+    ///   - session: Session used for POST requests. Inject a `URLProtocol`
+    ///     stub in tests. Default: `URLSession.shared`.
+    public init(
+        configuration: OpenAICompatibleProviderConfiguration,
+        session: URLSession = .shared
+    ) {
+        self.configuration = configuration
+        self.sessionBox = SessionBox(session)
+    }
+
+    // MARK: - Metadata
+
+    public var providerName: String? { configuration.providerName }
+    public var modelName: String? { configuration.model }
+    public var endpointURL: URL? { configuration.baseURL }
+
+    public var capabilities: InferenceProviderCapabilities {
+        [
+            .conversationMessages,
+            .nativeToolCalling,
+            .streamingToolCalls,
+            .structuredOutputs,
+        ]
+    }
+
+    // MARK: - InferenceProvider
+
+    public func generate(prompt: String, options: InferenceOptions) async throws -> String {
+        try await generate(messages: [.user(prompt)], options: options)
+    }
+
+    public func stream(prompt: String, options: InferenceOptions) -> AsyncThrowingStream<String, Error> {
+        stream(messages: [.user(prompt)], options: options)
+    }
+
+    public func generateWithToolCalls(
+        prompt: String,
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) async throws -> InferenceResponse {
+        try await generateWithToolCalls(messages: [.user(prompt)], tools: tools, options: options)
+    }
+
+    public func streamWithToolCalls(
+        prompt: String,
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) -> AsyncThrowingStream<InferenceStreamUpdate, Error> {
+        streamWithToolCalls(messages: [.user(prompt)], tools: tools, options: options)
+    }
+
+    // MARK: - ConversationInferenceProvider
+
+    public func generate(messages: [InferenceMessage], options: InferenceOptions) async throws -> String {
+        let response = try await generateWithToolCalls(messages: messages, tools: [], options: options)
+        return response.content ?? ""
+    }
+
+    public func generateWithToolCalls(
+        messages: [InferenceMessage],
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) async throws -> InferenceResponse {
+        try await complete(
+            messages: messages,
+            tools: tools,
+            options: options,
+            structuredOutput: options.structuredOutput
+        )
+    }
+
+    // MARK: - Streaming
+
+    public func stream(
+        messages: [InferenceMessage],
+        options: InferenceOptions
+    ) -> AsyncThrowingStream<String, Error> {
+        StreamHelper.makeTrackedStream { continuation in
+            do {
+                for try await update in self.streamWithToolCalls(
+                    messages: messages,
+                    tools: [],
+                    options: options
+                ) {
+                    if case let .outputChunk(chunk) = update, !chunk.isEmpty {
+                        continuation.yield(chunk)
+                    }
+                }
+                continuation.finish()
+            } catch {
+                continuation.finish(throwing: OpenAICompatibleErrorMapper.mapTransport(error))
+            }
+        }
+    }
+
+    public func streamWithToolCalls(
+        messages: [InferenceMessage],
+        tools: [ToolSchema],
+        options: InferenceOptions
+    ) -> AsyncThrowingStream<InferenceStreamUpdate, Error> {
+        StreamHelper.makeTrackedStream { continuation in
+            do {
+                try await self.streamCompletions(
+                    messages: messages,
+                    tools: tools,
+                    options: options,
+                    structuredOutput: options.structuredOutput,
+                    continuation: continuation
+                )
+                continuation.finish()
+            } catch {
+                continuation.finish(throwing: OpenAICompatibleErrorMapper.mapTransport(error))
+            }
+        }
+    }
+
+    // MARK: - Structured outputs
+
+    public func generateStructured(
+        prompt: String,
+        request: StructuredOutputRequest,
+        options: InferenceOptions
+    ) async throws -> StructuredOutputResult {
+        try await generateStructured(messages: [.user(prompt)], request: request, options: options)
+    }
+
+    public func generateStructured(
+        messages: [InferenceMessage],
+        request: StructuredOutputRequest,
+        options: InferenceOptions
+    ) async throws -> StructuredOutputResult {
+        switch configuration.structuredOutputMode {
+        case .nativeJSONSchema:
+            do {
+                _ = try OpenAICompatibleCodec.encodeResponseFormat(request)
+            } catch {
+                return try await promptFallbackStructured(
+                    messages: messages,
+                    request: request,
+                    options: options
+                )
+            }
+            let response = try await complete(
+                messages: messages,
+                tools: [],
+                options: options,
+                structuredOutput: request
+            )
+            return try StructuredOutputParser.parse(
+                response.content ?? "",
+                request: request,
+                source: .providerNative
+            )
+        case .promptFallback:
+            return try await promptFallbackStructured(
+                messages: messages,
+                request: request,
+                options: options
+            )
+        }
+    }
+
+    // MARK: - HTTP
+
+    private func complete(
+        messages: [InferenceMessage],
+        tools: [ToolSchema],
+        options: InferenceOptions,
+        structuredOutput: StructuredOutputRequest?
+    ) async throws -> InferenceResponse {
+        let request = try OpenAICompatibleCodec.makeRequest(
+            configuration: configuration,
+            messages: messages,
+            tools: tools,
+            options: options,
+            stream: false,
+            structuredOutput: structuredOutput
+        )
+        let (data, response): (Data, URLResponse)
+        do {
+            (data, response) = try await sessionBox.session.data(for: request)
+        } catch {
+            throw OpenAICompatibleErrorMapper.mapTransport(error)
+        }
+        try Task.checkCancellation()
+        let http = try httpResponse(response)
+        if http.statusCode >= 400 {
+            throw OpenAICompatibleErrorMapper.map(
+                statusCode: http.statusCode,
+                body: data,
+                headers: http.allHeaderFields,
+                model: configuration.model
+            )
+        }
+        guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw AgentError.generationFailed(reason: "OpenAI-compatible response is not a JSON object")
+        }
+        return try OpenAICompatibleCodec.inferenceResponse(from: OpenAICompatibleChatChunk(json: object))
+    }
+
+    private func streamCompletions(
+        messages: [InferenceMessage],
+        tools: [ToolSchema],
+        options: InferenceOptions,
+        structuredOutput: StructuredOutputRequest?,
+        continuation: AsyncThrowingStream<InferenceStreamUpdate, Error>.Continuation
+    ) async throws {
+        let request = try OpenAICompatibleCodec.makeRequest(
+            configuration: configuration,
+            messages: messages,
+            tools: tools,
+            options: options,
+            stream: true,
+            structuredOutput: structuredOutput
+        )
+
+        // `data(for:)` is used instead of `bytes(for:)` so URLProtocol stubs
+        // (and swift-corelibs-foundation) deliver the SSE body reliably.
+        // Events are still yielded in wire order after the body arrives.
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await sessionBox.session.data(for: request)
+        } catch {
+            throw OpenAICompatibleErrorMapper.mapTransport(error)
+        }
+
+        let http = try httpResponse(response)
+        if http.statusCode >= 400 {
+            throw OpenAICompatibleErrorMapper.map(
+                statusCode: http.statusCode,
+                body: data,
+                headers: http.allHeaderFields,
+                model: configuration.model
+            )
+        }
+
+        var parser = OpenAICompatibleSSEParser()
+        var accumulator = OpenAICompatibleStreamAccumulator()
+        var finished = false
+        let text = String(data: data, encoding: .utf8) ?? ""
+        let lines = text.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+
+        for line in lines {
+            try Task.checkCancellation()
+            let events = parser.consume(line: line)
+            if try emit(events, accumulator: &accumulator, continuation: continuation) {
+                finished = true
+                break
+            }
+        }
+
+        if !finished {
+            _ = try emit(parser.finish(), accumulator: &accumulator, continuation: continuation)
+            for update in accumulator.finish() {
+                continuation.yield(update)
+            }
+        }
+    }
+
+    private func emit(
+        _ events: [OpenAICompatibleSSEEvent],
+        accumulator: inout OpenAICompatibleStreamAccumulator,
+        continuation: AsyncThrowingStream<InferenceStreamUpdate, Error>.Continuation
+    ) throws -> Bool {
+        for event in events {
+            switch event {
+            case let .chunk(chunk):
+                if let message = chunk.errorMessage {
+                    throw AgentError.generationFailed(reason: message)
+                }
+                if let error = chunkError(chunk) {
+                    throw error
+                }
+                for update in accumulator.consume(chunk) {
+                    continuation.yield(update)
+                }
+            case .done:
+                for update in accumulator.finish() {
+                    continuation.yield(update)
+                }
+                return true
+            case .malformed:
+                continue
+            }
+        }
+        return false
+    }
+
+    private func chunkError(_ chunk: OpenAICompatibleChatChunk) -> AgentError? {
+        for choice in chunk.choices where choice.finishReason == "content_filter" {
+            return .contentFiltered(reason: "OpenAI-compatible content filter")
+        }
+        return nil
+    }
+
+    private func promptFallbackStructured(
+        messages: [InferenceMessage],
+        request: StructuredOutputRequest,
+        options: InferenceOptions
+    ) async throws -> StructuredOutputResult {
+        let structuredMessages = StructuredOutputPromptBuilder.appendInstruction(
+            to: messages,
+            request: request
+        )
+        let text = try await generate(messages: structuredMessages, options: options)
+        return try StructuredOutputParser.parse(text, request: request, source: .promptFallback)
+    }
+
+    private func httpResponse(_ response: URLResponse) throws -> HTTPURLResponse {
+        guard let http = response as? HTTPURLResponse else {
+            throw AgentError.generationFailed(reason: "OpenAI-compatible endpoint returned a non-HTTP response")
+        }
+        return http
+    }
+}
+
+// MARK: - Session box
+
+extension OpenAICompatibleProvider {
+    fileprivate final class SessionBox: @unchecked Sendable {
+        let session: URLSession
+
+        init(_ session: URLSession) {
+            self.session = session
+        }
+    }
+}
+
+// MARK: - Dot-syntax entry points
+
+public extension InferenceProvider where Self == OpenAICompatibleProvider {
+    /// Creates an OpenAI-compatible remote provider.
+    ///
+    /// - Parameters:
+    ///   - configuration: Endpoint, model, and auth. Use the convenience
+    ///     factories on ``OpenAICompatibleProviderConfiguration`` for OpenAI,
+    ///     Azure OpenAI, OpenRouter, Ollama, and LM Studio.
+    ///   - session: Session used for POST requests. Default: `URLSession.shared`.
+    static func openAICompatible(
+        _ configuration: OpenAICompatibleProviderConfiguration,
+        session: URLSession = .shared
+    ) -> OpenAICompatibleProvider {
+        OpenAICompatibleProvider(configuration: configuration, session: session)
+    }
+
+    /// Creates an OpenAI-compatible remote provider from raw fields.
+    static func openAICompatible(
+        baseURL: URL,
+        model: String,
+        apiKey: String? = nil,
+        httpHeaders: [String: String] = [:],
+        structuredOutputMode: OpenAICompatibleStructuredOutputMode = .nativeJSONSchema,
+        session: URLSession = .shared
+    ) -> OpenAICompatibleProvider {
+        OpenAICompatibleProvider(
+            configuration: OpenAICompatibleProviderConfiguration(
+                baseURL: baseURL,
+                apiKey: apiKey,
+                model: model,
+                httpHeaders: httpHeaders,
+                structuredOutputMode: structuredOutputMode
+            ),
+            session: session
+        )
+    }
+}

--- a/Sources/Swarm/Providers/OpenAICompatible/OpenAICompatibleSSEParser.swift
+++ b/Sources/Swarm/Providers/OpenAICompatible/OpenAICompatibleSSEParser.swift
@@ -1,0 +1,173 @@
+// OpenAICompatibleSSEParser.swift
+// Swarm Framework
+//
+// Server-Sent Events parser for OpenAI-compatible chat completion streams.
+
+import Foundation
+
+/// One decoded SSE payload from an OpenAI-compatible stream.
+enum OpenAICompatibleSSEEvent: Sendable, Equatable {
+    case chunk(OpenAICompatibleChatChunk)
+    case done
+    case malformed(String)
+}
+
+/// Incremental SSE parser for `data:` lines, `[DONE]`, and multi-line events.
+///
+/// Malformed JSON lines are reported as ``OpenAICompatibleSSEEvent/malformed(_:)``
+/// so the provider can skip them without aborting the stream.
+struct OpenAICompatibleSSEParser: Sendable {
+    private var pendingDataLines: [String] = []
+
+    init() {}
+
+    /// Consumes one raw SSE line (without the trailing LF).
+    ///
+    /// An empty line dispatches the accumulated `data:` payload. Comment lines
+    /// (`:`) and unknown fields are ignored.
+    mutating func consume(line: String) -> [OpenAICompatibleSSEEvent] {
+        let trimmed = line.trimmingCharacters(in: CharacterSet(charactersIn: "\r"))
+        if trimmed.isEmpty {
+            return flushEvent()
+        }
+        if trimmed.hasPrefix(":") {
+            return []
+        }
+        if trimmed.hasPrefix("data:") {
+            let payload = String(trimmed.dropFirst(5)).trimmingCharacters(in: .whitespaces)
+            pendingDataLines.append(payload)
+            return []
+        }
+        return []
+    }
+
+    /// Flushes a trailing event that was not terminated by a blank line.
+    mutating func finish() -> [OpenAICompatibleSSEEvent] {
+        flushEvent()
+    }
+
+    private mutating func flushEvent() -> [OpenAICompatibleSSEEvent] {
+        guard !pendingDataLines.isEmpty else {
+            return []
+        }
+        let payload = pendingDataLines.joined(separator: "\n")
+        pendingDataLines.removeAll(keepingCapacity: true)
+
+        if payload == "[DONE]" {
+            return [.done]
+        }
+        if payload.isEmpty {
+            return []
+        }
+        guard let data = payload.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return [.malformed(payload)]
+        }
+        return [.chunk(OpenAICompatibleChatChunk(json: object))]
+    }
+}
+
+/// Decoded chat-completion chunk or full response object.
+struct OpenAICompatibleChatChunk: Sendable, Equatable {
+    var id: String?
+    var choices: [Choice]
+    var usage: TokenUsage?
+    var errorMessage: String?
+
+    struct Choice: Sendable, Equatable {
+        var index: Int
+        var finishReason: String?
+        var message: Message?
+        var delta: Message?
+    }
+
+    struct Message: Sendable, Equatable {
+        var role: String?
+        var content: String?
+        var toolCalls: [ToolCallDelta]
+    }
+
+    struct ToolCallDelta: Sendable, Equatable {
+        var index: Int
+        var id: String?
+        var name: String?
+        var arguments: String
+    }
+
+    init(json: [String: Any]) {
+        id = json["id"] as? String
+        usage = Self.parseUsage(json["usage"])
+        if let error = json["error"] as? [String: Any] {
+            errorMessage = error["message"] as? String ?? "OpenAI-compatible stream error"
+        } else {
+            errorMessage = nil
+        }
+        let rawChoices = json["choices"] as? [[String: Any]] ?? []
+        choices = rawChoices.enumerated().map { offset, choice in
+            Choice(
+                index: choice["index"] as? Int ?? offset,
+                finishReason: choice["finish_reason"] as? String,
+                message: Self.parseMessage(choice["message"]),
+                delta: Self.parseMessage(choice["delta"])
+            )
+        }
+    }
+
+    static func parseUsage(_ value: Any?) -> TokenUsage? {
+        guard let object = value as? [String: Any] else {
+            return nil
+        }
+        let prompt = intValue(object["prompt_tokens"])
+        let completion = intValue(object["completion_tokens"])
+        guard prompt != nil || completion != nil else {
+            return nil
+        }
+        return TokenUsage(inputTokens: prompt ?? 0, outputTokens: completion ?? 0)
+    }
+
+    private static func parseMessage(_ value: Any?) -> Message? {
+        guard let object = value as? [String: Any] else {
+            return nil
+        }
+        let content: String?
+        if object["content"] is NSNull {
+            content = nil
+        } else {
+            content = object["content"] as? String
+        }
+        return Message(
+            role: object["role"] as? String,
+            content: content,
+            toolCalls: parseToolCalls(object["tool_calls"])
+        )
+    }
+
+    private static func parseToolCalls(_ value: Any?) -> [ToolCallDelta] {
+        guard let array = value as? [[String: Any]] else {
+            return []
+        }
+        return array.enumerated().map { offset, call in
+            let function = call["function"] as? [String: Any] ?? [:]
+            return ToolCallDelta(
+                index: call["index"] as? Int ?? offset,
+                id: call["id"] as? String,
+                name: function["name"] as? String,
+                arguments: function["arguments"] as? String ?? ""
+            )
+        }
+    }
+
+    private static func intValue(_ value: Any?) -> Int? {
+        if let int = value as? Int {
+            return int
+        }
+        if let double = value as? Double {
+            return Int(double)
+        }
+        if let number = value as? NSNumber {
+            return number.intValue
+        }
+        return nil
+    }
+}

--- a/Tests/SwarmTests/Providers/OpenAICompatibleAgentLoopTests.swift
+++ b/Tests/SwarmTests/Providers/OpenAICompatibleAgentLoopTests.swift
@@ -1,0 +1,186 @@
+import Foundation
+import Testing
+@testable import Swarm
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+@Suite("OpenAI-compatible Linux agent loop")
+struct OpenAICompatibleAgentLoopTests {
+    @Test("Agent run executes tools against an OpenAI-compatible fixture")
+    func agentRunExecutesTools() async throws {
+        OpenAICompatibleURLProtocol.reset()
+        defer { OpenAICompatibleURLProtocol.reset() }
+
+        OpenAICompatibleURLProtocol.handle { _, body in
+            let object = (try? JSONSerialization.jsonObject(with: body) as? [String: Any]) ?? [:]
+            let messages = object["messages"] as? [[String: Any]] ?? []
+            let hasToolResult = messages.contains { ($0["role"] as? String) == "tool" }
+            if hasToolResult {
+                return .init(
+                    status: 200,
+                    headers: ["Content-Type": "application/json"],
+                    body: Data(Self.finalJSON.utf8)
+                )
+            }
+            return .init(
+                status: 200,
+                headers: ["Content-Type": "application/json"],
+                body: Data(Self.toolCallJSON.utf8)
+            )
+        }
+
+        let provider = OpenAICompatibleProvider(
+            configuration: .init(
+                baseURL: URL(string: "https://api.example.test/v1")!,
+                model: "fixture-model"
+            ),
+            session: OpenAICompatibleURLProtocol.makeSession()
+        )
+        let agent = try Agent(
+            "Use the add tool.",
+            inferenceProvider: provider
+        ) {
+            FunctionTool(
+                name: "add",
+                description: "Adds two integers",
+                parameters: [
+                    ToolParameter(name: "a", description: "First addend", type: .int),
+                    ToolParameter(name: "b", description: "Second addend", type: .int),
+                ]
+            ) { args in
+                let a = try args.require("a", as: Int.self)
+                let b = try args.require("b", as: Int.self)
+                return .int(a + b)
+            }
+        }
+
+        let result = try await agent.run("What is 2+3?")
+        #expect(result.output.contains("5"))
+        #expect(result.tokenUsage == TokenUsage(inputTokens: 20, outputTokens: 8))
+        #expect(OpenAICompatibleURLProtocol.requests.count == 2)
+    }
+
+    @Test("Agent stream assembles tool-call deltas then final tokens")
+    func agentStreamAssemblesToolCallsAndTokens() async throws {
+        OpenAICompatibleURLProtocol.reset()
+        defer { OpenAICompatibleURLProtocol.reset() }
+
+        OpenAICompatibleURLProtocol.handle { _, body in
+            let object = (try? JSONSerialization.jsonObject(with: body) as? [String: Any]) ?? [:]
+            let messages = object["messages"] as? [[String: Any]] ?? []
+            let hasToolResult = messages.contains { ($0["role"] as? String) == "tool" }
+            let sse = hasToolResult ? Self.finalSSE : Self.toolCallSSE
+            return .init(
+                status: 200,
+                headers: ["Content-Type": "text/event-stream"],
+                body: Data(sse.utf8)
+            )
+        }
+
+        let provider = OpenAICompatibleProvider(
+            configuration: .init(
+                baseURL: URL(string: "https://api.example.test/v1")!,
+                model: "fixture-model"
+            ),
+            session: OpenAICompatibleURLProtocol.makeSession()
+        )
+        let agent = try Agent(
+            "Use the add tool.",
+            inferenceProvider: provider
+        ) {
+            FunctionTool(
+                name: "add",
+                description: "Adds two integers",
+                parameters: [
+                    ToolParameter(name: "a", description: "First addend", type: .int),
+                    ToolParameter(name: "b", description: "Second addend", type: .int),
+                ]
+            ) { args in
+                let a = try args.require("a", as: Int.self)
+                let b = try args.require("b", as: Int.self)
+                return .int(a + b)
+            }
+        }
+
+        var tokens: [String] = []
+        var sawTool = false
+        for try await event in agent.stream("What is 2+3?") {
+            switch event {
+            case let .output(.token(token)):
+                tokens.append(token)
+            case .tool(.completed):
+                sawTool = true
+            default:
+                break
+            }
+        }
+
+        #expect(sawTool)
+        #expect(tokens.joined().contains("5"))
+        #expect(OpenAICompatibleURLProtocol.requests.count >= 2)
+        let firstBody = try OpenAICompatibleJSON.object(
+            from: OpenAICompatibleURLProtocol.requests[0].body
+        )
+        #expect(firstBody["stream"] as? Bool == true)
+    }
+
+    private static let toolCallJSON = """
+    {
+      "choices": [
+        {
+          "index": 0,
+          "message": {
+            "role": "assistant",
+            "content": null,
+            "tool_calls": [
+              {
+                "id": "call_add",
+                "type": "function",
+                "function": { "name": "add", "arguments": "{\\"a\\":2,\\"b\\":3}" }
+              }
+            ]
+          },
+          "finish_reason": "tool_calls"
+        }
+      ],
+      "usage": { "prompt_tokens": 12, "completion_tokens": 4 }
+    }
+    """
+
+    private static let finalJSON = """
+    {
+      "choices": [
+        {
+          "index": 0,
+          "message": { "role": "assistant", "content": "The sum is 5." },
+          "finish_reason": "stop"
+        }
+      ],
+      "usage": { "prompt_tokens": 8, "completion_tokens": 4 }
+    }
+    """
+
+    private static let toolCallSSE = """
+    data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_add","function":{"name":"add","arguments":""}}]}}]}
+
+    data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\\"a\\":2,\\"b\\":3}"}}]}}]}
+
+    data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}
+
+    data: [DONE]
+
+    """
+
+    private static let finalSSE = """
+    data: {"choices":[{"delta":{"content":"The sum is "}}]}
+
+    data: {"choices":[{"delta":{"content":"5."}}]}
+
+    data: {"choices":[{"delta":{}}],"usage":{"prompt_tokens":8,"completion_tokens":4}}
+
+    data: [DONE]
+
+    """
+}

--- a/Tests/SwarmTests/Providers/OpenAICompatibleErrorMappingTests.swift
+++ b/Tests/SwarmTests/Providers/OpenAICompatibleErrorMappingTests.swift
@@ -1,0 +1,133 @@
+import Foundation
+import Testing
+@testable import Swarm
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+@Suite("OpenAI-compatible error mapping")
+struct OpenAICompatibleErrorMappingTests {
+    private let endpoint = URL(string: "https://api.example.test/v1")!
+
+    @Test("HTTP 429 maps to retryable rateLimitExceeded")
+    func status429IsRetryableRateLimit() async throws {
+        let error = try await failure(status: 429, body: #"{"error":{"message":"slow down"}}"#, headers: ["Retry-After": "2"])
+        guard case let .rateLimitExceeded(retryAfter) = error else {
+            Issue.record("expected rateLimitExceeded, got \(error)")
+            return
+        }
+        #expect(retryAfter == 2)
+        #expect(error.isRetryable)
+        #expect(InferenceRetryability.isRetryable(error))
+    }
+
+    @Test("HTTP 500 maps to retryable generationFailed")
+    func status500IsRetryableGenerationFailed() async throws {
+        let error = try await failure(status: 500, body: #"{"error":{"message":"boom"}}"#)
+        guard case .generationFailed = error else {
+            Issue.record("expected generationFailed, got \(error)")
+            return
+        }
+        #expect(error.isRetryable)
+        #expect(InferenceRetryability.isRetryable(error))
+    }
+
+    @Test("HTTP 503 maps to retryable generationFailed")
+    func status503IsRetryableGenerationFailed() async throws {
+        let error = try await failure(status: 503, body: "unavailable")
+        guard case .generationFailed = error else {
+            Issue.record("expected generationFailed, got \(error)")
+            return
+        }
+        #expect(InferenceRetryability.isRetryable(error))
+    }
+
+    @Test("HTTP 400 is not retryable")
+    func status400IsNotRetryable() async throws {
+        let error = try await failure(status: 400, body: #"{"error":{"message":"bad schema"}}"#)
+        guard case .invalidInput = error else {
+            Issue.record("expected invalidInput, got \(error)")
+            return
+        }
+        #expect(error.isRetryable == false)
+        #expect(InferenceRetryability.isRetryable(error) == false)
+    }
+
+    @Test("HTTP 401 is not retryable")
+    func status401IsNotRetryable() async throws {
+        let error = try await failure(status: 401, body: #"{"error":{"message":"nope"}}"#)
+        guard case .invalidInput = error else {
+            Issue.record("expected invalidInput, got \(error)")
+            return
+        }
+        #expect(InferenceRetryability.isRetryable(error) == false)
+    }
+
+    @Test("HTTP 403 is not retryable")
+    func status403IsNotRetryable() async throws {
+        let error = try await failure(status: 403, body: #"{"error":{"message":"forbidden"}}"#)
+        guard case .invalidInput = error else {
+            Issue.record("expected invalidInput, got \(error)")
+            return
+        }
+        #expect(InferenceRetryability.isRetryable(error) == false)
+    }
+
+    @Test("Network URLError remains retryable without wrapping")
+    func networkURLErrorStaysRetryable() {
+        let error = URLError(.cannotConnectToHost)
+        let mapped = OpenAICompatibleErrorMapper.mapTransport(error)
+        #expect(mapped is URLError)
+        #expect(InferenceRetryability.isRetryable(mapped))
+    }
+
+    @Test("Streaming HTTP 400 is not retryable")
+    func streamingStatus400IsNotRetryable() async throws {
+        OpenAICompatibleURLProtocol.reset()
+        defer { OpenAICompatibleURLProtocol.reset() }
+        OpenAICompatibleURLProtocol.enqueue(
+            status: 400,
+            json: #"{"error":{"message":"bad stream"}}"#
+        )
+        let provider = makeProvider()
+        do {
+            for try await _ in provider.stream(messages: [.user("hi")], options: .default) {}
+            Issue.record("expected stream to throw")
+        } catch let error as AgentError {
+            guard case .invalidInput = error else {
+                Issue.record("expected invalidInput, got \(error)")
+                return
+            }
+            #expect(InferenceRetryability.isRetryable(error) == false)
+        }
+    }
+
+    private func failure(
+        status: Int,
+        body: String,
+        headers: [String: String] = [:]
+    ) async throws -> AgentError {
+        OpenAICompatibleURLProtocol.reset()
+        defer { OpenAICompatibleURLProtocol.reset() }
+        var responseHeaders = ["Content-Type": "application/json"]
+        for (key, value) in headers {
+            responseHeaders[key] = value
+        }
+        OpenAICompatibleURLProtocol.enqueue(status: status, headers: responseHeaders, json: body)
+        do {
+            _ = try await makeProvider().generate(messages: [.user("hi")], options: .default)
+            Issue.record("expected provider to throw")
+            throw AgentError.internalError(reason: "expected throw")
+        } catch let error as AgentError {
+            return error
+        }
+    }
+
+    private func makeProvider() -> OpenAICompatibleProvider {
+        OpenAICompatibleProvider(
+            configuration: .init(baseURL: endpoint, apiKey: "sk-test", model: "gpt-test"),
+            session: OpenAICompatibleURLProtocol.makeSession()
+        )
+    }
+}

--- a/Tests/SwarmTests/Providers/OpenAICompatibleOllamaLiveTests.swift
+++ b/Tests/SwarmTests/Providers/OpenAICompatibleOllamaLiveTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Testing
+@testable import Swarm
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+enum OpenAICompatibleOllamaLiveGate {
+    static var isEnabled: Bool {
+        ProcessInfo.processInfo.environment["SWARM_OLLAMA_LIVE_TESTS"] == "1"
+    }
+
+    static var baseURL: URL {
+        let raw = ProcessInfo.processInfo.environment["SWARM_OLLAMA_BASE_URL"]
+            ?? "http://127.0.0.1:11434/v1"
+        return URL(string: raw) ?? URL(string: "http://127.0.0.1:11434/v1")!
+    }
+
+    static var model: String {
+        ProcessInfo.processInfo.environment["SWARM_OLLAMA_MODEL"] ?? "llama3.2"
+    }
+}
+
+@Suite("OpenAI-compatible Ollama live tests")
+struct OpenAICompatibleOllamaLiveTests {
+    @Test(
+        "Live Ollama generate returns text",
+        .enabled(if: OpenAICompatibleOllamaLiveGate.isEnabled)
+    )
+    func liveOllamaGenerateReturnsText() async throws {
+        let provider = OpenAICompatibleProvider(
+            configuration: .ollama(
+                model: OpenAICompatibleOllamaLiveGate.model,
+                baseURL: OpenAICompatibleOllamaLiveGate.baseURL
+            )
+        )
+        let text = try await provider.generate(
+            messages: [.user("Reply with the single word pong.")],
+            options: .precise.maxTokens(32)
+        )
+        #expect(!text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+    }
+
+    @Test(
+        "Live Ollama streaming yields at least one chunk",
+        .enabled(if: OpenAICompatibleOllamaLiveGate.isEnabled)
+    )
+    func liveOllamaStreamingYieldsChunks() async throws {
+        let provider = OpenAICompatibleProvider(
+            configuration: .ollama(
+                model: OpenAICompatibleOllamaLiveGate.model,
+                baseURL: OpenAICompatibleOllamaLiveGate.baseURL
+            )
+        )
+        var chunks: [String] = []
+        for try await chunk in provider.stream(
+            messages: [.user("Reply with the single word pong.")],
+            options: .precise.maxTokens(32)
+        ) {
+            chunks.append(chunk)
+        }
+        #expect(!chunks.isEmpty)
+        #expect(!chunks.joined().trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+    }
+}

--- a/Tests/SwarmTests/Providers/OpenAICompatibleProviderTests.swift
+++ b/Tests/SwarmTests/Providers/OpenAICompatibleProviderTests.swift
@@ -1,0 +1,296 @@
+import Foundation
+import Testing
+@testable import Swarm
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+@Suite("OpenAI-compatible provider request and response shape")
+struct OpenAICompatibleProviderTests {
+    private let endpoint = URL(string: "https://api.example.test/v1")!
+
+    @Test("Chat request maps messages, tools, stream flags, and Bearer auth")
+    func chatRequestMapsMessagesToolsStreamAndAuth() async throws {
+        OpenAICompatibleURLProtocol.reset()
+        defer { OpenAICompatibleURLProtocol.reset() }
+        OpenAICompatibleURLProtocol.enqueue(json: Self.completionJSON(content: "hello", prompt: 9, completion: 3))
+
+        let session = OpenAICompatibleURLProtocol.makeSession()
+        let provider = OpenAICompatibleProvider(
+            configuration: OpenAICompatibleProviderConfiguration(
+                baseURL: endpoint,
+                apiKey: "sk-test",
+                model: "gpt-test",
+                httpHeaders: ["X-Custom": "swarm"]
+            ),
+            session: session
+        )
+
+        let messages: [InferenceMessage] = [
+            .system("Be concise."),
+            .user("Call echo"),
+            .assistant(
+                "",
+                toolCalls: [
+                    InferenceMessage.ToolCall(
+                        id: "call_1",
+                        name: "echo",
+                        arguments: ["text": .string("hi")]
+                    ),
+                ]
+            ),
+            .tool(name: "echo", content: "hi", toolCallID: "call_1"),
+        ]
+        let tools = [
+            ToolSchema(
+                name: "echo",
+                description: "Echo text",
+                parameters: [
+                    ToolParameter(name: "text", description: "Text to echo", type: .string),
+                ]
+            ),
+        ]
+
+        let response = try await provider.generateWithToolCalls(
+            messages: messages,
+            tools: tools,
+            options: .default.temperature(0.2).maxTokens(64).toolChoice(.auto)
+        )
+
+        #expect(response.content == "hello")
+        #expect(response.usage == TokenUsage(inputTokens: 9, outputTokens: 3))
+
+        let recorded = try #require(OpenAICompatibleURLProtocol.requests.first)
+        #expect(recorded.url?.absoluteString == "https://api.example.test/v1/chat/completions")
+        #expect(recorded.headers["Authorization"] == "Bearer sk-test")
+        #expect(recorded.headers["X-Custom"] == "swarm")
+        #expect(recorded.headers["Content-Type"] == "application/json")
+
+        let body = try OpenAICompatibleJSON.object(from: recorded.body)
+        #expect(body["model"] as? String == "gpt-test")
+        #expect(body["temperature"] as? Double == 0.2)
+        #expect(body["max_tokens"] as? Int == 64)
+        #expect(body["stream"] == nil)
+        #expect(body["tool_choice"] as? String == "auto")
+
+        let encodedMessages = try #require(body["messages"] as? [[String: Any]])
+        #expect(encodedMessages.count == 4)
+        #expect(encodedMessages[0]["role"] as? String == "system")
+        #expect(encodedMessages[2]["role"] as? String == "assistant")
+        let toolCalls = try #require(encodedMessages[2]["tool_calls"] as? [[String: Any]])
+        #expect(toolCalls[0]["id"] as? String == "call_1")
+        #expect(encodedMessages[3]["role"] as? String == "tool")
+        #expect(encodedMessages[3]["tool_call_id"] as? String == "call_1")
+
+        let encodedTools = try #require(body["tools"] as? [[String: Any]])
+        let function = try #require(encodedTools[0]["function"] as? [String: Any])
+        #expect(function["name"] as? String == "echo")
+    }
+
+    @Test("Streaming request sets stream and include_usage")
+    func streamingRequestSetsStreamFlags() async throws {
+        OpenAICompatibleURLProtocol.reset()
+        defer { OpenAICompatibleURLProtocol.reset() }
+        OpenAICompatibleURLProtocol.enqueueSSE(
+            """
+            data: {"choices":[{"delta":{"content":"Hi"}}]}
+
+            data: {"choices":[{"delta":{}}],"usage":{"prompt_tokens":4,"completion_tokens":1}}
+
+            data: [DONE]
+
+            """
+        )
+
+        let provider = OpenAICompatibleProvider(
+            configuration: .init(baseURL: endpoint, apiKey: "sk-test", model: "gpt-test"),
+            session: OpenAICompatibleURLProtocol.makeSession()
+        )
+
+        var chunks: [String] = []
+        var usage: TokenUsage?
+        for try await update in provider.streamWithToolCalls(
+            messages: [.user("Hi")],
+            tools: [],
+            options: .default
+        ) {
+            switch update {
+            case let .outputChunk(text):
+                chunks.append(text)
+            case let .usage(value):
+                usage = value
+            default:
+                break
+            }
+        }
+
+        #expect(chunks == ["Hi"])
+        #expect(usage == TokenUsage(inputTokens: 4, outputTokens: 1))
+
+        let body = try OpenAICompatibleJSON.object(
+            from: #require(OpenAICompatibleURLProtocol.requests.first).body
+        )
+        #expect(body["stream"] as? Bool == true)
+        let streamOptions = try #require(body["stream_options"] as? [String: Any])
+        #expect(streamOptions["include_usage"] as? Bool == true)
+    }
+
+    @Test("Injects current W3C trace-context headers")
+    func injectsTraceContextHeaders() async throws {
+        OpenAICompatibleURLProtocol.reset()
+        defer { OpenAICompatibleURLProtocol.reset() }
+        OpenAICompatibleURLProtocol.enqueue(json: Self.completionJSON(content: "ok"))
+
+        let headers = try #require(
+            TraceContextHeaders(
+                traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+                tracestate: "rojo=00f067aa0ba902b7"
+            )
+        )
+        let provider = OpenAICompatibleProvider(
+            configuration: .init(baseURL: endpoint, apiKey: "sk-test", model: "gpt-test"),
+            session: OpenAICompatibleURLProtocol.makeSession()
+        )
+
+        _ = try await TraceContextHeaders.withCurrent(headers) {
+            try await provider.generate(messages: [.user("ping")], options: .default)
+        }
+
+        let recorded = try #require(OpenAICompatibleURLProtocol.requests.first)
+        #expect(recorded.headers["traceparent"] == headers.traceparent)
+        #expect(recorded.headers["tracestate"] == "rojo=00f067aa0ba902b7")
+    }
+
+    @Test("Native structured output sends response_format and labels providerNative")
+    func nativeStructuredOutputUsesResponseFormat() async throws {
+        OpenAICompatibleURLProtocol.reset()
+        defer { OpenAICompatibleURLProtocol.reset() }
+        OpenAICompatibleURLProtocol.enqueue(json: Self.completionJSON(content: #"{"ok":true}"#))
+
+        let provider = OpenAICompatibleProvider(
+            configuration: .init(
+                baseURL: endpoint,
+                model: "gpt-test",
+                structuredOutputMode: .nativeJSONSchema
+            ),
+            session: OpenAICompatibleURLProtocol.makeSession()
+        )
+        let request = StructuredOutputRequest(
+            format: .jsonSchema(name: "Status", schemaJSON: #"{"type":"object","properties":{"ok":{"type":"boolean"}}}"#)
+        )
+        let result = try await provider.generateStructured(
+            messages: [.user("status")],
+            request: request,
+            options: .default
+        )
+
+        #expect(result.source == .providerNative)
+        #expect(result.value["ok"]?.boolValue == true)
+
+        let body = try OpenAICompatibleJSON.object(
+            from: #require(OpenAICompatibleURLProtocol.requests.first).body
+        )
+        let format = try #require(body["response_format"] as? [String: Any])
+        #expect(format["type"] as? String == "json_schema")
+    }
+
+    @Test("Prompt-fallback structured output omits response_format and labels promptFallback")
+    func promptFallbackStructuredOutputIsHonest() async throws {
+        OpenAICompatibleURLProtocol.reset()
+        defer { OpenAICompatibleURLProtocol.reset() }
+        OpenAICompatibleURLProtocol.enqueue(json: Self.completionJSON(content: #"{"ok":true}"#))
+
+        let provider = OpenAICompatibleProvider(
+            configuration: .ollama(model: "llama3.2", baseURL: endpoint),
+            session: OpenAICompatibleURLProtocol.makeSession()
+        )
+        let result = try await provider.generateStructured(
+            messages: [.user("status")],
+            request: StructuredOutputRequest(format: .jsonObject),
+            options: .default
+        )
+
+        #expect(result.source == .promptFallback)
+        let body = try OpenAICompatibleJSON.object(
+            from: #require(OpenAICompatibleURLProtocol.requests.first).body
+        )
+        #expect(body["response_format"] == nil)
+        let messages = try #require(body["messages"] as? [[String: Any]])
+        #expect(messages.contains { ($0["content"] as? String)?.contains("valid JSON") == true })
+    }
+
+    @Test("Azure convenience factory uses api-key and api-version")
+    func azureConvenienceFactoryUsesApiKeyAndVersion() async throws {
+        OpenAICompatibleURLProtocol.reset()
+        defer { OpenAICompatibleURLProtocol.reset() }
+        OpenAICompatibleURLProtocol.enqueue(json: Self.completionJSON(content: "ok"))
+
+        let configuration = OpenAICompatibleProviderConfiguration.azureOpenAI(
+            resource: "contoso",
+            deployment: "gpt-4o",
+            apiKey: "azure-key"
+        )
+        let provider = OpenAICompatibleProvider(
+            configuration: configuration,
+            session: OpenAICompatibleURLProtocol.makeSession()
+        )
+        _ = try await provider.generate(messages: [.user("hi")], options: .default)
+
+        let recorded = try #require(OpenAICompatibleURLProtocol.requests.first)
+        #expect(recorded.headers["api-key"] == "azure-key")
+        #expect(recorded.headers["Authorization"] == nil)
+        #expect(recorded.url?.absoluteString.contains("/openai/deployments/gpt-4o/chat/completions") == true)
+        #expect(recorded.url?.absoluteString.contains("api-version=2024-10-21") == true)
+    }
+
+    @Test("Does not send Bearer when apiKey is omitted")
+    func omitsBearerWhenAPIKeyMissing() async throws {
+        OpenAICompatibleURLProtocol.reset()
+        defer { OpenAICompatibleURLProtocol.reset() }
+        OpenAICompatibleURLProtocol.enqueue(json: Self.completionJSON(content: "ok"))
+
+        let provider = OpenAICompatibleProvider(
+            configuration: .ollama(model: "llama3.2", baseURL: endpoint),
+            session: OpenAICompatibleURLProtocol.makeSession()
+        )
+        _ = try await provider.generate(messages: [.user("hi")], options: .default)
+
+        let recorded = try #require(OpenAICompatibleURLProtocol.requests.first)
+        #expect(recorded.headers["Authorization"] == nil)
+    }
+
+    @Test("Reports conversation, tool, streaming, and structured capabilities")
+    func reportsExpectedCapabilities() {
+        let provider = OpenAICompatibleProvider(
+            configuration: .openAI(apiKey: "sk", model: "gpt-4o")
+        )
+        #expect(provider.capabilities.contains(.conversationMessages))
+        #expect(provider.capabilities.contains(.nativeToolCalling))
+        #expect(provider.capabilities.contains(.streamingToolCalls))
+        #expect(provider.capabilities.contains(.structuredOutputs))
+        #expect(provider.capabilities.contains(.privateInference) == false)
+        #expect(provider.providerName == "openai")
+        #expect(provider.modelName == "gpt-4o")
+    }
+
+    private static func completionJSON(content: String, prompt: Int = 1, completion: Int = 1) -> String {
+        """
+        {
+          "choices": [
+            {
+              "index": 0,
+              "message": { "role": "assistant", "content": \(encode(content)) },
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": { "prompt_tokens": \(prompt), "completion_tokens": \(completion) }
+        }
+        """
+    }
+
+    private static func encode(_ string: String) -> String {
+        let data = try? JSONSerialization.data(withJSONObject: string, options: [.fragmentsAllowed])
+        return String(data: data ?? Data("\"\"".utf8), encoding: .utf8) ?? "\"\""
+    }
+}

--- a/Tests/SwarmTests/Providers/OpenAICompatibleProviderTests.swift
+++ b/Tests/SwarmTests/Providers/OpenAICompatibleProviderTests.swift
@@ -260,6 +260,78 @@ struct OpenAICompatibleProviderTests {
         #expect(recorded.headers["Authorization"] == nil)
     }
 
+    @Test("Omits response_format when tools are present on a structured turn")
+    func omitsResponseFormatWhenToolsArePresent() async throws {
+        OpenAICompatibleURLProtocol.reset()
+        defer { OpenAICompatibleURLProtocol.reset() }
+        OpenAICompatibleURLProtocol.enqueue(json: Self.completionJSON(content: #"{"ok":true}"#))
+
+        let provider = OpenAICompatibleProvider(
+            configuration: .init(
+                baseURL: endpoint,
+                model: "gpt-test",
+                structuredOutputMode: .nativeJSONSchema
+            ),
+            session: OpenAICompatibleURLProtocol.makeSession()
+        )
+        var options = InferenceOptions.default
+        options.structuredOutput = StructuredOutputRequest(
+            format: .jsonSchema(name: "Status", schemaJSON: #"{"type":"object"}"#)
+        )
+        _ = try await provider.generateWithToolCalls(
+            messages: [.user("status")],
+            tools: [
+                ToolSchema(name: "echo", description: "Echo", parameters: []),
+            ],
+            options: options
+        )
+
+        let body = try OpenAICompatibleJSON.object(
+            from: #require(OpenAICompatibleURLProtocol.requests.first).body
+        )
+        #expect(body["tools"] != nil)
+        #expect(body["response_format"] == nil)
+    }
+
+    @Test("Correlates tool_call_id from the prior assistant call when the result omits it")
+    func correlatesToolCallIDFromAssistantCall() async throws {
+        OpenAICompatibleURLProtocol.reset()
+        defer { OpenAICompatibleURLProtocol.reset() }
+        OpenAICompatibleURLProtocol.enqueue(json: Self.completionJSON(content: "done"))
+
+        let provider = OpenAICompatibleProvider(
+            configuration: .init(baseURL: endpoint, model: "gpt-test"),
+            session: OpenAICompatibleURLProtocol.makeSession()
+        )
+        _ = try await provider.generateWithToolCalls(
+            messages: [
+                .user("add"),
+                .assistant(
+                    "",
+                    toolCalls: [
+                        InferenceMessage.ToolCall(
+                            id: "call_add",
+                            name: "add",
+                            arguments: ["a": .int(2)]
+                        ),
+                    ]
+                ),
+                .tool(name: "add", content: "5"),
+            ],
+            tools: [
+                ToolSchema(name: "add", description: "Add", parameters: []),
+            ],
+            options: .default
+        )
+
+        let body = try OpenAICompatibleJSON.object(
+            from: #require(OpenAICompatibleURLProtocol.requests.first).body
+        )
+        let messages = try #require(body["messages"] as? [[String: Any]])
+        #expect(messages[2]["tool_call_id"] as? String == "call_add")
+        #expect(messages[2]["tool_call_id"] as? String != "add")
+    }
+
     @Test("Reports conversation, tool, streaming, and structured capabilities")
     func reportsExpectedCapabilities() {
         let provider = OpenAICompatibleProvider(

--- a/Tests/SwarmTests/Providers/OpenAICompatibleSSEParserTests.swift
+++ b/Tests/SwarmTests/Providers/OpenAICompatibleSSEParserTests.swift
@@ -1,0 +1,134 @@
+import Foundation
+import Testing
+@testable import Swarm
+
+@Suite("OpenAI-compatible SSE parser")
+struct OpenAICompatibleSSEParserTests {
+    @Test("Parses multi-event content deltas and [DONE]")
+    func parsesMultiEventContentDeltas() {
+        var parser = OpenAICompatibleSSEParser()
+        var events: [OpenAICompatibleSSEEvent] = []
+        events += parser.consume(line: #"data: {"choices":[{"delta":{"content":"Hel"}}]}"#)
+        events += parser.consume(line: "")
+        events += parser.consume(line: #"data: {"choices":[{"delta":{"content":"lo"}}]}"#)
+        events += parser.consume(line: "")
+        events += parser.consume(line: "data: [DONE]")
+        events += parser.consume(line: "")
+        events += parser.finish()
+
+        #expect(events.count == 3)
+        guard case let .chunk(first) = events[0] else {
+            Issue.record("expected first chunk")
+            return
+        }
+        #expect(first.choices.first?.delta?.content == "Hel")
+        guard case let .chunk(second) = events[1] else {
+            Issue.record("expected second chunk")
+            return
+        }
+        #expect(second.choices.first?.delta?.content == "lo")
+        #expect(events[2] == .done)
+    }
+
+    @Test("Accumulates split tool-call argument deltas")
+    func accumulatesToolCallDeltas() {
+        var parser = OpenAICompatibleSSEParser()
+        var accumulator = OpenAICompatibleStreamAccumulator()
+        var updates: [InferenceStreamUpdate] = []
+
+        let lines = [
+            #"data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"echo","arguments":""}}]}}]}"#,
+            "",
+            #"data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"t"}}]}}]}"#,
+            "",
+            #"data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"ext\":\"hi\"}"}}]}}],"usage":{"prompt_tokens":11,"completion_tokens":4}}"#,
+            "",
+            #"data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}"#,
+            "",
+            "data: [DONE]",
+            "",
+        ]
+
+        for line in lines {
+            for event in parser.consume(line: line) {
+                switch event {
+                case let .chunk(chunk):
+                    updates += accumulator.consume(chunk)
+                case .done:
+                    updates += accumulator.finish()
+                case .malformed:
+                    Issue.record("unexpected malformed event")
+                }
+            }
+        }
+
+        let partials = updates.compactMap { update -> PartialToolCallUpdate? in
+            if case let .toolCallPartial(partial) = update { return partial }
+            return nil
+        }
+        #expect(partials.count == 3)
+        #expect(partials.last?.argumentsFragment == #"{"text":"hi"}"#)
+
+        guard case let .toolCallsCompleted(calls) = updates.last(where: {
+            if case .toolCallsCompleted = $0 { return true }
+            return false
+        }) else {
+            Issue.record("expected completed tool calls")
+            return
+        }
+        #expect(calls.count == 1)
+        #expect(calls[0].id == "call_1")
+        #expect(calls[0].name == "echo")
+        #expect(calls[0].arguments["text"]?.stringValue == "hi")
+
+        guard case let .usage(usage) = updates.first(where: {
+            if case .usage = $0 { return true }
+            return false
+        }) else {
+            Issue.record("expected usage payload")
+            return
+        }
+        #expect(usage == TokenUsage(inputTokens: 11, outputTokens: 4))
+    }
+
+    @Test("Skips truncated and malformed data lines without aborting")
+    func skipsTruncatedAndMalformedLines() {
+        var parser = OpenAICompatibleSSEParser()
+        var events: [OpenAICompatibleSSEEvent] = []
+        events += parser.consume(line: "data: {\"choices\":")
+        events += parser.consume(line: "")
+        events += parser.consume(line: "data: not-json")
+        events += parser.consume(line: "")
+        events += parser.consume(line: #"data: {"choices":[{"delta":{"content":"ok"}}]}"#)
+        events += parser.consume(line: "")
+        events += parser.consume(line: "data: [DONE]")
+        events += parser.consume(line: "")
+
+        let malformed = events.compactMap { event -> String? in
+            if case let .malformed(payload) = event { return payload }
+            return nil
+        }
+        #expect(malformed.count == 2)
+        #expect(events.contains { event in
+            if case let .chunk(chunk) = event {
+                return chunk.choices.first?.delta?.content == "ok"
+            }
+            return false
+        })
+        #expect(events.contains(.done))
+    }
+
+    @Test("Joins multi-line data payloads into one event")
+    func joinsMultiLineDataPayloads() {
+        var parser = OpenAICompatibleSSEParser()
+        var events: [OpenAICompatibleSSEEvent] = []
+        events += parser.consume(line: #"data: {"choices":[{"delta":{"content":"ab"}}]}"#)
+        events += parser.consume(line: "")
+        #expect(events.count == 1)
+        guard case let .chunk(chunk) = events[0] else {
+            Issue.record("expected joined chunk")
+            return
+        }
+        #expect(chunk.choices.first?.delta?.content == "ab")
+    }
+}

--- a/Tests/SwarmTests/Providers/OpenAICompatibleSSEParserTests.swift
+++ b/Tests/SwarmTests/Providers/OpenAICompatibleSSEParserTests.swift
@@ -91,6 +91,46 @@ struct OpenAICompatibleSSEParserTests {
         #expect(usage == TokenUsage(inputTokens: 11, outputTokens: 4))
     }
 
+    @Test("Emits usage before toolCallsCompleted so Agent can record it")
+    func emitsUsageBeforeToolCallsCompleted() {
+        var accumulator = OpenAICompatibleStreamAccumulator()
+        var updates: [InferenceStreamUpdate] = []
+
+        updates += accumulator.consume(
+            OpenAICompatibleChatChunk(json: [
+                "choices": [[
+                    "delta": [
+                        "tool_calls": [[
+                            "index": 0,
+                            "id": "call_1",
+                            "function": ["name": "echo", "arguments": "{\"text\":\"hi\"}"],
+                        ]],
+                    ],
+                    "finish_reason": "tool_calls",
+                ]],
+            ])
+        )
+        updates += accumulator.consume(
+            OpenAICompatibleChatChunk(json: [
+                "choices": [] as [Any],
+                "usage": ["prompt_tokens": 11, "completion_tokens": 4],
+            ])
+        )
+        updates += accumulator.finish()
+
+        let kinds = updates.map { update -> String in
+            switch update {
+            case .outputChunk: "chunk"
+            case .toolCallPartial: "partial"
+            case .usage: "usage"
+            case .toolCallsCompleted: "completed"
+            }
+        }
+        #expect(kinds.contains("usage"))
+        #expect(kinds.contains("completed"))
+        #expect(kinds.lastIndex(of: "usage")! < kinds.lastIndex(of: "completed")!)
+    }
+
     @Test("Skips truncated and malformed data lines without aborting")
     func skipsTruncatedAndMalformedLines() {
         var parser = OpenAICompatibleSSEParser()

--- a/Tests/SwarmTests/Providers/OpenAICompatibleURLProtocol.swift
+++ b/Tests/SwarmTests/Providers/OpenAICompatibleURLProtocol.swift
@@ -1,0 +1,183 @@
+// OpenAICompatibleURLProtocol.swift
+// SwarmTests
+//
+// URLProtocol stub for OpenAI-compatible HTTP tests.
+
+import Foundation
+@testable import Swarm
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+final class OpenAICompatibleURLProtocol: URLProtocol {
+    struct EnqueuedResponse: Sendable {
+        var status: Int
+        var headers: [String: String]
+        var body: Data
+    }
+
+    struct RecordedRequest: Sendable {
+        var url: URL?
+        var method: String?
+        var headers: [String: String]
+        var body: Data
+    }
+
+    private static let state = OpenAICompatibleURLProtocolState()
+
+    static var requests: [RecordedRequest] {
+        state.requests
+    }
+
+    static func reset() {
+        state.reset()
+    }
+
+    static func enqueue(
+        status: Int = 200,
+        headers: [String: String] = ["Content-Type": "application/json"],
+        json: String
+    ) {
+        enqueue(status: status, headers: headers, body: Data(json.utf8))
+    }
+
+    static func enqueue(
+        status: Int = 200,
+        headers: [String: String] = ["Content-Type": "application/json"],
+        body: Data
+    ) {
+        state.enqueue(EnqueuedResponse(status: status, headers: headers, body: body))
+    }
+
+    static func enqueueSSE(_ events: String, status: Int = 200) {
+        enqueue(
+            status: status,
+            headers: ["Content-Type": "text/event-stream"],
+            body: Data(events.utf8)
+        )
+    }
+
+    static func handle(_ handler: @escaping @Sendable (URLRequest, Data) -> EnqueuedResponse) {
+        state.setHandler(handler)
+    }
+
+    static func makeSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [OpenAICompatibleURLProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+
+    override class func canInit(with _: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        let body = request.httpBody
+            ?? request.httpBodyStream.flatMap { Self.readAll(from: $0) }
+            ?? Data()
+
+        let recorded = RecordedRequest(
+            url: request.url,
+            method: request.httpMethod,
+            headers: request.allHTTPHeaderFields ?? [:],
+            body: body
+        )
+        let response = Self.state.record(recorded, request: request, body: body)
+
+        let url = request.url ?? URL(string: "https://example.invalid")!
+        let http = HTTPURLResponse(
+            url: url,
+            statusCode: response.status,
+            httpVersion: "HTTP/1.1",
+            headerFields: response.headers
+        )!
+        client?.urlProtocol(self, didReceive: http, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: response.body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    private static func readAll(from stream: InputStream) -> Data {
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while stream.hasBytesAvailable {
+            let count = stream.read(&buffer, maxLength: buffer.count)
+            if count <= 0 { break }
+            data.append(buffer, count: count)
+        }
+        return data
+    }
+}
+
+private final class OpenAICompatibleURLProtocolState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var queued: [OpenAICompatibleURLProtocol.EnqueuedResponse] = []
+    private var recorded: [OpenAICompatibleURLProtocol.RecordedRequest] = []
+    private var dynamicHandler: (@Sendable (URLRequest, Data) -> OpenAICompatibleURLProtocol.EnqueuedResponse)?
+
+    var requests: [OpenAICompatibleURLProtocol.RecordedRequest] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recorded
+    }
+
+    func reset() {
+        lock.lock()
+        queued = []
+        recorded = []
+        dynamicHandler = nil
+        lock.unlock()
+    }
+
+    func enqueue(_ response: OpenAICompatibleURLProtocol.EnqueuedResponse) {
+        lock.lock()
+        queued.append(response)
+        lock.unlock()
+    }
+
+    func setHandler(
+        _ handler: @escaping @Sendable (URLRequest, Data) -> OpenAICompatibleURLProtocol.EnqueuedResponse
+    ) {
+        lock.lock()
+        dynamicHandler = handler
+        lock.unlock()
+    }
+
+    func record(
+        _ recordedRequest: OpenAICompatibleURLProtocol.RecordedRequest,
+        request: URLRequest,
+        body: Data
+    ) -> OpenAICompatibleURLProtocol.EnqueuedResponse {
+        lock.lock()
+        defer { lock.unlock() }
+        recorded.append(recordedRequest)
+        if let handler = dynamicHandler {
+            return handler(request, body)
+        }
+        if !queued.isEmpty {
+            return queued.removeFirst()
+        }
+        return OpenAICompatibleURLProtocol.EnqueuedResponse(
+            status: 500,
+            headers: ["Content-Type": "application/json"],
+            body: Data(#"{"error":{"message":"no stubbed response"}}"#.utf8)
+        )
+    }
+}
+
+enum OpenAICompatibleJSON {
+    static func object(from data: Data) throws -> [String: Any] {
+        guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw AgentError.generationFailed(reason: "stub body is not a JSON object")
+        }
+        return object
+    }
+}

--- a/Tests/SwarmTests/V3/ReadmeProviderCompileTests.swift
+++ b/Tests/SwarmTests/V3/ReadmeProviderCompileTests.swift
@@ -52,6 +52,15 @@ struct ReadmeProviderCompileTests {
         _ = try Agent("Use a custom backend.", inferenceProvider: mock) {
             PublicCompileTool()
         }
+
+        _ = try Agent(
+            "Use a remote OpenAI-compatible backend.",
+            inferenceProvider: .openAICompatible(.ollama(model: "llama3.2"))
+        )
+        _ = try Agent(
+            "Use OpenAI.",
+            inferenceProvider: .openAICompatible(.openAI(apiKey: "sk-test", model: "gpt-4o"))
+        )
     }
 
     @Test("README dynamic tool examples compile through public import")
@@ -237,6 +246,11 @@ struct ReadmeProviderCompileTests {
 
         let agent = try Agent("Be helpful.", inferenceProvider: myCustomProvider)
         _ = agent.environment(\.inferenceProvider, myCustomProvider)
+
+        _ = try Agent(
+            "Be helpful.",
+            inferenceProvider: .openAICompatible(.ollama(model: "llama3.2"))
+        )
     }
 
     @Test("README Conversation sample compiles")

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -72,6 +72,7 @@ export default defineConfig({
             { text: 'Getting Started', link: '/guide/getting-started' },
             { text: 'Durable Execution', link: '/guide/durable-execution' },
             { text: 'Foundation Models', link: '/guide/foundation-models' },
+            { text: 'Remote Providers', link: '/guide/remote-providers' },
             { text: 'Capability Showcase', link: '/guide/capability-showcase' },
             { text: 'Agent Workspace', link: '/guide/agent-workspace' },
             { text: 'OpenTelemetry Tracing', link: '/guide/opentelemetry-tracing' },

--- a/docs/guide/foundation-models.md
+++ b/docs/guide/foundation-models.md
@@ -76,7 +76,8 @@ checkpoints do not fire.
 ## Availability
 
 Requires macOS/iOS 26+ with Apple Intelligence available. Linux and CI use
-capture-equivalent mock providers; the flag is ignored there.
+``OpenAICompatibleProvider`` (see [Remote Providers](remote-providers.md)) or
+capture-equivalent mock providers; the native-session flag is ignored there.
 
 Live on-device tests:
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -153,10 +153,32 @@ guard let provider = FoundationModelsInferenceProvider.ifAvailable() else {
 let agent = try Agent("You are helpful.", inferenceProvider: provider)
 ```
 
+### OpenAI-compatible remote provider (Linux / no Apple Intelligence)
+
+Same agent loop, `URLSession` only. Prompt content is sent to `baseURL` —
+contrast with on-device Foundation Models.
+
+```swift
+let agent = try Agent(
+    "Answer finance questions using real data.",
+    configuration: .default.name("Analyst"),
+    memory: .conversation(maxMessages: 50),
+    inferenceProvider: .openAICompatible(.ollama(model: "llama3.2")),
+    inputGuardrails: [InputGuard.maxLength(5000), InputGuard.notEmpty()]
+) {
+    PriceTool()
+}
+```
+
+Factories: `.openAI(apiKey:model:)`, `.azureOpenAI(resource:deployment:apiKey:)`,
+`.openRouter(apiKey:model:)`, `.ollama(model:)`, `.lmStudio(model:)`. See
+[Remote Providers](remote-providers.md).
+
 ### Custom `InferenceProvider`
 
-For non–Foundation Models backends, implement or inject any type that conforms to
-`InferenceProvider` and pass it explicitly (or via `await Swarm.configure(provider:)`):
+For non–Foundation Models / non–OpenAI-compatible backends, implement or inject
+any type that conforms to `InferenceProvider` and pass it explicitly (or via
+`await Swarm.configure(provider:)`):
 
 ```swift
 let agent = try Agent(
@@ -475,13 +497,14 @@ and unmappable schemas stay prompt-instruction + parse (`.promptFallback`).
 | Linux | Ubuntu 22.04+ with Swift 6.2 |
 
 ::: tip
-The default Swarm graph is CI-tested on Ubuntu with Swift 6.2. Apple-only features such as Foundation Models, SwiftData, OSLog, and some built-in tool behavior are unavailable or different on Linux; inject a mock or custom `InferenceProvider` there.
+The default Swarm graph is CI-tested on Ubuntu with Swift 6.2. Apple-only features such as Foundation Models, SwiftData, OSLog, and some built-in tool behavior are unavailable or different on Linux; use ``OpenAICompatibleProvider`` or inject a mock.
 :::
 
 ## Next Steps
 
 - **[Agents](../reference/front-facing-api.md#3-agent-struct-primary-init)** -- Agent types, configuration, tool calling
 - **[Foundation Models](foundation-models.md)** -- Capture vs experimental native session mode
+- **[Remote Providers](remote-providers.md)** -- OpenAI-compatible HTTP (OpenAI, Azure, OpenRouter, Ollama, LM Studio)
 - **[Tools](../reference/front-facing-api.md#5-tool-and-functiontool)** -- `@Tool` macro, `FunctionTool`, `ToolCollection`, and `@ToolBuilder`
 - **[Workflow](../reference/front-facing-api.md#7-workflow)** -- Sequential, parallel, and routed execution
 - **[Memory](../reference/front-facing-api.md#9-memory-factories)** -- Conversation, vector, summary, persistent

--- a/docs/guide/remote-providers.md
+++ b/docs/guide/remote-providers.md
@@ -1,0 +1,140 @@
+# Remote Providers
+
+Swarm's built-in **on-device** path is Apple Foundation Models. When that is
+unavailable — Linux, CI, or a machine without Apple Intelligence — use
+``OpenAICompatibleProvider``. It speaks the OpenAI Chat Completions wire format
+over `URLSession` (no extra package dependencies).
+
+## Privacy
+
+Prompt text, tool schemas, tool results, and structured-output schemas are
+**sent to `baseURL`**. That is the opposite of
+``FoundationModelsInferenceProvider``, which keeps inference on-device when
+Apple Intelligence is available.
+
+Use Foundation Models when the data must stay on the device. Use the
+OpenAI-compatible provider when you need a remote or local HTTP model.
+
+## Configuration
+
+Every host is `baseURL` + optional `apiKey` + `model` + extra headers:
+
+```swift
+import Swarm
+
+let provider: any InferenceProvider = .openAICompatible(
+    baseURL: URL(string: "https://api.openai.com/v1")!,
+    model: "gpt-4o",
+    apiKey: ProcessInfo.processInfo.environment["OPENAI_API_KEY"]
+)
+
+let agent = try Agent("Be helpful.", inferenceProvider: provider)
+```
+
+Convenience factories fill those fields for common hosts.
+
+### OpenAI
+
+```swift
+let provider: any InferenceProvider = .openAICompatible(
+    .openAI(apiKey: "sk-...", model: "gpt-4o")
+)
+```
+
+`baseURL` is `https://api.openai.com/v1`. Auth is `Authorization: Bearer`.
+Structured outputs use native `response_format` (`source: .providerNative`).
+
+### Azure OpenAI
+
+```swift
+let provider: any InferenceProvider = .openAICompatible(
+    .azureOpenAI(
+        resource: "contoso",
+        deployment: "gpt-4o",
+        apiKey: "azure-key",
+        apiVersion: "2024-10-21"
+    )
+)
+```
+
+`baseURL` is `https://{resource}.openai.azure.com/openai/deployments/{deployment}`.
+Auth is the `api-key` header. `api-version` is a query item.
+
+### OpenRouter
+
+```swift
+let provider: any InferenceProvider = .openAICompatible(
+    .openRouter(
+        apiKey: "sk-or-...",
+        model: "openai/gpt-4o-mini",
+        httpHeaders: [
+            "HTTP-Referer": "https://example.com",
+            "X-Title": "Swarm",
+        ]
+    )
+)
+```
+
+`baseURL` is `https://openrouter.ai/api/v1`. Auth is Bearer. Extra headers are
+optional but recommended by OpenRouter.
+
+### Ollama (local)
+
+```swift
+let provider: any InferenceProvider = .openAICompatible(
+    .ollama(model: "llama3.2")
+)
+```
+
+`baseURL` defaults to `http://127.0.0.1:11434/v1`. No API key. Structured
+outputs use labeled prompt-parse fallback (`source: .promptFallback`) because
+Ollama does not reliably honor `response_format.json_schema`.
+
+### LM Studio (local)
+
+```swift
+let provider: any InferenceProvider = .openAICompatible(
+    .lmStudio(model: "local-model")
+)
+```
+
+`baseURL` defaults to `http://127.0.0.1:1234/v1`. API key is optional. Structured
+outputs default to prompt-parse fallback; switch
+``OpenAICompatibleStructuredOutputMode/nativeJSONSchema`` if your build
+supports it.
+
+## When to use which provider
+
+| Provider | Use when | Data leaves the device? |
+|---|---|---|
+| ``FoundationModelsInferenceProvider`` | Apple platforms with Apple Intelligence | No |
+| OpenAI / Azure / OpenRouter | Cloud models, Linux, or no Apple Intelligence | Yes — to that host |
+| Ollama / LM Studio | Local HTTP models, Linux CI, offline labs | Yes — to `localhost` (still HTTP) |
+| Your own `InferenceProvider` | A non–OpenAI-compatible backend | Depends on the implementation |
+
+## Capabilities
+
+The provider implements the conversation seams the agent loop prefers:
+
+- Chat Completions with roles, `tool_calls`, and `tool_call_id`
+- SSE streaming (`data:` lines, `[DONE]`, multi-event deltas)
+- Token usage from `usage.prompt_tokens` / `usage.completion_tokens`
+- W3C `traceparent` / `tracestate` via ``TraceContextHeaders``
+- HTTP errors classified for ``InferenceRetryability`` (429 / 5xx / network
+  retryable; 400 / 401 / 403 not)
+
+## Live Ollama tests
+
+Gated behind `SWARM_OLLAMA_LIVE_TESTS=1`. They are skipped in CI.
+
+```bash
+# Install: https://ollama.com
+ollama pull llama3.2
+ollama serve   # listens on 127.0.0.1:11434
+
+SWARM_OLLAMA_LIVE_TESTS=1 \
+SWARM_OLLAMA_MODEL=llama3.2 \
+swift test --filter OpenAICompatibleOllamaLiveTests
+```
+
+Optional: `SWARM_OLLAMA_BASE_URL` (default `http://127.0.0.1:11434/v1`).

--- a/docs/reference/api-catalog.md
+++ b/docs/reference/api-catalog.md
@@ -1,9 +1,9 @@
 # Swarm Public API Catalog
 
-Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for high-risk public rows on 2026-07-28 (Conduit hard-removed in 0.6). MCP client rows refreshed 2026-08-14.
+Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for high-risk public rows on 2026-07-28 (Conduit hard-removed in 0.6). MCP client rows refreshed 2026-08-14. OpenAI-compatible provider rows added 2026-08-14.
 
 - Scope: all `.swift` files under `Sources/Swarm/`, excluding `Internal/GraphRuntime/`
-- Source files scanned: 169
+- Source files scanned: 174
 - Public/open symbols cataloged: 2495
 
 ## 1. Swarm (entry point)
@@ -2686,6 +2686,22 @@ Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for
 | 69 | func | public | MCPToolBridge.bridgeTools() | `public func bridgeTools() async throws -> [any AnyJSONTool]` |
 
 ## 11. Providers
+
+### Providers/OpenAICompatible/OpenAICompatibleProvider.swift
+
+OpenAI-compatible Chat Completions provider (`URLSession` only). Covers OpenAI, Azure OpenAI, OpenRouter, Ollama, and LM Studio.
+
+| Kind | Access | Name | Signature |
+|------|--------|------|-----------|
+| enum | public | OpenAICompatibleStructuredOutputMode | `public enum OpenAICompatibleStructuredOutputMode` |
+| struct | public | OpenAICompatibleProviderConfiguration | `public struct OpenAICompatibleProviderConfiguration` |
+| func | public | OpenAICompatibleProviderConfiguration.openAI(apiKey:model:) | `public static func openAI(apiKey: String, model: String = "gpt-4o") -> OpenAICompatibleProviderConfiguration` |
+| func | public | OpenAICompatibleProviderConfiguration.azureOpenAI(resource:deployment:apiKey:apiVersion:model:) | `public static func azureOpenAI(resource: String, deployment: String, apiKey: String, apiVersion: String = "2024-10-21", model: String? = nil) -> OpenAICompatibleProviderConfiguration` |
+| func | public | OpenAICompatibleProviderConfiguration.openRouter(apiKey:model:httpHeaders:) | `public static func openRouter(apiKey: String, model: String, httpHeaders: [String: String] = [:]) -> OpenAICompatibleProviderConfiguration` |
+| func | public | OpenAICompatibleProviderConfiguration.ollama(model:baseURL:) | `public static func ollama(model: String, baseURL: URL = URL(string: "http://127.0.0.1:11434/v1")!) -> OpenAICompatibleProviderConfiguration` |
+| func | public | OpenAICompatibleProviderConfiguration.lmStudio(model:baseURL:apiKey:) | `public static func lmStudio(model: String, baseURL: URL = URL(string: "http://127.0.0.1:1234/v1")!, apiKey: String? = nil) -> OpenAICompatibleProviderConfiguration` |
+| struct | public | OpenAICompatibleProvider | `public struct OpenAICompatibleProvider` |
+| func | public | InferenceProvider.openAICompatible(_:) | `public static func openAICompatible(_ configuration: OpenAICompatibleProviderConfiguration, session: URLSession = .shared) -> OpenAICompatibleProvider` |
 
 ### Providers/FoundationModels/FoundationModelsInferenceProvider.swift
 

--- a/docs/reference/front-facing-api.md
+++ b/docs/reference/front-facing-api.md
@@ -538,13 +538,16 @@ public protocol ConversationInferenceProvider: InferenceProvider {
 
 ### Provider factories (dot-syntax)
 
-Built-in inference is Apple Foundation Models only. Custom backends implement
+Built-in inference is Apple Foundation Models (on-device) and
+``OpenAICompatibleProvider`` (remote / local HTTP). Other backends implement
 ``InferenceProvider`` and are passed explicitly (or via
 `await Swarm.configure(provider:)`).
 
 ```swift
 .foundationModels()                 // On-device first-class provider
 .foundationModels(profile: profile) // Dynamic profile re-resolved each turn
+.openAICompatible(.ollama(model: "llama3.2"))
+.openAICompatible(.openAI(apiKey: "sk-...", model: "gpt-4o"))
 // Custom: pass any InferenceProvider value
 ```
 
@@ -552,7 +555,8 @@ Built-in inference is Apple Foundation Models only. Custom backends implement
 |----------------|-------------|-------|
 | `.foundationModels()` | `FoundationModelsInferenceProvider` | Built-in on-device path; native tool calling via Apple's Tool protocol |
 | `.foundationModels(profile:)` | `FoundationModelsInferenceProvider` | Same, driven by Swarm ``DynamicProfile`` (WWDC 2026–aligned; re-resolves each turn) |
-| Custom `InferenceProvider` | your type | Implement the protocol for non-FM backends |
+| `.openAICompatible(_:)` | `OpenAICompatibleProvider` | OpenAI / Azure / OpenRouter / Ollama / LM Studio over Chat Completions; Linux-first |
+| Custom `InferenceProvider` | your type | Implement the protocol for other backends |
 
 Opt in to experimental native session mode with
 ``AgentConfiguration/foundationModelsExecution(_:)``. Capture remains the

--- a/docs/reference/overview.md
+++ b/docs/reference/overview.md
@@ -17,5 +17,6 @@ The current API reference covers the supported public surface for Swarm 0.6.0. P
 | [Resilience](/reference/api-catalog) | Retry, circuit breakers, fallback, timeouts |
 | [Observability](/guide/opentelemetry-tracing) | Tracing, OpenTelemetry, `OSLogTracer`, `SwiftLogTracer`, metrics |
 | [MCP](/reference/api-catalog) | Model Context Protocol client and server |
-| [Providers](/reference/front-facing-api) | Foundation Models, `InferenceProvider`, `MultiProvider` routing |
+| [Providers](/reference/front-facing-api) | Foundation Models, OpenAI-compatible remote, `InferenceProvider`, `MultiProvider` routing |
+| [Remote providers](/guide/remote-providers) | OpenAI / Azure / OpenRouter / Ollama / LM Studio |
 | [Foundation Models modes](/guide/foundation-models) | Capture vs experimental native session |


### PR DESCRIPTION
## Summary

- Add `OpenAICompatibleProvider` in core Swarm (`URLSession` only, zero new dependencies) so agents run without Apple Intelligence — Linux is first-class.
- Chat Completions maps `InferenceMessage` ↔ OpenAI roles / `tool_calls` / `tool_call_id`, streams SSE (including tool-call deltas), and records `TokenUsage` from `usage.prompt_tokens` / `completion_tokens` (`stream_options.include_usage` when streaming).
- Structured outputs honor Chunk I: native `response_format` is labeled `.providerNative`; Ollama/LM Studio use labeled prompt-parse fallback. HTTP errors match Chunk J (429/5xx/network retryable; 400/401/403 not). Every request injects Chunk K `TraceContextHeaders`.

## Endpoint compatibility matrix

| Host | Factory | Auth | Structured outputs | Privacy |
|---|---|---|---|---|
| OpenAI | `.openAICompatible(.openAI(apiKey:model:))` | Bearer | native `response_format` | leaves device |
| Azure OpenAI | `.openAICompatible(.azureOpenAI(...))` | `api-key` + `api-version` | native | leaves device |
| OpenRouter | `.openAICompatible(.openRouter(...))` | Bearer + extra headers | native | leaves device |
| Ollama | `.openAICompatible(.ollama(model:))` | none | prompt-parse fallback | localhost HTTP |
| LM Studio | `.openAICompatible(.lmStudio(model:))` | optional | prompt-parse fallback | localhost HTTP |
| Foundation Models (existing) | `.foundationModels()` | none | native / fallback | on-device |

## Test evidence

- URLProtocol stubs: request shape (messages, tools, stream flags, auth), SSE (multi-event, tool-call deltas, usage, truncated/malformed lines), error mapping + retryability.
- Linux agent-loop proof: `Agent.run` + `Agent.stream` with tools against a fixture (suite `OpenAICompatible`). CI step on the Linux job: `swift test --no-parallel --filter OpenAICompatible`.
- Gated live Ollama tests skipped in CI.

### Live Ollama

```bash
# https://ollama.com — default listen 127.0.0.1:11434
ollama pull llama3.2
ollama serve

SWARM_OLLAMA_LIVE_TESTS=1 \
SWARM_OLLAMA_MODEL=llama3.2 \
swift test --filter OpenAICompatibleOllamaLiveTests
```

Optional: `SWARM_OLLAMA_BASE_URL` (default `http://127.0.0.1:11434/v1`).

## Docs

- README provider section + Linux note
- New [Remote Providers](docs/guide/remote-providers.md) guide (OpenAI / Azure / OpenRouter / Ollama / LM Studio + privacy contrast)
- getting-started, foundation-models, front-facing-api, api-catalog, overview

## Baseline comparison

| Lane | Chunk A / recent | This PR |
|---|---|---|
| `bash scripts/ci/lean-build-test.sh` | Chunk J: **1809 / 235** | **PASS — 1867 tests in 248 suites** |
| `swift test --no-parallel --traits Integrations` | Chunk J: **1953 / 258** | **PASS — 2020 tests in 274 suites** |
| `swift run --traits Integrations SwarmCapabilityShowcase matrix` | all `passed` | **unchanged — all 14 rows `passed`** |
| `swift test --filter OpenAICompatible` | n/a | **24 tests / 5 suites passed** (2 live Ollama skipped) |

Based on `main` after Chunk O (#134) merged. No spill — single session.

## Follow-up (not this chunk)

`URLSession.bytes(for:)` did not deliver `URLProtocol` stub bodies, so streaming parses the complete SSE body via `data(for:)` and yields events in wire order. File an issue if token-by-token socket flush is required.

## Test plan

- [x] `bash scripts/ci/lean-build-test.sh`
- [x] `swift test --no-parallel --traits Integrations`
- [x] `swift run --traits Integrations SwarmCapabilityShowcase matrix`
- [x] `swift test --no-parallel --traits Integrations --filter OpenAICompatible`
- [x] SwiftFormat + SwiftLint clean on changed files
- [ ] Linux CI lane (`filter OpenAICompatible`) on this PR
- [ ] Optional: live Ollama against `llama3.2`


Made with [Cursor](https://cursor.com)