### PR TITLE
refactor(config): enforce ModelSettings and AgentConfiguration invariants on every write path (T3)

### DIFF
--- a/Sources/Swarm/Core/AgentConfiguration.swift
+++ b/Sources/Swarm/Core/AgentConfiguration.swift
@@ -206,6 +206,14 @@ public enum FoundationModelsExecutionMode: String, Sendable, Equatable {
 ///
 /// `AgentConfiguration` is a value type (`struct`) and is `Sendable`, making it
 /// safe to pass across concurrency boundaries.
+///
+/// ## Post-Initialization Writes
+///
+/// ``maxIterations``, ``timeout``, and ``temperature`` are mutation-proofed:
+/// `didSet` observers coerce any write with the exact same rules (and
+/// ``Log/agents`` warnings) as the designated initializer, so e.g.
+/// `config.maxIterations = 0` reads back as `1`. Property setters cannot
+/// throw, which is why invalid values are coerced rather than rejected.
 public struct AgentConfiguration: Sendable, Equatable {
     // MARK: - Default Configuration
 
@@ -237,17 +245,33 @@ public struct AgentConfiguration: Sendable, Equatable {
 
     /// Maximum number of reasoning iterations before stopping.
     /// Default: 10
-    public var maxIterations: Int
+    ///
+    /// Post-initialization writes are coerced like the initializer: values
+    /// below 1 self-correct to 1 (with a `Log.agents` warning), so a write of
+    /// `0` reads back as `1`.
+    public var maxIterations: Int {
+        didSet { maxIterations = Self.coercedMaxIterations(maxIterations) }
+    }
 
     /// Maximum time allowed for the entire execution.
     /// Default: 60 seconds
-    public var timeout: Duration
+    ///
+    /// Post-initialization writes are coerced like the initializer: non-positive
+    /// durations fall back to the 60-second default (with a `Log.agents` warning).
+    public var timeout: Duration {
+        didSet { timeout = Self.coercedTimeout(timeout) }
+    }
 
     // MARK: - Model Settings
 
     /// Temperature for model generation (0.0 = deterministic, 2.0 = creative).
     /// Default: 1.0
-    public var temperature: Double
+    ///
+    /// Post-initialization writes are coerced like the initializer: non-finite
+    /// or out-of-range values fall back to 1.0 (with a `Log.agents` warning).
+    public var temperature: Double {
+        didSet { temperature = Self.coercedTemperature(temperature) }
+    }
 
     /// Maximum tokens to generate per response.
     /// Default: nil (model default)
@@ -693,19 +717,10 @@ public struct AgentConfiguration: Sendable, Equatable {
         foundationModelsExecution: FoundationModelsExecutionMode = .capture,
         resilience: ResilienceConfiguration = .disabled
     ) {
-        if maxIterations < 1 {
-            Log.agents.warning("AgentConfiguration: maxIterations \(maxIterations) must be >= 1; using 1")
-        }
-        if timeout <= .zero {
-            Log.agents.warning("AgentConfiguration: timeout must be positive; using default 60 seconds")
-        }
-        if !temperature.isFinite || !(0.0 ... 2.0).contains(temperature) {
-            Log.agents.warning("AgentConfiguration: temperature \(temperature) out of [0.0, 2.0]; using default 1.0")
-        }
         self.name = name
-        self.maxIterations = max(1, maxIterations)
-        self.timeout = timeout > .zero ? timeout : .seconds(60)
-        self.temperature = (temperature.isFinite && (0.0 ... 2.0).contains(temperature)) ? temperature : 1.0
+        self.maxIterations = Self.coercedMaxIterations(maxIterations)
+        self.timeout = Self.coercedTimeout(timeout)
+        self.temperature = Self.coercedTemperature(temperature)
         self.maxTokens = maxTokens
         self.stopSequences = stopSequences
         self.modelSettings = modelSettings
@@ -725,6 +740,35 @@ public struct AgentConfiguration: Sendable, Equatable {
         self.autoAttachMetricsCollector = autoAttachMetricsCollector
         self.foundationModelsExecution = foundationModelsExecution
         self.resilience = resilience
+    }
+}
+
+// MARK: - Write-Path Coercion
+
+private extension AgentConfiguration {
+    /// Coerces `maxIterations` to at least 1, matching the designated
+    /// initializer; warns via ``Log/agents`` when clamping occurs. Shared by
+    /// `init` and `didSet` so both write paths stay identical.
+    static func coercedMaxIterations(_ value: Int) -> Int {
+        guard value < 1 else { return value }
+        Log.agents.warning("AgentConfiguration: maxIterations \(value) must be >= 1; using 1")
+        return max(1, value)
+    }
+
+    /// Falls back to the 60-second default for non-positive timeouts, matching
+    /// the designated initializer; warns via ``Log/agents`` when replaced.
+    static func coercedTimeout(_ value: Duration) -> Duration {
+        guard value <= .zero else { return value }
+        Log.agents.warning("AgentConfiguration: timeout must be positive; using default 60 seconds")
+        return .seconds(60)
+    }
+
+    /// Falls back to 1.0 for non-finite or out-of-range temperatures, matching
+    /// the designated initializer; warns via ``Log/agents`` when replaced.
+    static func coercedTemperature(_ value: Double) -> Double {
+        guard !value.isFinite || !(0.0 ... 2.0).contains(value) else { return value }
+        Log.agents.warning("AgentConfiguration: temperature \(value) out of [0.0, 2.0]; using default 1.0")
+        return 1.0
     }
 }
 

--- a/Sources/Swarm/Core/AgentConfiguration.swift
+++ b/Sources/Swarm/Core/AgentConfiguration.swift
@@ -69,8 +69,15 @@ public struct InferencePolicy: Sendable, Equatable {
     ///
     /// This limits the model's generation length, not the context window.
     /// For context window management, see ``AgentConfiguration/contextProfile``.
+    ///
+    /// Post-initialization writes are coerced like the initializer: values of
+    /// zero or less are dropped to `nil` (with a `Log.agents` warning), so a
+    /// write of `-5` reads back as `nil`.
+    ///
     /// Default: `nil`
-    public var tokenBudget: Int?
+    public var tokenBudget: Int? {
+        didSet { tokenBudget = Self.coercedTokenBudget(tokenBudget) }
+    }
 
     /// Current network state hint. Default: `.online`
     public var networkState: NetworkState
@@ -81,13 +88,27 @@ public struct InferencePolicy: Sendable, Equatable {
         tokenBudget: Int? = nil,
         networkState: NetworkState = .online
     ) {
-        if let tokenBudget, tokenBudget <= 0 {
-            Log.agents.warning("InferencePolicy: tokenBudget \(tokenBudget) must be > 0; dropping value")
-        }
         self.latencyTier = latencyTier
         self.privacyRequired = privacyRequired
-        self.tokenBudget = tokenBudget.flatMap { $0 > 0 ? $0 : nil }
+        self.tokenBudget = Self.coercedTokenBudget(tokenBudget)
         self.networkState = networkState
+    }
+}
+
+// MARK: - InferencePolicy Write-Path Coercion
+
+private extension InferencePolicy {
+    /// Drops non-positive token budgets to `nil`, matching the designated
+    /// initializer; warns via ``Log/agents`` when dropped. Shared by `init`
+    /// and `didSet` so both write paths stay identical.
+    static func coercedTokenBudget(_ value: Int?) -> Int? {
+        guard let value, value > 0 else {
+            if let value {
+                Log.agents.warning("InferencePolicy: tokenBudget \(value) must be > 0; dropping value")
+            }
+            return nil
+        }
+        return value
     }
 }
 
@@ -765,10 +786,14 @@ private extension AgentConfiguration {
 
     /// Falls back to 1.0 for non-finite or out-of-range temperatures, matching
     /// the designated initializer; warns via ``Log/agents`` when replaced.
+    /// Shares ``ModelSettings/temperatureRange`` so both types' temperature
+    /// bounds cannot drift apart.
     static func coercedTemperature(_ value: Double) -> Double {
-        guard !value.isFinite || !(0.0 ... 2.0).contains(value) else { return value }
-        Log.agents.warning("AgentConfiguration: temperature \(value) out of [0.0, 2.0]; using default 1.0")
-        return 1.0
+        guard value.isFinite, ModelSettings.temperatureRange.contains(value) else {
+            Log.agents.warning("AgentConfiguration: temperature \(value) out of [0.0, 2.0]; using default 1.0")
+            return 1.0
+        }
+        return value
     }
 }
 

--- a/Sources/Swarm/Core/ModelSettings.swift
+++ b/Sources/Swarm/Core/ModelSettings.swift
@@ -38,6 +38,23 @@ import Foundation
 /// let merged = base.merged(with: override)
 /// // Result: temperature 0.7, maxTokens 2048
 /// ```
+///
+/// ## Write-Path Invariants
+///
+/// Settings are mutation-proofed on every write path:
+///
+/// - **Initialization** (including the fluent builders, which are sugar over
+///   `init`) preserves raw values so programmatic mistakes surface loudly via
+///   ``validate()`` or ``merged(with:)`` instead of being silently rewritten.
+/// - **Direct property writes after initialization** (`settings.temperature = 99`)
+///   cannot throw, so `didSet` normalization clamps them into the valid range
+///   instead (e.g. temperature into `0.0...2.0`, counts to at least 1). Any
+///   post-write read therefore satisfies the same invariants that
+///   ``validate()`` enforces.
+/// - **Decoding bypasses `didSet` by design**: synthesized `Codable`
+///   conformance assigns stored properties during initialization, where Swift
+///   property observers do not run. Decoded values are assumed to have been
+///   valid when they were encoded and are preserved as-is.
 public struct ModelSettings: Sendable, Equatable {
     // MARK: - Sampling Parameters
 
@@ -46,41 +63,53 @@ public struct ModelSettings: Sendable, Equatable {
     /// Lower values produce more focused, deterministic outputs.
     /// Higher values produce more diverse, creative outputs.
     /// - Valid range: 0.0 to 2.0
-    public var temperature: Double?
+    public var temperature: Double? {
+        didSet { temperature = Self.clamped(temperature, in: Self.temperatureRange) }
+    }
 
     /// Nucleus sampling threshold.
     ///
     /// Only consider tokens with cumulative probability up to this threshold.
     /// Lower values produce more focused outputs.
     /// - Valid range: 0.0 to 1.0
-    public var topP: Double?
+    public var topP: Double? {
+        didSet { topP = Self.clamped(topP, in: Self.probabilityRange) }
+    }
 
     /// Top-k sampling parameter.
     ///
     /// Only consider the top k most likely tokens.
     /// Lower values produce more focused outputs.
     /// - Valid range: > 0
-    public var topK: Int?
+    public var topK: Int? {
+        didSet { topK = Self.clampedPositive(topK) }
+    }
 
     /// Maximum tokens to generate per response.
     ///
     /// Limits the length of the generated response.
     /// - Valid range: > 0
-    public var maxTokens: Int?
+    public var maxTokens: Int? {
+        didSet { maxTokens = Self.clampedPositive(maxTokens) }
+    }
 
     /// Frequency penalty for repeated tokens.
     ///
     /// Positive values discourage repetition of tokens based on their frequency.
     /// Negative values encourage repetition.
     /// - Valid range: -2.0 to 2.0
-    public var frequencyPenalty: Double?
+    public var frequencyPenalty: Double? {
+        didSet { frequencyPenalty = Self.clamped(frequencyPenalty, in: Self.penaltyRange) }
+    }
 
     /// Presence penalty for new tokens.
     ///
     /// Positive values encourage the model to use new tokens.
     /// Negative values encourage staying with tokens already used.
     /// - Valid range: -2.0 to 2.0
-    public var presencePenalty: Double?
+    public var presencePenalty: Double? {
+        didSet { presencePenalty = Self.clamped(presencePenalty, in: Self.penaltyRange) }
+    }
 
     /// Sequences that will stop generation when encountered.
     ///
@@ -129,13 +158,17 @@ public struct ModelSettings: Sendable, Equatable {
     ///
     /// Values greater than 1.0 discourage repetition.
     /// Values less than 1.0 encourage repetition.
-    public var repetitionPenalty: Double?
+    public var repetitionPenalty: Double? {
+        didSet { repetitionPenalty = Self.clampedNonNegative(repetitionPenalty) }
+    }
 
     /// Minimum probability threshold for tokens.
     ///
     /// Tokens with probability below this threshold are filtered out.
     /// - Valid range: 0.0 to 1.0
-    public var minP: Double?
+    public var minP: Double? {
+        didSet { minP = Self.clamped(minP, in: Self.probabilityRange) }
+    }
 
     // MARK: - Provider-Specific Settings
 
@@ -160,7 +193,9 @@ public struct ModelSettings: Sendable, Equatable {
     /// Without this, reasoning models may run unbounded — see one-fhx for the
     /// production failure mode (gpt-5 returning response_bytes=0 after 800-1000
     /// reasoning tokens).
-    public var reasoning: ReasoningConfig?
+    public var reasoning: ReasoningConfig? {
+        didSet { reasoning = reasoning?.clampedToValidMaxTokens() }
+    }
 
     // MARK: - Initialization
 
@@ -210,46 +245,148 @@ public struct ModelSettings: Sendable, Equatable {
 // MARK: - Fluent Builders
 
 public extension ModelSettings {
+    /// Returns new settings with the given temperature.
+    ///
+    /// Builders are sugar over ``init(temperature:topP:topK:maxTokens:frequencyPenalty:presencePenalty:stopSequences:seed:toolChoice:parallelToolCalls:truncation:verbosity:promptCacheRetention:repetitionPenalty:minP:providerSettings:reasoning:)``,
+    /// so raw values — including out-of-range ones — are preserved for
+    /// ``validate()``/``merged(with:)`` to judge. Only direct property writes
+    /// after initialization clamp via `didSet`.
     @discardableResult
     func temperature(_ value: Double?) -> Self {
-        var copy = self
-        copy.temperature = value
-        return copy
+        Self(
+            temperature: value,
+            topP: topP,
+            topK: topK,
+            maxTokens: maxTokens,
+            frequencyPenalty: frequencyPenalty,
+            presencePenalty: presencePenalty,
+            stopSequences: stopSequences,
+            seed: seed,
+            toolChoice: toolChoice,
+            parallelToolCalls: parallelToolCalls,
+            truncation: truncation,
+            verbosity: verbosity,
+            promptCacheRetention: promptCacheRetention,
+            repetitionPenalty: repetitionPenalty,
+            minP: minP,
+            providerSettings: providerSettings,
+            reasoning: reasoning
+        )
     }
 
     @discardableResult
     func topP(_ value: Double?) -> Self {
-        var copy = self
-        copy.topP = value
-        return copy
+        Self(
+            temperature: temperature,
+            topP: value,
+            topK: topK,
+            maxTokens: maxTokens,
+            frequencyPenalty: frequencyPenalty,
+            presencePenalty: presencePenalty,
+            stopSequences: stopSequences,
+            seed: seed,
+            toolChoice: toolChoice,
+            parallelToolCalls: parallelToolCalls,
+            truncation: truncation,
+            verbosity: verbosity,
+            promptCacheRetention: promptCacheRetention,
+            repetitionPenalty: repetitionPenalty,
+            minP: minP,
+            providerSettings: providerSettings,
+            reasoning: reasoning
+        )
     }
 
     @discardableResult
     func topK(_ value: Int?) -> Self {
-        var copy = self
-        copy.topK = value
-        return copy
+        Self(
+            temperature: temperature,
+            topP: topP,
+            topK: value,
+            maxTokens: maxTokens,
+            frequencyPenalty: frequencyPenalty,
+            presencePenalty: presencePenalty,
+            stopSequences: stopSequences,
+            seed: seed,
+            toolChoice: toolChoice,
+            parallelToolCalls: parallelToolCalls,
+            truncation: truncation,
+            verbosity: verbosity,
+            promptCacheRetention: promptCacheRetention,
+            repetitionPenalty: repetitionPenalty,
+            minP: minP,
+            providerSettings: providerSettings,
+            reasoning: reasoning
+        )
     }
 
     @discardableResult
     func maxTokens(_ value: Int?) -> Self {
-        var copy = self
-        copy.maxTokens = value
-        return copy
+        Self(
+            temperature: temperature,
+            topP: topP,
+            topK: topK,
+            maxTokens: value,
+            frequencyPenalty: frequencyPenalty,
+            presencePenalty: presencePenalty,
+            stopSequences: stopSequences,
+            seed: seed,
+            toolChoice: toolChoice,
+            parallelToolCalls: parallelToolCalls,
+            truncation: truncation,
+            verbosity: verbosity,
+            promptCacheRetention: promptCacheRetention,
+            repetitionPenalty: repetitionPenalty,
+            minP: minP,
+            providerSettings: providerSettings,
+            reasoning: reasoning
+        )
     }
 
     @discardableResult
     func frequencyPenalty(_ value: Double?) -> Self {
-        var copy = self
-        copy.frequencyPenalty = value
-        return copy
+        Self(
+            temperature: temperature,
+            topP: topP,
+            topK: topK,
+            maxTokens: maxTokens,
+            frequencyPenalty: value,
+            presencePenalty: presencePenalty,
+            stopSequences: stopSequences,
+            seed: seed,
+            toolChoice: toolChoice,
+            parallelToolCalls: parallelToolCalls,
+            truncation: truncation,
+            verbosity: verbosity,
+            promptCacheRetention: promptCacheRetention,
+            repetitionPenalty: repetitionPenalty,
+            minP: minP,
+            providerSettings: providerSettings,
+            reasoning: reasoning
+        )
     }
 
     @discardableResult
     func presencePenalty(_ value: Double?) -> Self {
-        var copy = self
-        copy.presencePenalty = value
-        return copy
+        Self(
+            temperature: temperature,
+            topP: topP,
+            topK: topK,
+            maxTokens: maxTokens,
+            frequencyPenalty: frequencyPenalty,
+            presencePenalty: value,
+            stopSequences: stopSequences,
+            seed: seed,
+            toolChoice: toolChoice,
+            parallelToolCalls: parallelToolCalls,
+            truncation: truncation,
+            verbosity: verbosity,
+            promptCacheRetention: promptCacheRetention,
+            repetitionPenalty: repetitionPenalty,
+            minP: minP,
+            providerSettings: providerSettings,
+            reasoning: reasoning
+        )
     }
 
     @discardableResult
@@ -303,16 +440,48 @@ public extension ModelSettings {
 
     @discardableResult
     func repetitionPenalty(_ value: Double?) -> Self {
-        var copy = self
-        copy.repetitionPenalty = value
-        return copy
+        Self(
+            temperature: temperature,
+            topP: topP,
+            topK: topK,
+            maxTokens: maxTokens,
+            frequencyPenalty: frequencyPenalty,
+            presencePenalty: presencePenalty,
+            stopSequences: stopSequences,
+            seed: seed,
+            toolChoice: toolChoice,
+            parallelToolCalls: parallelToolCalls,
+            truncation: truncation,
+            verbosity: verbosity,
+            promptCacheRetention: promptCacheRetention,
+            repetitionPenalty: value,
+            minP: minP,
+            providerSettings: providerSettings,
+            reasoning: reasoning
+        )
     }
 
     @discardableResult
     func minP(_ value: Double?) -> Self {
-        var copy = self
-        copy.minP = value
-        return copy
+        Self(
+            temperature: temperature,
+            topP: topP,
+            topK: topK,
+            maxTokens: maxTokens,
+            frequencyPenalty: frequencyPenalty,
+            presencePenalty: presencePenalty,
+            stopSequences: stopSequences,
+            seed: seed,
+            toolChoice: toolChoice,
+            parallelToolCalls: parallelToolCalls,
+            truncation: truncation,
+            verbosity: verbosity,
+            promptCacheRetention: promptCacheRetention,
+            repetitionPenalty: repetitionPenalty,
+            minP: value,
+            providerSettings: providerSettings,
+            reasoning: reasoning
+        )
     }
 
     @discardableResult
@@ -324,9 +493,25 @@ public extension ModelSettings {
 
     @discardableResult
     func reasoning(_ value: ReasoningConfig?) -> Self {
-        var copy = self
-        copy.reasoning = value
-        return copy
+        Self(
+            temperature: temperature,
+            topP: topP,
+            topK: topK,
+            maxTokens: maxTokens,
+            frequencyPenalty: frequencyPenalty,
+            presencePenalty: presencePenalty,
+            stopSequences: stopSequences,
+            seed: seed,
+            toolChoice: toolChoice,
+            parallelToolCalls: parallelToolCalls,
+            truncation: truncation,
+            verbosity: verbosity,
+            promptCacheRetention: promptCacheRetention,
+            repetitionPenalty: repetitionPenalty,
+            minP: minP,
+            providerSettings: providerSettings,
+            reasoning: value
+        )
     }
 }
 
@@ -365,6 +550,62 @@ public extension ModelSettings {
     }
 }
 
+// MARK: - Shared Invariant Bounds & Clamps
+
+extension ModelSettings {
+    /// Valid temperature bounds. Single source of truth shared by
+    /// ``validate()`` and write-path clamping so the two cannot drift.
+    static let temperatureRange: ClosedRange<Double> = 0.0 ... 2.0
+
+    /// Valid probability bounds (`topP`, `minP`).
+    static let probabilityRange: ClosedRange<Double> = 0.0 ... 1.0
+
+    /// Valid penalty bounds (`frequencyPenalty`, `presencePenalty`).
+    static let penaltyRange: ClosedRange<Double> = -2.0 ... 2.0
+
+    /// Clamps an optional double into `range`.
+    ///
+    /// `nil` stays `nil` and finite values are pulled into `range`. Positive
+    /// infinity collapses onto the upper bound and negative infinity onto the
+    /// lower bound. NaN has no direction to clamp toward, so it falls back to
+    /// `nil` (provider default).
+    static func clamped(_ value: Double?, in range: ClosedRange<Double>) -> Double? {
+        guard let value else { return nil }
+        if !value.isFinite {
+            if value > range.upperBound { return range.upperBound }
+            if value < range.lowerBound { return range.lowerBound }
+            return nil // NaN
+        }
+        return min(range.upperBound, max(range.lowerBound, value))
+    }
+
+    /// Clamps an optional count to at least 1 (zero and negatives become 1).
+    static func clampedPositive(_ value: Int?) -> Int? {
+        value.map { max(1, $0) }
+    }
+
+    /// Clamps an optional double to a finite value of at least 0; non-finite
+    /// values fall back to `nil` (provider default).
+    static func clampedNonNegative(_ value: Double?) -> Double? {
+        guard let value, value.isFinite else { return nil }
+        return max(0.0, value)
+    }
+}
+
+// MARK: - ReasoningConfig + Invariant Normalization
+
+extension ReasoningConfig {
+    /// Returns a copy whose ``ReasoningConfig/maxTokens`` satisfies the "> 0"
+    /// invariant enforced by ``ModelSettings/validate()``; returns `self`
+    /// when already valid or unset.
+    func clampedToValidMaxTokens() -> ReasoningConfig {
+        guard let maxTokens, maxTokens < 1 else { return self }
+        var copy = self
+        copy.maxTokens = 1
+        return copy
+    }
+}
+
 // MARK: - Validation
 
 public extension ModelSettings {
@@ -385,13 +626,13 @@ public extension ModelSettings {
     /// ```
     func validate() throws {
         if let temperature {
-            guard temperature.isFinite, temperature >= 0.0, temperature <= 2.0 else {
+            guard temperature.isFinite, Self.temperatureRange.contains(temperature) else {
                 throw ModelSettingsValidationError.invalidTemperature(temperature)
             }
         }
 
         if let topP {
-            guard topP.isFinite, topP >= 0.0, topP <= 1.0 else {
+            guard topP.isFinite, Self.probabilityRange.contains(topP) else {
                 throw ModelSettingsValidationError.invalidTopP(topP)
             }
         }
@@ -409,19 +650,19 @@ public extension ModelSettings {
         }
 
         if let frequencyPenalty {
-            guard frequencyPenalty.isFinite, frequencyPenalty >= -2.0, frequencyPenalty <= 2.0 else {
+            guard frequencyPenalty.isFinite, Self.penaltyRange.contains(frequencyPenalty) else {
                 throw ModelSettingsValidationError.invalidFrequencyPenalty(frequencyPenalty)
             }
         }
 
         if let presencePenalty {
-            guard presencePenalty.isFinite, presencePenalty >= -2.0, presencePenalty <= 2.0 else {
+            guard presencePenalty.isFinite, Self.penaltyRange.contains(presencePenalty) else {
                 throw ModelSettingsValidationError.invalidPresencePenalty(presencePenalty)
             }
         }
 
         if let minP {
-            guard minP.isFinite, minP >= 0.0, minP <= 1.0 else {
+            guard minP.isFinite, Self.probabilityRange.contains(minP) else {
                 throw ModelSettingsValidationError.invalidMinP(minP)
             }
         }

--- a/Tests/SwarmTests/Core/AgentConfigurationTests.swift
+++ b/Tests/SwarmTests/Core/AgentConfigurationTests.swift
@@ -87,3 +87,34 @@ struct AgentConfigurationPostInitClampTests {
         #expect(config.name == "Agent")
     }
 }
+
+// MARK: - InferencePolicyPostInitClampTests
+
+@Suite("InferencePolicy Post-Init Clamp Tests")
+struct InferencePolicyPostInitClampTests {
+    @Test("Initializer drops non-positive tokenBudget")
+    func initializerDropsNonPositiveTokenBudget() {
+        #expect(InferencePolicy(tokenBudget: -5).tokenBudget == nil)
+        #expect(InferencePolicy(tokenBudget: 0).tokenBudget == nil)
+        #expect(InferencePolicy(tokenBudget: 500).tokenBudget == 500)
+        #expect(InferencePolicy().tokenBudget == nil)
+    }
+
+    @Test("Writing a non-positive tokenBudget drops the value on read")
+    func nonPositiveTokenBudgetWriteDrops() {
+        var policy = InferencePolicy(tokenBudget: 500)
+
+        policy.tokenBudget = -5
+        #expect(policy.tokenBudget == nil)
+
+        policy.tokenBudget = 0
+        #expect(policy.tokenBudget == nil)
+    }
+
+    @Test("Writing a positive tokenBudget survives unchanged")
+    func positiveTokenBudgetWriteSurvives() {
+        var policy = InferencePolicy()
+        policy.tokenBudget = 250
+        #expect(policy.tokenBudget == 250)
+    }
+}

--- a/Tests/SwarmTests/Core/AgentConfigurationTests.swift
+++ b/Tests/SwarmTests/Core/AgentConfigurationTests.swift
@@ -1,0 +1,89 @@
+// AgentConfigurationTests.swift
+// SwarmTests
+//
+// Mutation-proof write-path tests for AgentConfiguration: post-initialization
+// property writes (and builder writes, which mutate a copy) must self-correct
+// exactly like initializer-time coercion.
+//
+// Initializer and general fluent-builder coverage lives in CoreTests.swift
+// (`AgentConfigurationTests` suite); this file covers write-path coercion only.
+
+import Foundation
+@testable import Swarm
+import Testing
+
+// MARK: - AgentConfigurationPostInitClampTests
+
+@Suite("AgentConfiguration Post-Init Clamp Tests")
+struct AgentConfigurationPostInitClampTests {
+    @Test("Writing zero maxIterations self-corrects to 1")
+    func zeroMaxIterationsSelfCorrects() {
+        var config = AgentConfiguration.default
+        config.maxIterations = 0
+        #expect(config.maxIterations == 1)
+    }
+
+    @Test("Writing negative maxIterations self-corrects to 1")
+    func negativeMaxIterationsSelfCorrects() {
+        var config = AgentConfiguration.default
+        config.maxIterations = -7
+        #expect(config.maxIterations == 1)
+    }
+
+    @Test("Builder write of zero maxIterations self-corrects to 1")
+    func builderZeroMaxIterationsSelfCorrects() {
+        let config = AgentConfiguration.default.maxIterations(0)
+        #expect(config.maxIterations == 1)
+    }
+
+    @Test("Writing zero timeout falls back to the 60 second default")
+    func zeroTimeoutFallsBackToDefault() {
+        var config = AgentConfiguration.default
+        config.timeout = .zero
+        #expect(config.timeout == .seconds(60))
+    }
+
+    @Test("Writing a negative timeout falls back to the 60 second default")
+    func negativeTimeoutFallsBackToDefault() {
+        var config = AgentConfiguration.default
+        config.timeout = .seconds(-30)
+        #expect(config.timeout == .seconds(60))
+    }
+
+    @Test("Writing an out-of-range temperature falls back to 1.0")
+    func outOfRangeTemperatureFallsBackToDefault() {
+        var config = AgentConfiguration.default
+
+        config.temperature = 99.0
+        #expect(config.temperature == 1.0)
+
+        config.temperature = -0.5
+        #expect(config.temperature == 1.0)
+
+        config.temperature = .infinity
+        #expect(config.temperature == 1.0)
+    }
+
+    @Test("Boundary temperatures survive writes unchanged")
+    func boundaryTemperaturesSurvive() {
+        var config = AgentConfiguration.default
+
+        config.temperature = 0.0
+        #expect(config.temperature == 0.0)
+
+        config.temperature = 2.0
+        #expect(config.temperature == 2.0)
+    }
+
+    @Test("Coerced writes leave other fields untouched")
+    func coercedWriteLeavesOtherFieldsUntouched() {
+        var config = AgentConfiguration.default
+        config.maxIterations = -1
+
+        #expect(config.maxIterations == 1)
+        #expect(config.timeout == .seconds(60))
+        #expect(config.temperature == 1.0)
+        #expect(config.enableStreaming == true)
+        #expect(config.name == "Agent")
+    }
+}

--- a/Tests/SwarmTests/Core/ModelSettingsTests.swift
+++ b/Tests/SwarmTests/Core/ModelSettingsTests.swift
@@ -460,3 +460,131 @@ struct ModelSettingsDescriptionTests {
         #expect(settings.description.contains("reasoning: ReasoningConfig("))
     }
 }
+
+// MARK: - ModelSettingsPostInitClampTests
+
+/// Post-initialization property writes clamp via `didSet` so every read
+/// satisfies the invariants `validate()` enforces. Fluent builders are
+/// intentionally exempt (they are sugar over `init` and preserve raw values
+/// for `validate()`/`merged(with:)` to judge), and decoding bypasses `didSet`
+/// by design.
+@Suite("ModelSettings Post-Init Clamp Tests")
+struct ModelSettingsPostInitClampTests {
+    @Test("Writing temperature 99 clamps to 2.0 on read")
+    func temperatureAboveRangeClamps() {
+        var settings = ModelSettings()
+        settings.temperature = 99
+        #expect(settings.temperature == 2.0)
+    }
+
+    @Test("Writing a negative temperature clamps to 0.0")
+    func temperatureBelowRangeClamps() {
+        var settings = ModelSettings()
+        settings.temperature = -1
+        #expect(settings.temperature == 0.0)
+    }
+
+    @Test("Writing infinite temperature collapses onto the nearest bound")
+    func infiniteTemperatureCollapsesOntoBound() {
+        var settings = ModelSettings()
+
+        settings.temperature = .infinity
+        #expect(settings.temperature == 2.0)
+
+        settings.temperature = -.infinity
+        #expect(settings.temperature == 0.0)
+    }
+
+    @Test("Writing NaN temperature falls back to nil (provider default)")
+    func nanTemperatureFallsBackToNil() {
+        var settings = ModelSettings()
+        settings.temperature = .nan
+        #expect(settings.temperature == nil)
+    }
+
+    @Test("Writing out-of-range topP and minP clamps into 0.0...1.0")
+    func probabilitiesClamp() {
+        var settings = ModelSettings()
+
+        settings.topP = 1.5
+        #expect(settings.topP == 1.0)
+
+        settings.minP = -0.2
+        #expect(settings.minP == 0.0)
+    }
+
+    @Test("Writing zero or negative counts clamps to at least 1")
+    func countsClampToAtLeastOne() {
+        var settings = ModelSettings()
+
+        settings.topK = 0
+        #expect(settings.topK == 1)
+
+        settings.maxTokens = -100
+        #expect(settings.maxTokens == 1)
+    }
+
+    @Test("Writing out-of-range penalties clamps into -2.0...2.0")
+    func penaltiesClamp() {
+        var settings = ModelSettings()
+
+        settings.frequencyPenalty = 5.0
+        #expect(settings.frequencyPenalty == 2.0)
+
+        settings.presencePenalty = -5.0
+        #expect(settings.presencePenalty == -2.0)
+    }
+
+    @Test("Writing negative repetitionPenalty clamps to 0.0; non-finite falls back to nil")
+    func repetitionPenaltyClamp() {
+        var settings = ModelSettings()
+
+        settings.repetitionPenalty = -0.5
+        #expect(settings.repetitionPenalty == 0.0)
+
+        settings.repetitionPenalty = .nan
+        #expect(settings.repetitionPenalty == nil)
+
+        settings.repetitionPenalty = .infinity
+        #expect(settings.repetitionPenalty == nil)
+    }
+
+    @Test("Writing reasoning with invalid maxTokens normalizes the nested value on read")
+    func reasoningMaxTokensNormalizes() {
+        var settings = ModelSettings()
+
+        settings.reasoning = ReasoningConfig(maxTokens: 0)
+        #expect(settings.reasoning?.maxTokens == 1)
+
+        settings.reasoning?.maxTokens = -25
+        #expect(settings.reasoning?.maxTokens == 1)
+    }
+
+    @Test("Clamped post-write reads satisfy validate()")
+    func clampedReadsValidate() throws {
+        var settings = ModelSettings()
+        settings.temperature = 99
+        settings.topP = 4.2
+        settings.maxTokens = 0
+        settings.frequencyPenalty = 12.0
+        try settings.validate()
+    }
+
+    @Test("Fluent builders preserve raw values for validate() to judge")
+    func builderPreservesRawValues() {
+        let settings = ModelSettings().temperature(3.0)
+        #expect(settings.temperature == 3.0)
+        #expect(throws: ModelSettingsValidationError.self) {
+            try settings.validate()
+        }
+    }
+
+    @Test("Decoding bypasses didSet normalization by design")
+    func decodingBypassesDidSet() throws {
+        let json = #"{"temperature":99,"maxTokens":-5}"#
+        let decoded = try JSONDecoder().decode(ModelSettings.self, from: Data(json.utf8))
+
+        #expect(decoded.temperature == 99)
+        #expect(decoded.maxTokens == -5)
+    }
+}


### PR DESCRIPTION
Ticket **T3** of spec `spec-architecture-surface-errors-config.md` (architecture run cff6c62e).

**What**
- ModelSettings: 9 invariant-carrying stored vars clamp via `didSet` using the SAME shared range helpers `validate()` uses — post-write reads always satisfy init-time invariants (`temperature = 99` clamps, counts to ≥1, NaN/±inf normalized). Fluent builders rewritten to rebuild through the designated initializer so raw values (incl. explicit nil-clearing) are preserved for `validate()` to judge — didSet must not fire during builder chaining. Codable decode bypasses didSet by design (documented).
- AgentConfiguration: init coercion extracted into private static coercers shared with didSet — `maxIterations = 0`, non-positive timeouts, and out-of-range temperature self-correct exactly like init, byte-identical warnings via Log.agents.
- Source-compatible: memberwise inits unchanged, no public API removed; pre-existing validation-throw tests pass unmodified.
- New PostInitClamp suites (20 tests).

**Evidence**: full gate **2121 green** on this branch; targeted 148 green after rebase onto main.

**Review**: standard pass per review-routing (largest file 1352 LOC). Findings: none open.