### PR TITLE
Explicit TurnMode + pure transition kernel in AgentTurnKernel (spec T2)

### DIFF
--- a/Sources/Swarm/Agents/Agent.swift
+++ b/Sources/Swarm/Agents/Agent.swift
@@ -1190,7 +1190,6 @@ public struct Agent: AgentRuntime, Sendable {
     ) async throws -> ToolLoopOutcome {
         let toolRegistry = dependencies.toolRegistry
         let provider = dependencies.provider
-        var iteration = 0
         let startTime = ContinuousClock.now
         var inferenceOptions = await resolvedInferenceOptions(session: session, provider: provider)
         if let structuredOutputRequest {
@@ -1239,8 +1238,25 @@ public struct Agent: AgentRuntime, Sendable {
         let useToolStreaming = enableStreaming && capabilities.contains(.streamingToolCalls)
         let membraneAdapter = dependencies.membraneAdapter
 
-        while iteration < configuration.maxIterations {
-            iteration += 1
+        var iteration = 0
+        var turnState = AgentTurnKernel.TurnState(
+            iteration: 0,
+            maxIterations: configuration.maxIterations
+        )
+
+        while true {
+            // Kernel: admit the next iteration before any per-iteration effects
+            // run (mirrors the previous `while iteration < maxIterations` head).
+            switch AgentTurnKernel.transition(turnState, .startNextIteration) {
+            case .fail(let error):
+                throw error
+            case .performInference(let admitted):
+                turnState = admitted
+                iteration = admitted.iteration
+            default:
+                throw AgentError.internalError(reason: "Unexpected admission transition")
+            }
+
             _ = resultBuilder.incrementIteration()
             await observer?.onIterationStart(context: nil, agent: self, number: iteration)
 
@@ -1282,13 +1298,18 @@ public struct Agent: AgentRuntime, Sendable {
                     messages: conversationHistory.map(\.inferenceMessage),
                     profile: configuration.effectiveContextProfile
                 )
-                let useProviderOwnedToolLoop = provider.capabilities.contains(.providerOwnedToolLoop)
-                try AgentTurnKernel.requireOwnedLoopGate(
-                    useProviderOwnedToolLoop: useProviderOwnedToolLoop,
+                // REQ-003: the turn mode is derived in exactly one place.
+                let mode = try AgentTurnKernel.resolveMode(
+                    toolSchemasEmpty: toolSchemas.isEmpty,
+                    providerOwnsToolLoop: provider.capabilities.contains(.providerOwnedToolLoop),
+                    streamsToolCalls: useToolStreaming,
                     hasExecutionGate: executionGate != nil
                 )
+                turnState.mode = mode
+                turnState.hasToolSchemas = !toolSchemas.isEmpty
+
                 let toolExecutor: ToolCallExecutor?
-                if useProviderOwnedToolLoop, let executionGate {
+                if case .ownedLoopTools = mode, let executionGate {
                     toolExecutor = makeToolCallExecutor(
                         toolRegistry: toolRegistry,
                         resultBuilder: resultBuilder,
@@ -1302,15 +1323,9 @@ public struct Agent: AgentRuntime, Sendable {
                     toolExecutor = nil
                 }
 
-                let inferenceKind = AgentTurnKernel.inferenceKind(
-                    toolSchemasEmpty: toolSchemas.isEmpty,
-                    useProviderOwnedToolLoop: useProviderOwnedToolLoop,
-                    streamingToolCalls: useToolStreaming
-                )
-
                 // If no tools defined, generate without tool calling unless the
                 // adapter owns the tool loop (empty tool list).
-                if inferenceKind == .withoutTools {
+                if mode == .textOnly {
                     let loopInferenceOptions = inferenceOptions
                     let response = try await executeProviderInference(
                         startTime: startTime,
@@ -1346,12 +1361,12 @@ public struct Agent: AgentRuntime, Sendable {
                 let loopInferenceOptions = inferenceOptions
                 // Owned-loop tools run inside inference; retrying would replay them.
                 let ownedLoopInferenceRetryPolicy = AgentTurnKernel.ownedLoopInferenceRetryPolicy(
-                    useProviderOwnedToolLoop: useProviderOwnedToolLoop,
+                    mode: mode,
                     hasToolSchemas: !toolSchemas.isEmpty
                 )
                 let response: InferenceResponse
                 do {
-                    let streamToolCalls = inferenceKind == .withTools(streaming: true)
+                    let streamToolCalls = mode.streamsToolCalls
                     response = if streamToolCalls {
                         try await executeProviderInference(
                             startTime: startTime,
@@ -1429,14 +1444,11 @@ public struct Agent: AgentRuntime, Sendable {
                 }
                 recordUsage(response.usage, on: resultBuilder)
 
-                switch AgentTurnKernel.afterInference(
-                    useProviderOwnedToolLoop: useProviderOwnedToolLoop,
-                    response: response
-                ) {
-                case .failMissingContent:
-                    throw AgentError.generationFailed(reason: "Model returned no content or tool calls")
+                switch AgentTurnKernel.transition(turnState, .inferenceCompleted(response)) {
+                case .fail(let error):
+                    throw error
 
-                case let .finishAssistant(content):
+                case .finish(let content):
                     let finalResponse = try finalizeAssistantResponse(
                         content: content,
                         request: structuredOutputRequest,
@@ -1454,7 +1466,8 @@ public struct Agent: AgentRuntime, Sendable {
                         transcriptMessages: transcriptMessages
                     )
 
-                case .processHostToolCalls:
+                case .executeTools(let toolsState):
+                    turnState = toolsState
                     let handoffResult = try await processToolCallsWithHandoffs(
                         response: response,
                         toolRegistry: toolRegistry,
@@ -1477,14 +1490,14 @@ public struct Agent: AgentRuntime, Sendable {
                         )
                     }
                     await observer?.onIterationEnd(context: nil, agent: self, number: iteration)
+                default:
+                    throw AgentError.internalError(reason: "Unexpected inference transition")
                 }
             } catch {
                 await observer?.onIterationEnd(context: nil, agent: self, number: iteration)
                 throw normalizeCancellation(error)
             }
         }
-
-        throw AgentError.maxIterationsExceeded(iterations: iteration)
     }
 
     /// Builds the initial conversation history from session history and user input.

--- a/Sources/Swarm/Agents/AgentTurnKernel.swift
+++ b/Sources/Swarm/Agents/AgentTurnKernel.swift
@@ -135,6 +135,14 @@ enum AgentTurnKernel: Sendable {
     }
 
     /// Facts the shell reports to the kernel after executing an effect.
+    ///
+    /// `Agent.executeToolCallingLoop` currently feeds only
+    /// `.startNextIteration` (loop head) and `.inferenceCompleted`. The
+    /// remaining actions are modeled but not yet wired into the shell:
+    /// `.toolsCompleted` is equivalent to the shell re-entering
+    /// `.startNextIteration` at the loop head, and `.ownedLoopInferenceFailed`
+    /// corresponds to failures the shell currently handles through
+    /// `ownedLoopInferenceRetryPolicy` inside `executeProviderInference`.
     enum TurnAction: Equatable, Sendable {
         /// Loop head: request admission of the next iteration.
         case startNextIteration

--- a/Sources/Swarm/Agents/AgentTurnKernel.swift
+++ b/Sources/Swarm/Agents/AgentTurnKernel.swift
@@ -8,14 +8,59 @@ import Foundation
 /// Closed decisions for one Agent iteration.
 ///
 /// The kernel does not call providers, tools, observers, or clocks. `Agent`
-/// snapshots booleans from the run, asks for a decision, then executes I/O.
+/// derives a ``TurnMode`` snapshot from the run, feeds ``TurnState`` /
+/// ``TurnAction`` values through ``transition(_:_:)``, then executes I/O.
 enum AgentTurnKernel: Sendable {
-    /// How this iteration should invoke the inference provider.
-    enum InferenceKind: Sendable, Equatable {
-        /// Empty host-loop tool list: generate text only, then finish.
-        case withoutTools
-        /// Host or owned tool loop: `generateWithTools` / streaming variant.
-        case withTools(streaming: Bool)
+    /// How a turn executes the tool loop (REQ-003).
+    ///
+    /// Replaces the parallel boolean snapshots (`toolSchemasEmpty`,
+    /// `useProviderOwnedToolLoop`, `streamingToolCalls`, `hasExecutionGate`)
+    /// with one closed enum, so contradictory flag combinations are
+    /// unrepresentable.
+    enum TurnMode: Equatable, Sendable {
+        /// No host tool schemas and the provider does not own the loop:
+        /// one text-only generation, then the turn finishes.
+        case textOnly
+        /// The Agent owns the tool loop; tools execute between inference calls.
+        case hostTools(streaming: Bool)
+        /// The provider owns the tool loop; tools execute inside inference and
+        /// require the execution gate created by `runInternal`.
+        case ownedLoopTools(streaming: Bool)
+
+        /// Whether this mode consumes the streaming tool-call seam.
+        var streamsToolCalls: Bool {
+            switch self {
+            case .textOnly: return false
+            case .hostTools(streaming: let streaming), .ownedLoopTools(streaming: let streaming):
+                return streaming
+            }
+        }
+    }
+
+    /// Derives the turn mode from the run's flags. Single derivation point
+    /// (REQ-003): `Agent` must not reconstruct the mode from booleans.
+    ///
+    /// An owned-loop provider still uses the tool-calling path when schemas are
+    /// empty so the adapter can run an empty inner loop. Owned-loop execution
+    /// requires the timeout gate created by `runInternal`.
+    static func resolveMode(
+        toolSchemasEmpty: Bool,
+        providerOwnsToolLoop: Bool,
+        streamsToolCalls: Bool,
+        hasExecutionGate: Bool
+    ) throws -> TurnMode {
+        if providerOwnsToolLoop {
+            guard hasExecutionGate else {
+                throw AgentError.internalError(
+                    reason: "Provider-owned tool loop missing execution gate"
+                )
+            }
+            return .ownedLoopTools(streaming: streamsToolCalls)
+        }
+        if toolSchemasEmpty {
+            return .textOnly
+        }
+        return .hostTools(streaming: streamsToolCalls)
     }
 
     /// What to do with a completed `InferenceResponse`.
@@ -25,50 +70,23 @@ enum AgentTurnKernel: Sendable {
         case failMissingContent
     }
 
-    /// Chooses text-only vs tool-calling inference for this iteration.
-    ///
-    /// An owned-loop provider still uses the tool-calling path when schemas are
-    /// empty so the adapter can run an empty inner loop.
-    static func inferenceKind(
-        toolSchemasEmpty: Bool,
-        useProviderOwnedToolLoop: Bool,
-        streamingToolCalls: Bool
-    ) -> InferenceKind {
-        if toolSchemasEmpty, !useProviderOwnedToolLoop {
-            return .withoutTools
-        }
-        return .withTools(streaming: streamingToolCalls)
-    }
-
     /// Owned-loop tool execution is not retry-safe; empty owned loops may retry.
     static func ownedLoopInferenceRetryPolicy(
-        useProviderOwnedToolLoop: Bool,
+        mode: TurnMode,
         hasToolSchemas: Bool
     ) -> RetryPolicy? {
-        if useProviderOwnedToolLoop, hasToolSchemas {
+        if case .ownedLoopTools = mode, hasToolSchemas {
             return .noRetry
         }
         return nil
     }
 
-    /// Owned-loop execution requires the timeout gate created by `runInternal`.
-    static func requireOwnedLoopGate(
-        useProviderOwnedToolLoop: Bool,
-        hasExecutionGate: Bool
-    ) throws {
-        if useProviderOwnedToolLoop, !hasExecutionGate {
-            throw AgentError.internalError(
-                reason: "Provider-owned tool loop missing execution gate"
-            )
-        }
-    }
-
     /// Interprets a finished model response for host vs owned-loop control flow.
     static func afterInference(
-        useProviderOwnedToolLoop: Bool,
+        mode: TurnMode,
         response: InferenceResponse
     ) -> AfterInference {
-        if useProviderOwnedToolLoop {
+        if case .ownedLoopTools = mode {
             guard let content = response.content else {
                 return .failMissingContent
             }
@@ -83,6 +101,104 @@ enum AgentTurnKernel: Sendable {
             return .failMissingContent
         }
         return .finishAssistant(content: content)
+    }
+
+    // MARK: - Turn transition (REQ-004)
+
+    /// Pure control state for one tool-calling turn.
+    ///
+    /// `iteration` counts admitted iterations; `mode` is resolved per iteration
+    /// by ``resolveMode(toolSchemasEmpty:providerOwnsToolLoop:streamsToolCalls:hasExecutionGate:)``
+    /// and is `nil` between iterations (before the loop's per-iteration effects
+    /// have produced tool schemas).
+    struct TurnState: Equatable, Sendable {
+        /// Iterations admitted so far (0 at turn start).
+        var iteration: Int
+        /// Configured iteration cap.
+        var maxIterations: Int
+        /// Mode resolved for the current iteration, if any.
+        var mode: TurnMode?
+        /// Whether host-visible tool schemas are non-empty this iteration.
+        var hasToolSchemas: Bool
+
+        init(
+            iteration: Int,
+            maxIterations: Int,
+            mode: TurnMode? = nil,
+            hasToolSchemas: Bool = false
+        ) {
+            self.iteration = iteration
+            self.maxIterations = maxIterations
+            self.mode = mode
+            self.hasToolSchemas = hasToolSchemas
+        }
+    }
+
+    /// Facts the shell reports to the kernel after executing an effect.
+    enum TurnAction: Equatable, Sendable {
+        /// Loop head: request admission of the next iteration.
+        case startNextIteration
+        /// The provider returned a response for the current iteration.
+        case inferenceCompleted(InferenceResponse)
+        /// Host tools executed without a handoff; the loop continues.
+        case toolsCompleted
+        /// Owned-loop inference failed; `AgentError` is the underlying failure.
+        case ownedLoopInferenceFailed(AgentError)
+    }
+
+    /// The kernel's decision plus the state the shell carries forward.
+    enum TurnTransition: Equatable, Sendable {
+        /// Iteration admitted; run inference for it.
+        case performInference(TurnState)
+        /// Host tool calls are pending; execute them, then report
+        /// `.toolsCompleted`.
+        case executeTools(TurnState)
+        /// Owned-loop inference may be retried (empty tool list only; tools
+        /// already ran inside inference).
+        case retryOwnedLoopInference(TurnState)
+        /// The turn finished with assistant content.
+        case finish(content: String)
+        /// The turn failed.
+        case fail(AgentError)
+    }
+
+    /// Pure transition over the turn's control state. No effects: `Agent`
+    /// executes the effect each case names and feeds the next action back.
+    static func transition(_ state: TurnState, _ action: TurnAction) -> TurnTransition {
+        switch action {
+        case .startNextIteration:
+            guard state.iteration < state.maxIterations else {
+                return .fail(.maxIterationsExceeded(iterations: state.iteration))
+            }
+            var admitted = state
+            admitted.iteration += 1
+            admitted.mode = nil
+            return .performInference(admitted)
+
+        case .inferenceCompleted(let response):
+            guard let mode = state.mode else {
+                return .fail(.internalError(reason: "Turn mode not resolved before inference"))
+            }
+            switch afterInference(mode: mode, response: response) {
+            case .finishAssistant(let content):
+                return .finish(content: content)
+            case .failMissingContent:
+                return .fail(.generationFailed(reason: "Model returned no content or tool calls"))
+            case .processHostToolCalls:
+                return .executeTools(state)
+            }
+
+        case .toolsCompleted:
+            // Continuing the loop re-enters at the loop head, where the
+            // iteration cap is enforced before any per-iteration effects run.
+            return transition(state, .startNextIteration)
+
+        case .ownedLoopInferenceFailed(let error):
+            if case .ownedLoopTools = state.mode, !state.hasToolSchemas {
+                return .retryOwnedLoopInference(state)
+            }
+            return .fail(error)
+        }
     }
 
     /// How the host loop should treat one tool name.

--- a/Tests/SwarmTests/Agents/AgentToolLoopCharacterizationTests.swift
+++ b/Tests/SwarmTests/Agents/AgentToolLoopCharacterizationTests.swift
@@ -1,0 +1,169 @@
+// AgentToolLoopCharacterizationTests.swift
+// SwarmTests
+//
+// Characterization tests for the Agent tool-calling loop (spec ticket T2, AC-004).
+// They pin the CURRENT public behavior of `Agent.executeToolCallingLoop` and must
+// pass unchanged before and after the turn-kernel transition extraction.
+
+import Foundation
+@testable import Swarm
+import Testing
+
+@Suite("Tool-calling loop characterization (T2 AC-004)")
+struct AgentToolLoopCharacterizationTests {
+    private static let loopConfiguration = AgentConfiguration.default
+        .enableStreaming(false)
+        .timeout(.seconds(30))
+        .defaultTracingEnabled(false)
+
+    @Test("Host loop executes tool calls and continues to a final answer")
+    func hostLoopExecutesToolsThenFinishes() async throws {
+        let tool = SpyTool(name: "weather", result: .string("72F"))
+        let provider = await MockInferenceProvider()
+        await provider.configureToolCallingSequence(
+            toolCalls: [("weather", [:])],
+            finalAnswer: "It is 72F"
+        )
+        let agent = try Agent(
+            tools: [tool],
+            configuration: Self.loopConfiguration,
+            inferenceProvider: provider
+        )
+
+        let result = try await agent.run("What is the weather?")
+
+        #expect(result.output == "It is 72F")
+        #expect(await tool.callCount == 1)
+        // One tool-calling turn plus one final turn.
+        #expect(await provider.recordedInferenceCallCount == 2)
+        #expect(result.toolCalls.map(\.toolName) == ["weather"])
+    }
+
+    @Test("Iteration cap throws maxIterationsExceeded with the configured count")
+    func iterationCapThrowsMaxIterationsExceeded() async throws {
+        let tool = SpyTool(name: "noop", result: .string("ok"))
+        let provider = await MockInferenceProvider()
+        // Every response requests the same tool; the model never finishes.
+        let loopingToolCall = InferenceResponse(
+            content: nil,
+            toolCalls: [
+                InferenceResponse.ParsedToolCall(id: "call_loop", name: "noop", arguments: [:]),
+            ],
+            finishReason: .toolCall,
+            usage: nil
+        )
+        await provider.setToolCallResponses(Array(repeating: loopingToolCall, count: 5))
+        let agent = try Agent(
+            tools: [tool],
+            configuration: Self.loopConfiguration.maxIterations(2),
+            inferenceProvider: provider
+        )
+
+        do {
+            _ = try await agent.run("loop forever")
+            Issue.record("Expected AgentError.maxIterationsExceeded")
+        } catch let error as AgentError {
+            guard case let .maxIterationsExceeded(iterations) = error else {
+                Issue.record("Unexpected error: \(error)")
+                return
+            }
+            #expect(iterations == 2)
+        }
+
+        #expect(await tool.callCount == 2)
+        #expect(await provider.recordedInferenceCallCount == 2)
+    }
+
+    @Test("Provider-owned loop executes tools inside inference and finishes in one turn")
+    func providerOwnedLoopFinishesInSingleInferenceCall() async throws {
+        let tool = SpyTool(name: "ping", result: .string("pong"))
+        let provider = OwnedLoopCharacterizationProvider(toolName: "ping")
+        let agent = try Agent(
+            tools: [tool],
+            configuration: Self.loopConfiguration,
+            inferenceProvider: provider
+        )
+
+        let result = try await agent.run("use ping")
+
+        #expect(result.output == "owned done")
+        #expect(await tool.callCount == 1)
+        let inferenceCalls = await provider.inferenceCallCount
+        #expect(inferenceCalls == 1)
+        #expect(result.iterationCount == 1)
+    }
+
+    @Test("Streaming tool calls drive the loop through the streaming path")
+    func streamingToolCallPath() async throws {
+        let tool = SpyTool(name: "echo", result: .string("hi"))
+        let provider = await MockInferenceProvider(capabilities: [.streamingToolCalls])
+        await provider.configureToolCallingSequence(
+            toolCalls: [("echo", [:])],
+            finalAnswer: "done streaming"
+        )
+        let agent = try Agent(
+            tools: [tool],
+            configuration: AgentConfiguration.default
+                .maxIterations(3)
+                .timeout(.seconds(30))
+                .defaultTracingEnabled(false),
+            inferenceProvider: provider
+        )
+
+        var events: [AgentEvent] = []
+        for try await event in agent.stream("hi") {
+            events.append(event)
+        }
+
+        // Streaming path emits output events while consuming the update stream.
+        #expect(events.contains { event in
+            if case .output = event { return true }
+            return false
+        })
+
+        guard let completed = events.last(where: { event in
+            if case .lifecycle(.completed) = event { return true }
+            return false
+        }), case let .lifecycle(.completed(result: result)) = completed else {
+            Issue.record("Missing lifecycle(.completed) event")
+            return
+        }
+        #expect(result.output == "done streaming")
+        #expect(await tool.callCount == 1)
+    }
+}
+
+/// Owned-loop provider that runs one tool through the executor handed to it by
+/// the agent, then finishes the turn with a completed response.
+private actor OwnedLoopCharacterizationProvider: InferenceProvider {
+    nonisolated let capabilities: InferenceProviderCapabilities = [
+        .conversationMessages,
+        .nativeToolCalling,
+        .providerOwnedToolLoop,
+    ]
+
+    let toolName: String
+    private(set) var inferenceCallCount = 0
+
+    init(toolName: String) {
+        self.toolName = toolName
+    }
+
+    func generate(messages _: [InferenceMessage], options _: InferenceOptions) async throws -> String {
+        throw AgentError.generationFailed(reason: "expected generateWithToolCalls")
+    }
+
+    func generateWithToolCalls(
+        messages _: [InferenceMessage],
+        tools _: [ToolSchema],
+        options _: InferenceOptions,
+        toolExecutor: ToolCallExecutor?
+    ) async throws -> InferenceResponse {
+        inferenceCallCount += 1
+        guard let toolExecutor else {
+            throw AgentError.providerOwnedToolLoopRequiresExecutor
+        }
+        _ = try await toolExecutor.executeTool(named: toolName, arguments: [:])
+        return InferenceResponse(content: "owned done", finishReason: .completed)
+    }
+}

--- a/Tests/SwarmTests/Agents/AgentTurnKernelTests.swift
+++ b/Tests/SwarmTests/Agents/AgentTurnKernelTests.swift
@@ -9,72 +9,68 @@ import Testing
 
 struct AgentTurnKernelTests {
     @Test(
-        "Inference kind matches empty-schema and owned-loop combinations",
+        "Mode resolution collapses the flag snapshot into one closed mode",
         arguments: [
-            (true, false, false, AgentTurnKernel.InferenceKind.withoutTools),
-            (true, false, true, AgentTurnKernel.InferenceKind.withoutTools),
-            (true, true, false, AgentTurnKernel.InferenceKind.withTools(streaming: false)),
-            (true, true, true, AgentTurnKernel.InferenceKind.withTools(streaming: true)),
-            (false, false, false, AgentTurnKernel.InferenceKind.withTools(streaming: false)),
-            (false, false, true, AgentTurnKernel.InferenceKind.withTools(streaming: true)),
-            (false, true, true, AgentTurnKernel.InferenceKind.withTools(streaming: true)),
+            (true, false, false, true, AgentTurnKernel.TurnMode.textOnly),
+            (true, false, true, true, AgentTurnKernel.TurnMode.textOnly),
+            (false, false, false, false, AgentTurnKernel.TurnMode.hostTools(streaming: false)),
+            (false, false, true, false, AgentTurnKernel.TurnMode.hostTools(streaming: true)),
+            (true, true, false, true, AgentTurnKernel.TurnMode.ownedLoopTools(streaming: false)),
+            (true, true, true, true, AgentTurnKernel.TurnMode.ownedLoopTools(streaming: true)),
+            (false, true, true, true, AgentTurnKernel.TurnMode.ownedLoopTools(streaming: true)),
         ]
     )
-    func inferenceKind(
+    func resolveMode(
         toolSchemasEmpty: Bool,
-        useProviderOwnedToolLoop: Bool,
-        streamingToolCalls: Bool,
-        expected: AgentTurnKernel.InferenceKind
-    ) {
-        let kind = AgentTurnKernel.inferenceKind(
+        providerOwnsToolLoop: Bool,
+        streamsToolCalls: Bool,
+        hasExecutionGate: Bool,
+        expected: AgentTurnKernel.TurnMode
+    ) throws {
+        let mode = try AgentTurnKernel.resolveMode(
             toolSchemasEmpty: toolSchemasEmpty,
-            useProviderOwnedToolLoop: useProviderOwnedToolLoop,
-            streamingToolCalls: streamingToolCalls
+            providerOwnsToolLoop: providerOwnsToolLoop,
+            streamsToolCalls: streamsToolCalls,
+            hasExecutionGate: hasExecutionGate
         )
-        #expect(kind == expected)
+        #expect(mode == expected)
+        #expect(mode.streamsToolCalls == streamsToolCalls || mode == .textOnly)
+    }
+
+    @Test("Owned loop without an execution gate fails mode resolution")
+    func ownedLoopRequiresGate() {
+        #expect(throws: AgentError.internalError(
+            reason: "Provider-owned tool loop missing execution gate"
+        )) {
+            _ = try AgentTurnKernel.resolveMode(
+                toolSchemasEmpty: false,
+                providerOwnsToolLoop: true,
+                streamsToolCalls: false,
+                hasExecutionGate: false
+            )
+        }
     }
 
     @Test("Owned-loop inference retries only when tool schemas are empty")
     func ownedLoopRetryPolicy() {
         #expect(
             AgentTurnKernel.ownedLoopInferenceRetryPolicy(
-                useProviderOwnedToolLoop: true,
+                mode: .ownedLoopTools(streaming: false),
                 hasToolSchemas: true
             ) == .noRetry
         )
         #expect(
             AgentTurnKernel.ownedLoopInferenceRetryPolicy(
-                useProviderOwnedToolLoop: true,
+                mode: .ownedLoopTools(streaming: false),
                 hasToolSchemas: false
             ) == nil
         )
         #expect(
             AgentTurnKernel.ownedLoopInferenceRetryPolicy(
-                useProviderOwnedToolLoop: false,
+                mode: .hostTools(streaming: false),
                 hasToolSchemas: true
             ) == nil
         )
-    }
-
-    @Test("Owned loop requires an execution gate")
-    func ownedLoopRequiresGate() throws {
-        try AgentTurnKernel.requireOwnedLoopGate(
-            useProviderOwnedToolLoop: true,
-            hasExecutionGate: true
-        )
-        try AgentTurnKernel.requireOwnedLoopGate(
-            useProviderOwnedToolLoop: false,
-            hasExecutionGate: false
-        )
-
-        #expect(throws: AgentError.internalError(
-            reason: "Provider-owned tool loop missing execution gate"
-        )) {
-            try AgentTurnKernel.requireOwnedLoopGate(
-                useProviderOwnedToolLoop: true,
-                hasExecutionGate: false
-            )
-        }
     }
 
     @Test("Owned-loop responses finish even when the model also listed tool calls")
@@ -87,7 +83,7 @@ struct AgentTurnKernelTests {
             finishReason: .toolCall
         )
         let decision = AgentTurnKernel.afterInference(
-            useProviderOwnedToolLoop: true,
+            mode: .ownedLoopTools(streaming: false),
             response: response
         )
         #expect(decision == .finishAssistant(content: "done"))
@@ -103,7 +99,7 @@ struct AgentTurnKernelTests {
             finishReason: .toolCall
         )
         let decision = AgentTurnKernel.afterInference(
-            useProviderOwnedToolLoop: false,
+            mode: .hostTools(streaming: false),
             response: response
         )
         #expect(decision == .processHostToolCalls)
@@ -113,11 +109,11 @@ struct AgentTurnKernelTests {
     func missingContentFails() {
         let empty = InferenceResponse(content: nil, toolCalls: [], finishReason: .completed)
         #expect(
-            AgentTurnKernel.afterInference(useProviderOwnedToolLoop: false, response: empty)
+            AgentTurnKernel.afterInference(mode: .hostTools(streaming: false), response: empty)
                 == .failMissingContent
         )
         #expect(
-            AgentTurnKernel.afterInference(useProviderOwnedToolLoop: true, response: empty)
+            AgentTurnKernel.afterInference(mode: .ownedLoopTools(streaming: false), response: empty)
                 == .failMissingContent
         )
     }
@@ -126,9 +122,161 @@ struct AgentTurnKernelTests {
     func hostLoopFinishesOnText() {
         let response = InferenceResponse(content: "42", finishReason: .completed)
         #expect(
-            AgentTurnKernel.afterInference(useProviderOwnedToolLoop: false, response: response)
+            AgentTurnKernel.afterInference(mode: .hostTools(streaming: false), response: response)
                 == .finishAssistant(content: "42")
         )
+    }
+
+    // MARK: - Transition (REQ-004)
+
+    private let toolCallResponse = InferenceResponse(
+        content: nil,
+        toolCalls: [
+            InferenceResponse.ParsedToolCall(id: "1", name: "search", arguments: [:]),
+        ],
+        finishReason: .toolCall
+    )
+
+    private func state(
+        iteration: Int = 0,
+        maxIterations: Int = 3,
+        mode: AgentTurnKernel.TurnMode? = nil,
+        hasToolSchemas: Bool = true
+    ) -> AgentTurnKernel.TurnState {
+        AgentTurnKernel.TurnState(
+            iteration: iteration,
+            maxIterations: maxIterations,
+            mode: mode,
+            hasToolSchemas: hasToolSchemas
+        )
+    }
+
+    @Test("Admission increments the iteration and clears the per-iteration mode")
+    func admissionIncrementsIteration() {
+        let result = AgentTurnKernel.transition(
+            state(iteration: 1, maxIterations: 3, mode: .hostTools(streaming: false)),
+            .startNextIteration
+        )
+        #expect(result == .performInference(state(iteration: 2, maxIterations: 3, mode: nil)))
+    }
+
+    @Test("Admission at the cap fails with maxIterationsExceeded")
+    func admissionAtCapFails() {
+        let result = AgentTurnKernel.transition(
+            state(iteration: 3, maxIterations: 3),
+            .startNextIteration
+        )
+        #expect(result == .fail(.maxIterationsExceeded(iterations: 3)))
+    }
+
+    @Test("Inference completion with pending host tool calls executes tools")
+    func inferenceCompletionExecutesTools() {
+        let current = state(iteration: 1, mode: .hostTools(streaming: false))
+        let result = AgentTurnKernel.transition(current, .inferenceCompleted(toolCallResponse))
+        #expect(result == .executeTools(current))
+    }
+
+    @Test("Inference completion with assistant content finishes")
+    func inferenceCompletionFinishes() {
+        let response = InferenceResponse(content: "42", finishReason: .completed)
+        let result = AgentTurnKernel.transition(
+            state(iteration: 1, mode: .hostTools(streaming: false)),
+            .inferenceCompleted(response)
+        )
+        #expect(result == .finish(content: "42"))
+    }
+
+    @Test("Owned-loop inference completion finishes even with tool calls")
+    func ownedLoopInferenceCompletionFinishes() {
+        let response = InferenceResponse(
+            content: "done",
+            toolCalls: [
+                InferenceResponse.ParsedToolCall(id: "1", name: "search", arguments: [:]),
+            ],
+            finishReason: .toolCall
+        )
+        let result = AgentTurnKernel.transition(
+            state(iteration: 1, mode: .ownedLoopTools(streaming: false)),
+            .inferenceCompleted(response)
+        )
+        #expect(result == .finish(content: "done"))
+    }
+
+    @Test("Inference completion without content fails like the loop did")
+    func inferenceCompletionWithoutContentFails() {
+        let empty = InferenceResponse(content: nil, toolCalls: [], finishReason: .completed)
+        let result = AgentTurnKernel.transition(
+            state(iteration: 1, mode: .hostTools(streaming: false)),
+            .inferenceCompleted(empty)
+        )
+        #expect(result == .fail(.generationFailed(reason: "Model returned no content or tool calls")))
+    }
+
+    @Test("Inference completion before mode resolution fails closed")
+    func inferenceCompletionWithoutModeFails() {
+        let result = AgentTurnKernel.transition(
+            state(iteration: 1, mode: nil),
+            .inferenceCompleted(toolCallResponse)
+        )
+        #expect(result == .fail(.internalError(reason: "Turn mode not resolved before inference")))
+    }
+
+    @Test("Completed tools continue to the next admission, respecting the cap")
+    func toolsCompletedContinuesLoop() {
+        let continuing = AgentTurnKernel.transition(
+            state(iteration: 1, mode: .hostTools(streaming: false)),
+            .toolsCompleted
+        )
+        #expect(continuing == .performInference(state(iteration: 2, maxIterations: 3, mode: nil)))
+
+        let capped = AgentTurnKernel.transition(
+            state(iteration: 3, maxIterations: 3, mode: .hostTools(streaming: false)),
+            .toolsCompleted
+        )
+        #expect(capped == .fail(.maxIterationsExceeded(iterations: 3)))
+    }
+
+    @Test("Owned-loop inference failure retries only with an empty tool list")
+    func ownedLoopInferenceFailureRetryDecision() {
+        let transient = AgentError.generationFailed(reason: "transient 503")
+
+        let emptySchemasState = state(iteration: 1, mode: .ownedLoopTools(streaming: false), hasToolSchemas: false)
+        let emptySchemas = AgentTurnKernel.transition(
+            emptySchemasState,
+            .ownedLoopInferenceFailed(transient)
+        )
+        #expect(emptySchemas == .retryOwnedLoopInference(emptySchemasState))
+
+        let withSchemas = AgentTurnKernel.transition(
+            state(iteration: 1, mode: .ownedLoopTools(streaming: false), hasToolSchemas: true),
+            .ownedLoopInferenceFailed(transient)
+        )
+        #expect(withSchemas == .fail(transient))
+
+        let hostLoop = AgentTurnKernel.transition(
+            state(iteration: 1, mode: .hostTools(streaming: false), hasToolSchemas: true),
+            .ownedLoopInferenceFailed(transient)
+        )
+        #expect(hostLoop == .fail(transient))
+    }
+
+    @Test("Max iterations reached while tool calls are pending fails identically to the loop")
+    func maxIterationsWithPendingToolCalls() {
+        // Edge from the spec: the cap wins even though tool calls are pending;
+        // the failing admission happens at the next loop head.
+        let afterTools = AgentTurnKernel.transition(
+            state(iteration: 2, maxIterations: 3, mode: .hostTools(streaming: false)),
+            .toolsCompleted
+        )
+        guard case .performInference = afterTools else {
+            Issue.record("Expected the loop to continue under the cap")
+            return
+        }
+        let nextAdmission = AgentTurnKernel.transition(
+            state(iteration: 3, maxIterations: 3, mode: .hostTools(streaming: false)),
+            .startNextIteration
+        )
+        #expect(nextAdmission == .fail(.maxIterationsExceeded(iterations: 3)))
     }
 
     @Test("Assistant tool-turn content prefers model text, then a call summary")


### PR DESCRIPTION
## Summary
- Introduces internal `TurnMode` (`.textOnly`, `.hostTools(streaming:)`, `.ownedLoopTools(streaming:)`) with a single derivation point `AgentTurnKernel.resolveMode(...)`, replacing the boolean snapshots (`toolSchemasEmpty`/`useProviderOwnedToolLoop`/`streamingToolCalls`/`hasExecutionGate`); contradictory combinations are now unrepresentable and owned-loop-without-gate fails loudly at derivation.
- Adds a pure, Sendable transition machine to `AgentTurnKernel`: `TurnState` + `TurnAction` → `TurnTransition` (performInference / executeTools / retryOwnedLoopInference / finish / fail). The kernel has no effects; `Agent.executeToolCallingLoop` drives it as the imperative shell with identical effect ordering.
- 4 characterization tests written against the pre-refactor loop (verified by the reviewer by running them against the old sources) + 17 kernel/mode tests.
- Spec: `spec/spec-architecture-deterministic-turn-kernel.md` — ticket **T2** (candidate 1, "explicit turn state machine", Strong). Stacks on #155 (T1).
- Review: swift-pr-review at adversarial depth (1 doc fix: wired-vs-modeled `TurnAction` semantics) + second fresh final pass — clean, no fixes needed.

## Test plan
- `SWARM_OMIT_INTEGRATION_TARGETS=1 swift build` ✅
- `swift test --filter "AgentTurnKernel|ToolLoopCharacterization"`: 25/25 ✅
- Full filtered suite: no new failures vs baseline (known environmental: Documentation Freshness, OTLP, OpenAI-compatible URLProtocol networking; unfiltered default target set has a pre-existing MembraneCore/OrderedCollections environment issue).

After #155 merges, retarget this PR to `main`.