### PR TITLE
Encode durable workflow run-state as a closed phase enum with legacy migration (T3)

### DIFF
--- a/Sources/Swarm/Workflow/WorkflowDurableEngine.swift
+++ b/Sources/Swarm/Workflow/WorkflowDurableEngine.swift
@@ -26,6 +26,11 @@ enum WorkflowDurableInput: Sendable {
 /// channel) because completion and repeat-boundary evaluation happen in later
 /// supersteps than the last step write; the snapshot must survive the store
 /// round-trip so resumed runs return and evaluate the full ``AgentResult``.
+///
+/// Cursor *values* cannot be forbidden structurally (`Int` associated values),
+/// so the non-negative invariant is enforced once at the domain-read boundary
+/// in ``workflowNode(_:)-swift.func``, where every resume — migrated legacy or
+/// native — crosses back into engine logic.
 enum WorkflowDurablePhase: Codable, Sendable, Equatable {
     /// The run is still executing. `stepCursor` indexes the next step to run;
     /// `iterationCursor` counts completed passes of a repeating workflow;
@@ -283,6 +288,17 @@ private func workflowNode(_ input: HiveNodeInput<WorkflowDurableSchema>) async t
     let phase = try input.store.get(WorkflowDurableSchema.phaseKey)
     guard case .running(let stepCursor, let iterationCursor, let lastResult) = phase else {
         return HiveNodeOutput(next: .end)
+    }
+
+    // Cursors are untrusted persisted state: every engine-written cursor is
+    // non-negative by construction, so a negative value can only come from a
+    // tampered or truncated checkpoint. Fail the resume with a typed error
+    // instead of trapping on `steps[stepCursor]` below.
+    guard stepCursor >= 0, iterationCursor >= 0 else {
+        throw WorkflowError.invalidWorkflow(
+            reason: "durable checkpoint carries negative cursors "
+                + "(stepCursor: \(stepCursor), iterationCursor: \(iterationCursor))"
+        )
     }
 
     let currentInput = try input.store.get(WorkflowDurableSchema.currentInputKey)

--- a/Sources/Swarm/Workflow/WorkflowDurableEngine.swift
+++ b/Sources/Swarm/Workflow/WorkflowDurableEngine.swift
@@ -13,6 +13,29 @@ enum WorkflowDurableInput: Sendable {
     case resume
 }
 
+/// Closed run-state phase for durable workflows.
+///
+/// The phase is the single checkpointed carrier of workflow progress: either the
+/// run is mid-flight (`running`, with its cursors and most recent step result) or
+/// it has terminated (`completed`, carrying the final result). Because the
+/// cursors live inside `running`'s payload, a completed run can never coexist
+/// with pending cursor state — the illegal combination is unrepresentable by
+/// construction rather than guarded at runtime.
+///
+/// Note: `lastResult` rides inside `running` (instead of a parallel result
+/// channel) because completion and repeat-boundary evaluation happen in later
+/// supersteps than the last step write; the snapshot must survive the store
+/// round-trip so resumed runs return and evaluate the full ``AgentResult``.
+enum WorkflowDurablePhase: Codable, Sendable, Equatable {
+    /// The run is still executing. `stepCursor` indexes the next step to run;
+    /// `iterationCursor` counts completed passes of a repeating workflow;
+    /// `lastResult` is the most recent step result, or nil before the first
+    /// step commits.
+    case running(stepCursor: Int, iterationCursor: Int, lastResult: WorkflowResultSnapshot?)
+    /// The run has finished. Carries the workflow's final result.
+    case completed(WorkflowResultSnapshot)
+}
+
 struct WorkflowDurableSchema: HiveSchema {
     typealias Context = WorkflowDurableContext
     typealias Input = WorkflowDurableInput
@@ -20,11 +43,8 @@ struct WorkflowDurableSchema: HiveSchema {
     typealias ResumePayload = String
 
     static let currentInputKey = HiveChannelKey<Self, String>(HiveChannelID("workflow.currentInput"))
-    static let lastResultKey = HiveChannelKey<Self, WorkflowResultSnapshot?>(HiveChannelID("workflow.lastResult"))
-    static let stepCursorKey = HiveChannelKey<Self, Int>(HiveChannelID("workflow.stepCursor"))
-    static let iterationCursorKey = HiveChannelKey<Self, Int>(HiveChannelID("workflow.iterationCursor"))
-    static let completedKey = HiveChannelKey<Self, Bool>(HiveChannelID("workflow.completed"))
     static let signatureKey = HiveChannelKey<Self, String>(HiveChannelID("workflow.signature"))
+    static let phaseKey = HiveChannelKey<Self, WorkflowDurablePhase>(HiveChannelID("workflow.phase"))
 
     static var channelSpecs: [AnyHiveChannelSpec<Self>] {
         [
@@ -41,56 +61,23 @@ struct WorkflowDurableSchema: HiveSchema {
             ),
             AnyHiveChannelSpec(
                 HiveChannelSpec(
-                    key: lastResultKey,
-                    scope: .global,
-                    reducer: .lastWriteWins(),
-                    updatePolicy: .single,
-                    initial: { Optional<WorkflowResultSnapshot>.none },
-                    codec: HiveAnyCodec(WorkflowCheckpointCodec<WorkflowResultSnapshot?>()),
-                    persistence: .checkpointed
-                )
-            ),
-            AnyHiveChannelSpec(
-                HiveChannelSpec(
-                    key: stepCursorKey,
-                    scope: .global,
-                    reducer: .lastWriteWins(),
-                    updatePolicy: .single,
-                    initial: { 0 },
-                    codec: HiveAnyCodec(WorkflowCheckpointCodec<Int>()),
-                    persistence: .checkpointed
-                )
-            ),
-            AnyHiveChannelSpec(
-                HiveChannelSpec(
-                    key: iterationCursorKey,
-                    scope: .global,
-                    reducer: .lastWriteWins(),
-                    updatePolicy: .single,
-                    initial: { 0 },
-                    codec: HiveAnyCodec(WorkflowCheckpointCodec<Int>()),
-                    persistence: .checkpointed
-                )
-            ),
-            AnyHiveChannelSpec(
-                HiveChannelSpec(
-                    key: completedKey,
-                    scope: .global,
-                    reducer: .lastWriteWins(),
-                    updatePolicy: .single,
-                    initial: { false },
-                    codec: HiveAnyCodec(WorkflowCheckpointCodec<Bool>()),
-                    persistence: .checkpointed
-                )
-            ),
-            AnyHiveChannelSpec(
-                HiveChannelSpec(
                     key: signatureKey,
                     scope: .global,
                     reducer: .lastWriteWins(),
                     updatePolicy: .single,
                     initial: { "" },
                     codec: HiveAnyCodec(WorkflowCheckpointCodec<String>()),
+                    persistence: .checkpointed
+                )
+            ),
+            AnyHiveChannelSpec(
+                HiveChannelSpec(
+                    key: phaseKey,
+                    scope: .global,
+                    reducer: .lastWriteWins(),
+                    updatePolicy: .single,
+                    initial: { WorkflowDurablePhase.running(stepCursor: 0, iterationCursor: 0, lastResult: nil) },
+                    codec: HiveAnyCodec(WorkflowCheckpointCodec<WorkflowDurablePhase>()),
                     persistence: .checkpointed
                 )
             ),
@@ -102,11 +89,8 @@ struct WorkflowDurableSchema: HiveSchema {
         case .start(let input, let signature):
             return [
                 AnyHiveWrite(currentInputKey, input),
-                AnyHiveWrite(lastResultKey, Optional<WorkflowResultSnapshot>.none),
-                AnyHiveWrite(stepCursorKey, 0),
-                AnyHiveWrite(iterationCursorKey, 0),
-                AnyHiveWrite(completedKey, false),
                 AnyHiveWrite(signatureKey, signature),
+                AnyHiveWrite(phaseKey, WorkflowDurablePhase.running(stepCursor: 0, iterationCursor: 0, lastResult: nil)),
             ]
 
         case .resume:
@@ -136,7 +120,13 @@ struct WorkflowDurableEngine: Sendable {
             context: context,
             clock: WorkflowDurableClock(),
             logger: WorkflowDurableLogger(),
-            checkpointStore: faultInjectingStore(wrapping: checkpointing.runtimeStore)
+            checkpointStore: faultInjectingStore(wrapping: AnyHiveCheckpointStore(
+                WorkflowLegacyMigratingCheckpointStore(
+                    inner: checkpointing.runtimeStore,
+                    schemaVersion: graph.schemaVersion,
+                    graphVersion: graph.graphVersion
+                )
+            ))
         )
 
         let runtime = try HiveRuntime(graph: graph, environment: environment)
@@ -186,8 +176,12 @@ struct WorkflowDurableEngine: Sendable {
         var builder = HiveGraphBuilder<WorkflowDurableSchema>(start: [WorkflowNodeID.execute])
         builder.addNode(WorkflowNodeID.execute, workflowNode)
         builder.addRouter(from: WorkflowNodeID.execute) { store in
-            let completed = (try? store.get(WorkflowDurableSchema.completedKey)) ?? false
-            return completed ? .end : .to([WorkflowNodeID.execute])
+            let phase = (try? store.get(WorkflowDurableSchema.phaseKey))
+                ?? .running(stepCursor: 0, iterationCursor: 0, lastResult: nil)
+            if case .completed = phase {
+                return .end
+            }
+            return .to([WorkflowNodeID.execute])
         }
         return try builder.compile()
     }
@@ -237,20 +231,38 @@ struct WorkflowDurableEngine: Sendable {
     private func extractResult(from output: HiveRunOutput<WorkflowDurableSchema>) throws -> AgentResult {
         switch output {
         case .fullStore(let store):
-            if let snapshot = try store.get(WorkflowDurableSchema.lastResultKey) {
+            let phase = try store.get(WorkflowDurableSchema.phaseKey)
+            switch phase {
+            case .completed(let snapshot):
                 return snapshot.agentResult
+            case .running(_, _, let lastResult):
+                if let lastResult {
+                    return lastResult.agentResult
+                }
+                return AgentResult(output: try store.get(WorkflowDurableSchema.currentInputKey))
             }
-            let currentInput = try store.get(WorkflowDurableSchema.currentInputKey)
-            return AgentResult(output: currentInput)
 
         case .channels(let values):
-            if let snapshot = values.first(where: { $0.id == WorkflowDurableSchema.lastResultKey.id })?.value as? WorkflowResultSnapshot {
+            guard let value = values.first(where: { $0.id == WorkflowDurableSchema.phaseKey.id })?.value
+            else {
+                return AgentResult(output: "")
+            }
+            guard let phase = value as? WorkflowDurablePhase else {
+                return AgentResult(output: "")
+            }
+            switch phase {
+            case .completed(let snapshot):
                 return snapshot.agentResult
+            case .running(_, _, let lastResult):
+                if let lastResult {
+                    return lastResult.agentResult
+                }
+                if let currentInput = values.first(where: { $0.id == WorkflowDurableSchema.currentInputKey.id })?
+                    .value as? String {
+                    return AgentResult(output: currentInput)
+                }
+                return AgentResult(output: "")
             }
-            if let currentInput = values.first(where: { $0.id == WorkflowDurableSchema.currentInputKey.id })?.value as? String {
-                return AgentResult(output: currentInput)
-            }
-            return AgentResult(output: "")
         }
     }
 }
@@ -268,22 +280,22 @@ private func workflowNode(_ input: HiveNodeInput<WorkflowDurableSchema>) async t
         throw mismatch
     }
 
-    let completed = try input.store.get(WorkflowDurableSchema.completedKey)
-    if completed {
+    let phase = try input.store.get(WorkflowDurableSchema.phaseKey)
+    guard case .running(let stepCursor, let iterationCursor, let lastResult) = phase else {
         return HiveNodeOutput(next: .end)
     }
 
     let currentInput = try input.store.get(WorkflowDurableSchema.currentInputKey)
-    let lastResultSnapshot = try input.store.get(WorkflowDurableSchema.lastResultKey)
-    var stepCursor = try input.store.get(WorkflowDurableSchema.stepCursorKey)
-    var iterationCursor = try input.store.get(WorkflowDurableSchema.iterationCursorKey)
+    // The final result of a pass: the last committed step result, or the
+    // original input for workflows that complete before running any step.
+    let finalSnapshot = { lastResult ?? WorkflowResultSnapshot(AgentResult(output: currentInput)) }
 
     if stepCursor >= input.context.workflow.steps.count {
         if let repeatCondition = input.context.workflow.repeatCondition {
-            let lastResult = lastResultSnapshot?.agentResult ?? AgentResult(output: currentInput)
-            if repeatCondition(lastResult) {
+            let lastResultValue = lastResult?.agentResult ?? AgentResult(output: currentInput)
+            if repeatCondition(lastResultValue) {
                 return HiveNodeOutput(
-                    writes: [AnyHiveWrite(WorkflowDurableSchema.completedKey, true)],
+                    writes: [AnyHiveWrite(WorkflowDurableSchema.phaseKey, .completed(finalSnapshot()))],
                     next: .end
                 )
             }
@@ -291,25 +303,24 @@ private func workflowNode(_ input: HiveNodeInput<WorkflowDurableSchema>) async t
             let nextIteration = iterationCursor + 1
             if nextIteration >= input.context.workflow.maxRepeatIterations {
                 return HiveNodeOutput(
-                    writes: [AnyHiveWrite(WorkflowDurableSchema.completedKey, true)],
+                    writes: [AnyHiveWrite(WorkflowDurableSchema.phaseKey, .completed(finalSnapshot()))],
                     next: .end
                 )
             }
 
-            stepCursor = 0
-            iterationCursor = nextIteration
-
             return HiveNodeOutput(
                 writes: [
-                    AnyHiveWrite(WorkflowDurableSchema.stepCursorKey, stepCursor),
-                    AnyHiveWrite(WorkflowDurableSchema.iterationCursorKey, iterationCursor),
-                    AnyHiveWrite(WorkflowDurableSchema.currentInputKey, lastResult.output),
+                    AnyHiveWrite(
+                        WorkflowDurableSchema.phaseKey,
+                        .running(stepCursor: 0, iterationCursor: nextIteration, lastResult: lastResult)
+                    ),
+                    AnyHiveWrite(WorkflowDurableSchema.currentInputKey, lastResultValue.output),
                 ]
             )
         }
 
         return HiveNodeOutput(
-            writes: [AnyHiveWrite(WorkflowDurableSchema.completedKey, true)],
+            writes: [AnyHiveWrite(WorkflowDurableSchema.phaseKey, .completed(finalSnapshot()))],
             next: .end
         )
     }
@@ -323,9 +334,11 @@ private func workflowNode(_ input: HiveNodeInput<WorkflowDurableSchema>) async t
 
     return HiveNodeOutput(
         writes: [
-            AnyHiveWrite(WorkflowDurableSchema.lastResultKey, Optional(snapshot)),
+            AnyHiveWrite(
+                WorkflowDurableSchema.phaseKey,
+                .running(stepCursor: stepCursor + 1, iterationCursor: iterationCursor, lastResult: Optional(snapshot))
+            ),
             AnyHiveWrite(WorkflowDurableSchema.currentInputKey, result.output),
-            AnyHiveWrite(WorkflowDurableSchema.stepCursorKey, stepCursor + 1),
         ]
     )
 }
@@ -422,6 +435,144 @@ actor WorkflowFaultInjectingCheckpointStore: HiveCheckpointStore {
 
     func loadLatest(threadID: HiveThreadID) async throws -> HiveCheckpoint<WorkflowDurableSchema>? {
         try await inner.loadLatest(threadID: threadID)
+    }
+}
+
+/// Checkpoint store wrapper that migrates pre-phase-enum checkpoints on load.
+///
+/// Loads matching the current schema version pass through untouched; anything
+/// else is offered to ``WorkflowLegacyCheckpointMigrator`` so durable runs
+/// checkpointed by earlier Swarm releases resume instead of failing with a
+/// version mismatch.
+private struct WorkflowLegacyMigratingCheckpointStore: HiveCheckpointStore {
+    typealias Schema = WorkflowDurableSchema
+
+    private let inner: AnyHiveCheckpointStore<Schema>
+    private let schemaVersion: String
+    private let graphVersion: String
+
+    init(
+        inner: AnyHiveCheckpointStore<Schema>,
+        schemaVersion: String,
+        graphVersion: String
+    ) {
+        self.inner = inner
+        self.schemaVersion = schemaVersion
+        self.graphVersion = graphVersion
+    }
+
+    func save(_ checkpoint: HiveCheckpoint<Schema>) async throws {
+        try await inner.save(checkpoint)
+    }
+
+    func loadLatest(threadID: HiveThreadID) async throws -> HiveCheckpoint<Schema>? {
+        guard let checkpoint = try await inner.loadLatest(threadID: threadID) else { return nil }
+        guard checkpoint.schemaVersion != schemaVersion else { return checkpoint }
+        return try WorkflowLegacyCheckpointMigrator.migrate(
+            checkpoint,
+            schemaVersion: schemaVersion,
+            graphVersion: graphVersion
+        )
+    }
+}
+
+/// Rewrites checkpoints persisted in the pre-phase-enum six-channel layout into
+/// the current three-channel phase-enum layout.
+///
+/// The legacy channels (`workflow.currentInput`, `workflow.lastResult`,
+/// `workflow.stepCursor`, `workflow.iterationCursor`, `workflow.completed`,
+/// `workflow.signature`) are decoded with the same deterministic JSON codecs
+/// that wrote them, then folded into one ``WorkflowDurablePhase``:
+/// `completed == true` becomes `.completed` (synthesizing the result from the
+/// current input when no step ever committed), otherwise `.running` carries the
+/// cursors and snapshot forward. A synthesized completion cannot leave pending
+/// cursors behind because the cursors are dropped with the legacy layout.
+///
+/// Checkpoints without the legacy discriminator channel are returned untouched
+/// so the runtime raises its regular version-mismatch error rather than
+/// guessing at an unknown format.
+enum WorkflowLegacyCheckpointMigrator {
+    static func migrate(
+        _ checkpoint: HiveCheckpoint<WorkflowDurableSchema>,
+        schemaVersion: String,
+        graphVersion: String
+    ) throws -> HiveCheckpoint<WorkflowDurableSchema> {
+        let legacyData = checkpoint.globalDataByChannelID
+        guard legacyData[LegacyRunState.completedChannelID] != nil else {
+            return checkpoint
+        }
+
+        let legacy = try LegacyRunState(globalDataByChannelID: legacyData)
+        let phase: WorkflowDurablePhase
+        if legacy.completed {
+            phase = .completed(legacy.lastResult ?? WorkflowResultSnapshot(AgentResult(output: legacy.currentInput)))
+        } else {
+            phase = .running(
+                stepCursor: legacy.stepCursor,
+                iterationCursor: legacy.iterationCursor,
+                lastResult: legacy.lastResult
+            )
+        }
+
+        var migratedData: [String: Data] = [:]
+        migratedData[WorkflowDurableSchema.phaseKey.id.rawValue] =
+            try WorkflowCheckpointCodec<WorkflowDurablePhase>().encode(phase)
+        migratedData[WorkflowDurableSchema.currentInputKey.id.rawValue] =
+            try WorkflowCheckpointCodec<String>().encode(legacy.currentInput)
+        migratedData[WorkflowDurableSchema.signatureKey.id.rawValue] =
+            try WorkflowCheckpointCodec<String>().encode(legacy.signature)
+
+        return HiveCheckpoint(
+            id: checkpoint.id,
+            threadID: checkpoint.threadID,
+            runID: checkpoint.runID,
+            stepIndex: checkpoint.stepIndex,
+            schemaVersion: schemaVersion,
+            graphVersion: graphVersion,
+            checkpointFormatVersion: checkpoint.checkpointFormatVersion,
+            channelVersionsByChannelID: checkpoint.channelVersionsByChannelID,
+            versionsSeenByNodeID: checkpoint.versionsSeenByNodeID,
+            updatedChannelsLastCommit: checkpoint.updatedChannelsLastCommit,
+            globalDataByChannelID: migratedData,
+            frontier: checkpoint.frontier,
+            deferredFrontier: checkpoint.deferredFrontier,
+            joinBarrierSeenByJoinID: checkpoint.joinBarrierSeenByJoinID,
+            interruption: checkpoint.interruption,
+            lineage: checkpoint.lineage
+        )
+    }
+}
+
+/// Channel identifiers and decoded values of the pre-phase-enum durable layout.
+private struct LegacyRunState {
+    static let currentInputChannelID = "workflow.currentInput"
+    static let signatureChannelID = "workflow.signature"
+    static let stepCursorChannelID = "workflow.stepCursor"
+    static let iterationCursorChannelID = "workflow.iterationCursor"
+    static let completedChannelID = "workflow.completed"
+    static let lastResultChannelID = "workflow.lastResult"
+
+    let currentInput: String
+    let signature: String
+    let stepCursor: Int
+    let iterationCursor: Int
+    let completed: Bool
+    let lastResult: WorkflowResultSnapshot?
+
+    init(globalDataByChannelID data: [String: Data]) throws {
+        // Missing entries fall back to start-of-run values; entries that are
+        // present but undecodable fail loudly instead of fabricating state.
+        currentInput = try Self.decoded(data[Self.currentInputChannelID], as: String.self) ?? ""
+        signature = try Self.decoded(data[Self.signatureChannelID], as: String.self) ?? ""
+        stepCursor = try Self.decoded(data[Self.stepCursorChannelID], as: Int.self) ?? 0
+        iterationCursor = try Self.decoded(data[Self.iterationCursorChannelID], as: Int.self) ?? 0
+        completed = try Self.decoded(data[Self.completedChannelID], as: Bool.self) ?? false
+        lastResult = try Self.decoded(data[Self.lastResultChannelID], as: WorkflowResultSnapshot?.self) ?? nil
+    }
+
+    private static func decoded<Value: Codable & Sendable>(_ data: Data?, as _: Value.Type) throws -> Value? {
+        guard let data else { return nil }
+        return try WorkflowCheckpointCodec<Value>().decode(data)
     }
 }
 #endif

--- a/Sources/Swarm/Workflow/WorkflowDurableEngine.swift
+++ b/Sources/Swarm/Workflow/WorkflowDurableEngine.swift
@@ -488,6 +488,13 @@ private struct WorkflowLegacyMigratingCheckpointStore: HiveCheckpointStore {
 /// cursors and snapshot forward. A synthesized completion cannot leave pending
 /// cursors behind because the cursors are dropped with the legacy layout.
 ///
+/// Version bookkeeping (`channelVersionsByChannelID`, `versionsSeenByNodeID`,
+/// `updatedChannelsLastCommit`) is pruned to channel IDs the current schema
+/// still registers: legacy checkpoints carry the removed channel IDs in these
+/// maps, and the runtime rejects any unknown ID there as corrupt. Surviving
+/// channels keep their write history; the phase channel starts at version 0
+/// like any newly registered channel.
+///
 /// Checkpoints without the legacy discriminator channel are returned untouched
 /// so the runtime raises its regular version-mismatch error rather than
 /// guessing at an unknown format.
@@ -522,6 +529,12 @@ enum WorkflowLegacyCheckpointMigrator {
         migratedData[WorkflowDurableSchema.signatureKey.id.rawValue] =
             try WorkflowCheckpointCodec<String>().encode(legacy.signature)
 
+        let registeredGlobalIDs = Set(
+            WorkflowDurableSchema.channelSpecs
+                .filter { $0.scope == .global }
+                .map { $0.id.rawValue }
+        )
+
         return HiveCheckpoint(
             id: checkpoint.id,
             threadID: checkpoint.threadID,
@@ -530,9 +543,13 @@ enum WorkflowLegacyCheckpointMigrator {
             schemaVersion: schemaVersion,
             graphVersion: graphVersion,
             checkpointFormatVersion: checkpoint.checkpointFormatVersion,
-            channelVersionsByChannelID: checkpoint.channelVersionsByChannelID,
-            versionsSeenByNodeID: checkpoint.versionsSeenByNodeID,
-            updatedChannelsLastCommit: checkpoint.updatedChannelsLastCommit,
+            channelVersionsByChannelID: checkpoint.channelVersionsByChannelID
+                .filter { registeredGlobalIDs.contains($0.key) },
+            versionsSeenByNodeID: checkpoint.versionsSeenByNodeID.mapValues { versions in
+                versions.filter { registeredGlobalIDs.contains($0.key) }
+            },
+            updatedChannelsLastCommit: checkpoint.updatedChannelsLastCommit
+                .filter { registeredGlobalIDs.contains($0) },
             globalDataByChannelID: migratedData,
             frontier: checkpoint.frontier,
             deferredFrontier: checkpoint.deferredFrontier,

--- a/Tests/SwarmTests/Workflow/WorkflowDurablePhaseTests.swift
+++ b/Tests/SwarmTests/Workflow/WorkflowDurablePhaseTests.swift
@@ -148,6 +148,33 @@ struct WorkflowDurablePhaseTests {
         #expect(migratedSnapshot.output == "seed")
     }
 
+    @Test("legacy completed checkpoint with residual cursors folds to completed with its snapshot")
+    func legacyCompletedWithResidualCursorsFoldsToCompleted() async throws {
+        let backend = WorkflowInMemoryCheckpointStore()
+        let checkpointing = WorkflowCheckpointing(backend: backend)
+        let log = ExecutionLog()
+        let workflow = makeTwoStepWorkflow(log: log, checkpointing: checkpointing, checkpointID: "wf-legacy-done-cursors")
+
+        let fixture = legacyCheckpoint(threadID: "wf-legacy-done-cursors", signature: workflow.workflowSignature) {
+            $0["workflow.completed"] = encodedJSON(true)
+            $0["workflow.stepCursor"] = encodedJSON(1)
+            $0["workflow.iterationCursor"] = encodedJSON(1)
+            $0["workflow.lastResult"] = encodedJSON(Optional(WorkflowResultSnapshot(AgentResult(output: "B-out"))))
+            $0["workflow.currentInput"] = encodedJSON("residual-input")
+        }
+        try await backend.save(fixture)
+
+        let result = try await workflow.durable.execute("ignored", resumeFrom: "wf-legacy-done-cursors")
+        // Completion wins over residual cursors: the fold must never produce
+        // .running, and the persisted snapshot — not the input-text fallback —
+        // becomes the result.
+        #expect(result.output == "B-out")
+
+        let counts = await log.counts
+        #expect(counts["A"] == nil)
+        #expect(counts["B"] == nil)
+    }
+
     @Test("legacy running checkpoint migrates cursors and finishes remaining steps")
     func legacyRunningCheckpointMigratesAndContinues() async throws {
         let backend = WorkflowInMemoryCheckpointStore()

--- a/Tests/SwarmTests/Workflow/WorkflowDurablePhaseTests.swift
+++ b/Tests/SwarmTests/Workflow/WorkflowDurablePhaseTests.swift
@@ -21,8 +21,9 @@ struct WorkflowDurablePhaseTests {
         let directory = try makeDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
 
+        let log = ExecutionLog()
         let checkpointing = WorkflowCheckpointing.fileSystem(directory: directory)
-        let workflow = makeLinearWorkflow(checkpointing: checkpointing, checkpointID: "wf-roundtrip")
+        let workflow = makeLinearWorkflow(log: log, checkpointing: checkpointing, checkpointID: "wf-roundtrip")
 
         let first = try await workflow.durable.execute("start")
         #expect(first.output == "C")
@@ -46,6 +47,12 @@ struct WorkflowDurablePhaseTests {
 
         let resumed = try await workflow.durable.execute("ignored", resumeFrom: "wf-roundtrip")
         #expect(resumed.output == "C")
+
+        // Resuming a completed run must end at the router without re-running steps.
+        let counts = await log.counts
+        #expect(counts["A"] == 1)
+        #expect(counts["B"] == 1)
+        #expect(counts["C"] == 1)
     }
 
     @Test("mid-run checkpoint encodes a running phase and resumes with step granularity")
@@ -201,6 +208,55 @@ struct WorkflowDurablePhaseTests {
         #expect(result.output == "B-out")
     }
 
+    @Test("checkpoints without the legacy discriminator pass through and fail version matching")
+    func unknownFormatPassesThroughToVersionMismatch() async throws {
+        let backend = WorkflowInMemoryCheckpointStore()
+        let checkpointing = WorkflowCheckpointing(backend: backend)
+        let workflow = makeTwoStepWorkflow(checkpointing: checkpointing, checkpointID: "wf-unknown-format")
+
+        // Mismatched schema versions but no legacy discriminator channel: the
+        // migrator must not guess at an unknown layout.
+        let fixture = legacyCheckpoint(threadID: "wf-unknown-format", signature: workflow.workflowSignature) { _ in }
+        try await backend.save(fixture)
+
+        do {
+            _ = try await workflow.durable.execute("ignored", resumeFrom: "wf-unknown-format")
+            Issue.record("expected version mismatch")
+        } catch let error as HiveRuntimeError {
+            guard case .checkpointVersionMismatch(let expectedSchema, _, let foundSchema, _) = error else {
+                Issue.record("unexpected HiveRuntimeError \(error)")
+                return
+            }
+            #expect(foundSchema == "legacy-pre-phase-enum-schema")
+            #expect(expectedSchema != foundSchema)
+        }
+    }
+
+    @Test("corrupt legacy payload fails resume instead of fabricating state")
+    func corruptLegacyPayloadFailsLoudly() async throws {
+        let backend = WorkflowInMemoryCheckpointStore()
+        let checkpointing = WorkflowCheckpointing(backend: backend)
+        let log = ExecutionLog()
+        let workflow = makeTwoStepWorkflow(log: log, checkpointing: checkpointing, checkpointID: "wf-legacy-corrupt")
+
+        let fixture = legacyCheckpoint(threadID: "wf-legacy-corrupt", signature: workflow.workflowSignature) {
+            $0["workflow.completed"] = encodedJSON(false)
+            $0["workflow.lastResult"] = Data("not-json".utf8)
+            $0["workflow.currentInput"] = encodedJSON("seed")
+        }
+        try await backend.save(fixture)
+
+        do {
+            _ = try await workflow.durable.execute("ignored", resumeFrom: "wf-legacy-corrupt")
+            Issue.record("expected decode failure")
+        } catch is DecodingError {
+            // Expected: present-but-undecodable legacy entries fail loudly.
+        }
+
+        let counts = await log.counts
+        #expect(counts.isEmpty)
+    }
+
     // MARK: - Result fidelity
 
     @Test("repeat conditions receive full agent results in durable runs")
@@ -225,6 +281,61 @@ struct WorkflowDurablePhaseTests {
         // If the mid-run result were reconstructed from the input text alone,
         // the metadata would be lost and neither observation would match.
         #expect(await observations.values == [.string("no"), .string("done")])
+        #expect(result.output == "again")
+        #expect(result.metadata["pass"] == .string("done"))
+    }
+
+    @Test("resumed repeat boundary evaluates metadata from the persisted snapshot")
+    func resumedRepeatBoundaryUsesPersistedMetadata() async throws {
+        let observations = MetadataRecorder()
+        let log = ExecutionLog()
+        let checkpointing = makeInMemoryCheckpointing()
+        let controller = WorkflowDurableFaultController(queue: [.afterCheckpointWrite])
+
+        try await WorkflowDurableFaultInjection.$controller.withValue(controller) {
+            do {
+                _ = try await Workflow()
+                    .step(MetadataEchoAgent(log: log))
+                    .repeatUntil(maxIterations: 4) { result in
+                        observations.record(result.metadata["pass"])
+                        return result.metadata["pass"] == .string("done")
+                    }
+                    .durable
+                    .checkpoint(id: "wf-repeat-resume", policy: .everyStep)
+                    .durable
+                    .checkpointing(checkpointing)
+                    .durable
+                    .execute("start")
+                Issue.record("expected injected fault")
+            } catch let fault as WorkflowDurableInjectedFault {
+                #expect(fault.point == .afterCheckpointWrite)
+            }
+        }
+
+        // No boundary ran before the fault, so nothing was observed yet; the
+        // committed step's snapshot only exists in the persisted checkpoint.
+        #expect(await observations.values.isEmpty)
+
+        let result = try await Workflow()
+            .step(MetadataEchoAgent(log: log))
+            .repeatUntil(maxIterations: 4) { result in
+                observations.record(result.metadata["pass"])
+                return result.metadata["pass"] == .string("done")
+            }
+            .durable
+            .checkpoint(id: "wf-repeat-resume", policy: .everyStep)
+            .durable
+            .checkpointing(checkpointing)
+            .durable
+            .execute("ignored", resumeFrom: "wf-repeat-resume")
+
+        // The first boundary observation must come from the decoded snapshot's
+        // metadata ("no"). A fallback AgentResult(currentInput) carries no
+        // metadata and would record "<nil>" instead. The agent then runs exactly
+        // one more time (pass 2), proving the committed step was not re-executed.
+        #expect(await observations.values == [.string("no"), .string("done")])
+        let counts = await log.counts
+        #expect(counts["MetadataEchoAgent"] == 2)
         #expect(result.output == "again")
         #expect(result.metadata["pass"] == .string("done"))
     }
@@ -285,6 +396,11 @@ struct WorkflowDurablePhaseTests {
         channels["workflow.signature"] = encodedJSON(signature)
         populate(&channels)
 
+        // Realistic pre-change bookkeeping: the old engine version-bumped every
+        // committed channel, stamped updatedChannelsLastCommit, and recorded
+        // per-node seen versions, so surviving checkpoints carry the removed
+        // channel IDs inside these maps. Migration must prune them or the
+        // runtime rejects the checkpoint as corrupt.
         return HiveCheckpoint(
             id: HiveCheckpointID("legacy-cp"),
             threadID: HiveThreadID(threadID),
@@ -293,9 +409,26 @@ struct WorkflowDurablePhaseTests {
             schemaVersion: "legacy-pre-phase-enum-schema",
             graphVersion: "legacy-pre-phase-enum-graph",
             checkpointFormatVersion: "HCP1",
-            channelVersionsByChannelID: [:],
-            versionsSeenByNodeID: [:],
-            updatedChannelsLastCommit: [],
+            channelVersionsByChannelID: [
+                "workflow.currentInput": 2,
+                "workflow.signature": 1,
+                "workflow.stepCursor": 2,
+                "workflow.iterationCursor": 1,
+                "workflow.completed": 1,
+                "workflow.lastResult": 2,
+            ],
+            versionsSeenByNodeID: [
+                "workflow.execute": [
+                    "workflow.currentInput": 2,
+                    "workflow.lastResult": 2,
+                    "workflow.stepCursor": 2,
+                ],
+            ],
+            updatedChannelsLastCommit: [
+                "workflow.currentInput",
+                "workflow.lastResult",
+                "workflow.stepCursor",
+            ],
             globalDataByChannelID: channels,
             frontier: [],
             deferredFrontier: [],
@@ -390,12 +523,20 @@ private actor CountingAgent: AgentRuntime {
 /// Agent whose result metadata flips once its input marks a completed pass.
 private actor MetadataEchoAgent: AgentRuntime {
     nonisolated let tools: [any AnyJSONTool] = []
-    nonisolated let instructions = "MetadataEchoAgent"
+    nonisolated let instructions: String
     nonisolated let configuration = AgentConfiguration(name: "MetadataEchoAgent")
     nonisolated let handoffs: [AnyHandoffConfiguration] = []
 
+    private let log: ExecutionLog?
+
+    init(log: ExecutionLog? = nil) {
+        self.log = log
+        instructions = "MetadataEchoAgent"
+    }
+
     func run(_ input: String, session: (any Session)?, observer: (any AgentObserver)?) async throws -> AgentResult {
-        AgentResult(
+        await log?.record(instructions)
+        return AgentResult(
             output: "again",
             metadata: ["pass": .string(input == "again" ? "done" : "no")]
         )

--- a/Tests/SwarmTests/Workflow/WorkflowDurablePhaseTests.swift
+++ b/Tests/SwarmTests/Workflow/WorkflowDurablePhaseTests.swift
@@ -284,6 +284,70 @@ struct WorkflowDurablePhaseTests {
         #expect(counts.isEmpty)
     }
 
+    @Test("tampered negative stepCursor fails resume with a typed error instead of trapping")
+    func negativeStepCursorFailsResumeWithTypedError() async throws {
+        let backend = WorkflowInMemoryCheckpointStore()
+        let checkpointing = WorkflowCheckpointing(backend: backend)
+        let log = ExecutionLog()
+        let workflow = makeTwoStepWorkflow(log: log, checkpointing: checkpointing, checkpointID: "wf-legacy-negative-step")
+
+        let fixture = legacyCheckpoint(threadID: "wf-legacy-negative-step", signature: workflow.workflowSignature) {
+            $0["workflow.completed"] = encodedJSON(false)
+            $0["workflow.stepCursor"] = encodedJSON(-1)
+            $0["workflow.iterationCursor"] = encodedJSON(0)
+            $0["workflow.lastResult"] = encodedJSON(Optional<WorkflowResultSnapshot>.none)
+            $0["workflow.currentInput"] = encodedJSON("seed")
+        }
+        try await backend.save(fixture)
+
+        do {
+            _ = try await workflow.durable.execute("ignored", resumeFrom: "wf-legacy-negative-step")
+            Issue.record("expected invalid-workflow error")
+        } catch let error as WorkflowError {
+            guard case .invalidWorkflow(let reason) = error else {
+                Issue.record("unexpected WorkflowError \(error)")
+                return
+            }
+            #expect(reason.contains("negative cursors"))
+            #expect(reason.contains("stepCursor: -1"))
+        }
+
+        // The tampered cursor must never reach the step table as a subscript.
+        let counts = await log.counts
+        #expect(counts.isEmpty)
+    }
+
+    @Test("tampered negative iterationCursor fails resume with a typed error")
+    func negativeIterationCursorFailsResumeWithTypedError() async throws {
+        let backend = WorkflowInMemoryCheckpointStore()
+        let checkpointing = WorkflowCheckpointing(backend: backend)
+        let log = ExecutionLog()
+        let workflow = makeTwoStepWorkflow(log: log, checkpointing: checkpointing, checkpointID: "wf-legacy-negative-iteration")
+
+        let fixture = legacyCheckpoint(threadID: "wf-legacy-negative-iteration", signature: workflow.workflowSignature) {
+            $0["workflow.completed"] = encodedJSON(false)
+            $0["workflow.stepCursor"] = encodedJSON(0)
+            $0["workflow.iterationCursor"] = encodedJSON(-3)
+            $0["workflow.lastResult"] = encodedJSON(Optional<WorkflowResultSnapshot>.none)
+            $0["workflow.currentInput"] = encodedJSON("seed")
+        }
+        try await backend.save(fixture)
+
+        do {
+            _ = try await workflow.durable.execute("ignored", resumeFrom: "wf-legacy-negative-iteration")
+            Issue.record("expected invalid-workflow error")
+        } catch let error as WorkflowError {
+            guard case .invalidWorkflow(let reason) = error else {
+                Issue.record("unexpected WorkflowError \(error)")
+                return
+            }
+            #expect(reason.contains("iterationCursor: -3"))
+        }
+
+        let counts = await log.counts
+        #expect(counts.isEmpty)
+    }
+
     // MARK: - Result fidelity
 
     @Test("repeat conditions receive full agent results in durable runs")

--- a/Tests/SwarmTests/Workflow/WorkflowDurablePhaseTests.swift
+++ b/Tests/SwarmTests/Workflow/WorkflowDurablePhaseTests.swift
@@ -1,0 +1,438 @@
+#if SWARM_INTEGRATIONS
+import Foundation
+import HiveCore
+@testable import Swarm
+import Testing
+
+/// AC-005 coverage for the durable workflow phase enum.
+///
+/// Invariant note: an invalid combination such as "completed with pending
+/// cursors" cannot be expressed in the current encoding by construction — the
+/// cursors exist only as associated values of `.running`, while `.completed`
+/// carries exclusively its result snapshot. The legacy-fixture tests below pin
+/// that migration folds the old parallel channels into exactly one phase case,
+/// never both.
+@Suite("Workflow durable phase")
+struct WorkflowDurablePhaseTests {
+    // MARK: - Round trip
+
+    @Test("phase survives encode-decode round trip and resumes to the same result")
+    func phaseRoundTripsAndResumesToSameResult() async throws {
+        let directory = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let checkpointing = WorkflowCheckpointing.fileSystem(directory: directory)
+        let workflow = makeLinearWorkflow(checkpointing: checkpointing, checkpointID: "wf-roundtrip")
+
+        let first = try await workflow.durable.execute("start")
+        #expect(first.output == "C")
+
+        let store = WorkflowFileCheckpointStore(directory: directory)
+        let checkpoint = try await requireLatestCheckpoint(from: store, threadID: HiveThreadID("wf-roundtrip"))
+
+        // The persisted phase payload decodes back to the terminal state and,
+        // under the deterministic sorted-keys codec, re-encodes byte-identically.
+        let phaseData = try requireChannelData(
+            checkpoint.globalDataByChannelID[WorkflowDurableSchema.phaseKey.id.rawValue],
+            channel: "workflow.phase"
+        )
+        let phase = try JSONDecoder().decode(WorkflowDurablePhase.self, from: phaseData)
+        guard case .completed(let snapshot) = phase else {
+            Issue.record("expected terminal phase, got \(phase)")
+            return
+        }
+        #expect(snapshot.output == "C")
+        #expect(try WorkflowCheckpointCodec<WorkflowDurablePhase>().encode(phase) == phaseData)
+
+        let resumed = try await workflow.durable.execute("ignored", resumeFrom: "wf-roundtrip")
+        #expect(resumed.output == "C")
+    }
+
+    @Test("mid-run checkpoint encodes a running phase and resumes with step granularity")
+    func midRunCheckpointEncodesRunningPhase() async throws {
+        let directory = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let log = ExecutionLog()
+        let checkpointing = WorkflowCheckpointing.fileSystem(directory: directory)
+        let controller = WorkflowDurableFaultController(queue: [.afterCheckpointWrite])
+
+        try await WorkflowDurableFaultInjection.$controller.withValue(controller) {
+            do {
+                _ = try await makeLinearWorkflow(log: log, checkpointing: checkpointing, checkpointID: "wf-midrun")
+                    .durable.execute("start")
+                Issue.record("expected injected fault")
+            } catch let fault as WorkflowDurableInjectedFault {
+                #expect(fault.point == .afterCheckpointWrite)
+            }
+        }
+
+        // Inspect the raw persisted bytes before resuming.
+        let store = WorkflowFileCheckpointStore(directory: directory)
+        let checkpoint = try await requireLatestCheckpoint(from: store, threadID: HiveThreadID("wf-midrun"))
+        let phaseData = try requireChannelData(
+            checkpoint.globalDataByChannelID[WorkflowDurableSchema.phaseKey.id.rawValue],
+            channel: "workflow.phase"
+        )
+        let phase = try JSONDecoder().decode(WorkflowDurablePhase.self, from: phaseData)
+        guard case .running(let stepCursor, let iterationCursor, let lastResult) = phase else {
+            Issue.record("expected running phase, got \(phase)")
+            return
+        }
+        #expect(stepCursor == 1)
+        #expect(iterationCursor == 0)
+        #expect(lastResult?.output == "A")
+
+        let resumed = try await makeLinearWorkflow(log: log, checkpointing: checkpointing, checkpointID: "wf-midrun")
+            .durable.execute("ignored", resumeFrom: "wf-midrun")
+        #expect(resumed.output == "C")
+
+        let counts = await log.counts
+        #expect(counts["A"] == 1)
+        #expect(counts["B"] == 1)
+        #expect(counts["C"] == 1)
+    }
+
+    // MARK: - Legacy migration
+
+    @Test("legacy completed checkpoint migrates and never re-runs steps")
+    func legacyCompletedCheckpointMigrates() async throws {
+        let backend = WorkflowInMemoryCheckpointStore()
+        let checkpointing = WorkflowCheckpointing(backend: backend)
+        let log = ExecutionLog()
+        let workflow = makeTwoStepWorkflow(log: log, checkpointing: checkpointing, checkpointID: "wf-legacy-done")
+
+        let fixture = legacyCheckpoint(threadID: "wf-legacy-done", signature: workflow.workflowSignature) {
+            $0["workflow.completed"] = encodedJSON(true)
+            $0["workflow.stepCursor"] = encodedJSON(0)
+            $0["workflow.iterationCursor"] = encodedJSON(0)
+            $0["workflow.lastResult"] = encodedJSON(Optional<WorkflowResultSnapshot>.none)
+            $0["workflow.currentInput"] = encodedJSON("seed")
+        }
+        try await backend.save(fixture)
+
+        let result = try await workflow.durable.execute("ignored", resumeFrom: "wf-legacy-done")
+        // Spec section 9 edge case: {"completed": true, "stepCursor": 0} decodes
+        // to .completed — never .running — so no step executes again and the
+        // synthesized snapshot falls back to the persisted current input.
+        #expect(result.output == "seed")
+
+        let counts = await log.counts
+        #expect(counts["A"] == nil)
+        #expect(counts["B"] == nil)
+
+        // The flushed post-migration state persists the phase channel only; no
+        // legacy cursor/completed channels survive migration.
+        let checkpoint = try await requireLatestCheckpoint(
+            from: checkpointing.runtimeStore,
+            threadID: HiveThreadID("wf-legacy-done")
+        )
+        #expect(checkpoint.globalDataByChannelID["workflow.completed"] == nil)
+        #expect(checkpoint.globalDataByChannelID["workflow.stepCursor"] == nil)
+        let phaseData = try requireChannelData(
+            checkpoint.globalDataByChannelID[WorkflowDurableSchema.phaseKey.id.rawValue],
+            channel: "workflow.phase"
+        )
+        guard case .completed(let migratedSnapshot)? = try? JSONDecoder()
+            .decode(WorkflowDurablePhase?.self, from: phaseData) else {
+            Issue.record("expected migrated phase to be completed")
+            return
+        }
+        #expect(migratedSnapshot.output == "seed")
+    }
+
+    @Test("legacy running checkpoint migrates cursors and finishes remaining steps")
+    func legacyRunningCheckpointMigratesAndContinues() async throws {
+        let backend = WorkflowInMemoryCheckpointStore()
+        let checkpointing = WorkflowCheckpointing(backend: backend)
+        let log = ExecutionLog()
+        let workflow = makeTwoStepWorkflow(log: log, checkpointing: checkpointing, checkpointID: "wf-legacy-running")
+
+        let fixture = legacyCheckpoint(threadID: "wf-legacy-running", signature: workflow.workflowSignature) {
+            $0["workflow.completed"] = encodedJSON(false)
+            $0["workflow.stepCursor"] = encodedJSON(1)
+            $0["workflow.iterationCursor"] = encodedJSON(0)
+            $0["workflow.lastResult"] = encodedJSON(Optional(WorkflowResultSnapshot(AgentResult(output: "A-out"))))
+            $0["workflow.currentInput"] = encodedJSON("A-out")
+        }
+        try await backend.save(fixture)
+
+        let result = try await workflow.durable.execute("ignored", resumeFrom: "wf-legacy-running")
+        #expect(result.output == "B-out")
+
+        let counts = await log.counts
+        #expect(counts["A"] == nil)
+        #expect(counts["B"] == 1)
+    }
+
+    @Test("legacy file-backed checkpoint fixture decodes and migrates")
+    func legacyFileBackedFixtureMigrates() async throws {
+        let directory = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let checkpointing = WorkflowCheckpointing.fileSystem(directory: directory)
+        let workflow = makeTwoStepWorkflow(checkpointing: checkpointing, checkpointID: "wf-legacy-file")
+
+        let fixture = legacyCheckpoint(threadID: "wf-legacy-file", signature: workflow.workflowSignature) {
+            $0["workflow.completed"] = encodedJSON(false)
+            $0["workflow.stepCursor"] = encodedJSON(0)
+            $0["workflow.iterationCursor"] = encodedJSON(0)
+            $0["workflow.lastResult"] = encodedJSON(Optional<WorkflowResultSnapshot>.none)
+            $0["workflow.currentInput"] = encodedJSON("start")
+        }
+        let fileName = "workflow-wf-legacy-file-legacy-cp.json"
+        try JSONEncoder().encode(fixture).write(to: directory.appendingPathComponent(fileName))
+        let manifest = WorkflowCheckpointManifest(
+            version: 1,
+            runs: [
+                "wf-legacy-file": [
+                    WorkflowCheckpointManifestEntry(
+                        checkpointID: "legacy-cp",
+                        stepIndex: 0,
+                        fileName: fileName
+                    )
+                ]
+            ]
+        )
+        try JSONEncoder().encode(manifest)
+            .write(to: directory.appendingPathComponent(WorkflowFileCheckpointStore.manifestFileName))
+
+        let result = try await workflow.durable.execute("ignored", resumeFrom: "wf-legacy-file")
+        #expect(result.output == "B-out")
+    }
+
+    // MARK: - Result fidelity
+
+    @Test("repeat conditions receive full agent results in durable runs")
+    func repeatConditionSeesFullAgentResults() async throws {
+        let observations = MetadataRecorder()
+        let checkpointing = makeInMemoryCheckpointing()
+
+        let workflow = Workflow()
+            .step(MetadataEchoAgent())
+            .repeatUntil(maxIterations: 4) { result in
+                observations.record(result.metadata["pass"])
+                return result.metadata["pass"] == .string("done")
+            }
+            .durable
+            .checkpoint(id: "wf-repeat-fidelity", policy: .onCompletion)
+            .durable
+            .checkpointing(checkpointing)
+
+        let result = try await workflow.durable.execute("start")
+
+        // Pass 1 observes "no" and iterates; pass 2 observes "done" and stops.
+        // If the mid-run result were reconstructed from the input text alone,
+        // the metadata would be lost and neither observation would match.
+        #expect(await observations.values == [.string("no"), .string("done")])
+        #expect(result.output == "again")
+        #expect(result.metadata["pass"] == .string("done"))
+    }
+
+    // MARK: - Helpers
+
+    private func makeDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("swarm-phase-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    private func makeInMemoryCheckpointing() -> WorkflowCheckpointing {
+        WorkflowCheckpointing(backend: WorkflowInMemoryCheckpointStore())
+    }
+
+    private func makeLinearWorkflow(
+        log: ExecutionLog? = nil,
+        checkpointing: WorkflowCheckpointing,
+        checkpointID: String
+    ) -> Workflow {
+        Workflow()
+            .step(CountingAgent(label: "A", log: log))
+            .step(CountingAgent(label: "B", log: log))
+            .step(CountingAgent(label: "C", log: log))
+            .durable
+            .checkpoint(id: checkpointID, policy: .everyStep)
+            .durable
+            .checkpointing(checkpointing)
+    }
+
+    private func makeTwoStepWorkflow(
+        log: ExecutionLog? = nil,
+        checkpointing: WorkflowCheckpointing,
+        checkpointID: String
+    ) -> Workflow {
+        Workflow()
+            .step(CountingAgent(label: "A", log: log, response: "A-out"))
+            .step(CountingAgent(label: "B", log: log, response: "B-out"))
+            .durable
+            .checkpoint(id: checkpointID, policy: .everyStep)
+            .durable
+            .checkpointing(checkpointing)
+    }
+
+    /// Builds a checkpoint pinned to the pre-phase-enum six-channel layout.
+    ///
+    /// The fixture is constructed inline (spec section 6: no binary fixtures);
+    /// `HiveCheckpoint`'s Codable shape is unchanged by this ticket, so these
+    /// bytes are exactly what earlier releases persisted.
+    private func legacyCheckpoint(
+        threadID: String,
+        signature: String,
+        populate: (inout [String: Data]) -> Void
+    ) -> HiveCheckpoint<WorkflowDurableSchema> {
+        var channels: [String: Data] = [:]
+        channels["workflow.signature"] = encodedJSON(signature)
+        populate(&channels)
+
+        return HiveCheckpoint(
+            id: HiveCheckpointID("legacy-cp"),
+            threadID: HiveThreadID(threadID),
+            runID: HiveRunID(UUID()),
+            stepIndex: 0,
+            schemaVersion: "legacy-pre-phase-enum-schema",
+            graphVersion: "legacy-pre-phase-enum-graph",
+            checkpointFormatVersion: "HCP1",
+            channelVersionsByChannelID: [:],
+            versionsSeenByNodeID: [:],
+            updatedChannelsLastCommit: [],
+            globalDataByChannelID: channels,
+            frontier: [],
+            deferredFrontier: [],
+            joinBarrierSeenByJoinID: [:],
+            interruption: nil,
+            lineage: nil
+        )
+    }
+
+    private func encodedJSON<T: Encodable & Sendable>(_ value: T) -> Data {
+        try! JSONEncoder().encode(value)
+    }
+
+    private func requireChannelData(_ data: Data?, channel: String) throws -> Data {
+        guard let data else {
+            throw LegacyFixtureError.missingChannel(channel)
+        }
+        return data
+    }
+
+    private func requireLatestCheckpoint(
+        from store: WorkflowFileCheckpointStore,
+        threadID: HiveThreadID
+    ) async throws -> HiveCheckpoint<WorkflowDurableSchema> {
+        guard let checkpoint = try await store.loadLatest(threadID: threadID) else {
+            throw LegacyFixtureError.missingCheckpoint(threadID.rawValue)
+        }
+        return checkpoint
+    }
+
+    private func requireLatestCheckpoint(
+        from store: AnyHiveCheckpointStore<WorkflowDurableSchema>,
+        threadID: HiveThreadID
+    ) async throws -> HiveCheckpoint<WorkflowDurableSchema> {
+        guard let checkpoint = try await store.loadLatest(threadID: threadID) else {
+            throw LegacyFixtureError.missingCheckpoint(threadID.rawValue)
+        }
+        return checkpoint
+    }
+}
+
+private enum LegacyFixtureError: Error {
+    case missingChannel(String)
+    case missingCheckpoint(String)
+}
+
+private actor ExecutionLog {
+    private var values: [String] = []
+
+    func record(_ label: String) {
+        values.append(label)
+    }
+
+    var counts: [String: Int] {
+        values.reduce(into: [:]) { $0[$1, default: 0] += 1 }
+    }
+}
+
+private actor CountingAgent: AgentRuntime {
+    nonisolated let tools: [any AnyJSONTool] = []
+    nonisolated let instructions: String
+    nonisolated let configuration = AgentConfiguration(name: "CountingAgent")
+    nonisolated let handoffs: [AnyHandoffConfiguration] = []
+
+    private let response: String
+    private let log: ExecutionLog?
+
+    init(label: String, log: ExecutionLog?, response: String? = nil) {
+        self.log = log
+        self.response = response ?? label
+        instructions = label
+    }
+
+    func run(_ input: String, session: (any Session)?, observer: (any AgentObserver)?) async throws -> AgentResult {
+        await log?.record(instructions)
+        return AgentResult(output: response)
+    }
+
+    nonisolated func stream(
+        _ input: String,
+        session: (any Session)?,
+        observer: (any AgentObserver)?
+    ) -> AsyncThrowingStream<AgentEvent, Error> {
+        StreamHelper.makeTrackedStream { continuation in
+            continuation.finish(throwing: AgentError.internalError(reason: "counting agent does not stream"))
+        }
+    }
+
+    func cancel() async {}
+}
+
+/// Agent whose result metadata flips once its input marks a completed pass.
+private actor MetadataEchoAgent: AgentRuntime {
+    nonisolated let tools: [any AnyJSONTool] = []
+    nonisolated let instructions = "MetadataEchoAgent"
+    nonisolated let configuration = AgentConfiguration(name: "MetadataEchoAgent")
+    nonisolated let handoffs: [AnyHandoffConfiguration] = []
+
+    func run(_ input: String, session: (any Session)?, observer: (any AgentObserver)?) async throws -> AgentResult {
+        AgentResult(
+            output: "again",
+            metadata: ["pass": .string(input == "again" ? "done" : "no")]
+        )
+    }
+
+    nonisolated func stream(
+        _ input: String,
+        session: (any Session)?,
+        observer: (any AgentObserver)?
+    ) -> AsyncThrowingStream<AgentEvent, Error> {
+        StreamHelper.makeTrackedStream { continuation in
+            continuation.finish(throwing: AgentError.internalError(reason: "metadata echo agent does not stream"))
+        }
+    }
+
+    func cancel() async {}
+}
+
+/// Thread-safe recorder for values observed inside repeat conditions.
+private final class MetadataRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var recorded: [SendableValue] = []
+
+    var values: [SendableValue] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recorded
+    }
+
+    func record(_ value: SendableValue?) {
+        lock.lock()
+        defer { lock.unlock() }
+        if let value {
+            recorded.append(value)
+        } else {
+            recorded.append(.string("<nil>"))
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Ticket T3 of spec-architecture-type-system-strong-set (spec local-only; decision report: swift-type-system-review-Swarm-1787334666.html). Independent of #157.

## What
WorkflowDurableSchema shrinks 6 parallel channels → 3:
\`\`\`swift
enum WorkflowDurablePhase: Codable, Sendable, Equatable {
    case running(stepCursor: Int, iterationCursor: Int, lastResult: WorkflowResultSnapshot?)
    case completed(WorkflowResultSnapshot)
}
\`\`\`
plus currentInput + signature. \`completed=true\` with pending cursors is now **unrepresentable by construction**. A migrating checkpoint store folds the legacy 6-channel layout into a phase on load; unknown formats pass through to the normal loud version-mismatch error.

## Deviation from spec sketch (evidence-based)
\`running\` carries \`lastResult\` because completion/repeat-boundary evaluation happens in later supersteps than the last step write — state must round-trip through the store. Spec-exact \`running(stepCursor:iterationCursor:)\` would strip metadata/toolCalls/tokenUsage from repeat conditions; pinned by fault-injected test proving post-resume metadata comes from persisted bytes and committed steps are not re-executed.

## Review-found P1 (fixed, red→green demonstrated)
Real legacy checkpoints carried removed channel IDs in bookkeeping maps (\`channelVersionsByChannelID\`, \`versionsSeenByNodeID\`, \`updatedChannelsLastCommit\`) → \`checkpointCorrupt\` on every post-start resume. Fix commit ab667bc6 prunes all three to currently-registered IDs; fixtures now reflect what earlier releases actually wrote.

## Verification
Full gate: **2121 tests / 287 suites** (sole failure = pre-existing api-catalog count at this base, fixed on #157). Reviews: fresh-context \`swift-pr-review\` pass 1 (APPROVE after P1 fix) + independent final pass verifying migration across every channel-ID surface (READY-FOR-PR).

## Release notes
Internal only. Older-release durable checkpoints transparently resume via migration; checkpoints written by this version are not readable by older binaries.