### PR TITLE
fix: keep long OpenAI-compatible SSE streams from dropping tokens

### DIFF
--- a/Sources/Swarm/Providers/OpenAICompatible/OpenAICompatibleProvider.swift
+++ b/Sources/Swarm/Providers/OpenAICompatible/OpenAICompatibleProvider.swift
@@ -139,7 +139,10 @@ public struct OpenAICompatibleProvider: InferenceProvider,
         messages: [InferenceMessage],
         options: InferenceOptions
     ) -> AsyncThrowingStream<String, Error> {
-        StreamHelper.makeTrackedStream { continuation in
+        // Unbounded: `streamCompletions` already holds the full SSE body and
+        // yields every event before the consumer may start iterating. A
+        // newest-100 buffer would drop the oldest tokens on long replies.
+        StreamHelper.makeTrackedStream(bufferingPolicy: .unbounded) { continuation in
             do {
                 for try await update in self.streamWithToolCalls(
                     messages: messages,
@@ -162,7 +165,7 @@ public struct OpenAICompatibleProvider: InferenceProvider,
         tools: [ToolSchema],
         options: InferenceOptions
     ) -> AsyncThrowingStream<InferenceStreamUpdate, Error> {
-        StreamHelper.makeTrackedStream { continuation in
+        StreamHelper.makeTrackedStream(bufferingPolicy: .unbounded) { continuation in
             do {
                 try await self.streamCompletions(
                     messages: messages,

--- a/Tests/SwarmTests/Providers/OpenAICompatibleProviderTests.swift
+++ b/Tests/SwarmTests/Providers/OpenAICompatibleProviderTests.swift
@@ -136,6 +136,51 @@ struct OpenAICompatibleProviderTests {
         #expect(streamOptions["include_usage"] as? Bool == true)
     }
 
+    @Test("Streaming a body larger than the default newest-100 buffer keeps every chunk")
+    func streamingLongSSEDoesNotDropOldestChunks() async throws {
+        OpenAICompatibleURLProtocol.reset()
+        defer { OpenAICompatibleURLProtocol.reset() }
+
+        let expected = (0 ..< 150).map { "c\($0)" }
+        var sse = expected.map { chunk in
+            #"data: {"choices":[{"delta":{"content":"\#(chunk)"}}]}"#
+        }.joined(separator: "\n\n")
+        sse += "\n\ndata: [DONE]\n\n"
+        OpenAICompatibleURLProtocol.enqueueSSE(sse)
+
+        let provider = OpenAICompatibleProvider(
+            configuration: .init(baseURL: endpoint, apiKey: "sk-test", model: "gpt-test"),
+            session: OpenAICompatibleURLProtocol.makeSession()
+        )
+
+        // The producer Task starts when the stream is created and dumps the
+        // already-downloaded SSE body. Delay iteration so a newest-100 buffer
+        // would drop the oldest chunks before the consumer starts.
+        let textStream = provider.stream(messages: [.user("Hi")], options: .default)
+        try await Task.sleep(for: .milliseconds(20))
+        var streamChunks: [String] = []
+        for try await chunk in textStream {
+            streamChunks.append(chunk)
+        }
+        #expect(streamChunks == expected)
+
+        OpenAICompatibleURLProtocol.reset()
+        OpenAICompatibleURLProtocol.enqueueSSE(sse)
+        let toolStream = provider.streamWithToolCalls(
+            messages: [.user("Hi")],
+            tools: [],
+            options: .default
+        )
+        try await Task.sleep(for: .milliseconds(20))
+        var toolStreamChunks: [String] = []
+        for try await update in toolStream {
+            if case let .outputChunk(text) = update {
+                toolStreamChunks.append(text)
+            }
+        }
+        #expect(toolStreamChunks == expected)
+    }
+
     @Test("Injects current W3C trace-context headers")
     func injectsTraceContextHeaders() async throws {
         OpenAICompatibleURLProtocol.reset()


### PR DESCRIPTION
## Summary
- Bugbot on the OpenAI-compatible provider: `streamCompletions` replays a completed SSE body into `StreamHelper.makeTrackedStream`'s default `bufferingNewest(100)`, so replies with more than 100 events dropped the oldest tokens while appearing to succeed.
- Both `stream` and `streamWithToolCalls` now use `.unbounded`, matching `Agent` / `Workflow` for event streams that must not drop under backpressure.
- Regression test delays consumption until the producer has dumped 150 chunks, then asserts every token arrives on both stream APIs.

## Test plan
- [x] `swift test --no-parallel --traits Integrations --filter OpenAICompatible` — 28 tests / 5 suites passed (2 live Ollama skipped)
- [x] SwiftFormat + SwiftLint `--strict` clean on changed files


Made with [Cursor](https://cursor.com)