### PR TITLE
Hoist memory capabilities onto Memory; cast-free MemoryHooks (T1)

### DIFF
--- a/Sources/Swarm/Memory/AgentMemory.swift
+++ b/Sources/Swarm/Memory/AgentMemory.swift
@@ -171,9 +171,71 @@ public protocol Memory: Actor, Sendable {
     /// Removes all messages from memory.
     ///
     /// After calling this method, ``isEmpty`` should return `true` and
-    /// ``count`` should return `0`. This is typically used when starting
+    /// `count` should return `0`. This is typically used when starting
     /// a new conversation or resetting the agent state.
     func clear() async
+
+    // MARK: - Optional Memory Capabilities
+
+    /// Marks the beginning of an agent run / stream session.
+    ///
+    /// Implement this to scope per-session state such as session tagging in
+    /// persistent stores. The default implementation is a no-op, so memories
+    /// without session lifecycle needs simply conform and do nothing.
+    ///
+    /// - Note: Implementing this method is the opt-in. No additional marker
+    ///   protocol conformance is required or consulted.
+    func beginMemorySession() async
+
+    /// Marks the end of an agent run / stream session (success or failure).
+    ///
+    /// The default implementation is a no-op.
+    ///
+    /// - Note: Implementing this method is the opt-in. No additional marker
+    ///   protocol conformance is required or consulted.
+    func endMemorySession() async
+
+    /// Retrieves context relevant to the query while respecting item-level
+    /// budgets.
+    ///
+    /// Implement this when simple token-limit retrieval is not enough — for
+    /// example to honor ``MemoryQuery/maxItems`` or per-item budgets. The
+    /// default implementation falls back to ``context(for:tokenLimit:)`` using
+    /// ``MemoryQuery/text`` and ``MemoryQuery/tokenLimit``.
+    func context(for query: MemoryQuery) async -> String
+
+    /// Imports a batch of replayed session history messages.
+    ///
+    /// Implement this when replayed history needs memory-specific handling
+    /// such as deduplication against persisted content. The default
+    /// implementation appends each message through ``add(_:)``.
+    func importSessionHistory(_ messages: [MemoryMessage]) async
+
+    /// Whether the agent runtime may seed session history into this memory.
+    ///
+    /// The default implementation returns ``isEmpty``, which seeds only fresh
+    /// memories and prevents duplicate imports into stores that already hold
+    /// content.
+    func shouldImportSessionHistory() async -> Bool
+
+    /// The memory layer that owns per-session clearing and serialization for
+    /// composite stacks.
+    ///
+    /// Default: `nil`. Composite memories return the layer that should be
+    /// cleared between sessions; single-layer memories return `nil`.
+    nonisolated var trackedSessionMemory: (any Memory)? { get }
+
+    /// Whether the agent runtime may seed session history automatically.
+    ///
+    /// Default: `true`. Return `false` to opt out of automatic seeding.
+    nonisolated var allowsAutomaticSessionSeeding: Bool { get }
+
+    /// Prompt metadata describing how retrieved memory context should be
+    /// presented to the model.
+    ///
+    /// Default: `nil`, which renders memory context under the generic
+    /// "Relevant Context from Memory" heading with no guidance text.
+    nonisolated var memoryPromptMetadata: MemoryPromptMetadata? { get }
 }
 
 // MARK: - MemoryMessage Context Formatting

--- a/Sources/Swarm/Memory/CompositeMemory.swift
+++ b/Sources/Swarm/Memory/CompositeMemory.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// A memory implementation that fans writes out to multiple memory layers and
 /// combines retrieved context from each layer.
-actor CompositeMemory: Memory, MemoryPromptDescriptor, MemorySessionLifecycle, MemorySessionReplayAware, MemoryRetrievalPolicyAware, MemorySessionImportPolicy, MemorySessionTrackingProvider, MemorySessionSeedControlling {
+actor CompositeMemory: Memory {
     nonisolated let memoryPromptTitle: String
     nonisolated let memoryPromptGuidance: String?
     nonisolated let memoryPriority: MemoryPriorityHint
@@ -31,6 +31,14 @@ actor CompositeMemory: Memory, MemoryPromptDescriptor, MemorySessionLifecycle, M
         self.trackedSessionMemory = trackedSessionMemory
         #endif
         self.allowsAutomaticSessionSeeding = memories.contains(where: Self.allowsSessionSeeding)
+    }
+
+    nonisolated var memoryPromptMetadata: MemoryPromptMetadata? {
+        MemoryPromptMetadata(
+            title: memoryPromptTitle,
+            guidance: memoryPromptGuidance,
+            priority: memoryPriority
+        )
     }
 
     var count: Int {

--- a/Sources/Swarm/Memory/ContextCoreMemory.swift
+++ b/Sources/Swarm/Memory/ContextCoreMemory.swift
@@ -57,11 +57,19 @@ public struct ContextCoreMemoryConfiguration: Sendable {
 ///
 /// Swarm uses this implementation as the primary working-memory layer inside
 /// its default composite memory stack.
-public actor ContextCoreMemory: Memory, MemoryPromptDescriptor, MemorySessionLifecycle, MemorySessionImportPolicy, MemorySessionReplayAware {
+public actor ContextCoreMemory: Memory {
     public nonisolated let memoryPromptTitle: String
     public nonisolated let memoryPromptGuidance: String?
     public nonisolated let memoryPriority: MemoryPriorityHint = .primary
     public nonisolated let allowsAutomaticSessionSeeding: Bool
+
+    public nonisolated var memoryPromptMetadata: MemoryPromptMetadata? {
+        MemoryPromptMetadata(
+            title: memoryPromptTitle,
+            guidance: memoryPromptGuidance,
+            priority: memoryPriority
+        )
+    }
 
     public var count: Int {
         messages.count

--- a/Sources/Swarm/Memory/DefaultAgentMemory.swift
+++ b/Sources/Swarm/Memory/DefaultAgentMemory.swift
@@ -13,7 +13,7 @@ import Foundation
 ///
 /// ContextCore remains the primary working-memory layer for multi-turn coding
 /// context. Wax is used as the durable long-term layer for persisted recall.
-public actor DefaultAgentMemory: Memory, MemoryPromptDescriptor, MemorySessionLifecycle, MemorySessionImportPolicy, MemorySessionReplayAware, MemoryRetrievalPolicyAware {
+public actor DefaultAgentMemory: Memory {
     public struct Configuration: Sendable {
         public static var `default`: Self {
             Configuration()
@@ -55,6 +55,14 @@ public actor DefaultAgentMemory: Memory, MemoryPromptDescriptor, MemorySessionLi
     public nonisolated let memoryPromptGuidance: String?
     public nonisolated let memoryPriority: MemoryPriorityHint = .primary
     public nonisolated let allowsAutomaticSessionSeeding = true
+
+    public nonisolated var memoryPromptMetadata: MemoryPromptMetadata? {
+        MemoryPromptMetadata(
+            title: memoryPromptTitle,
+            guidance: memoryPromptGuidance,
+            priority: memoryPriority
+        )
+    }
 
     /// Whether this memory stack can produce real semantic embeddings.
     ///

--- a/Sources/Swarm/Memory/MemoryHooks.swift
+++ b/Sources/Swarm/Memory/MemoryHooks.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-/// Package-internal optional memory behavior, resolved from public marker protocols.
+/// Package-internal snapshot of a memory's optional capabilities.
 ///
-/// Agent and ``CompositeMemory`` read this value instead of probing `as?` / `as AnyObject`.
-/// ``resolved(from:)`` is the compatibility shim: it is the only site that may cast the
-/// public marker protocols (and the package-internal tracking / seed controllers).
-///
-/// Memories that do not conform to a marker produce ``empty`` hooks for that capability
-/// (session begin/end is a no-op, retrieval falls back to ``Memory/context(for:tokenLimit:)``).
+/// Agent and ``CompositeMemory`` read this value instead of probing memory
+/// types at runtime. Every capability is a defaulted ``Memory`` requirement,
+/// so ``resolved(from:)`` is pure witness dispatch: memories that do not
+/// implement a capability resolve to hooks wrapping the protocol defaults
+/// (session begin/end is a no-op, retrieval falls back to
+/// ``Memory/context(for:tokenLimit:)``).
 ///
 /// - Note: `MemoryHooks` is not part of the public API. Generated `@AgentActor` `run()`
 ///   still uses ``MemorySessionLifecycle`` directly so consumer modules can compile.
@@ -51,51 +51,31 @@ package struct MemoryHooks: Sendable {
 package extension MemoryHooks {
     static let empty = MemoryHooks()
 
-    /// Fills hooks from public marker protocols and package-internal controllers.
+    /// Snapshots a memory's capabilities through defaulted `Memory` witnesses.
     ///
-    /// This is the only remaining `as?` pyramid for optional memory behavior.
+    /// Synchronously readable requirements (prompt metadata, tracking, seeding
+    /// policy) are captured eagerly; asynchronous ones are wrapped into
+    /// `@Sendable` closures that forward to the witness.
     static func resolved(from memory: any Memory) -> MemoryHooks {
         var hooks = MemoryHooks.empty
 
-        if let lifecycle = memory as? any MemorySessionLifecycle {
-            hooks.beginMemorySession = {
-                await lifecycle.beginMemorySession()
-            }
-            hooks.endMemorySession = {
-                await lifecycle.endMemorySession()
-            }
-        }
+        let metadata = memory.memoryPromptMetadata
+        hooks.memoryPromptTitle = metadata?.title
+        hooks.memoryPromptGuidance = metadata?.guidance
+        hooks.memoryPriority = metadata?.priority
+        hooks.trackedSessionMemory = memory.trackedSessionMemory
+        hooks.allowsAutomaticSessionSeeding = memory.allowsAutomaticSessionSeeding
 
-        if let policyAware = memory as? any MemoryRetrievalPolicyAware {
-            hooks.contextForQuery = { query in
-                await policyAware.context(for: query)
-            }
+        hooks.beginMemorySession = { await memory.beginMemorySession() }
+        hooks.endMemorySession = { await memory.endMemorySession() }
+        hooks.contextForQuery = { query in
+            await memory.context(for: query)
         }
-
-        if let descriptor = memory as? any MemoryPromptDescriptor {
-            hooks.memoryPromptTitle = descriptor.memoryPromptTitle
-            hooks.memoryPromptGuidance = descriptor.memoryPromptGuidance
-            hooks.memoryPriority = descriptor.memoryPriority
+        hooks.shouldImportSessionHistory = {
+            await memory.shouldImportSessionHistory()
         }
-
-        if let trackingProvider = memory as? any MemorySessionTrackingProvider {
-            hooks.trackedSessionMemory = trackingProvider.trackedSessionMemory
-        }
-
-        if let importPolicy = memory as? any MemorySessionImportPolicy {
-            hooks.allowsAutomaticSessionSeeding = importPolicy.allowsAutomaticSessionSeeding
-        }
-
-        if let seedController = memory as? any MemorySessionSeedControlling {
-            hooks.shouldImportSessionHistory = {
-                await seedController.shouldImportSessionHistory()
-            }
-        }
-
-        if let replayAware = memory as? any MemorySessionReplayAware {
-            hooks.importSessionHistory = { messages in
-                await replayAware.importSessionHistory(messages)
-            }
+        hooks.importSessionHistory = { messages in
+            await memory.importSessionHistory(messages)
         }
 
         return hooks
@@ -121,5 +101,5 @@ package func resolvedTrackedSessionMemory(
     if let defaultMemory, memoriesAreSameInstance(activeMemory, defaultMemory) {
         return defaultMemory
     }
-    return MemoryHooks.resolved(from: activeMemory).trackedSessionMemory
+    return activeMemory.trackedSessionMemory
 }

--- a/Sources/Swarm/Memory/MemoryHooks.swift
+++ b/Sources/Swarm/Memory/MemoryHooks.swift
@@ -10,7 +10,8 @@ import Foundation
 /// ``Memory/context(for:tokenLimit:)``).
 ///
 /// - Note: `MemoryHooks` is not part of the public API. Generated `@AgentActor` `run()`
-///   still uses ``MemorySessionLifecycle`` directly so consumer modules can compile.
+///   calls the defaulted ``Memory`` requirements directly, so consumer modules
+///   compile without seeing this type.
 package struct MemoryHooks: Sendable {
     var beginMemorySession: (@Sendable () async -> Void)?
     var endMemorySession: (@Sendable () async -> Void)?

--- a/Sources/Swarm/Memory/MemoryPromptDescriptor.swift
+++ b/Sources/Swarm/Memory/MemoryPromptDescriptor.swift
@@ -11,10 +11,39 @@ public enum MemoryPriorityHint: Sendable {
     case secondary
 }
 
+/// Prompt metadata describing how a memory's retrieved context should be
+/// presented to the model.
+///
+/// Return this from ``Memory/memoryPromptMetadata`` to label memory context in
+/// system prompts and to instruct the model on how to treat it.
+public struct MemoryPromptMetadata: Sendable {
+    /// The label/title to display above memory context in prompts.
+    public var title: String
+
+    /// Optional guidance text to instruct how memory should be used.
+    public var guidance: String?
+
+    /// Whether this memory should be treated as primary or secondary context.
+    public var priority: MemoryPriorityHint
+
+    public init(title: String, guidance: String?, priority: MemoryPriorityHint) {
+        self.title = title
+        self.guidance = guidance
+        self.priority = priority
+    }
+}
+
+public extension Memory {
+    /// Default prompt metadata: `nil`, which renders memory context under the
+    /// generic "Relevant Context from Memory" heading with no guidance text.
+    nonisolated var memoryPromptMetadata: MemoryPromptMetadata? { nil }
+}
+
 /// Optional prompt metadata for memory-backed context.
 ///
-/// Conform to this protocol to provide custom labels and guidance
-/// for how the model should treat retrieved memory.
+/// Prompt metadata is now a defaulted requirement on ``Memory``; return it from
+/// ``Memory/memoryPromptMetadata`` instead of conforming to this protocol.
+@available(*, deprecated, message: "Return MemoryPromptMetadata from your Memory conformance's memoryPromptMetadata instead.")
 public protocol MemoryPromptDescriptor: Sendable {
     /// The label/title to display above memory context in prompts.
     var memoryPromptTitle: String { get }
@@ -24,4 +53,17 @@ public protocol MemoryPromptDescriptor: Sendable {
 
     /// Whether this memory should be treated as primary or secondary context.
     var memoryPriority: MemoryPriorityHint { get }
+}
+
+public extension Memory where Self: MemoryPromptDescriptor {
+    /// Bridges deprecated ``MemoryPromptDescriptor`` conformances onto the
+    /// defaulted ``Memory/memoryPromptMetadata`` requirement so existing
+    /// conformers keep their prompt labels without source changes.
+    nonisolated var memoryPromptMetadata: MemoryPromptMetadata? {
+        MemoryPromptMetadata(
+            title: memoryPromptTitle,
+            guidance: memoryPromptGuidance,
+            priority: memoryPriority
+        )
+    }
 }

--- a/Sources/Swarm/Memory/MemoryRetrievalPolicy.swift
+++ b/Sources/Swarm/Memory/MemoryRetrievalPolicy.swift
@@ -35,12 +35,29 @@ public struct MemoryQuery: Sendable, Equatable {
 }
 
 /// Optional memory extension for retrieval implementations that need more than a token limit.
+///
+/// Item-aware retrieval is now a defaulted requirement on ``Memory``; implement
+/// ``Memory/context(for:)`` directly instead of conforming to this protocol.
+@available(*, deprecated, message: "Implement context(for: MemoryQuery) on your Memory conformance instead.")
 public protocol MemoryRetrievalPolicyAware: Memory {
     /// Retrieves context relevant to the query while respecting item-level budgets.
     func context(for query: MemoryQuery) async -> String
 }
 
+public extension Memory {
+    /// Default item-aware retrieval: falls back to ``Memory/context(for:tokenLimit:)``
+    /// using the query text and total token budget, ignoring per-item budgets.
+    func context(for query: MemoryQuery) async -> String {
+        await context(for: query.text, tokenLimit: query.tokenLimit)
+    }
+}
+
 /// Optional policy hook for memories that should not ingest session history automatically.
+///
+/// The seeding policy is now a defaulted requirement on ``Memory``; implement
+/// ``Memory/allowsAutomaticSessionSeeding`` directly instead of conforming to
+/// this protocol.
+@available(*, deprecated, message: "Implement allowsAutomaticSessionSeeding on your Memory conformance instead.")
 public protocol MemorySessionImportPolicy: Sendable {
     /// Whether the agent runtime may seed session history into this memory store.
     var allowsAutomaticSessionSeeding: Bool { get }

--- a/Sources/Swarm/Memory/MemorySessionLifecycle.swift
+++ b/Sources/Swarm/Memory/MemorySessionLifecycle.swift
@@ -2,8 +2,10 @@ import Foundation
 
 /// Optional lifecycle observer for memory implementations that need session scoping.
 ///
-/// This is primarily used by persistent, single-file memories (e.g. Wax) to tag
-/// ingested content per agent run without exposing storage-specific APIs to agents.
+/// Session begin/end are now defaulted requirements on ``Memory``; implement
+/// ``Memory/beginMemorySession()`` and ``Memory/endMemorySession()`` directly
+/// instead of conforming to this protocol.
+@available(*, deprecated, message: "Implement beginMemorySession() and endMemorySession() on your Memory conformance instead.")
 public protocol MemorySessionLifecycle: Memory {
     /// Called at the beginning of an agent `run` / `stream`.
     func beginMemorySession() async
@@ -14,9 +16,43 @@ public protocol MemorySessionLifecycle: Memory {
 
 /// Optional hook for memories that want custom handling when session history is replayed
 /// into a fresh memory instance.
+///
+/// History import is now a defaulted requirement on ``Memory``; implement
+/// ``Memory/importSessionHistory(_:)`` directly instead of conforming to this
+/// protocol.
+@available(*, deprecated, message: "Implement importSessionHistory(_:) on your Memory conformance instead.")
 public protocol MemorySessionReplayAware: Memory {
     /// Imports a batch of session history messages using memory-specific logic.
     func importSessionHistory(_ messages: [MemoryMessage]) async
+}
+
+// MARK: - Defaulted capability implementations
+
+public extension Memory {
+    /// Default no-op: memories without session state do nothing at session start.
+    func beginMemorySession() async {}
+
+    /// Default no-op: memories without session state do nothing at session end.
+    func endMemorySession() async {}
+
+    /// Default replay: appends each replayed message through ``add(_:)``.
+    func importSessionHistory(_ messages: [MemoryMessage]) async {
+        for message in messages {
+            await add(message)
+        }
+    }
+
+    /// Default seed gate: only fresh (empty) memories accept automatic seeding,
+    /// which prevents duplicate imports into stores that already hold content.
+    func shouldImportSessionHistory() async -> Bool {
+        await isEmpty
+    }
+
+    /// Default tracking: single-layer memories own no separate tracked layer.
+    nonisolated var trackedSessionMemory: (any Memory)? { nil }
+
+    /// Default policy: automatic session seeding is allowed.
+    nonisolated var allowsAutomaticSessionSeeding: Bool { true }
 }
 
 public extension Memory {
@@ -26,40 +62,15 @@ public extension Memory {
             return
         }
 
-        let hooks = MemoryHooks.resolved(from: self)
-        guard hooks.allowsAutomaticSessionSeeding else {
+        guard allowsAutomaticSessionSeeding else {
             return
         }
 
-        let shouldSeed = if let shouldImport = hooks.shouldImportSessionHistory {
-            await shouldImport()
-        } else {
-            await isEmpty
-        }
+        let shouldSeed = await shouldImportSessionHistory()
         guard shouldSeed else {
             return
         }
 
-        if let importHistory = hooks.importSessionHistory {
-            await importHistory(messages)
-        } else {
-            for message in messages {
-                await add(message)
-            }
-        }
+        await importSessionHistory(messages)
     }
-}
-
-/// Internal hook for composite memories that contain the agent's default memory
-/// as one layer. The agent runtime uses this to preserve the default memory's
-/// per-session clearing and serialization behavior without clearing static
-/// memory layers such as workspace context.
-protocol MemorySessionTrackingProvider: Sendable {
-    var trackedSessionMemory: (any Memory)? { get }
-}
-
-/// Internal hook for memories that need per-layer control over when session
-/// replay should be imported.
-protocol MemorySessionSeedControlling: Memory {
-    func shouldImportSessionHistory() async -> Bool
 }

--- a/Sources/SwarmMacros/AgentMacro.swift
+++ b/Sources/SwarmMacros/AgentMacro.swift
@@ -161,7 +161,6 @@ public struct AgentMacro: MemberMacro, ExtensionMacro {
 
                         let activeTracer = tracer ?? AgentEnvironmentValues.current.tracer
                         let activeMemory = resolvedMemory()
-                        let lifecycleMemory = activeMemory as? any MemorySessionLifecycle
 
                         let tracing = TracingHelper(
                             tracer: activeTracer,
@@ -171,8 +170,8 @@ public struct AgentMacro: MemberMacro, ExtensionMacro {
 
                         await observer?.onAgentStart(context: nil, agent: self, input: input)
 
-                        if let lifecycleMemory {
-                            await lifecycleMemory.beginMemorySession()
+                        if let activeMemory {
+                            await activeMemory.beginMemorySession()
                         }
 
                         do {
@@ -229,16 +228,16 @@ public struct AgentMacro: MemberMacro, ExtensionMacro {
                             await tracing.traceComplete(result: result)
                             await observer?.onAgentEnd(context: nil, agent: self, result: result)
 
-                            if let lifecycleMemory {
-                                await lifecycleMemory.endMemorySession()
+                            if let activeMemory {
+                                await activeMemory.endMemorySession()
                             }
 
                             return result
                         } catch {
                             await observer?.onError(context: nil, agent: self, error: error)
                             await tracing.traceError(error)
-                            if let lifecycleMemory {
-                                await lifecycleMemory.endMemorySession()
+                            if let activeMemory {
+                                await activeMemory.endMemorySession()
                             }
                             throw error
                         }

--- a/Tests/SwarmMacrosTests/AgentMacroTests.swift
+++ b/Tests/SwarmMacrosTests/AgentMacroTests.swift
@@ -104,7 +104,6 @@ final class AgentMacroTests: XCTestCase {
 
                         let activeTracer = tracer ?? AgentEnvironmentValues.current.tracer
                         let activeMemory = resolvedMemory()
-                        let lifecycleMemory = activeMemory as? any MemorySessionLifecycle
 
                         let tracing = TracingHelper(
                             tracer: activeTracer,
@@ -114,8 +113,8 @@ final class AgentMacroTests: XCTestCase {
 
                         await observer?.onAgentStart(context: nil, agent: self, input: input)
 
-                        if let lifecycleMemory {
-                            await lifecycleMemory.beginMemorySession()
+                        if let activeMemory {
+                            await activeMemory.beginMemorySession()
                         }
 
                         do {
@@ -172,16 +171,16 @@ final class AgentMacroTests: XCTestCase {
                             await tracing.traceComplete(result: result)
                             await observer?.onAgentEnd(context: nil, agent: self, result: result)
 
-                            if let lifecycleMemory {
-                                await lifecycleMemory.endMemorySession()
+                            if let activeMemory {
+                                await activeMemory.endMemorySession()
                             }
 
                             return result
                         } catch {
                             await observer?.onError(context: nil, agent: self, error: error)
                             await tracing.traceError(error)
-                            if let lifecycleMemory {
-                                await lifecycleMemory.endMemorySession()
+                            if let activeMemory {
+                                await activeMemory.endMemorySession()
                             }
                             throw error
                         }
@@ -401,7 +400,6 @@ final class AgentMacroTests: XCTestCase {
 
                         let activeTracer = tracer ?? AgentEnvironmentValues.current.tracer
                         let activeMemory = resolvedMemory()
-                        let lifecycleMemory = activeMemory as? any MemorySessionLifecycle
 
                         let tracing = TracingHelper(
                             tracer: activeTracer,
@@ -411,8 +409,8 @@ final class AgentMacroTests: XCTestCase {
 
                         await observer?.onAgentStart(context: nil, agent: self, input: input)
 
-                        if let lifecycleMemory {
-                            await lifecycleMemory.beginMemorySession()
+                        if let activeMemory {
+                            await activeMemory.beginMemorySession()
                         }
 
                         do {
@@ -469,16 +467,16 @@ final class AgentMacroTests: XCTestCase {
                             await tracing.traceComplete(result: result)
                             await observer?.onAgentEnd(context: nil, agent: self, result: result)
 
-                            if let lifecycleMemory {
-                                await lifecycleMemory.endMemorySession()
+                            if let activeMemory {
+                                await activeMemory.endMemorySession()
                             }
 
                             return result
                         } catch {
                             await observer?.onError(context: nil, agent: self, error: error)
                             await tracing.traceError(error)
-                            if let lifecycleMemory {
-                                await lifecycleMemory.endMemorySession()
+                            if let activeMemory {
+                                await activeMemory.endMemorySession()
                             }
                             throw error
                         }

--- a/Tests/SwarmTests/Agents/AgentMemoryHooksTests.swift
+++ b/Tests/SwarmTests/Agents/AgentMemoryHooksTests.swift
@@ -20,8 +20,11 @@ struct AgentMemoryHooksTests {
         let result = try await agent.run("hello", session: session)
 
         #expect(result.output == "ok")
-        #expect(MemoryHooks.resolved(from: memory).beginMemorySession == nil)
-        #expect(MemoryHooks.resolved(from: memory).endMemorySession == nil)
+        // Witness-based dispatch: a memory without lifecycle implementations
+        // resolves hooks that wrap the protocol's no-op defaults, so the run
+        // above exercises begin/end harmlessly.
+        #expect(MemoryHooks.resolved(from: memory).beginMemorySession != nil)
+        #expect(MemoryHooks.resolved(from: memory).endMemorySession != nil)
     }
 
     @Test("Agent still invokes lifecycle through resolved hooks")
@@ -126,7 +129,7 @@ struct AgentMemoryHooksTests {
     }
 }
 
-private actor SessionLifecycleProbeMemory: Memory, MemorySessionLifecycle {
+private actor SessionLifecycleProbeMemory: Memory {
     private(set) var beginCount = 0
     private(set) var endCount = 0
 
@@ -155,10 +158,18 @@ private actor SessionLifecycleProbeMemory: Memory, MemorySessionLifecycle {
     }
 }
 
-private actor TitledMemory: Memory, MemoryPromptDescriptor {
+private actor TitledMemory: Memory {
     nonisolated let memoryPromptTitle = "Custom Hook Title"
     nonisolated let memoryPromptGuidance: String? = "Treat hooks as primary."
     nonisolated let memoryPriority: MemoryPriorityHint = .primary
+
+    nonisolated var memoryPromptMetadata: MemoryPromptMetadata? {
+        MemoryPromptMetadata(
+            title: memoryPromptTitle,
+            guidance: memoryPromptGuidance,
+            priority: memoryPriority
+        )
+    }
 
     private let contextText: String
 

--- a/Tests/SwarmTests/Macros/AgentActorMacroConformanceTests.swift
+++ b/Tests/SwarmTests/Macros/AgentActorMacroConformanceTests.swift
@@ -92,6 +92,51 @@ struct AgentActorMacroConformanceTests {
         #expect(seedableContext.contains("prism-session marker"))
         #expect(seedableContext.contains("current turn"))
     }
+
+    @Test("Generated run dispatches lifecycle to defaulted Memory requirements without marker conformance")
+    func generatedRunDispatchesLifecycleWithoutMarkerConformance() async throws {
+        let memory = WitnessLifecycleMemory()
+        let agent = MacroEchoAgent(memory: memory)
+
+        _ = try await agent.run("lifecycle probe")
+
+        let counts = await memory.sessionCounts()
+        #expect(counts.begins == 1)
+        #expect(counts.ends == 1)
+    }
+}
+
+private actor WitnessLifecycleMemory: Memory {
+    private(set) var beginCount = 0
+    private(set) var endCount = 0
+
+    var count: Int { get async { 0 } }
+    var isEmpty: Bool { get async { true } }
+
+    func add(_ message: MemoryMessage) async {
+        _ = message
+    }
+
+    func context(for query: String, tokenLimit: Int) async -> String {
+        _ = query
+        _ = tokenLimit
+        return ""
+    }
+
+    func allMessages() async -> [MemoryMessage] { [] }
+    func clear() async {}
+
+    func beginMemorySession() async {
+        beginCount += 1
+    }
+
+    func endMemorySession() async {
+        endCount += 1
+    }
+
+    func sessionCounts() -> (begins: Int, ends: Int) {
+        (beginCount, endCount)
+    }
 }
 
 private actor StaticMacroContextMemory: Memory, MemorySessionImportPolicy {

--- a/Tests/SwarmTests/Memory/MemoryCapabilityWitnessTests.swift
+++ b/Tests/SwarmTests/Memory/MemoryCapabilityWitnessTests.swift
@@ -70,6 +70,45 @@ struct MemoryCapabilityWitnessTests {
 
         #expect(await memory.importedBatches.isEmpty)
     }
+
+    @Test("Deprecated MemoryPromptDescriptor conformance still supplies prompt metadata through the bridge")
+    func deprecatedDescriptorConformanceResolvesThroughBridge() async throws {
+        let memory = BridgeOnlyMemory()
+        let hooks = MemoryHooks.resolved(from: memory)
+
+        // The constrained bridge extension (most-specialized witness) must win
+        // over the unconstrained {nil} default for marker-only conformers.
+        #expect(hooks.memoryPromptTitle == "Bridge Title")
+        #expect(hooks.memoryPromptGuidance == "Bridge guidance.")
+        #expect(hooks.memoryPriority == .secondary)
+    }
+}
+
+/// Conforms only to the deprecated ``MemoryPromptDescriptor`` marker; prompt
+/// metadata must flow through the `Memory where Self: MemoryPromptDescriptor`
+/// bridge without any direct implementation. Marked deprecated so referencing
+/// the deprecated protocol inside does not warn.
+@available(*, deprecated)
+private actor BridgeOnlyMemory: Memory, MemoryPromptDescriptor {
+    nonisolated let memoryPromptTitle = "Bridge Title"
+    nonisolated let memoryPromptGuidance: String? = "Bridge guidance."
+    nonisolated let memoryPriority: MemoryPriorityHint = .secondary
+
+    var count: Int { get async { 0 } }
+    var isEmpty: Bool { get async { true } }
+
+    func add(_ message: MemoryMessage) async {
+        _ = message
+    }
+
+    func context(for query: String, tokenLimit: Int) async -> String {
+        _ = query
+        _ = tokenLimit
+        return ""
+    }
+
+    func allMessages() async -> [MemoryMessage] { [] }
+    func clear() async {}
 }
 
 private actor WitnessOnlyMemory: Memory {

--- a/Tests/SwarmTests/Memory/MemoryCapabilityWitnessTests.swift
+++ b/Tests/SwarmTests/Memory/MemoryCapabilityWitnessTests.swift
@@ -1,0 +1,125 @@
+import Foundation
+@testable import Swarm
+import Testing
+
+/// Regression coverage for capability-witness dispatch on ``Memory``.
+///
+/// Every capability below is implemented WITHOUT declaring any of the
+/// deprecated marker protocols (`MemorySessionLifecycle`,
+/// `MemorySessionReplayAware`, `MemoryRetrievalPolicyAware`,
+/// `MemorySessionImportPolicy`, `MemoryPromptDescriptor`). Under the former
+/// marker-probe discovery these implementations were silently ignored; they
+/// must now be dispatched through defaulted `Memory` requirements.
+@Suite("Memory Capability Witness")
+struct MemoryCapabilityWitnessTests {
+    @Test("Implementing lifecycle methods without marker conformance fires through resolved hooks")
+    func implementWithoutDeclareFiresThroughResolvedHooks() async throws {
+        let memory = WitnessOnlyMemory(contextText: "witness-context")
+        let hooks = MemoryHooks.resolved(from: memory)
+
+        let begin = try #require(hooks.beginMemorySession)
+        let end = try #require(hooks.endMemorySession)
+        await begin()
+        await end()
+
+        #expect(await memory.beginCount == 1)
+        #expect(await memory.endCount == 1)
+
+        // Prompt metadata also resolves without any marker conformance.
+        #expect(hooks.memoryPromptTitle == "Witness Title")
+        #expect(hooks.memoryPriority == .primary)
+    }
+
+    @Test("Implementing lifecycle methods without marker conformance fires during an Agent run")
+    func implementWithoutDeclareFiresDuringAgentRun() async throws {
+        let memory = WitnessOnlyMemory(contextText: "witness-context")
+        let provider = MockInferenceProvider(responses: ["ok"])
+        let agent = try Agent(
+            "You are helpful.",
+            configuration: AgentConfiguration(name: "capability-witness", defaultTracingEnabled: false),
+            memory: memory,
+            inferenceProvider: provider
+        )
+
+        _ = try await agent.run("hello")
+
+        #expect(await memory.beginCount == 1)
+        #expect(await memory.endCount == 1)
+    }
+
+    @Test("Implementing retrieval policy without marker conformance routes item-aware queries")
+    func implementWithoutDeclareRetrievalPolicyRoutesQueries() async throws {
+        let memory = WitnessOnlyMemory(contextText: "witness-context")
+        let hooks = MemoryHooks.resolved(from: memory)
+        let contextForQuery = try #require(hooks.contextForQuery)
+
+        let query = MemoryQuery(text: "obsidian", tokenLimit: 90, maxItems: 3, maxItemTokens: 30)
+        let context = await contextForQuery(query)
+
+        #expect(context == "witness-context")
+        let observedQueries = await memory.queries
+        #expect(observedQueries.count == 1)
+        #expect(observedQueries.first?.maxItems == 3)
+    }
+
+    @Test("Implementing seeding opt-out without marker conformance is respected")
+    func implementWithoutDeclareSeedingOptOutIsRespected() async throws {
+        let memory = WitnessOnlyMemory(contextText: "", allowsAutomaticSessionSeeding: false)
+
+        await memory.seedSessionHistoryIfNeeded([.user("should-not-import")])
+
+        #expect(await memory.importedBatches.isEmpty)
+    }
+}
+
+private actor WitnessOnlyMemory: Memory {
+    let contextText: String
+    nonisolated let allowsAutomaticSessionSeeding: Bool
+
+    private(set) var beginCount = 0
+    private(set) var endCount = 0
+    private(set) var queries: [MemoryQuery] = []
+    private(set) var importedBatches: [[MemoryMessage]] = []
+
+    init(contextText: String, allowsAutomaticSessionSeeding: Bool = true) {
+        self.contextText = contextText
+        self.allowsAutomaticSessionSeeding = allowsAutomaticSessionSeeding
+    }
+
+    nonisolated var memoryPromptMetadata: MemoryPromptMetadata? {
+        MemoryPromptMetadata(title: "Witness Title", guidance: nil, priority: .primary)
+    }
+
+    var count: Int { get async { 0 } }
+    var isEmpty: Bool { get async { true } }
+
+    func add(_ message: MemoryMessage) async {
+        _ = message
+    }
+
+    func context(for query: String, tokenLimit: Int) async -> String {
+        _ = query
+        _ = tokenLimit
+        return contextText
+    }
+
+    func context(for query: MemoryQuery) async -> String {
+        queries.append(query)
+        return contextText
+    }
+
+    func allMessages() async -> [MemoryMessage] { [] }
+    func clear() async {}
+
+    func beginMemorySession() async {
+        beginCount += 1
+    }
+
+    func endMemorySession() async {
+        endCount += 1
+    }
+
+    func importSessionHistory(_ messages: [MemoryMessage]) async {
+        importedBatches.append(messages)
+    }
+}

--- a/Tests/SwarmTests/Memory/MemoryHooksTests.swift
+++ b/Tests/SwarmTests/Memory/MemoryHooksTests.swift
@@ -4,25 +4,41 @@ import Testing
 
 @Suite("Memory Hooks")
 struct MemoryHooksTests {
-    @Test("Memory that does not conform to lifecycle resolves to empty hooks")
-    func memoryWithoutLifecycleResolvesToEmptyHooks() async {
+    @Test("Memory without capability implementations resolves defaulted hooks")
+    func memoryWithoutCapabilitiesResolvesDefaultedHooks() async throws {
         let memory = ConversationMemory()
         let hooks = MemoryHooks.resolved(from: memory)
 
-        #expect(hooks.beginMemorySession == nil)
-        #expect(hooks.endMemorySession == nil)
-        #expect(hooks.contextForQuery == nil)
+        // Capability closures always wrap witnesses, defaulted ones included.
+        let begin = try #require(hooks.beginMemorySession)
+        let end = try #require(hooks.endMemorySession)
+        await begin()
+        await end()
+
+        let contextForQuery = try #require(hooks.contextForQuery)
+        let context = await contextForQuery(
+            MemoryQuery(text: "query", tokenLimit: 10, maxItems: 1, maxItemTokens: 10)
+        )
+        #expect(context == "")
+
+        // Prompt metadata defaults to nil for memories without descriptor data.
         #expect(hooks.memoryPromptTitle == nil)
         #expect(hooks.memoryPromptGuidance == nil)
         #expect(hooks.memoryPriority == nil)
         #expect(hooks.trackedSessionMemory == nil)
         #expect(hooks.allowsAutomaticSessionSeeding)
-        #expect(hooks.shouldImportSessionHistory == nil)
-        #expect(hooks.importSessionHistory == nil)
+
+        // Default seed gate mirrors isEmpty; default replay appends via add(_:).
+        let shouldImport = try #require(hooks.shouldImportSessionHistory)
+        #expect(await shouldImport())
+
+        let importHistory = try #require(hooks.importSessionHistory)
+        await importHistory([.user("seeded")])
+        #expect(await memory.count == 1)
     }
 
-    @Test("Public marker protocols still fill hooks through the shim")
-    func publicMarkerProtocolsFillHooks() async throws {
+    @Test("Implemented capabilities fill hooks through witness dispatch")
+    func implementedCapabilitiesFillHooks() async throws {
         let memory = RecordingLifecycleMemory()
         let hooks = MemoryHooks.resolved(from: memory)
 
@@ -64,10 +80,18 @@ struct MemoryHooksTests {
     }
 }
 
-private actor RecordingLifecycleMemory: Memory, MemorySessionLifecycle, MemoryPromptDescriptor, MemoryRetrievalPolicyAware {
+private actor RecordingLifecycleMemory: Memory {
     nonisolated let memoryPromptTitle = "Recording Title"
     nonisolated let memoryPromptGuidance: String? = "Use recorded context."
     nonisolated let memoryPriority: MemoryPriorityHint = .primary
+
+    nonisolated var memoryPromptMetadata: MemoryPromptMetadata? {
+        MemoryPromptMetadata(
+            title: memoryPromptTitle,
+            guidance: memoryPromptGuidance,
+            priority: memoryPriority
+        )
+    }
 
     private(set) var beginCount = 0
     private(set) var endCount = 0

--- a/docs/reference/api-catalog.md
+++ b/docs/reference/api-catalog.md
@@ -4,7 +4,7 @@ Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for
 
 - Scope: all `.swift` files under `Sources/Swarm/`, excluding `Internal/GraphRuntime/`
 - Source files scanned: 183
-- Public/open symbols cataloged: 2310
+- Public/open symbols cataloged: 2325
 
 ## 1. Swarm (entry point)
 
@@ -1405,15 +1405,23 @@ Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for
 
 | Line | Kind | Access | Name | Signature |
 |------|------|--------|------|-----------|
-| 47 | protocol | public | Memory | `public protocol Memory : Actor` |
-| 49 | var | public | Memory.count | `public var count: Int { get async }` |
-| 55 | var | public | Memory.isEmpty | `public var isEmpty: Bool { get async }` |
-| 60 | func | public | Memory.add(_:) | `public func add(_ message: MemoryMessage) async` |
-| 72 | func | public | Memory.context(for:tokenLimit:) | `public func context(for query: String, tokenLimit: Int) async -> String` |
-| 77 | func | public | Memory.allMessages() | `public func allMessages() async -> [MemoryMessage]` |
-| 80 | func | public | Memory.clear() | `public func clear() async` |
-| 96 | func | public | MemoryMessage.formatContext(_:tokenLimit:tokenEstimator:) | `public static func formatContext(_ messages: [MemoryMessage], tokenLimit: Int, tokenEstimator: any TokenEstimator = CharacterBasedTokenEstimator.shared) -> String` |
-| 128 | func | public | MemoryMessage.formatContext(_:tokenLimit:separator:tokenEstimator:) | `public static func formatContext(_ messages: [MemoryMessage], tokenLimit: Int, separator: String, tokenEstimator: any TokenEstimator = CharacterBasedTokenEstimator.shared) -> String` |
+| 101 | protocol | public | Memory | `public protocol Memory : Actor` |
+| 110 | var | public | Memory.count | `public var count: Int { get async }` |
+| 120 | var | public | Memory.isEmpty | `public var isEmpty: Bool { get async }` |
+| 132 | func | public | Memory.add(_:) | `public func add(_ message: MemoryMessage) async` |
+| 158 | func | public | Memory.context(for:tokenLimit:) | `public func context(for query: String, tokenLimit: Int) async -> String` |
+| 169 | func | public | Memory.allMessages() | `public func allMessages() async -> [MemoryMessage]` |
+| 176 | func | public | Memory.clear() | `public func clear() async` |
+| 188 | func | public | Memory.beginMemorySession() | `public func beginMemorySession() async` |
+| 196 | func | public | Memory.endMemorySession() | `public func endMemorySession() async` |
+| 205 | func | public | Memory.context(for:) | `public func context(for query: MemoryQuery) async -> String` |
+| 212 | func | public | Memory.importSessionHistory(_:) | `public func importSessionHistory(_ messages: [MemoryMessage]) async` |
+| 219 | func | public | Memory.shouldImportSessionHistory() | `public func shouldImportSessionHistory() async -> Bool` |
+| 226 | var | public | Memory.trackedSessionMemory | `public nonisolated var trackedSessionMemory: (any Memory)? { get }` |
+| 231 | var | public | Memory.allowsAutomaticSessionSeeding | `public nonisolated var allowsAutomaticSessionSeeding: Bool { get }` |
+| 238 | var | public | Memory.memoryPromptMetadata | `public nonisolated var memoryPromptMetadata: MemoryPromptMetadata? { get }` |
+| 274 | func | public | MemoryMessage.formatContext(_:tokenLimit:tokenEstimator:) | `public static func formatContext(_ messages: [MemoryMessage], tokenLimit: Int, tokenEstimator: any TokenEstimator = CharacterBasedTokenEstimator.shared) -> String` |
+| 318 | func | public | MemoryMessage.formatContext(_:tokenLimit:separator:tokenEstimator:) | `public static func formatContext(_ messages: [MemoryMessage], tokenLimit: Int, separator: String, tokenEstimator: any TokenEstimator = CharacterBasedTokenEstimator.shared) -> String` |
 ### Memory/Backends/InMemoryBackend.swift
 
 | Line | Kind | Access | Name | Signature |
@@ -1609,18 +1617,25 @@ Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for
 | 9 | enum | public | MemoryPriorityHint | `public enum MemoryPriorityHint` |
 | 10 | case | public | MemoryPriorityHint.primary | `public case primary` |
 | 11 | case | public | MemoryPriorityHint.secondary | `public case secondary` |
-| 18 | protocol | public | MemoryPromptDescriptor | `public protocol MemoryPromptDescriptor : Sendable` |
-| 20 | var | public | MemoryPromptDescriptor.memoryPromptTitle | `public var memoryPromptTitle: String { get }` |
-| 23 | var | public | MemoryPromptDescriptor.memoryPromptGuidance | `public var memoryPromptGuidance: String? { get }` |
-| 26 | var | public | MemoryPromptDescriptor.memoryPriority | `public var memoryPriority: MemoryPriorityHint { get }` |
+| 19 | struct | public | MemoryPromptMetadata | `public struct MemoryPromptMetadata: Sendable` |
+| 21 | var | public | MemoryPromptMetadata.title | `public var title: String` |
+| 24 | var | public | MemoryPromptMetadata.guidance | `public var guidance: String?` |
+| 27 | var | public | MemoryPromptMetadata.priority | `public var priority: MemoryPriorityHint` |
+| 29 | init | public | MemoryPromptMetadata.init(title:guidance:priority:) | `public init(title: String, guidance: String?, priority: MemoryPriorityHint)` |
+| 47 | protocol | public | MemoryPromptDescriptor | `public protocol MemoryPromptDescriptor : Sendable` |
+| 49 | var | public | MemoryPromptDescriptor.memoryPromptTitle | `public var memoryPromptTitle: String { get }` |
+| 52 | var | public | MemoryPromptDescriptor.memoryPromptGuidance | `public var memoryPromptGuidance: String? { get }` |
+| 55 | var | public | MemoryPromptDescriptor.memoryPriority | `public var memoryPriority: MemoryPriorityHint { get }` |
 
 ### Memory/MemorySessionLifecycle.swift
 
 | Line | Kind | Access | Name | Signature |
 |------|------|--------|------|-----------|
-| 7 | protocol | public | MemorySessionLifecycle | `public protocol MemorySessionLifecycle : Memory` |
-| 9 | func | public | MemorySessionLifecycle.beginMemorySession() | `public func beginMemorySession() async` |
-| 12 | func | public | MemorySessionLifecycle.endMemorySession() | `public func endMemorySession() async` |
+| 9 | protocol | public | MemorySessionLifecycle | `public protocol MemorySessionLifecycle : Memory` |
+| 11 | func | public | MemorySessionLifecycle.beginMemorySession() | `public func beginMemorySession() async` |
+| 14 | func | public | MemorySessionLifecycle.endMemorySession() | `public func endMemorySession() async` |
+| 24 | protocol | public | MemorySessionReplayAware | `public protocol MemorySessionReplayAware : Memory` |
+| 26 | func | public | MemorySessionReplayAware.importSessionHistory(_:) | `public func importSessionHistory(_ messages: [MemoryMessage]) async` |
 
 ### Memory/PersistentMemory.swift
 

--- a/docs/reference/front-facing-api.md
+++ b/docs/reference/front-facing-api.md
@@ -489,6 +489,50 @@ let vector: VectorMemory = .vector(
 )
 ```
 
+### Optional memory capabilities (`Memory` protocol)
+
+Custom `Memory` conformers opt into optional runtime behaviors by implementing
+defaulted `Memory` requirements — no marker protocol conformance is required or
+consulted. Implementing the member is the opt-in:
+
+```swift
+public protocol Memory: Actor, Sendable {
+    // ...required members...
+
+    // Session lifecycle (defaults: no-op)
+    func beginMemorySession() async
+    func endMemorySession() async
+
+    // Item-aware retrieval (default: falls back to context(for:tokenLimit:))
+    func context(for query: MemoryQuery) async -> String
+
+    // Session-history replay (default: appends each message via add(_:))
+    func importSessionHistory(_ messages: [MemoryMessage]) async
+
+    // Seed gate (default: isEmpty — only fresh memories accept seeding)
+    func shouldImportSessionHistory() async -> Bool
+
+    // Composite session layer (default: nil)
+    nonisolated var trackedSessionMemory: (any Memory)? { get }
+
+    // Automatic seeding policy (default: true)
+    nonisolated var allowsAutomaticSessionSeeding: Bool { get }
+
+    // Prompt labels for retrieved context (default: nil)
+    nonisolated var memoryPromptMetadata: MemoryPromptMetadata? { get }
+}
+```
+
+`MemoryPromptMetadata(title:guidance:priority:)` labels memory context in
+system prompts; `nil` renders under the generic "Relevant Context from Memory"
+heading with no guidance text.
+
+The former marker protocols are deprecated and still compile so existing
+conformances keep working: `MemorySessionLifecycle`,
+`MemorySessionReplayAware`, `MemoryRetrievalPolicyAware`,
+`MemorySessionImportPolicy`, and `MemoryPromptDescriptor`. Migrate by
+implementing the corresponding `Memory` requirement directly.
+
 ## 10) HandoffTool
 
 Agents passed via the `handoffs` or `handoffAgents` init parameters are automatically wrapped as tool calls. The LLM can invoke them to delegate control.


### PR DESCRIPTION
Ticket T1 of spec-architecture-type-system-strong-set (spec kept local per repo hygiene; decision report: swift-type-system-review-Swarm-1787334666.html).

## What
Replaces the last `as?` cast pyramid with compiler-checked capability dispatch — the same pattern PR #150 applied to InferenceProvider:
- Eight optional memory behaviors hoisted from marker protocols into **defaulted requirements** on \`public protocol Memory\` (signatures taken verbatim; defaults preserve old nil-hook fallback semantics, incl. \`shouldImportSessionHistory == isEmpty\`).
- New public struct \`MemoryPromptMetadata(title:guidance:priority:)\` + single \`memoryPromptMetadata\` requirement (probe-proved that same-name optional properties would silently strip WaxMemory/WorkspaceMemory witnesses).
- Bridge extension \`Memory where Self: MemoryPromptDescriptor\` keeps deprecated-marker conformers dispatching unchanged.
- \`MemoryHooks.resolved(from:)\` is now pure witness reads — zero casts.
- Five public markers deprecated (not removed); internal tracking/seed controllers folded into defaults.

## Compiler gain
Silent misconfiguration (hook method implemented, marker forgotten ⇒ hook never fires) is now impossible: implementing the requirement IS the opt-in. Regression test pins implement-without-declare firing via both resolved hooks and a real Agent run.

## Verification
- Full gate on this branch: \`swift build --traits Integrations && swift test --no-parallel --traits Integrations\` → **2116 tests / 287 suites green** (also fixes the pre-existing PR#150 api-catalog count fallout).
- Reviews: fresh-context \`swift-pr-review\` pass 1 (APPROVE, no fixes) + independent final pass (READY-FOR-PR). Witness matching audited across all conformer families (WaxMemory via inheritance, ContextCore, Composite, Default, plain conformers).

## Release notes callouts
- Custom memories implementing hook methods without declaring markers now have them dispatched (intended fix).
- Marker protocols deprecated; migrate to direct requirement implementations.