### PR TITLE
feat: extract a pure Agent turn kernel from the tool loop

### DIFF
--- a/Sources/Swarm/Agents/Agent.swift
+++ b/Sources/Swarm/Agents/Agent.swift
@@ -1856,14 +1856,10 @@ public struct Agent: AgentRuntime, Sendable {
     ) async throws {
         let activeMemory = resolvedMemory()
 
-        // This function never runs handoff I/O; a stray `.handoff` kind becomes
-        // `.regular` so transfer tools cannot take the Membrane path.
-        let resolvedKind = AgentTurnKernel.resolvedHostToolCallKind(
-            kind,
-            hasHandoffConfiguration: false,
-            hasMembraneAdapter: membraneAdapter != nil
-        )
-        switch (resolvedKind, membraneAdapter) {
+        // Handoff I/O lives in `processToolCallsWithHandoffs`. A `.handoff` kind
+        // here is the missing-configuration fallback and must not take the
+        // Membrane internal path.
+        switch (kind, membraneAdapter) {
         case (.membraneInternal, let membraneAdapter?):
             let call = ToolCall(
                 providerCallId: parsedCall.id,
@@ -2154,14 +2150,10 @@ public struct Agent: AgentRuntime, Sendable {
         )
 
         for parsedCall in response.toolCalls {
-            let kind = AgentTurnKernel.resolvedHostToolCallKind(
-                AgentTurnKernel.hostToolCallKind(
-                    isHandoffTool: handoffMap[parsedCall.name] != nil,
-                    isMembraneInternal: membraneAdapter != nil
-                        && MembraneInternalTools.isInternalTool(parsedCall.name)
-                ),
-                hasHandoffConfiguration: handoffMap[parsedCall.name] != nil,
-                hasMembraneAdapter: membraneAdapter != nil
+            let kind = AgentTurnKernel.hostToolCallKind(
+                isHandoffTool: handoffMap[parsedCall.name] != nil,
+                isMembraneInternal: membraneAdapter != nil
+                    && MembraneInternalTools.isInternalTool(parsedCall.name)
             )
 
             switch kind {

--- a/Sources/Swarm/Agents/Agent.swift
+++ b/Sources/Swarm/Agents/Agent.swift
@@ -1850,16 +1850,21 @@ public struct Agent: AgentRuntime, Sendable {
         resultBuilder: AgentResult.Builder,
         observer: (any AgentObserver)?,
         tracing: TracingHelper?,
+        kind: AgentTurnKernel.HostToolCallKind,
         membraneAdapter: (any MembraneAgentAdapter)?,
         startTime: ContinuousClock.Instant
     ) async throws {
         let activeMemory = resolvedMemory()
 
-        if AgentTurnKernel.hostToolCallKind(
-            isHandoffTool: false,
-            isMembraneInternal: membraneAdapter != nil && MembraneInternalTools.isInternalTool(parsedCall.name)
-        ) == .membraneInternal,
-           let membraneAdapter {
+        // This function never runs handoff I/O; a stray `.handoff` kind becomes
+        // `.regular` so transfer tools cannot take the Membrane path.
+        let resolvedKind = AgentTurnKernel.resolvedHostToolCallKind(
+            kind,
+            hasHandoffConfiguration: false,
+            hasMembraneAdapter: membraneAdapter != nil
+        )
+        switch (resolvedKind, membraneAdapter) {
+        case (.membraneInternal, let membraneAdapter?):
             let call = ToolCall(
                 providerCallId: parsedCall.id,
                 toolName: parsedCall.name,
@@ -1941,85 +1946,86 @@ public struct Agent: AgentRuntime, Sendable {
                 }
                 return
             }
-        }
 
-        let engine = ToolExecutionEngine()
-        let outcome = try await executeWithinRemainingTimeout(startTime: startTime) {
-            try await engine.execute(
-                parsedCall,
-                registry: toolRegistry,
-                agent: self,
-                context: nil,
-                resultBuilder: resultBuilder,
-                observer: observer,
-                tracing: tracing,
-                stopOnToolError: false
-            )
-        }
+        case (.handoff, _), (.regular, _), (.membraneInternal, nil):
+            let engine = ToolExecutionEngine()
+            let outcome = try await executeWithinRemainingTimeout(startTime: startTime) {
+                try await engine.execute(
+                    parsedCall,
+                    registry: toolRegistry,
+                    agent: self,
+                    context: nil,
+                    resultBuilder: resultBuilder,
+                    observer: observer,
+                    tracing: tracing,
+                    stopOnToolError: false
+                )
+            }
 
-        if outcome.result.isSuccess {
-            var toolOutputText = Self.toolOutputText(for: outcome.result.output)
-            if let membraneAdapter {
-                do {
-                    let currentToolOutput = toolOutputText
-                    let transformed = try await executeWithinRemainingTimeout(startTime: startTime) {
-                        try await membraneAdapter.transformToolResult(
-                            toolName: parsedCall.name,
-                            output: currentToolOutput,
-                            profile: configuration.effectiveContextProfile
-                        )
+            if outcome.result.isSuccess {
+                var toolOutputText = Self.toolOutputText(for: outcome.result.output)
+                if let membraneAdapter {
+                    do {
+                        let currentToolOutput = toolOutputText
+                        let transformed = try await executeWithinRemainingTimeout(startTime: startTime) {
+                            try await membraneAdapter.transformToolResult(
+                                toolName: parsedCall.name,
+                                output: currentToolOutput,
+                                profile: configuration.effectiveContextProfile
+                            )
+                        }
+                        toolOutputText = transformed.textForConversation
+                        if let pointerID = transformed.pointerID {
+                            _ = resultBuilder.setMetadata("membrane.pointerized", .bool(true))
+                            _ = resultBuilder.setMetadata("membrane.pointer.last_id", .string(pointerID))
+                        }
+                    } catch {
+                        _ = resultBuilder.setMetadata("membrane.fallback.used", .bool(true))
+                        _ = resultBuilder.setMetadata("membrane.fallback.error", .string(fallbackDiagnosticMessage(for: error)))
                     }
-                    toolOutputText = transformed.textForConversation
-                    if let pointerID = transformed.pointerID {
-                        _ = resultBuilder.setMetadata("membrane.pointerized", .bool(true))
-                        _ = resultBuilder.setMetadata("membrane.pointer.last_id", .string(pointerID))
-                    }
-                } catch {
-                    _ = resultBuilder.setMetadata("membrane.fallback.used", .bool(true))
-                    _ = resultBuilder.setMetadata("membrane.fallback.error", .string(fallbackDiagnosticMessage(for: error)))
                 }
-            }
 
-            conversationHistory.append(.toolResult(
-                toolName: parsedCall.name,
-                result: toolOutputText,
-                toolCallID: parsedCall.id
-            ))
-            transcriptMessages.append(
-                SwarmTranscriptCodec.encodeMessage(
-                    role: .tool,
-                    content: toolOutputText,
+                conversationHistory.append(.toolResult(
                     toolName: parsedCall.name,
+                    result: toolOutputText,
                     toolCallID: parsedCall.id
-                )
-            )
-            if let activeMemory {
-                await activeMemory.add(.tool(toolOutputText, toolName: parsedCall.name))
-            }
-        } else {
-            let errorMessage = outcome.result.errorMessage ?? "Unknown error"
-            conversationHistory.append(.toolResult(
-                toolName: parsedCall.name,
-                result: AgentTurnKernel.toolFailureConversationText(message: errorMessage),
-                toolCallID: parsedCall.id
-            ))
-            transcriptMessages.append(
-                SwarmTranscriptCodec.encodeMessage(
-                    role: .tool,
-                    content: AgentTurnKernel.toolFailureConversationText(message: errorMessage),
-                    toolName: parsedCall.name,
-                    toolCallID: parsedCall.id
-                )
-            )
-            if let activeMemory {
-                await activeMemory.add(.tool(
-                    AgentTurnKernel.memoryToolErrorText(message: errorMessage),
-                    toolName: parsedCall.name
                 ))
-            }
+                transcriptMessages.append(
+                    SwarmTranscriptCodec.encodeMessage(
+                        role: .tool,
+                        content: toolOutputText,
+                        toolName: parsedCall.name,
+                        toolCallID: parsedCall.id
+                    )
+                )
+                if let activeMemory {
+                    await activeMemory.add(.tool(toolOutputText, toolName: parsedCall.name))
+                }
+            } else {
+                let errorMessage = outcome.result.errorMessage ?? "Unknown error"
+                conversationHistory.append(.toolResult(
+                    toolName: parsedCall.name,
+                    result: AgentTurnKernel.toolFailureConversationText(message: errorMessage),
+                    toolCallID: parsedCall.id
+                ))
+                transcriptMessages.append(
+                    SwarmTranscriptCodec.encodeMessage(
+                        role: .tool,
+                        content: AgentTurnKernel.toolFailureConversationText(message: errorMessage),
+                        toolName: parsedCall.name,
+                        toolCallID: parsedCall.id
+                    )
+                )
+                if let activeMemory {
+                    await activeMemory.add(.tool(
+                        AgentTurnKernel.memoryToolErrorText(message: errorMessage),
+                        toolName: parsedCall.name
+                    ))
+                }
 
-            if configuration.stopOnToolError {
-                throw AgentError.toolExecutionFailed(toolName: parsedCall.name, underlyingError: errorMessage)
+                if configuration.stopOnToolError {
+                    throw AgentError.toolExecutionFailed(toolName: parsedCall.name, underlyingError: errorMessage)
+                }
             }
         }
     }
@@ -2148,13 +2154,33 @@ public struct Agent: AgentRuntime, Sendable {
         )
 
         for parsedCall in response.toolCalls {
-            let kind = AgentTurnKernel.hostToolCallKind(
-                isHandoffTool: handoffMap[parsedCall.name] != nil,
-                isMembraneInternal: membraneAdapter != nil
-                    && MembraneInternalTools.isInternalTool(parsedCall.name)
+            let kind = AgentTurnKernel.resolvedHostToolCallKind(
+                AgentTurnKernel.hostToolCallKind(
+                    isHandoffTool: handoffMap[parsedCall.name] != nil,
+                    isMembraneInternal: membraneAdapter != nil
+                        && MembraneInternalTools.isInternalTool(parsedCall.name)
+                ),
+                hasHandoffConfiguration: handoffMap[parsedCall.name] != nil,
+                hasMembraneAdapter: membraneAdapter != nil
             )
 
-            if kind == .handoff, let handoffConfig = handoffMap[parsedCall.name] {
+            switch kind {
+            case .handoff:
+                guard let handoffConfig = handoffMap[parsedCall.name] else {
+                    try await executeSingleToolCall(
+                        parsedCall: parsedCall,
+                        toolRegistry: toolRegistry,
+                        conversationHistory: &conversationHistory,
+                        transcriptMessages: &transcriptMessages,
+                        resultBuilder: resultBuilder,
+                        observer: observer,
+                        tracing: tracing,
+                        kind: .regular,
+                        membraneAdapter: membraneAdapter,
+                        startTime: startTime
+                    )
+                    continue
+                }
                 if let when = handoffConfig.when, await !when(context, handoffConfig.targetAgent) {
                     let message = "Handoff is not enabled"
                     let handoffCall = ToolCall(
@@ -2333,20 +2359,21 @@ public struct Agent: AgentRuntime, Sendable {
 
                 // Return the handoff output to be used as the final result
                 return FinalAssistantResponse(content: result.output, structuredOutput: nil)
-            }
 
-            // Regular tool call
-            try await executeSingleToolCall(
-                parsedCall: parsedCall,
-                toolRegistry: toolRegistry,
-                conversationHistory: &conversationHistory,
-                transcriptMessages: &transcriptMessages,
-                resultBuilder: resultBuilder,
-                observer: observer,
-                tracing: tracing,
-                membraneAdapter: membraneAdapter,
-                startTime: startTime
-            )
+            case .membraneInternal, .regular:
+                try await executeSingleToolCall(
+                    parsedCall: parsedCall,
+                    toolRegistry: toolRegistry,
+                    conversationHistory: &conversationHistory,
+                    transcriptMessages: &transcriptMessages,
+                    resultBuilder: resultBuilder,
+                    observer: observer,
+                    tracing: tracing,
+                    kind: kind,
+                    membraneAdapter: membraneAdapter,
+                    startTime: startTime
+                )
+            }
         }
 
         return nil

--- a/Sources/Swarm/Agents/Agent.swift
+++ b/Sources/Swarm/Agents/Agent.swift
@@ -1471,13 +1471,12 @@ public struct Agent: AgentRuntime, Sendable {
                 )
                 let prompt = InferenceMessage.flattenPrompt(structuredMessages)
                 let useProviderOwnedToolLoop = provider.capabilities.contains(.providerOwnedToolLoop)
+                try AgentTurnKernel.requireOwnedLoopGate(
+                    useProviderOwnedToolLoop: useProviderOwnedToolLoop,
+                    hasExecutionGate: executionGate != nil
+                )
                 let toolExecutor: ToolCallExecutor?
-                if useProviderOwnedToolLoop {
-                    guard let executionGate else {
-                        throw AgentError.internalError(
-                            reason: "Provider-owned tool loop missing execution gate"
-                        )
-                    }
+                if useProviderOwnedToolLoop, let executionGate {
                     toolExecutor = makeToolCallExecutor(
                         toolRegistry: toolRegistry,
                         resultBuilder: resultBuilder,
@@ -1491,9 +1490,15 @@ public struct Agent: AgentRuntime, Sendable {
                     toolExecutor = nil
                 }
 
+                let inferenceKind = AgentTurnKernel.inferenceKind(
+                    toolSchemasEmpty: toolSchemas.isEmpty,
+                    useProviderOwnedToolLoop: useProviderOwnedToolLoop,
+                    streamingToolCalls: useToolStreaming
+                )
+
                 // If no tools defined, generate without tool calling unless the
                 // adapter owns the tool loop (empty tool list).
-                if toolSchemas.isEmpty && !useProviderOwnedToolLoop {
+                if inferenceKind == .withoutTools {
                     let loopInferenceOptions = inferenceOptions
                     let response = try await executeProviderInference(
                         startTime: startTime,
@@ -1529,13 +1534,14 @@ public struct Agent: AgentRuntime, Sendable {
                 // Generate response with tool calls
                 let loopInferenceOptions = inferenceOptions
                 // Owned-loop tools run inside inference; retrying would replay them.
-                let ownedLoopInferenceRetryPolicy: RetryPolicy? =
-                    useProviderOwnedToolLoop && !toolSchemas.isEmpty
-                    ? .noRetry
-                    : nil
+                let ownedLoopInferenceRetryPolicy = AgentTurnKernel.ownedLoopInferenceRetryPolicy(
+                    useProviderOwnedToolLoop: useProviderOwnedToolLoop,
+                    hasToolSchemas: !toolSchemas.isEmpty
+                )
                 let response: InferenceResponse
                 do {
-                    response = if useToolStreaming {
+                    let streamToolCalls = inferenceKind == .withTools(streaming: true)
+                    response = if streamToolCalls {
                         try await executeProviderInference(
                             startTime: startTime,
                             observer: observer,
@@ -1610,10 +1616,14 @@ public struct Agent: AgentRuntime, Sendable {
                 }
                 recordUsage(response.usage, on: resultBuilder)
 
-                if useProviderOwnedToolLoop {
-                    guard let content = response.content else {
-                        throw AgentError.generationFailed(reason: "Model returned no content or tool calls")
-                    }
+                switch AgentTurnKernel.afterInference(
+                    useProviderOwnedToolLoop: useProviderOwnedToolLoop,
+                    response: response
+                ) {
+                case .failMissingContent:
+                    throw AgentError.generationFailed(reason: "Model returned no content or tool calls")
+
+                case let .finishAssistant(content):
                     let finalResponse = try finalizeAssistantResponse(
                         content: content,
                         request: structuredOutputRequest,
@@ -1630,9 +1640,8 @@ public struct Agent: AgentRuntime, Sendable {
                         structuredOutput: finalResponse.structuredOutput,
                         transcriptMessages: transcriptMessages
                     )
-                }
 
-                if response.hasToolCalls {
+                case .processHostToolCalls:
                     let handoffResult = try await processToolCallsWithHandoffs(
                         response: response,
                         toolRegistry: toolRegistry,
@@ -1645,7 +1654,6 @@ public struct Agent: AgentRuntime, Sendable {
                         context: executionContext,
                         startTime: startTime
                     )
-                    // If a handoff occurred, return the target agent's result
                     if let handoffOutput = handoffResult {
                         await observer?.onIterationEnd(context: nil, agent: self, number: iteration)
                         return ToolLoopOutcome(
@@ -1654,29 +1662,8 @@ public struct Agent: AgentRuntime, Sendable {
                             transcriptMessages: transcriptMessages
                         )
                     }
-                } else {
-                    guard let content = response.content else {
-                        throw AgentError.generationFailed(reason: "Model returned no content or tool calls")
-                    }
-                    let finalResponse = try finalizeAssistantResponse(
-                        content: content,
-                        request: structuredOutputRequest,
-                        provider: provider
-                    )
-                    appendOwnedLoopTranscript(
-                        response.transcriptMessages,
-                        finalized: finalResponse,
-                        to: &transcriptMessages
-                    )
                     await observer?.onIterationEnd(context: nil, agent: self, number: iteration)
-                    return ToolLoopOutcome(
-                        output: finalResponse.content,
-                        structuredOutput: finalResponse.structuredOutput,
-                        transcriptMessages: transcriptMessages
-                    )
                 }
-
-                await observer?.onIterationEnd(context: nil, agent: self, number: iteration)
             } catch {
                 await observer?.onIterationEnd(context: nil, agent: self, number: iteration)
                 throw normalizeCancellation(error)
@@ -1854,43 +1841,6 @@ public struct Agent: AgentRuntime, Sendable {
         return FinalAssistantResponse(content: content, structuredOutput: structuredOutput)
     }
 
-    /// Processes tool calls from the model response.
-    private func processToolCalls(
-        response: InferenceResponse,
-        toolRegistry: ToolRegistry,
-        conversationHistory: inout [ConversationMessage],
-        transcriptMessages: inout [MemoryMessage],
-        resultBuilder: AgentResult.Builder,
-        observer: (any AgentObserver)?,
-        tracing: TracingHelper?,
-        membraneAdapter: (any MembraneAgentAdapter)?
-    ) async throws {
-        let toolCallSummary = response.toolCalls.map { "Calling tool: \($0.name)" }.joined(separator: ", ")
-        let assistantContent = response.content ?? toolCallSummary
-        conversationHistory.append(.assistant(assistantContent, toolCalls: response.toolCalls))
-        transcriptMessages.append(
-            SwarmTranscriptCodec.encodeMessage(
-                role: .assistant,
-                content: assistantContent,
-                toolCalls: response.toolCalls
-            )
-        )
-
-        for parsedCall in response.toolCalls {
-            try await executeSingleToolCall(
-                parsedCall: parsedCall,
-                toolRegistry: toolRegistry,
-                conversationHistory: &conversationHistory,
-                transcriptMessages: &transcriptMessages,
-                resultBuilder: resultBuilder,
-                observer: observer,
-                tracing: tracing,
-                membraneAdapter: membraneAdapter,
-                startTime: ContinuousClock.now
-            )
-        }
-    }
-
     /// Executes a single tool call and updates conversation history.
     private func executeSingleToolCall(
         parsedCall: InferenceResponse.ParsedToolCall,
@@ -1905,8 +1855,11 @@ public struct Agent: AgentRuntime, Sendable {
     ) async throws {
         let activeMemory = resolvedMemory()
 
-        if let membraneAdapter,
-           MembraneInternalTools.isInternalTool(parsedCall.name) {
+        if AgentTurnKernel.hostToolCallKind(
+            isHandoffTool: false,
+            isMembraneInternal: membraneAdapter != nil && MembraneInternalTools.isInternalTool(parsedCall.name)
+        ) == .membraneInternal,
+           let membraneAdapter {
             let call = ToolCall(
                 providerCallId: parsedCall.id,
                 toolName: parsedCall.name,
@@ -1969,19 +1922,22 @@ public struct Agent: AgentRuntime, Sendable {
                 }
                 conversationHistory.append(.toolResult(
                     toolName: parsedCall.name,
-                    result: "[TOOL ERROR] Execution failed: \(message). Please try a different approach or tool.",
+                    result: AgentTurnKernel.toolFailureConversationText(message: message),
                     toolCallID: parsedCall.id
                 ))
                 transcriptMessages.append(
                     SwarmTranscriptCodec.encodeMessage(
                         role: .tool,
-                        content: "[TOOL ERROR] Execution failed: \(message). Please try a different approach or tool.",
+                        content: AgentTurnKernel.toolFailureConversationText(message: message),
                         toolName: parsedCall.name,
                         toolCallID: parsedCall.id
                     )
                 )
                 if let activeMemory {
-                    await activeMemory.add(.tool("Error - \(message)", toolName: parsedCall.name))
+                    await activeMemory.add(.tool(
+                        AgentTurnKernel.memoryToolErrorText(message: message),
+                        toolName: parsedCall.name
+                    ))
                 }
                 return
             }
@@ -2044,19 +2000,22 @@ public struct Agent: AgentRuntime, Sendable {
             let errorMessage = outcome.result.errorMessage ?? "Unknown error"
             conversationHistory.append(.toolResult(
                 toolName: parsedCall.name,
-                result: "[TOOL ERROR] Execution failed: \(errorMessage). Please try a different approach or tool.",
+                result: AgentTurnKernel.toolFailureConversationText(message: errorMessage),
                 toolCallID: parsedCall.id
             ))
             transcriptMessages.append(
                 SwarmTranscriptCodec.encodeMessage(
                     role: .tool,
-                    content: "[TOOL ERROR] Execution failed: \(errorMessage). Please try a different approach or tool.",
+                    content: AgentTurnKernel.toolFailureConversationText(message: errorMessage),
                     toolName: parsedCall.name,
                     toolCallID: parsedCall.id
                 )
             )
             if let activeMemory {
-                await activeMemory.add(.tool("Error - \(errorMessage)", toolName: parsedCall.name))
+                await activeMemory.add(.tool(
+                    AgentTurnKernel.memoryToolErrorText(message: errorMessage),
+                    toolName: parsedCall.name
+                ))
             }
 
             if configuration.stopOnToolError {
@@ -2178,8 +2137,7 @@ public struct Agent: AgentRuntime, Sendable {
             uniqueKeysWithValues: _handoffs.map { ($0.effectiveToolName, $0) }
         )
 
-        let toolCallSummary = response.toolCalls.map { "Calling tool: \($0.name)" }.joined(separator: ", ")
-        let assistantContent = response.content ?? toolCallSummary
+        let assistantContent = AgentTurnKernel.assistantContent(for: response)
         conversationHistory.append(.assistant(assistantContent, toolCalls: response.toolCalls))
         transcriptMessages.append(
             SwarmTranscriptCodec.encodeMessage(
@@ -2190,8 +2148,13 @@ public struct Agent: AgentRuntime, Sendable {
         )
 
         for parsedCall in response.toolCalls {
-            // Check if this is a handoff tool call
-            if let handoffConfig = handoffMap[parsedCall.name] {
+            let kind = AgentTurnKernel.hostToolCallKind(
+                isHandoffTool: handoffMap[parsedCall.name] != nil,
+                isMembraneInternal: membraneAdapter != nil
+                    && MembraneInternalTools.isInternalTool(parsedCall.name)
+            )
+
+            if kind == .handoff, let handoffConfig = handoffMap[parsedCall.name] {
                 if let when = handoffConfig.when, await !when(context, handoffConfig.targetAgent) {
                     let message = "Handoff is not enabled"
                     let handoffCall = ToolCall(
@@ -2207,7 +2170,7 @@ public struct Agent: AgentRuntime, Sendable {
                         throw AgentError.toolExecutionFailed(toolName: parsedCall.name, underlyingError: message)
                     }
 
-                    let toolError = "[TOOL ERROR] Execution failed: \(message). Please try a different approach or tool."
+                    let toolError = AgentTurnKernel.toolFailureConversationText(message: message)
                     conversationHistory.append(.toolResult(
                         toolName: parsedCall.name,
                         result: toolError,
@@ -2242,11 +2205,15 @@ public struct Agent: AgentRuntime, Sendable {
                     if case .user = $0 { return true }
                     return false
                 })
-                let handoffInput: String = if case let .user(content) = lastUserMessage {
+                let lastUserText: String? = if case let .user(content) = lastUserMessage {
                     content
                 } else {
-                    reason.isEmpty ? "Continue the conversation" : reason
+                    nil
                 }
+                let handoffInput = AgentTurnKernel.handoffInput(
+                    lastUserText: lastUserText,
+                    reason: reason
+                )
 
                 let initialHandoffData = HandoffInputData(
                     sourceAgentName: name,

--- a/Sources/Swarm/Agents/AgentTurnKernel.swift
+++ b/Sources/Swarm/Agents/AgentTurnKernel.swift
@@ -1,0 +1,134 @@
+// AgentTurnKernel.swift
+// Swarm Framework
+//
+// Pure turn decisions for the Agent tool loop. Effects stay in Agent.
+
+import Foundation
+
+/// Closed decisions for one Agent iteration.
+///
+/// The kernel does not call providers, tools, observers, or clocks. `Agent`
+/// snapshots booleans from the run, asks for a decision, then executes I/O.
+enum AgentTurnKernel: Sendable {
+    /// How this iteration should invoke the inference provider.
+    enum InferenceKind: Sendable, Equatable {
+        /// Empty host-loop tool list: generate text only, then finish.
+        case withoutTools
+        /// Host or owned tool loop: `generateWithTools` / streaming variant.
+        case withTools(streaming: Bool)
+    }
+
+    /// What to do with a completed `InferenceResponse`.
+    enum AfterInference: Sendable, Equatable {
+        case finishAssistant(content: String)
+        case processHostToolCalls
+        case failMissingContent
+    }
+
+    /// Chooses text-only vs tool-calling inference for this iteration.
+    ///
+    /// An owned-loop provider still uses the tool-calling path when schemas are
+    /// empty so the adapter can run an empty inner loop.
+    static func inferenceKind(
+        toolSchemasEmpty: Bool,
+        useProviderOwnedToolLoop: Bool,
+        streamingToolCalls: Bool
+    ) -> InferenceKind {
+        if toolSchemasEmpty, !useProviderOwnedToolLoop {
+            return .withoutTools
+        }
+        return .withTools(streaming: streamingToolCalls)
+    }
+
+    /// Owned-loop tool execution is not retry-safe; empty owned loops may retry.
+    static func ownedLoopInferenceRetryPolicy(
+        useProviderOwnedToolLoop: Bool,
+        hasToolSchemas: Bool
+    ) -> RetryPolicy? {
+        if useProviderOwnedToolLoop, hasToolSchemas {
+            return .noRetry
+        }
+        return nil
+    }
+
+    /// Owned-loop execution requires the timeout gate created by `runInternal`.
+    static func requireOwnedLoopGate(
+        useProviderOwnedToolLoop: Bool,
+        hasExecutionGate: Bool
+    ) throws {
+        if useProviderOwnedToolLoop, !hasExecutionGate {
+            throw AgentError.internalError(
+                reason: "Provider-owned tool loop missing execution gate"
+            )
+        }
+    }
+
+    /// Interprets a finished model response for host vs owned-loop control flow.
+    static func afterInference(
+        useProviderOwnedToolLoop: Bool,
+        response: InferenceResponse
+    ) -> AfterInference {
+        if useProviderOwnedToolLoop {
+            guard let content = response.content else {
+                return .failMissingContent
+            }
+            return .finishAssistant(content: content)
+        }
+
+        if response.hasToolCalls {
+            return .processHostToolCalls
+        }
+
+        guard let content = response.content else {
+            return .failMissingContent
+        }
+        return .finishAssistant(content: content)
+    }
+
+    /// How the host loop should treat one tool name.
+    enum HostToolCallKind: Sendable, Equatable {
+        case handoff
+        case membraneInternal
+        case regular
+    }
+
+    /// Assistant text recorded for a tool-calling turn.
+    static func assistantContent(for response: InferenceResponse) -> String {
+        if let content = response.content {
+            return content
+        }
+        return response.toolCalls.map { "Calling tool: \($0.name)" }.joined(separator: ", ")
+    }
+
+    /// Handoff names win so transfer tools are never treated as Membrane internals.
+    static func hostToolCallKind(
+        isHandoffTool: Bool,
+        isMembraneInternal: Bool
+    ) -> HostToolCallKind {
+        if isHandoffTool {
+            return .handoff
+        }
+        if isMembraneInternal {
+            return .membraneInternal
+        }
+        return .regular
+    }
+
+    /// Input passed to the target agent when a handoff tool fires.
+    static func handoffInput(lastUserText: String?, reason: String) -> String {
+        if let lastUserText {
+            return lastUserText
+        }
+        return reason.isEmpty ? "Continue the conversation" : reason
+    }
+
+    /// Tool-error text the model sees on the next turn.
+    static func toolFailureConversationText(message: String) -> String {
+        "[TOOL ERROR] Execution failed: \(message). Please try a different approach or tool."
+    }
+
+    /// Shorter tool-error text stored in memory.
+    static func memoryToolErrorText(message: String) -> String {
+        "Error - \(message)"
+    }
+}

--- a/Sources/Swarm/Agents/AgentTurnKernel.swift
+++ b/Sources/Swarm/Agents/AgentTurnKernel.swift
@@ -101,6 +101,11 @@ enum AgentTurnKernel: Sendable {
     }
 
     /// Handoff names win so transfer tools are never treated as Membrane internals.
+    ///
+    /// Pass `isHandoffTool` only when a handoff configuration exists for the
+    /// name, and `isMembraneInternal` only when an adapter is present and the
+    /// name is a Membrane internal. Agent then switches this result exhaustively;
+    /// a missing handle is a `.regular` execution arm, never a remapped kind.
     static func hostToolCallKind(
         isHandoffTool: Bool,
         isMembraneInternal: Bool
@@ -112,26 +117,6 @@ enum AgentTurnKernel: Sendable {
             return .membraneInternal
         }
         return .regular
-    }
-
-    /// Maps a classified kind plus handle snapshots onto the arm Agent should run.
-    ///
-    /// Missing handoff configuration or a missing Membrane adapter becomes
-    /// `.regular`. Handoff never becomes `.membraneInternal`, even when an
-    /// adapter is present.
-    static func resolvedHostToolCallKind(
-        _ kind: HostToolCallKind,
-        hasHandoffConfiguration: Bool,
-        hasMembraneAdapter: Bool
-    ) -> HostToolCallKind {
-        switch kind {
-        case .handoff:
-            return hasHandoffConfiguration ? .handoff : .regular
-        case .membraneInternal:
-            return hasMembraneAdapter ? .membraneInternal : .regular
-        case .regular:
-            return .regular
-        }
     }
 
     /// Input passed to the target agent when a handoff tool fires.

--- a/Sources/Swarm/Agents/AgentTurnKernel.swift
+++ b/Sources/Swarm/Agents/AgentTurnKernel.swift
@@ -114,6 +114,26 @@ enum AgentTurnKernel: Sendable {
         return .regular
     }
 
+    /// Maps a classified kind plus handle snapshots onto the arm Agent should run.
+    ///
+    /// Missing handoff configuration or a missing Membrane adapter becomes
+    /// `.regular`. Handoff never becomes `.membraneInternal`, even when an
+    /// adapter is present.
+    static func resolvedHostToolCallKind(
+        _ kind: HostToolCallKind,
+        hasHandoffConfiguration: Bool,
+        hasMembraneAdapter: Bool
+    ) -> HostToolCallKind {
+        switch kind {
+        case .handoff:
+            return hasHandoffConfiguration ? .handoff : .regular
+        case .membraneInternal:
+            return hasMembraneAdapter ? .membraneInternal : .regular
+        case .regular:
+            return .regular
+        }
+    }
+
     /// Input passed to the target agent when a handoff tool fires.
     static func handoffInput(lastUserText: String?, reason: String) -> String {
         if let lastUserText {

--- a/Tests/SwarmTests/Agents/AgentTurnKernelTests.swift
+++ b/Tests/SwarmTests/Agents/AgentTurnKernelTests.swift
@@ -156,25 +156,57 @@ struct AgentTurnKernelTests {
         )
     }
 
-    @Test("Host tool-call kind prefers handoff over membrane internals")
-    func hostToolCallKind() {
+    @Test(
+        "Host tool-call kind is exhaustive for Agent dispatch",
+        arguments: [
+            (true, true, AgentTurnKernel.HostToolCallKind.handoff),
+            (true, false, AgentTurnKernel.HostToolCallKind.handoff),
+            (false, true, AgentTurnKernel.HostToolCallKind.membraneInternal),
+            (false, false, AgentTurnKernel.HostToolCallKind.regular),
+        ]
+    )
+    func hostToolCallKind(
+        isHandoffTool: Bool,
+        isMembraneInternal: Bool,
+        expected: AgentTurnKernel.HostToolCallKind
+    ) {
         #expect(
             AgentTurnKernel.hostToolCallKind(
-                isHandoffTool: true,
-                isMembraneInternal: true
-            ) == .handoff
+                isHandoffTool: isHandoffTool,
+                isMembraneInternal: isMembraneInternal
+            ) == expected
         )
+    }
+
+    @Test(
+        "Resolved host-tool kind maps missing handles to regular, never Membrane for handoff",
+        arguments: [
+            (AgentTurnKernel.HostToolCallKind.handoff, true, true, AgentTurnKernel.HostToolCallKind.handoff),
+            (AgentTurnKernel.HostToolCallKind.handoff, true, false, AgentTurnKernel.HostToolCallKind.handoff),
+            (AgentTurnKernel.HostToolCallKind.handoff, false, true, AgentTurnKernel.HostToolCallKind.regular),
+            (AgentTurnKernel.HostToolCallKind.handoff, false, false, AgentTurnKernel.HostToolCallKind.regular),
+            (AgentTurnKernel.HostToolCallKind.membraneInternal, true, true, AgentTurnKernel.HostToolCallKind.membraneInternal),
+            (AgentTurnKernel.HostToolCallKind.membraneInternal, true, false, AgentTurnKernel.HostToolCallKind.regular),
+            (AgentTurnKernel.HostToolCallKind.membraneInternal, false, true, AgentTurnKernel.HostToolCallKind.membraneInternal),
+            (AgentTurnKernel.HostToolCallKind.membraneInternal, false, false, AgentTurnKernel.HostToolCallKind.regular),
+            (AgentTurnKernel.HostToolCallKind.regular, true, true, AgentTurnKernel.HostToolCallKind.regular),
+            (AgentTurnKernel.HostToolCallKind.regular, true, false, AgentTurnKernel.HostToolCallKind.regular),
+            (AgentTurnKernel.HostToolCallKind.regular, false, true, AgentTurnKernel.HostToolCallKind.regular),
+            (AgentTurnKernel.HostToolCallKind.regular, false, false, AgentTurnKernel.HostToolCallKind.regular),
+        ]
+    )
+    func resolvedHostToolCallKind(
+        kind: AgentTurnKernel.HostToolCallKind,
+        hasHandoffConfiguration: Bool,
+        hasMembraneAdapter: Bool,
+        expected: AgentTurnKernel.HostToolCallKind
+    ) {
         #expect(
-            AgentTurnKernel.hostToolCallKind(
-                isHandoffTool: false,
-                isMembraneInternal: true
-            ) == .membraneInternal
-        )
-        #expect(
-            AgentTurnKernel.hostToolCallKind(
-                isHandoffTool: false,
-                isMembraneInternal: false
-            ) == .regular
+            AgentTurnKernel.resolvedHostToolCallKind(
+                kind,
+                hasHandoffConfiguration: hasHandoffConfiguration,
+                hasMembraneAdapter: hasMembraneAdapter
+            ) == expected
         )
     }
 

--- a/Tests/SwarmTests/Agents/AgentTurnKernelTests.swift
+++ b/Tests/SwarmTests/Agents/AgentTurnKernelTests.swift
@@ -1,0 +1,196 @@
+// AgentTurnKernelTests.swift
+// SwarmTests
+//
+// Pure turn-kernel decisions for the Agent tool loop.
+
+import Foundation
+@testable import Swarm
+import Testing
+
+struct AgentTurnKernelTests {
+    @Test(
+        "Inference kind matches empty-schema and owned-loop combinations",
+        arguments: [
+            (true, false, false, AgentTurnKernel.InferenceKind.withoutTools),
+            (true, false, true, AgentTurnKernel.InferenceKind.withoutTools),
+            (true, true, false, AgentTurnKernel.InferenceKind.withTools(streaming: false)),
+            (true, true, true, AgentTurnKernel.InferenceKind.withTools(streaming: true)),
+            (false, false, false, AgentTurnKernel.InferenceKind.withTools(streaming: false)),
+            (false, false, true, AgentTurnKernel.InferenceKind.withTools(streaming: true)),
+            (false, true, true, AgentTurnKernel.InferenceKind.withTools(streaming: true)),
+        ]
+    )
+    func inferenceKind(
+        toolSchemasEmpty: Bool,
+        useProviderOwnedToolLoop: Bool,
+        streamingToolCalls: Bool,
+        expected: AgentTurnKernel.InferenceKind
+    ) {
+        let kind = AgentTurnKernel.inferenceKind(
+            toolSchemasEmpty: toolSchemasEmpty,
+            useProviderOwnedToolLoop: useProviderOwnedToolLoop,
+            streamingToolCalls: streamingToolCalls
+        )
+        #expect(kind == expected)
+    }
+
+    @Test("Owned-loop inference retries only when tool schemas are empty")
+    func ownedLoopRetryPolicy() {
+        #expect(
+            AgentTurnKernel.ownedLoopInferenceRetryPolicy(
+                useProviderOwnedToolLoop: true,
+                hasToolSchemas: true
+            ) == .noRetry
+        )
+        #expect(
+            AgentTurnKernel.ownedLoopInferenceRetryPolicy(
+                useProviderOwnedToolLoop: true,
+                hasToolSchemas: false
+            ) == nil
+        )
+        #expect(
+            AgentTurnKernel.ownedLoopInferenceRetryPolicy(
+                useProviderOwnedToolLoop: false,
+                hasToolSchemas: true
+            ) == nil
+        )
+    }
+
+    @Test("Owned loop requires an execution gate")
+    func ownedLoopRequiresGate() throws {
+        try AgentTurnKernel.requireOwnedLoopGate(
+            useProviderOwnedToolLoop: true,
+            hasExecutionGate: true
+        )
+        try AgentTurnKernel.requireOwnedLoopGate(
+            useProviderOwnedToolLoop: false,
+            hasExecutionGate: false
+        )
+
+        #expect(throws: AgentError.internalError(
+            reason: "Provider-owned tool loop missing execution gate"
+        )) {
+            try AgentTurnKernel.requireOwnedLoopGate(
+                useProviderOwnedToolLoop: true,
+                hasExecutionGate: false
+            )
+        }
+    }
+
+    @Test("Owned-loop responses finish even when the model also listed tool calls")
+    func ownedLoopFinishesFromResponse() {
+        let response = InferenceResponse(
+            content: "done",
+            toolCalls: [
+                InferenceResponse.ParsedToolCall(id: "1", name: "search", arguments: [:]),
+            ],
+            finishReason: .toolCall
+        )
+        let decision = AgentTurnKernel.afterInference(
+            useProviderOwnedToolLoop: true,
+            response: response
+        )
+        #expect(decision == .finishAssistant(content: "done"))
+    }
+
+    @Test("Host loop processes tool calls before finishing")
+    func hostLoopProcessesToolCalls() {
+        let response = InferenceResponse(
+            content: nil,
+            toolCalls: [
+                InferenceResponse.ParsedToolCall(id: "1", name: "search", arguments: [:]),
+            ],
+            finishReason: .toolCall
+        )
+        let decision = AgentTurnKernel.afterInference(
+            useProviderOwnedToolLoop: false,
+            response: response
+        )
+        #expect(decision == .processHostToolCalls)
+    }
+
+    @Test("Missing assistant content fails closed")
+    func missingContentFails() {
+        let empty = InferenceResponse(content: nil, toolCalls: [], finishReason: .completed)
+        #expect(
+            AgentTurnKernel.afterInference(useProviderOwnedToolLoop: false, response: empty)
+                == .failMissingContent
+        )
+        #expect(
+            AgentTurnKernel.afterInference(useProviderOwnedToolLoop: true, response: empty)
+                == .failMissingContent
+        )
+    }
+
+    @Test("Host loop finishes on assistant text")
+    func hostLoopFinishesOnText() {
+        let response = InferenceResponse(content: "42", finishReason: .completed)
+        #expect(
+            AgentTurnKernel.afterInference(useProviderOwnedToolLoop: false, response: response)
+                == .finishAssistant(content: "42")
+        )
+    }
+
+    @Test("Assistant tool-turn content prefers model text, then a call summary")
+    func assistantContentForToolTurn() {
+        let withText = InferenceResponse(
+            content: "I'll search",
+            toolCalls: [
+                InferenceResponse.ParsedToolCall(id: "1", name: "search", arguments: [:]),
+            ],
+            finishReason: .toolCall
+        )
+        #expect(AgentTurnKernel.assistantContent(for: withText) == "I'll search")
+
+        let callsOnly = InferenceResponse(
+            content: nil,
+            toolCalls: [
+                InferenceResponse.ParsedToolCall(id: "1", name: "search", arguments: [:]),
+                InferenceResponse.ParsedToolCall(id: "2", name: "lookup", arguments: [:]),
+            ],
+            finishReason: .toolCall
+        )
+        #expect(
+            AgentTurnKernel.assistantContent(for: callsOnly)
+                == "Calling tool: search, Calling tool: lookup"
+        )
+    }
+
+    @Test("Host tool-call kind prefers handoff over membrane internals")
+    func hostToolCallKind() {
+        #expect(
+            AgentTurnKernel.hostToolCallKind(
+                isHandoffTool: true,
+                isMembraneInternal: true
+            ) == .handoff
+        )
+        #expect(
+            AgentTurnKernel.hostToolCallKind(
+                isHandoffTool: false,
+                isMembraneInternal: true
+            ) == .membraneInternal
+        )
+        #expect(
+            AgentTurnKernel.hostToolCallKind(
+                isHandoffTool: false,
+                isMembraneInternal: false
+            ) == .regular
+        )
+    }
+
+    @Test("Handoff input uses the last user message, then reason, then a default")
+    func handoffInput() {
+        #expect(AgentTurnKernel.handoffInput(lastUserText: "summarize this", reason: "writer") == "summarize this")
+        #expect(AgentTurnKernel.handoffInput(lastUserText: nil, reason: "need writer") == "need writer")
+        #expect(AgentTurnKernel.handoffInput(lastUserText: nil, reason: "") == "Continue the conversation")
+    }
+
+    @Test("Tool failure text for the model and for memory stay distinct")
+    func toolFailureText() {
+        #expect(
+            AgentTurnKernel.toolFailureConversationText(message: "boom")
+                == "[TOOL ERROR] Execution failed: boom. Please try a different approach or tool."
+        )
+        #expect(AgentTurnKernel.memoryToolErrorText(message: "boom") == "Error - boom")
+    }
+}

--- a/Tests/SwarmTests/Agents/AgentTurnKernelTests.swift
+++ b/Tests/SwarmTests/Agents/AgentTurnKernelTests.swift
@@ -178,38 +178,6 @@ struct AgentTurnKernelTests {
         )
     }
 
-    @Test(
-        "Resolved host-tool kind maps missing handles to regular, never Membrane for handoff",
-        arguments: [
-            (AgentTurnKernel.HostToolCallKind.handoff, true, true, AgentTurnKernel.HostToolCallKind.handoff),
-            (AgentTurnKernel.HostToolCallKind.handoff, true, false, AgentTurnKernel.HostToolCallKind.handoff),
-            (AgentTurnKernel.HostToolCallKind.handoff, false, true, AgentTurnKernel.HostToolCallKind.regular),
-            (AgentTurnKernel.HostToolCallKind.handoff, false, false, AgentTurnKernel.HostToolCallKind.regular),
-            (AgentTurnKernel.HostToolCallKind.membraneInternal, true, true, AgentTurnKernel.HostToolCallKind.membraneInternal),
-            (AgentTurnKernel.HostToolCallKind.membraneInternal, true, false, AgentTurnKernel.HostToolCallKind.regular),
-            (AgentTurnKernel.HostToolCallKind.membraneInternal, false, true, AgentTurnKernel.HostToolCallKind.membraneInternal),
-            (AgentTurnKernel.HostToolCallKind.membraneInternal, false, false, AgentTurnKernel.HostToolCallKind.regular),
-            (AgentTurnKernel.HostToolCallKind.regular, true, true, AgentTurnKernel.HostToolCallKind.regular),
-            (AgentTurnKernel.HostToolCallKind.regular, true, false, AgentTurnKernel.HostToolCallKind.regular),
-            (AgentTurnKernel.HostToolCallKind.regular, false, true, AgentTurnKernel.HostToolCallKind.regular),
-            (AgentTurnKernel.HostToolCallKind.regular, false, false, AgentTurnKernel.HostToolCallKind.regular),
-        ]
-    )
-    func resolvedHostToolCallKind(
-        kind: AgentTurnKernel.HostToolCallKind,
-        hasHandoffConfiguration: Bool,
-        hasMembraneAdapter: Bool,
-        expected: AgentTurnKernel.HostToolCallKind
-    ) {
-        #expect(
-            AgentTurnKernel.resolvedHostToolCallKind(
-                kind,
-                hasHandoffConfiguration: hasHandoffConfiguration,
-                hasMembraneAdapter: hasMembraneAdapter
-            ) == expected
-        )
-    }
-
     @Test("Handoff input uses the last user message, then reason, then a default")
     func handoffInput() {
         #expect(AgentTurnKernel.handoffInput(lastUserText: "summarize this", reason: "writer") == "summarize this")


### PR DESCRIPTION
## Summary
- Move host vs owned-loop turn decisions out of `Agent` into an internal `AgentTurnKernel` (inference kind, owned-loop retry/gate, after-inference, assistant tool-turn text, host tool-call kind, handoff input, shared tool-error strings).
- Collapse the duplicated “finalize assistant and return” paths and delete unused `processToolCalls`.
- Public `Agent` / `AgentRuntime` APIs are unchanged.

## Test plan
- [x] `SWARM_OMIT_INTEGRATION_TARGETS=1 swift test --filter 'AgentTurnKernelTests|ProviderOwnedToolLoopTests|ReActAgentTests|AgentHandoffRuntimeTests'` (37 tests)
- [ ] CI lean + Integrations lanes
- [ ] Confirm no public DocC / catalog updates needed (internal types only)


Made with [Cursor](https://cursor.com)