### PR TITLE
release: bump version to 0.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ HiveCore, Membrane, and ContextCore are **native in-tree** `Sources/` targets (i
 
 ```swift
 // Lean default link (recommended for most apps). Macros are on by default.
-.package(url: "https://github.com/christopherkarani/Swarm.git", from: "0.6.0")
+.package(url: "https://github.com/christopherkarani/Swarm.git", from: "0.6.2")
 
 // Full integrations: durable Hive workflows, ContextCore+Wax default memory,
 // Membrane adapters, and web helpers. Integrations also enables Macros.
 .package(
     url: "https://github.com/christopherkarani/Swarm.git",
-    from: "0.6.0",
+    from: "0.6.2",
     traits: ["Integrations"]
 )
 
@@ -50,7 +50,7 @@ HiveCore, Membrane, and ContextCore are **native in-tree** `Sources/` targets (i
 // and @Traceable — use FunctionTool instead.
 .package(
     url: "https://github.com/christopherkarani/Swarm.git",
-    from: "0.6.0",
+    from: "0.6.2",
     traits: []
 )
 ```

--- a/Sources/Swarm/Swarm.swift
+++ b/Sources/Swarm/Swarm.swift
@@ -41,7 +41,7 @@
 ///
 public enum Swarm {
     /// The current version of the Swarm framework.
-    public static let version = "0.6.0"
+    public static let version = "0.6.2"
 
     /// The minimum macOS platform version required by Swarm.
     public static let minimumMacOSVersion = "26.0"

--- a/Tests/SwarmTests/DocumentationFreshnessTests.swift
+++ b/Tests/SwarmTests/DocumentationFreshnessTests.swift
@@ -150,7 +150,7 @@ struct DocumentationFreshnessTests {
         for file in checkedFiles {
             let text = try readRepoFile(file)
             #expect(text.contains(expectedVersion), "\(file) should mention \(expectedVersion)")
-            #expect(!text.contains("0.6.1"), "\(file) should not advertise unreleased 0.6.1")
+            #expect(!text.contains("0.6.3"), "\(file) should not advertise unreleased 0.6.3")
         }
     }
 

--- a/Tests/SwarmTests/V2SurfaceAuditTests.swift
+++ b/Tests/SwarmTests/V2SurfaceAuditTests.swift
@@ -22,9 +22,9 @@ struct V2SurfaceAuditTests {
 
     // MARK: - Version
 
-    @Test("Swarm.version is 0.6.0")
+    @Test("Swarm.version is 0.6.2")
     func versionIsV2() {
-        #expect(Swarm.version == "0.6.0")
+        #expect(Swarm.version == "0.6.2")
     }
 
     // MARK: - TokenUsage (module-level, not nested)

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -11,7 +11,7 @@ Add Swarm to your `Package.swift`:
 ```swift
 // Lean default (core + Foundation Models). No Integrations trait.
 dependencies: [
-    .package(url: "https://github.com/christopherkarani/Swarm.git", from: "0.6.0")
+    .package(url: "https://github.com/christopherkarani/Swarm.git", from: "0.6.2")
 ],
 targets: [
     .target(name: "YourApp", dependencies: ["Swarm"])
@@ -35,7 +35,7 @@ Enable Integrations when you need any of:
 ```swift
 .package(
     url: "https://github.com/christopherkarani/Swarm.git",
-    from: "0.6.0",
+    from: "0.6.2",
     traits: ["Integrations"]
 )
 ```
@@ -77,7 +77,7 @@ keeps macros (Integrations enables Macros). To drop `swift-syntax` entirely:
 ```swift
 .package(
     url: "https://github.com/christopherkarani/Swarm.git",
-    from: "0.6.0",
+    from: "0.6.2",
     traits: []
 )
 ```

--- a/docs/guide/opentelemetry-tracing.md
+++ b/docs/guide/opentelemetry-tracing.md
@@ -21,10 +21,10 @@ inside those turns:
 ## Add the Package Product
 
 If your app already configures OpenTelemetry, add `SwarmOpenTelemetry` to the
-target that creates agents. Swarm `0.6.0` is the current published tag:
+target that creates agents. Swarm `0.6.2` is the current published tag:
 
 ```swift
-.package(url: "https://github.com/christopherkarani/Swarm.git", from: "0.6.0")
+.package(url: "https://github.com/christopherkarani/Swarm.git", from: "0.6.2")
 
 .target(
     name: "YourApp",

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,7 +54,7 @@ features:
 ## Install
 
 ```swift
-.package(url: "https://github.com/christopherkarani/Swarm.git", from: "0.6.0")
+.package(url: "https://github.com/christopherkarani/Swarm.git", from: "0.6.2")
 ```
 
 ## Quick Start

--- a/docs/reference/front-facing-api.md
+++ b/docs/reference/front-facing-api.md
@@ -11,7 +11,7 @@ memory, Membrane adapters, and web helpers:
 ```swift
 .package(
     url: "https://github.com/christopherkarani/Swarm.git",
-    from: "0.6.0",
+    from: "0.6.2",
     traits: ["Integrations"]
 )
 ```

--- a/docs/reference/overview.md
+++ b/docs/reference/overview.md
@@ -1,6 +1,6 @@
 # API Reference
 
-The current API reference covers the supported public surface for Swarm 0.6.0. Prefer the front-facing API page for user-facing examples and the API catalog for source-derived symbol lookup.
+The current API reference covers the supported public surface for Swarm 0.6.2. Prefer the front-facing API page for user-facing examples and the API catalog for source-derived symbol lookup.
 
 ## By Topic
 


### PR DESCRIPTION
## Summary
- Bump `Swarm.version` and public package pins from 0.6.0 to 0.6.2 so the next GitHub tag matches the advertised version.
- Update the documentation freshness guard so it rejects unreleased 0.6.3 instead of 0.6.1.

## Test plan
- [x] Version strings updated in Swarm.swift, README, getting-started, overview, front-facing-api, OpenTelemetry guide, and V2 surface audit
- [ ] Tag `0.6.2` on the merge commit and publish the GitHub release after merge


Made with [Cursor](https://cursor.com)