### PR TITLE
Make GuardrailResult a closed enum

### DIFF
--- a/Sources/Swarm/Core/RunHooks.swift
+++ b/Sources/Swarm/Core/RunHooks.swift
@@ -559,7 +559,12 @@ public struct LoggingObserver: AgentObserver {
         } else {
             ""
         }
-        let message = result.message ?? "No message provided"
+        let message = switch result {
+        case let .passed(message, _, _):
+            message ?? "No message provided"
+        case let .tripwire(message, _, _):
+            message
+        }
         Log.agents.warning("Guardrail triggered\(contextId) - name: \(guardrailName), type: \(guardrailType.rawValue), message: \(message)")
     }
 

--- a/Sources/Swarm/Guardrails/GuardrailError.swift
+++ b/Sources/Swarm/Guardrails/GuardrailError.swift
@@ -14,13 +14,13 @@ public enum GuardrailError: Error, Sendable, LocalizedError, Equatable {
     public var errorDescription: String? {
         switch self {
         case let .inputTripwireTriggered(name, message, _):
-            "Input guardrail '\(name)' tripwire triggered: \(message ?? "No message")"
+            "Input guardrail '\(name)' tripwire triggered: \(message)"
         case let .outputTripwireTriggered(name, agentName, message, _):
-            "Output guardrail '\(name)' tripwire triggered for agent '\(agentName)': \(message ?? "No message")"
+            "Output guardrail '\(name)' tripwire triggered for agent '\(agentName)': \(message)"
         case let .toolInputTripwireTriggered(name, toolName, message, _):
-            "Tool input guardrail '\(name)' tripwire triggered for tool '\(toolName)': \(message ?? "No message")"
+            "Tool input guardrail '\(name)' tripwire triggered for tool '\(toolName)': \(message)"
         case let .toolOutputTripwireTriggered(name, toolName, message, _):
-            "Tool output guardrail '\(name)' tripwire triggered for tool '\(toolName)': \(message ?? "No message")"
+            "Tool output guardrail '\(name)' tripwire triggered for tool '\(toolName)': \(message)"
         case let .executionFailed(name, error):
             "Guardrail '\(name)' execution failed: \(error)"
         }
@@ -29,7 +29,7 @@ public enum GuardrailError: Error, Sendable, LocalizedError, Equatable {
     /// Input guardrail tripwire was triggered
     case inputTripwireTriggered(
         guardrailName: String,
-        message: String?,
+        message: String,
         outputInfo: SendableValue?
     )
 
@@ -37,7 +37,7 @@ public enum GuardrailError: Error, Sendable, LocalizedError, Equatable {
     case outputTripwireTriggered(
         guardrailName: String,
         agentName: String,
-        message: String?,
+        message: String,
         outputInfo: SendableValue?
     )
 
@@ -45,7 +45,7 @@ public enum GuardrailError: Error, Sendable, LocalizedError, Equatable {
     case toolInputTripwireTriggered(
         guardrailName: String,
         toolName: String,
-        message: String?,
+        message: String,
         outputInfo: SendableValue?
     )
 
@@ -53,7 +53,7 @@ public enum GuardrailError: Error, Sendable, LocalizedError, Equatable {
     case toolOutputTripwireTriggered(
         guardrailName: String,
         toolName: String,
-        message: String?,
+        message: String,
         outputInfo: SendableValue?
     )
 

--- a/Sources/Swarm/Guardrails/GuardrailResult.swift
+++ b/Sources/Swarm/Guardrails/GuardrailResult.swift
@@ -10,44 +10,24 @@ import Foundation
 
 /// The result of a guardrail validation check.
 ///
-/// `GuardrailResult` encapsulates the outcome of a guardrail check, indicating whether
-/// validation passed or a tripwire was triggered. Use the static factory methods to create results:
+/// `GuardrailResult` is a closed outcome: validation either passed or a tripwire
+/// fired. Construct values with the enum cases (the historical factory names):
 ///
-/// | Method | Purpose | Tripwire Triggered |
-/// |--------|---------|-------------------|
+/// | Case | Purpose | Tripwire |
+/// |------|---------|----------|
 /// | ``passed(message:outputInfo:metadata:)`` | Validation succeeded | `false` |
 /// | ``tripwire(message:outputInfo:metadata:)`` | Validation failed | `true` |
 ///
+/// A tripwire always carries a ``message``. Compatibility accessors
+/// (``tripwireTriggered``, ``message``, ``outputInfo``, ``metadata``) preserve
+/// the previous stored-property surface for runners, observers, and tests.
+///
 /// ## Creating Results
 ///
-/// ### Passed Results
-///
-/// Use ``passed(message:outputInfo:metadata:)`` for successful validations:
-///
 /// ```swift
-/// // Simple pass
 /// return .passed()
-///
-/// // Pass with message
 /// return .passed(message: "Input validation successful")
-///
-/// // Pass with diagnostic info
-/// return .passed(
-///     message: "Content approved",
-///     outputInfo: .dictionary(["category": .string("safe")]),
-///     metadata: ["tokensChecked": .int(42)]
-/// )
-/// ```
-///
-/// ### Tripwire Results
-///
-/// Use ``tripwire(message:outputInfo:metadata:)`` when validation fails:
-///
-/// ```swift
-/// // Simple tripwire
 /// return .tripwire(message: "Sensitive data detected")
-///
-/// // Tripwire with detailed info
 /// return .tripwire(
 ///     message: "PII detected in input",
 ///     outputInfo: .dictionary([
@@ -61,274 +41,96 @@ import Foundation
 /// )
 /// ```
 ///
-/// ## Understanding Fields
-///
-/// ### `tripwireTriggered`
-///
-/// The primary indicator of validation result:
-/// - `false`: Validation passed, processing continues
-/// - `true`: Validation failed, ``GuardrailError`` is thrown
-///
-/// ### `message`
-///
-/// A human-readable description of the result. For tripwires, this becomes the
-/// error message in ``GuardrailError``.
-///
-/// ### `outputInfo`
-///
-/// Structured diagnostic information about what was validated or what violation
-/// was detected. This is typed as ``SendableValue`` for flexibility.
-///
-/// ```swift
-/// // For PII detection
-/// outputInfo: .dictionary([
-///     "type": .string("EMAIL"),
-///     "count": .int(2),
-///     "positions": .array([.int(10), .int(50)])
-/// ])
-///
-/// // For content classification
-/// outputInfo: .dictionary([
-///     "category": .string("safe"),
-///     "confidence": .double(0.98)
-/// ])
-/// ```
-///
-/// ### `metadata`
-///
-/// Operational data about the guardrail execution itself:
-///
-/// ```swift
-/// metadata: [
-///     "executionTimeMs": .double(42.5),
-///     "modelVersion": .string("v2.1"),
-///     "cacheHit": .bool(true),
-///     "tokensProcessed": .int(150)
-/// ]
-/// ```
-///
-/// ## Complete Example
-///
-/// ```swift
-/// struct ContentModerationGuardrail: InputGuardrail {
-///     let name = "ContentModeration"
-///
-///     func validate(_ input: String, context: AgentContext?) async -> GuardrailResult {
-///         let startTime = Date()
-///
-///         // Perform moderation check
-///         let result = await moderationService.check(input)
-///
-///         let executionTime = Date().timeIntervalSince(startTime) * 1000
-///
-///         if result.isFlagged {
-///             return .tripwire(
-///                 message: "Content violates usage policy",
-///                 outputInfo: .dictionary([
-///                     "categories": .array(result.categories.map { .string($0) }),
-///                     "scores": .dictionary(result.scores.mapValues { .double($0) })
-///                 ]),
-///                 metadata: [
-///                     "executionTimeMs": .double(executionTime),
-///                     "model": .string("moderation-v1")
-///                 ]
-///             )
-///         }
-///
-///         return .passed(
-///             message: "Content is safe",
-///             outputInfo: .dictionary(["safetyScore": .double(result.safetyScore)]),
-///             metadata: [
-///                 "executionTimeMs": .double(executionTime),
-///                 "tokensChecked": .int(input.count)
-///             ]
-///         )
-///     }
-/// }
-/// ```
-///
-/// ## Handling Results
-///
-/// When running guardrails directly:
-///
-/// ```swift
-/// let guardrail = SensitiveDataGuardrail()
-/// let result = try await guardrail.validate(userInput, context: context)
-///
-/// if result.tripwireTriggered {
-///     print("Blocked: \(result.message ?? "Unknown reason")")
-///     if let info = result.outputInfo {
-///         print("Details: \(info)")
-///     }
-/// } else {
-///     print("Passed: \(result.message ?? "OK")")
-/// }
-/// ```
-///
 /// - SeeAlso: ``InputGuardrail``, ``OutputGuardrail``, ``GuardrailError``
-public struct GuardrailResult: Sendable, Equatable {
-    /// Indicates whether a tripwire was triggered during the check.
-    ///
-    /// `true` if the guardrail blocked the input/output, `false` if it passed.
-    /// This is the primary indicator of validation success or failure.
-    public let tripwireTriggered: Bool
-
-    /// Optional diagnostic information about what was detected or validated.
-    ///
-    /// Use this to provide structured data about the validation result:
-    /// - For tripwires: Details about what triggered the violation (e.g., detected patterns, PII types)
-    /// - For passes: Optional summary of what was checked
-    ///
-    /// The value is typed as ``SendableValue`` to support various data structures
-    /// while maintaining `Sendable` conformance.
-    ///
-    /// Example:
-    /// ```swift
-    /// // For a PII detection tripwire
-    /// outputInfo: .dictionary([
-    ///     "violationType": .string("PII_DETECTED"),
-    ///     "patterns": .array([.string("SSN"), .string("email")]),
-    ///     "positions": .array([.int(10), .int(45)])
-    /// ])
-    ///
-    /// // For a content classification pass
-    /// outputInfo: .dictionary([
-    ///     "category": .string("general"),
-    ///     "confidence": .double(0.95)
-    /// ])
-    /// ```
-    public let outputInfo: SendableValue?
-
-    /// Optional human-readable message describing the result.
-    ///
-    /// For tripwire results, this message is included in the thrown ``GuardrailError``.
-    /// For passed results, this can be used for logging or debugging.
-    ///
-    /// Example messages:
-    /// - `"Input contains sensitive data"`
-    /// - `"Content passed safety check"`
-    /// - `"Output exceeds maximum length of 1000 characters"`
-    public let message: String?
-
-    /// Additional metadata about the guardrail execution.
-    ///
-    /// Use this for operational/diagnostic data about the guardrail execution itself:
-    /// - Execution time
-    /// - Model version used
-    /// - Confidence scores
-    /// - Cache hits
-    /// - Tokens processed
-    ///
-    /// This metadata is useful for monitoring, debugging, and optimizing guardrail performance.
-    ///
-    /// Example:
-    /// ```swift
-    /// metadata: [
-    ///     "executionTimeMs": .double(42.5),
-    ///     "modelVersion": .string("v2.1"),
-    ///     "cacheHit": .bool(true),
-    ///     "tokensProcessed": .int(150)
-    /// ]
-    /// ```
-    public let metadata: [String: SendableValue]
-
-    // MARK: - Initializer
-
-    /// Creates a guardrail result with all properties.
-    ///
-    /// Generally, you should use the static factory methods ``passed(message:outputInfo:metadata:)``
-    /// or ``tripwire(message:outputInfo:metadata:)`` instead of this initializer.
+public enum GuardrailResult: Sendable, Equatable {
+    /// Validation succeeded; processing continues.
     ///
     /// - Parameters:
-    ///   - tripwireTriggered: Whether a tripwire was triggered.
-    ///   - outputInfo: Optional diagnostic information.
-    ///   - message: Optional descriptive message.
-    ///   - metadata: Additional metadata about the check.
+    ///   - message: Optional description of what passed.
+    ///   - outputInfo: Optional structured diagnostics about what was checked.
+    ///   - metadata: Operational data about the check (timing, model version, cache).
+    case passed(
+        message: String? = nil,
+        outputInfo: SendableValue? = nil,
+        metadata: [String: SendableValue] = [:]
+    )
+
+    /// Validation failed; the runner converts this to a ``GuardrailError``.
+    ///
+    /// - Parameters:
+    ///   - message: Required description of the tripwire. Included in ``GuardrailError``.
+    ///   - outputInfo: Optional structured diagnostics about the violation.
+    ///   - metadata: Operational data about the check.
+    case tripwire(
+        message: String,
+        outputInfo: SendableValue? = nil,
+        metadata: [String: SendableValue] = [:]
+    )
+
+    /// Indicates whether a tripwire was triggered during the check.
+    public var tripwireTriggered: Bool {
+        switch self {
+        case .passed:
+            false
+        case .tripwire:
+            true
+        }
+    }
+
+    /// Diagnostic information about what was validated or what violation was detected.
+    public var outputInfo: SendableValue? {
+        switch self {
+        case let .passed(_, outputInfo, _), let .tripwire(_, outputInfo, _):
+            outputInfo
+        }
+    }
+
+    /// Human-readable description of the result.
+    ///
+    /// For tripwires this is always non-nil (the associated ``tripwire(message:outputInfo:metadata:)``
+    /// message). For passes it matches the optional associated message.
+    public var message: String? {
+        switch self {
+        case let .passed(message, _, _):
+            message
+        case let .tripwire(message, _, _):
+            message
+        }
+    }
+
+    /// Operational metadata about the guardrail execution itself.
+    public var metadata: [String: SendableValue] {
+        switch self {
+        case let .passed(_, _, metadata), let .tripwire(_, _, metadata):
+            metadata
+        }
+    }
+
+    /// Creates a result from the historical boolean stored-property shape.
+    ///
+    /// Prefer ``passed(message:outputInfo:metadata:)`` or
+    /// ``tripwire(message:outputInfo:metadata:)``. A tripwire with a nil message
+    /// is stored as `"Tripwire triggered"`.
+    @available(*, deprecated, message: "Use GuardrailResult.passed(...) or .tripwire(message:)")
     public init(
         tripwireTriggered: Bool,
         outputInfo: SendableValue? = nil,
         message: String? = nil,
         metadata: [String: SendableValue] = [:]
     ) {
-        self.tripwireTriggered = tripwireTriggered
-        self.outputInfo = outputInfo
-        self.message = message
-        self.metadata = metadata
-    }
-
-    // MARK: - Factory Methods
-
-    /// Creates a result indicating the check passed successfully.
-    ///
-    /// Use this method when validation succeeds and the input/output should be allowed.
-    ///
-    /// - Parameters:
-    ///   - message: Optional message describing what passed. Example: `"Content is safe"`
-    ///   - outputInfo: Optional diagnostic information about what was checked.
-    ///   - metadata: Additional metadata about the check execution.
-    /// - Returns: A result with `tripwireTriggered = false`.
-    ///
-    /// Example:
-    /// ```swift
-    /// return .passed()
-    ///
-    /// return .passed(message: "Validation successful")
-    ///
-    /// return .passed(
-    ///     message: "No PII detected",
-    ///     outputInfo: .dictionary(["scanType": .string("PII")]),
-    ///     metadata: ["durationMs": .double(15.2)]
-    /// )
-    /// ```
-    public static func passed(
-        message: String? = nil,
-        outputInfo: SendableValue? = nil,
-        metadata: [String: SendableValue] = [:]
-    ) -> GuardrailResult {
-        GuardrailResult(
-            tripwireTriggered: false,
-            outputInfo: outputInfo,
-            message: message,
-            metadata: metadata
-        )
-    }
-
-    /// Creates a result indicating a tripwire was triggered.
-    ///
-    /// Use this method when validation fails and the input/output should be blocked.
-    /// The runner will convert this to a ``GuardrailError`` and throw it.
-    ///
-    /// - Parameters:
-    ///   - message: **Required** description of why the tripwire was triggered.
-    ///              This becomes the error message in ``GuardrailError``.
-    ///   - outputInfo: Optional diagnostic information about the violation.
-    ///   - metadata: Additional metadata about the check execution.
-    /// - Returns: A result with `tripwireTriggered = true`.
-    ///
-    /// Example:
-    /// ```swift
-    /// return .tripwire(message: "Sensitive data detected")
-    ///
-    /// return .tripwire(
-    ///     message: "PII detected in output",
-    ///     outputInfo: .dictionary([
-    ///         "type": .string("EMAIL"),
-    ///         "value": .string("user@example.com")
-    ///     ]),
-    ///     metadata: ["detectionConfidence": .double(0.98)]
-    /// )
-    /// ```
-    public static func tripwire(
-        message: String,
-        outputInfo: SendableValue? = nil,
-        metadata: [String: SendableValue] = [:]
-    ) -> GuardrailResult {
-        GuardrailResult(
-            tripwireTriggered: true,
-            outputInfo: outputInfo,
-            message: message,
-            metadata: metadata
-        )
+        if tripwireTriggered {
+            self = .tripwire(
+                message: message ?? "Tripwire triggered",
+                outputInfo: outputInfo,
+                metadata: metadata
+            )
+        } else {
+            self = .passed(
+                message: message,
+                outputInfo: outputInfo,
+                metadata: metadata
+            )
+        }
     }
 }
 
@@ -336,23 +138,17 @@ public struct GuardrailResult: Sendable, Equatable {
 
 extension GuardrailResult: CustomDebugStringConvertible {
     public var debugDescription: String {
-        var components: [String] = []
-
-        components.append("GuardrailResult(")
+        var components: [String] = ["GuardrailResult("]
         components.append("tripwireTriggered: \(tripwireTriggered)")
-
         if let message {
             components.append("message: \"\(message)\"")
         }
-
         if let outputInfo {
             components.append("outputInfo: \(outputInfo.debugDescription)")
         }
-
         if !metadata.isEmpty {
             components.append("metadata: \(metadata)")
         }
-
         return components.joined(separator: ", ") + ")"
     }
 }

--- a/Sources/Swarm/Guardrails/GuardrailRunner.swift
+++ b/Sources/Swarm/Guardrails/GuardrailRunner.swift
@@ -115,12 +115,22 @@ public struct GuardrailExecutionResult: Sendable, Equatable {
 
     /// Whether this execution triggered a tripwire.
     public var didTriggerTripwire: Bool {
-        result.tripwireTriggered
+        switch result {
+        case .passed:
+            false
+        case .tripwire:
+            true
+        }
     }
 
     /// Whether this execution passed without triggering.
     public var passed: Bool {
-        !result.tripwireTriggered
+        switch result {
+        case .passed:
+            true
+        case .tripwire:
+            false
+        }
     }
 
     // MARK: - Initialization
@@ -261,13 +271,87 @@ public actor GuardrailRunner {
         result: GuardrailResult,
         context: AgentContext?
     ) async {
-        guard result.tripwireTriggered else { return }
-        await observer?.onGuardrailTriggered(
-            context: context,
-            guardrailName: guardrailName,
-            guardrailType: guardrailType,
-            result: result
-        )
+        switch result {
+        case .passed:
+            return
+        case .tripwire:
+            await observer?.onGuardrailTriggered(
+                context: context,
+                guardrailName: guardrailName,
+                guardrailType: guardrailType,
+                result: result
+            )
+        }
+    }
+
+    private func inputTripwireError(
+        guardrailName: String,
+        result: GuardrailResult
+    ) -> GuardrailError? {
+        switch result {
+        case .passed:
+            nil
+        case let .tripwire(message, outputInfo, _):
+            .inputTripwireTriggered(
+                guardrailName: guardrailName,
+                message: message,
+                outputInfo: outputInfo
+            )
+        }
+    }
+
+    private func outputTripwireError(
+        guardrailName: String,
+        agentName: String,
+        result: GuardrailResult
+    ) -> GuardrailError? {
+        switch result {
+        case .passed:
+            nil
+        case let .tripwire(message, outputInfo, _):
+            .outputTripwireTriggered(
+                guardrailName: guardrailName,
+                agentName: agentName,
+                message: message,
+                outputInfo: outputInfo
+            )
+        }
+    }
+
+    private func toolInputTripwireError(
+        guardrailName: String,
+        toolName: String,
+        result: GuardrailResult
+    ) -> GuardrailError? {
+        switch result {
+        case .passed:
+            nil
+        case let .tripwire(message, outputInfo, _):
+            .toolInputTripwireTriggered(
+                guardrailName: guardrailName,
+                toolName: toolName,
+                message: message,
+                outputInfo: outputInfo
+            )
+        }
+    }
+
+    private func toolOutputTripwireError(
+        guardrailName: String,
+        toolName: String,
+        result: GuardrailResult
+    ) -> GuardrailError? {
+        switch result {
+        case .passed:
+            nil
+        case let .tripwire(message, outputInfo, _):
+            .toolOutputTripwireTriggered(
+                guardrailName: guardrailName,
+                toolName: toolName,
+                message: message,
+                outputInfo: outputInfo
+            )
+        }
     }
 
     private func validateWithTimeout<Result: Sendable>(
@@ -444,22 +528,16 @@ extension GuardrailRunner {
                 )
                 results.append(executionResult)
 
-                // Emit guardrail event if tripwire triggered
-                if result.tripwireTriggered {
+                if let error = inputTripwireError(guardrailName: guardrail.name, result: result) {
                     await emitGuardrailEvent(
                         guardrailName: guardrail.name,
                         guardrailType: .input,
                         result: result,
                         context: context
                     )
-                }
-
-                if result.tripwireTriggered, configuration.stopOnFirstTripwire {
-                    throw GuardrailError.inputTripwireTriggered(
-                        guardrailName: guardrail.name,
-                        message: result.message,
-                        outputInfo: result.outputInfo
-                    )
+                    if configuration.stopOnFirstTripwire {
+                        throw error
+                    }
                 }
             } catch let error as GuardrailError {
                 throw error
@@ -472,12 +550,12 @@ extension GuardrailRunner {
         }
 
         // Check if any tripwires were triggered (when not stopping on first)
-        if let tripwiredResult = results.first(where: { $0.result.tripwireTriggered }) {
-            throw GuardrailError.inputTripwireTriggered(
-                guardrailName: tripwiredResult.guardrailName,
-                message: tripwiredResult.result.message,
-                outputInfo: tripwiredResult.result.outputInfo
-            )
+        if let tripwiredResult = results.first(where: \.didTriggerTripwire),
+           let error = inputTripwireError(
+               guardrailName: tripwiredResult.guardrailName,
+               result: tripwiredResult.result
+           ) {
+            throw error
         }
 
         return results
@@ -504,23 +582,20 @@ extension GuardrailRunner {
                 )
                 results.append(executionResult)
 
-                // Emit guardrail event if tripwire triggered
-                if result.tripwireTriggered {
+                if let error = outputTripwireError(
+                    guardrailName: guardrail.name,
+                    agentName: agent.configuration.name,
+                    result: result
+                ) {
                     await emitGuardrailEvent(
                         guardrailName: guardrail.name,
                         guardrailType: .output,
                         result: result,
                         context: context
                     )
-                }
-
-                if result.tripwireTriggered, configuration.stopOnFirstTripwire {
-                    throw GuardrailError.outputTripwireTriggered(
-                        guardrailName: guardrail.name,
-                        agentName: agent.configuration.name,
-                        message: result.message,
-                        outputInfo: result.outputInfo
-                    )
+                    if configuration.stopOnFirstTripwire {
+                        throw error
+                    }
                 }
             } catch let error as GuardrailError {
                 throw error
@@ -533,13 +608,13 @@ extension GuardrailRunner {
         }
 
         // Check if any tripwires were triggered (when not stopping on first)
-        if let tripwiredResult = results.first(where: { $0.result.tripwireTriggered }) {
-            throw GuardrailError.outputTripwireTriggered(
-                guardrailName: tripwiredResult.guardrailName,
-                agentName: agent.configuration.name,
-                message: tripwiredResult.result.message,
-                outputInfo: tripwiredResult.result.outputInfo
-            )
+        if let tripwiredResult = results.first(where: \.didTriggerTripwire),
+           let error = outputTripwireError(
+               guardrailName: tripwiredResult.guardrailName,
+               agentName: agent.configuration.name,
+               result: tripwiredResult.result
+           ) {
+            throw error
         }
 
         return results
@@ -564,23 +639,20 @@ extension GuardrailRunner {
                 )
                 results.append(executionResult)
 
-                // Emit guardrail event if tripwire triggered
-                if result.tripwireTriggered {
+                if let error = toolInputTripwireError(
+                    guardrailName: guardrail.name,
+                    toolName: data.tool.name,
+                    result: result
+                ) {
                     await emitGuardrailEvent(
                         guardrailName: guardrail.name,
                         guardrailType: .toolInput,
                         result: result,
                         context: data.context
                     )
-                }
-
-                if result.tripwireTriggered, configuration.stopOnFirstTripwire {
-                    throw GuardrailError.toolInputTripwireTriggered(
-                        guardrailName: guardrail.name,
-                        toolName: data.tool.name,
-                        message: result.message,
-                        outputInfo: result.outputInfo
-                    )
+                    if configuration.stopOnFirstTripwire {
+                        throw error
+                    }
                 }
             } catch let error as GuardrailError {
                 throw error
@@ -593,13 +665,13 @@ extension GuardrailRunner {
         }
 
         // Check if any tripwires were triggered (when not stopping on first)
-        if let tripwiredResult = results.first(where: { $0.result.tripwireTriggered }) {
-            throw GuardrailError.toolInputTripwireTriggered(
-                guardrailName: tripwiredResult.guardrailName,
-                toolName: data.tool.name,
-                message: tripwiredResult.result.message,
-                outputInfo: tripwiredResult.result.outputInfo
-            )
+        if let tripwiredResult = results.first(where: \.didTriggerTripwire),
+           let error = toolInputTripwireError(
+               guardrailName: tripwiredResult.guardrailName,
+               toolName: data.tool.name,
+               result: tripwiredResult.result
+           ) {
+            throw error
         }
 
         return results
@@ -625,23 +697,20 @@ extension GuardrailRunner {
                 )
                 results.append(executionResult)
 
-                // Emit guardrail event if tripwire triggered
-                if result.tripwireTriggered {
+                if let error = toolOutputTripwireError(
+                    guardrailName: guardrail.name,
+                    toolName: data.tool.name,
+                    result: result
+                ) {
                     await emitGuardrailEvent(
                         guardrailName: guardrail.name,
                         guardrailType: .toolOutput,
                         result: result,
                         context: data.context
                     )
-                }
-
-                if result.tripwireTriggered, configuration.stopOnFirstTripwire {
-                    throw GuardrailError.toolOutputTripwireTriggered(
-                        guardrailName: guardrail.name,
-                        toolName: data.tool.name,
-                        message: result.message,
-                        outputInfo: result.outputInfo
-                    )
+                    if configuration.stopOnFirstTripwire {
+                        throw error
+                    }
                 }
             } catch let error as GuardrailError {
                 throw error
@@ -654,13 +723,13 @@ extension GuardrailRunner {
         }
 
         // Check if any tripwires were triggered (when not stopping on first)
-        if let tripwiredResult = results.first(where: { $0.result.tripwireTriggered }) {
-            throw GuardrailError.toolOutputTripwireTriggered(
-                guardrailName: tripwiredResult.guardrailName,
-                toolName: data.tool.name,
-                message: tripwiredResult.result.message,
-                outputInfo: tripwiredResult.result.outputInfo
-            )
+        if let tripwiredResult = results.first(where: \.didTriggerTripwire),
+           let error = toolOutputTripwireError(
+               guardrailName: tripwiredResult.guardrailName,
+               toolName: data.tool.name,
+               result: tripwiredResult.result
+           ) {
+            throw error
         }
 
         return results
@@ -705,7 +774,11 @@ extension GuardrailRunner {
 
             // Collect results
             for try await (index, executionResult) in group {
-                if executionResult.result.tripwireTriggered, configuration.stopOnFirstTripwire {
+                if configuration.stopOnFirstTripwire,
+                   let error = inputTripwireError(
+                       guardrailName: executionResult.guardrailName,
+                       result: executionResult.result
+                   ) {
                     await emitGuardrailEvent(
                         guardrailName: executionResult.guardrailName,
                         guardrailType: .input,
@@ -714,11 +787,7 @@ extension GuardrailRunner {
                     )
                     // Cancel remaining tasks
                     group.cancelAll()
-                    throw GuardrailError.inputTripwireTriggered(
-                        guardrailName: executionResult.guardrailName,
-                        message: executionResult.result.message,
-                        outputInfo: executionResult.result.outputInfo
-                    )
+                    throw error
                 }
                 indexedResults.append((index, executionResult))
             }
@@ -727,8 +796,12 @@ extension GuardrailRunner {
             let results = indexedResults.map(\.1)
 
             // Check if any tripwires were triggered (when not stopping on first)
-            if let tripwiredResult = results.first(where: { $0.result.tripwireTriggered }) {
-                for result in results where result.result.tripwireTriggered {
+            if let tripwiredResult = results.first(where: \.didTriggerTripwire),
+               let error = inputTripwireError(
+                   guardrailName: tripwiredResult.guardrailName,
+                   result: tripwiredResult.result
+               ) {
+                for result in results where result.didTriggerTripwire {
                     await emitGuardrailEvent(
                         guardrailName: result.guardrailName,
                         guardrailType: .input,
@@ -736,11 +809,7 @@ extension GuardrailRunner {
                         context: context
                     )
                 }
-                throw GuardrailError.inputTripwireTriggered(
-                    guardrailName: tripwiredResult.guardrailName,
-                    message: tripwiredResult.result.message,
-                    outputInfo: tripwiredResult.result.outputInfo
-                )
+                throw error
             }
 
             return results
@@ -785,7 +854,12 @@ extension GuardrailRunner {
 
             // Collect results
             for try await (index, executionResult) in group {
-                if executionResult.result.tripwireTriggered, configuration.stopOnFirstTripwire {
+                if configuration.stopOnFirstTripwire,
+                   let error = outputTripwireError(
+                       guardrailName: executionResult.guardrailName,
+                       agentName: agentName,
+                       result: executionResult.result
+                   ) {
                     await emitGuardrailEvent(
                         guardrailName: executionResult.guardrailName,
                         guardrailType: .output,
@@ -794,12 +868,7 @@ extension GuardrailRunner {
                     )
                     // Cancel remaining tasks
                     group.cancelAll()
-                    throw GuardrailError.outputTripwireTriggered(
-                        guardrailName: executionResult.guardrailName,
-                        agentName: agentName,
-                        message: executionResult.result.message,
-                        outputInfo: executionResult.result.outputInfo
-                    )
+                    throw error
                 }
                 indexedResults.append((index, executionResult))
             }
@@ -808,8 +877,13 @@ extension GuardrailRunner {
             let results = indexedResults.map(\.1)
 
             // Check if any tripwires were triggered (when not stopping on first)
-            if let tripwiredResult = results.first(where: { $0.result.tripwireTriggered }) {
-                for result in results where result.result.tripwireTriggered {
+            if let tripwiredResult = results.first(where: \.didTriggerTripwire),
+               let error = outputTripwireError(
+                   guardrailName: tripwiredResult.guardrailName,
+                   agentName: agentName,
+                   result: tripwiredResult.result
+               ) {
+                for result in results where result.didTriggerTripwire {
                     await emitGuardrailEvent(
                         guardrailName: result.guardrailName,
                         guardrailType: .output,
@@ -817,12 +891,7 @@ extension GuardrailRunner {
                         context: context
                     )
                 }
-                throw GuardrailError.outputTripwireTriggered(
-                    guardrailName: tripwiredResult.guardrailName,
-                    agentName: agentName,
-                    message: tripwiredResult.result.message,
-                    outputInfo: tripwiredResult.result.outputInfo
-                )
+                throw error
             }
 
             return results
@@ -865,7 +934,12 @@ extension GuardrailRunner {
 
             // Collect results
             for try await (index, executionResult) in group {
-                if executionResult.result.tripwireTriggered, configuration.stopOnFirstTripwire {
+                if configuration.stopOnFirstTripwire,
+                   let error = toolInputTripwireError(
+                       guardrailName: executionResult.guardrailName,
+                       toolName: toolName,
+                       result: executionResult.result
+                   ) {
                     await emitGuardrailEvent(
                         guardrailName: executionResult.guardrailName,
                         guardrailType: .toolInput,
@@ -874,12 +948,7 @@ extension GuardrailRunner {
                     )
                     // Cancel remaining tasks
                     group.cancelAll()
-                    throw GuardrailError.toolInputTripwireTriggered(
-                        guardrailName: executionResult.guardrailName,
-                        toolName: toolName,
-                        message: executionResult.result.message,
-                        outputInfo: executionResult.result.outputInfo
-                    )
+                    throw error
                 }
                 indexedResults.append((index, executionResult))
             }
@@ -888,8 +957,13 @@ extension GuardrailRunner {
             let results = indexedResults.map(\.1)
 
             // Check if any tripwires were triggered (when not stopping on first)
-            if let tripwiredResult = results.first(where: { $0.result.tripwireTriggered }) {
-                for result in results where result.result.tripwireTriggered {
+            if let tripwiredResult = results.first(where: \.didTriggerTripwire),
+               let error = toolInputTripwireError(
+                   guardrailName: tripwiredResult.guardrailName,
+                   toolName: toolName,
+                   result: tripwiredResult.result
+               ) {
+                for result in results where result.didTriggerTripwire {
                     await emitGuardrailEvent(
                         guardrailName: result.guardrailName,
                         guardrailType: .toolInput,
@@ -897,12 +971,7 @@ extension GuardrailRunner {
                         context: data.context
                     )
                 }
-                throw GuardrailError.toolInputTripwireTriggered(
-                    guardrailName: tripwiredResult.guardrailName,
-                    toolName: toolName,
-                    message: tripwiredResult.result.message,
-                    outputInfo: tripwiredResult.result.outputInfo
-                )
+                throw error
             }
 
             return results
@@ -946,7 +1015,12 @@ extension GuardrailRunner {
 
             // Collect results
             for try await (index, executionResult) in group {
-                if executionResult.result.tripwireTriggered, configuration.stopOnFirstTripwire {
+                if configuration.stopOnFirstTripwire,
+                   let error = toolOutputTripwireError(
+                       guardrailName: executionResult.guardrailName,
+                       toolName: toolName,
+                       result: executionResult.result
+                   ) {
                     await emitGuardrailEvent(
                         guardrailName: executionResult.guardrailName,
                         guardrailType: .toolOutput,
@@ -955,12 +1029,7 @@ extension GuardrailRunner {
                     )
                     // Cancel remaining tasks
                     group.cancelAll()
-                    throw GuardrailError.toolOutputTripwireTriggered(
-                        guardrailName: executionResult.guardrailName,
-                        toolName: toolName,
-                        message: executionResult.result.message,
-                        outputInfo: executionResult.result.outputInfo
-                    )
+                    throw error
                 }
                 indexedResults.append((index, executionResult))
             }
@@ -969,8 +1038,13 @@ extension GuardrailRunner {
             let results = indexedResults.map(\.1)
 
             // Check if any tripwires were triggered (when not stopping on first)
-            if let tripwiredResult = results.first(where: { $0.result.tripwireTriggered }) {
-                for result in results where result.result.tripwireTriggered {
+            if let tripwiredResult = results.first(where: \.didTriggerTripwire),
+               let error = toolOutputTripwireError(
+                   guardrailName: tripwiredResult.guardrailName,
+                   toolName: toolName,
+                   result: tripwiredResult.result
+               ) {
+                for result in results where result.didTriggerTripwire {
                     await emitGuardrailEvent(
                         guardrailName: result.guardrailName,
                         guardrailType: .toolOutput,
@@ -978,12 +1052,7 @@ extension GuardrailRunner {
                         context: data.context
                     )
                 }
-                throw GuardrailError.toolOutputTripwireTriggered(
-                    guardrailName: tripwiredResult.guardrailName,
-                    toolName: toolName,
-                    message: tripwiredResult.result.message,
-                    outputInfo: tripwiredResult.result.outputInfo
-                )
+                throw error
             }
 
             return results

--- a/Sources/Swarm/Guardrails/InputGuardrail.swift
+++ b/Sources/Swarm/Guardrails/InputGuardrail.swift
@@ -123,7 +123,7 @@ public typealias InputValidationHandler = @Sendable (String, AgentContext?) asyn
 /// } catch let error as GuardrailError {
 ///     switch error {
 ///     case .inputTripwireTriggered(let name, let message, let info):
-///         print("Guardrail '\(name)' blocked input: \(message ?? "")")
+///         print("Guardrail '\(name)' blocked input: \(message)")
 ///     default:
 ///         break
 ///     }

--- a/Sources/Swarm/Guardrails/OutputGuardrail.swift
+++ b/Sources/Swarm/Guardrails/OutputGuardrail.swift
@@ -137,7 +137,7 @@ public typealias OutputValidationHandler = @Sendable (String, any AgentRuntime, 
 /// } catch let error as GuardrailError {
 ///     switch error {
 ///     case .outputTripwireTriggered(let name, let agentName, let message, _):
-///         print("Guardrail '\(name)' blocked output from '\(agentName)': \(message ?? "")")
+///         print("Guardrail '\(name)' blocked output from '\(agentName)': \(message)")
 ///     default:
 ///         break
 ///     }

--- a/Tests/SwarmTests/Core/RunHooksTests.swift
+++ b/Tests/SwarmTests/Core/RunHooksTests.swift
@@ -113,7 +113,7 @@ struct AgentObserverDefaultImplementationTests {
             context: nil,
             guardrailName: "test",
             guardrailType: .input,
-            result: GuardrailResult(tripwireTriggered: false)
+            result: .passed()
         )
 
         // No assertions needed - if we get here, all methods completed successfully
@@ -249,7 +249,7 @@ struct CompositeAgentObserverTests {
             context: context,
             guardrailName: "pii_filter",
             guardrailType: .output,
-            result: GuardrailResult(tripwireTriggered: true, message: "PII detected")
+            result: .tripwire(message: "PII detected")
         )
 
         // Then: All events should be recorded
@@ -360,7 +360,7 @@ struct LoggingAgentObserverTests {
             context: nil,
             guardrailName: "content_filter",
             guardrailType: .input,
-            result: GuardrailResult(tripwireTriggered: true, message: "Inappropriate content detected")
+            result: .tripwire(message: "Inappropriate content detected")
         )
     }
 

--- a/Tests/SwarmTests/Guardrails/AgentRunGuardrailBehaviorTests.swift
+++ b/Tests/SwarmTests/Guardrails/AgentRunGuardrailBehaviorTests.swift
@@ -74,4 +74,33 @@ struct AgentRunGuardrailBehaviorTests {
         #expect(try await session.getAllItems().isEmpty)
         #expect(await memory.addCalls.isEmpty)
     }
+
+    @Test("Deprecated nil tripwire message is forwarded on GuardrailError")
+    func deprecatedNilTripwireMessageReachesError() async throws {
+        let provider = MockInferenceProvider(responses: ["should not be used"])
+        let session = InMemorySession(sessionId: "legacy-tripwire")
+        let guardrail = InputGuard("legacy") { _ in
+            GuardrailResult(tripwireTriggered: true)
+        }
+        let agent = try Agent(
+            instructions: "Respond briefly.",
+            configuration: AgentConfiguration(defaultTracingEnabled: false),
+            inferenceProvider: provider,
+            inputGuardrails: [guardrail]
+        )
+
+        do {
+            _ = try await agent.run("blocked request", session: session)
+            Issue.record("Expected input guardrail tripwire")
+        } catch let error as GuardrailError {
+            guard case let .inputTripwireTriggered(guardrailName, message, _) = error else {
+                Issue.record("Expected inputTripwireTriggered, got \(error)")
+                return
+            }
+            #expect(guardrailName == "legacy")
+            #expect(message == "Tripwire triggered")
+        }
+
+        #expect(await provider.generateCallCount == 0)
+    }
 }

--- a/Tests/SwarmTests/Guardrails/GuardrailErrorTests.swift
+++ b/Tests/SwarmTests/Guardrails/GuardrailErrorTests.swift
@@ -63,22 +63,17 @@ struct GuardrailErrorTests {
         }
     }
 
-    @Test("Input tripwire error with nil message")
-    func inputTripwireWithNilMessage() {
-        // Given
-        let guardrailName = "Validator"
-
-        // When
+    @Test("Input tripwire error always includes a message")
+    func inputTripwireMessageIsRequired() {
         let error = GuardrailError.inputTripwireTriggered(
-            guardrailName: guardrailName,
-            message: nil,
+            guardrailName: "Validator",
+            message: "blocked",
             outputInfo: nil
         )
 
-        // Then
         if case let .inputTripwireTriggered(name, msg, _) = error {
-            #expect(name == guardrailName)
-            #expect(msg == nil)
+            #expect(name == "Validator")
+            #expect(msg == "blocked")
         } else {
             Issue.record("Expected inputTripwireTriggered case")
         }
@@ -315,21 +310,19 @@ struct GuardrailErrorTests {
         #expect(description!.contains("Input blocked"))
     }
 
-    @Test("Input tripwire error description with nil message")
-    func inputTripwireErrorDescriptionNilMessage() {
-        // Given
+    @Test("Input tripwire error description interpolates the required message")
+    func inputTripwireErrorDescriptionIncludesMessage() {
         let error = GuardrailError.inputTripwireTriggered(
             guardrailName: "TestGuard",
-            message: nil,
+            message: "blocked",
             outputInfo: nil
         )
 
-        // When
         let description = error.errorDescription
-
-        // Then
         #expect(description != nil)
         #expect(description!.contains("TestGuard"))
+        #expect(description!.contains("blocked"))
+        #expect(!(description!.contains("No message")))
     }
 
     @Test("Output tripwire error has descriptive errorDescription")
@@ -522,7 +515,7 @@ extension GuardrailErrorTests {
 
         // Then
         if case let .inputTripwireTriggered(_, msg, _) = error {
-            #expect(msg?.isEmpty == true)
+            #expect(msg.isEmpty)
         } else {
             Issue.record("Expected inputTripwireTriggered case")
         }

--- a/Tests/SwarmTests/Guardrails/GuardrailResultTests.swift
+++ b/Tests/SwarmTests/Guardrails/GuardrailResultTests.swift
@@ -336,4 +336,33 @@ struct GuardrailResultTests {
         #expect(result.outputInfo == complexInfo)
         #expect(result.tripwireTriggered == true)
     }
+
+    @Test("Tripwire case always carries a message on the enum")
+    func tripwireCaseMessageIsRequired() {
+        let result = GuardrailResult.tripwire(message: "blocked")
+        guard case let .tripwire(message, _, _) = result else {
+            Issue.record("expected tripwire case")
+            return
+        }
+        #expect(message == "blocked")
+        #expect(result.message == "blocked")
+    }
+
+    @Test("Passed and tripwire are distinct enum cases")
+    func enumCasesAreExhaustivePair() {
+        let passed = GuardrailResult.passed()
+        let tripwire = GuardrailResult.tripwire(message: "blocked")
+        var sawPassed = false
+        var sawTripwire = false
+        for result in [passed, tripwire] {
+            switch result {
+            case .passed:
+                sawPassed = true
+            case .tripwire:
+                sawTripwire = true
+            }
+        }
+        #expect(sawPassed)
+        #expect(sawTripwire)
+    }
 }

--- a/Tests/SwarmTests/Guardrails/GuardrailResultTests.swift
+++ b/Tests/SwarmTests/Guardrails/GuardrailResultTests.swift
@@ -348,6 +348,16 @@ struct GuardrailResultTests {
         #expect(result.message == "blocked")
     }
 
+    @Test("Deprecated tripwire initializer fills a default message when nil")
+    func deprecatedInitNilTripwireMessage() {
+        let tripwire = GuardrailResult(tripwireTriggered: true)
+        let passed = GuardrailResult(tripwireTriggered: false)
+        #expect(tripwire.message == "Tripwire triggered")
+        #expect(tripwire.tripwireTriggered)
+        #expect(passed.message == nil)
+        #expect(!passed.tripwireTriggered)
+    }
+
     @Test("Passed and tripwire are distinct enum cases")
     func enumCasesAreExhaustivePair() {
         let passed = GuardrailResult.passed()

--- a/Tests/SwarmTests/Integration/FullAPIScenarioTests.swift
+++ b/Tests/SwarmTests/Integration/FullAPIScenarioTests.swift
@@ -108,7 +108,7 @@ struct FullAPIScenarioTests {
         let mock = MockInferenceProvider()
         await mock.setResponses(["ok"])
         let guardrail = InputGuard("always_trip") { _, _ in
-            GuardrailResult(tripwireTriggered: true, message: "blocked")
+            .tripwire(message: "blocked")
         }
         let agent = try Agent(instructions: "Service", inferenceProvider: mock, inputGuardrails: [guardrail])
         await #expect(throws: Error.self) {

--- a/docs/reference/api-catalog.md
+++ b/docs/reference/api-catalog.md
@@ -1918,15 +1918,15 @@ Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for
 
 | Line | Kind | Access | Name | Signature |
 |------|------|--------|------|-----------|
-| 35 | struct | public | GuardrailResult | `public struct GuardrailResult` |
-| 38 | var | public | GuardrailResult.tripwireTriggered | `public let tripwireTriggered: Bool` |
-| 53 | var | public | GuardrailResult.outputInfo | `public let outputInfo: SendableValue?` |
-| 56 | var | public | GuardrailResult.message | `public let message: String?` |
-| 74 | var | public | GuardrailResult.metadata | `public let metadata: [String : SendableValue]` |
-| 85 | func | public | GuardrailResult.init(tripwireTriggered:outputInfo:message:metadata:) | `public init(tripwireTriggered: Bool, outputInfo: SendableValue? = nil, message: String? = nil, metadata: [String : SendableValue] = [:])` |
-| 106 | func | public | GuardrailResult.passed(message:outputInfo:metadata:) | `public static func passed(message: String? = nil, outputInfo: SendableValue? = nil, metadata: [String : SendableValue] = [:]) -> GuardrailResult` |
-| 126 | func | public | GuardrailResult.tripwire(message:outputInfo:metadata:) | `public static func tripwire(message: String, outputInfo: SendableValue? = nil, metadata: [String : SendableValue] = [:]) -> GuardrailResult` |
-| 143 | var | public | GuardrailResult.debugDescription | `public var debugDescription: String { get }` |
+| 45 | enum | public | GuardrailResult | `public enum GuardrailResult` |
+| 52 | case | public | GuardrailResult.passed | `case passed(message: String? = nil, outputInfo: SendableValue? = nil, metadata: [String : SendableValue] = [:])` |
+| 64 | case | public | GuardrailResult.tripwire | `case tripwire(message: String, outputInfo: SendableValue? = nil, metadata: [String : SendableValue] = [:])` |
+| 71 | var | public | GuardrailResult.tripwireTriggered | `public var tripwireTriggered: Bool { get }` |
+| 81 | var | public | GuardrailResult.outputInfo | `public var outputInfo: SendableValue? { get }` |
+| 92 | var | public | GuardrailResult.message | `public var message: String? { get }` |
+| 102 | var | public | GuardrailResult.metadata | `public var metadata: [String : SendableValue] { get }` |
+| 116 | func | public | GuardrailResult.init(tripwireTriggered:outputInfo:message:metadata:) | `public init(tripwireTriggered: Bool, outputInfo: SendableValue? = nil, message: String? = nil, metadata: [String : SendableValue] = [:])` |
+| 140 | var | public | GuardrailResult.debugDescription | `public var debugDescription: String { get }` |
 
 ### Guardrails/GuardrailRunner.swift
 

--- a/docs/reference/api-catalog.md
+++ b/docs/reference/api-catalog.md
@@ -1907,10 +1907,10 @@ Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for
 |------|------|--------|------|-----------|
 | 11 | enum | public | GuardrailError | `public enum GuardrailError` |
 | 14 | var | public | GuardrailError.errorDescription | `public var errorDescription: String? { get }` |
-| 30 | case | public | GuardrailError.inputTripwireTriggered(guardrailName:message:outputInfo:) | `public case inputTripwireTriggered(guardrailName: String, message: String?, outputInfo: SendableValue?)` |
-| 37 | case | public | GuardrailError.outputTripwireTriggered(guardrailName:agentName:message:outputInfo:) | `public case outputTripwireTriggered(guardrailName: String, agentName: String, message: String?, outputInfo: SendableValue?)` |
-| 45 | case | public | GuardrailError.toolInputTripwireTriggered(guardrailName:toolName:message:outputInfo:) | `public case toolInputTripwireTriggered(guardrailName: String, toolName: String, message: String?, outputInfo: SendableValue?)` |
-| 53 | case | public | GuardrailError.toolOutputTripwireTriggered(guardrailName:toolName:message:outputInfo:) | `public case toolOutputTripwireTriggered(guardrailName: String, toolName: String, message: String?, outputInfo: SendableValue?)` |
+| 30 | case | public | GuardrailError.inputTripwireTriggered(guardrailName:message:outputInfo:) | `public case inputTripwireTriggered(guardrailName: String, message: String, outputInfo: SendableValue?)` |
+| 37 | case | public | GuardrailError.outputTripwireTriggered(guardrailName:agentName:message:outputInfo:) | `public case outputTripwireTriggered(guardrailName: String, agentName: String, message: String, outputInfo: SendableValue?)` |
+| 45 | case | public | GuardrailError.toolInputTripwireTriggered(guardrailName:toolName:message:outputInfo:) | `public case toolInputTripwireTriggered(guardrailName: String, toolName: String, message: String, outputInfo: SendableValue?)` |
+| 53 | case | public | GuardrailError.toolOutputTripwireTriggered(guardrailName:toolName:message:outputInfo:) | `public case toolOutputTripwireTriggered(guardrailName: String, toolName: String, message: String, outputInfo: SendableValue?)` |
 | 61 | case | public | GuardrailError.executionFailed(guardrailName:underlyingError:) | `public case executionFailed(guardrailName: String, underlyingError: String)` |
 | 67 | var | public | GuardrailError.debugDescription | `public var debugDescription: String { get }` |
 

--- a/docs/reference/front-facing-api.md
+++ b/docs/reference/front-facing-api.md
@@ -430,6 +430,8 @@ public struct OutputGuard: OutputGuardrail, Sendable {
 }
 ```
 
+`GuardrailResult` is a closed enum: `.passed(...)` or `.tripwire(message:)` (a tripwire always has a message). Compatibility accessors `tripwireTriggered`, `message`, `outputInfo`, and `metadata` remain for runners and observers.
+
 ### Guardrail protocols (for advanced use)
 
 ```swift

--- a/docs/reference/front-facing-api.md
+++ b/docs/reference/front-facing-api.md
@@ -430,7 +430,7 @@ public struct OutputGuard: OutputGuardrail, Sendable {
 }
 ```
 
-`GuardrailResult` is a closed enum: `.passed(...)` or `.tripwire(message:)` (a tripwire always has a message). Compatibility accessors `tripwireTriggered`, `message`, `outputInfo`, and `metadata` remain for runners and observers.
+`GuardrailResult` is a closed enum: `.passed(...)` or `.tripwire(message:)` (a tripwire always has a message). Compatibility accessors `tripwireTriggered`, `message`, `outputInfo`, and `metadata` remain for observers. `GuardrailRunner` switches on the enum cases and `GuardrailError` tripwire cases carry a required `message: String`.
 
 ### Guardrail protocols (for advanced use)
 


### PR DESCRIPTION
## Summary
- Model `GuardrailResult` as `.passed` / `.tripwire(message:)` so a tripwire without a message cannot be represented.
- Keep `tripwireTriggered`, `message`, `outputInfo`, and `metadata` as compatibility accessors; deprecate the boolean memberwise initializer (nil tripwire message becomes `"Tripwire triggered"`).
- `GuardrailRunner` switches on the enum cases instead of the boolean accessor. Tripwire `GuardrailError` cases now carry a required `message: String`.

## Test plan
- [x] `SWARM_OMIT_INTEGRATION_TARGETS=1 swift test` filtered to guardrail suites (`GuardrailResultTests`, `GuardrailErrorTests`, factory/integration/input/output/tool, `AgentRunGuardrailBehaviorTests`, `RunHooksTests`, `FullAPIScenarioTests`, `InferenceRetryabilityTests`, `AnyToolTests`)
- [ ] CI lean + Integrations lanes
- [ ] Confirm custom `InputGuardrail` / `OutputGuardrail` types that already return `.passed()` / `.tripwire(message:)` still compile
- [ ] Confirm remaining `GuardrailResult(tripwireTriggered:)` call sites get the deprecation (in-repo tests migrated)
- [ ] Confirm callers constructing `GuardrailError.*TripwireTriggered(message: nil)` are updated (`message` is now `String`)