### PR TITLE
refactor(providers): share one finished-turn-to-stream emitter across adapters

### DIFF
--- a/Sources/Swarm/Providers/ConversationInferenceProvider.swift
+++ b/Sources/Swarm/Providers/ConversationInferenceProvider.swift
@@ -316,11 +316,15 @@ public extension InferenceProvider {
 /// Degrades a finished, non-streaming turn into the canonical
 /// ``InferenceStreamUpdate`` sequence.
 ///
-/// Shared adapter toolkit: any backend that cannot stream natively must emit
-/// its finished turn through this helper so update ordering stays identical
-/// across adapters — `outputChunk`, then `toolCallsCompleted`, then `usage`,
-/// then `finishedTurn` (only when the turn carries a provider-owned inner
-/// transcript), then finish.
+/// Shared adapter toolkit for in-package backends that cannot stream natively:
+/// route the finished turn through this helper so update ordering stays
+/// identical across adapters — `outputChunk`, then `toolCallsCompleted`, then
+/// `usage`, then `finishedTurn` (only when the turn carries a provider-owned
+/// inner transcript), then finish.
+///
+/// Out-of-package providers need nothing: they inherit this exact sequence via
+/// the `streamWithToolCalls(messages:tools:options:toolExecutor:)` protocol
+/// default as long as they do not override that requirement.
 package func streamFinishedToolTurn(
     _ generate: @escaping @Sendable () async throws -> InferenceResponse
 ) -> AsyncThrowingStream<InferenceStreamUpdate, Error> {

--- a/Sources/Swarm/Providers/ConversationInferenceProvider.swift
+++ b/Sources/Swarm/Providers/ConversationInferenceProvider.swift
@@ -313,7 +313,15 @@ public extension InferenceProvider {
     }
 }
 
-private func streamFinishedToolTurn(
+/// Degrades a finished, non-streaming turn into the canonical
+/// ``InferenceStreamUpdate`` sequence.
+///
+/// Shared adapter toolkit: any backend that cannot stream natively must emit
+/// its finished turn through this helper so update ordering stays identical
+/// across adapters — `outputChunk`, then `toolCallsCompleted`, then `usage`,
+/// then `finishedTurn` (only when the turn carries a provider-owned inner
+/// transcript), then finish.
+package func streamFinishedToolTurn(
     _ generate: @escaping @Sendable () async throws -> InferenceResponse
 ) -> AsyncThrowingStream<InferenceStreamUpdate, Error> {
     StreamHelper.makeTrackedStream { continuation in

--- a/Sources/Swarm/Providers/FoundationModels/FoundationModelsInferenceProvider.swift
+++ b/Sources/Swarm/Providers/FoundationModels/FoundationModelsInferenceProvider.swift
@@ -288,26 +288,16 @@ public struct FoundationModelsInferenceProvider: InferenceProvider,
         options: InferenceOptions,
         toolExecutor: ToolCallExecutor?
     ) -> AsyncThrowingStream<InferenceStreamUpdate, Error> {
-        StreamHelper.makeTrackedStream { continuation in
-            let response = try await self.generateWithToolCalls(
+        // Foundation Models has no native tool-call stream; degrade the finished
+        // turn through the shared emitter so update ordering matches the
+        // default provider ladder exactly.
+        streamFinishedToolTurn {
+            try await self.generateWithToolCalls(
                 messages: messages,
                 tools: tools,
                 options: options,
                 toolExecutor: toolExecutor
             )
-            if let content = response.content, !content.isEmpty {
-                continuation.yield(.outputChunk(content))
-            }
-            if !response.toolCalls.isEmpty {
-                continuation.yield(.toolCallsCompleted(response.toolCalls))
-            }
-            if let usage = response.usage {
-                continuation.yield(.usage(usage))
-            }
-            if !response.transcriptMessages.isEmpty {
-                continuation.yield(.finishedTurn(response))
-            }
-            continuation.finish()
         }
     }
 

--- a/Sources/Swarm/Providers/FoundationModels/FoundationModelsInferenceProvider.swift
+++ b/Sources/Swarm/Providers/FoundationModels/FoundationModelsInferenceProvider.swift
@@ -282,24 +282,10 @@ public struct FoundationModelsInferenceProvider: InferenceProvider,
         return try await generateWithToolCalls(messages: messages, tools: tools, options: options)
     }
 
-    public func streamWithToolCalls(
-        messages: [InferenceMessage],
-        tools: [ToolSchema],
-        options: InferenceOptions,
-        toolExecutor: ToolCallExecutor?
-    ) -> AsyncThrowingStream<InferenceStreamUpdate, Error> {
-        // Foundation Models has no native tool-call stream; degrade the finished
-        // turn through the shared emitter so update ordering matches the
-        // default provider ladder exactly.
-        streamFinishedToolTurn {
-            try await self.generateWithToolCalls(
-                messages: messages,
-                tools: tools,
-                options: options,
-                toolExecutor: toolExecutor
-            )
-        }
-    }
+    // No `streamWithToolCalls` override: Foundation Models has no native
+    // tool-call stream, so the protocol default's shared finished-turn emitter
+    // is used verbatim. Its closure dispatches into
+    // `generateWithToolCalls(messages:tools:options:toolExecutor:)` below.
 
     public func generateWithToolCalls(
         messages: [InferenceMessage],

--- a/Tests/SwarmTests/Providers/FinishedTurnStreamEmissionTests.swift
+++ b/Tests/SwarmTests/Providers/FinishedTurnStreamEmissionTests.swift
@@ -49,6 +49,26 @@ struct FinishedTurnStreamEmissionTests {
         #expect(updates.isEmpty)
     }
 
+    @Test("Omits usage when nil while remaining segments keep canonical order")
+    func omitsUsageWhenAbsent() async throws {
+        let toolCall = InferenceResponse.ParsedToolCall(id: "t2", name: "echo", arguments: [:])
+        let transcript = [InferenceMessage.assistant("", toolCalls: [InferenceMessage.ToolCall(toolCall)])]
+        let response = InferenceResponse(
+            content: "answer",
+            toolCalls: [toolCall],
+            finishReason: .toolCall,
+            usage: nil,
+            transcriptMessages: transcript
+        )
+
+        let updates = try await collect(streamFinishedToolTurn { response })
+
+        #expect(updates.count == 3)
+        #expect(updates[0] == .outputChunk("answer"))
+        #expect(updates[1] == .toolCallsCompleted([toolCall]))
+        #expect(updates[2] == .finishedTurn(response))
+    }
+
     @Test("Propagates generation errors to the stream consumer")
     func propagatesErrors() async {
         struct Boom: Error {}

--- a/Tests/SwarmTests/Providers/FinishedTurnStreamEmissionTests.swift
+++ b/Tests/SwarmTests/Providers/FinishedTurnStreamEmissionTests.swift
@@ -1,0 +1,60 @@
+// FinishedTurnStreamEmissionTests.swift
+// SwarmTests
+//
+// The shared finished-turn degradation helper emits the canonical
+// InferenceStreamUpdate ordering every non-streaming adapter must match.
+
+import Foundation
+@testable import Swarm
+import Testing
+
+@Suite("Finished-turn stream emission")
+struct FinishedTurnStreamEmissionTests {
+    private func collect(_ stream: AsyncThrowingStream<InferenceStreamUpdate, Error>) async throws -> [InferenceStreamUpdate] {
+        var updates: [InferenceStreamUpdate] = []
+        for try await update in stream {
+            updates.append(update)
+        }
+        return updates
+    }
+
+    @Test("Emits canonical order: outputChunk, toolCallsCompleted, usage, finishedTurn")
+    func canonicalOrdering() async throws {
+        let toolCall = InferenceResponse.ParsedToolCall(id: "t1", name: "echo", arguments: [:])
+        let transcript = [InferenceMessage.assistant("", toolCalls: [InferenceMessage.ToolCall(toolCall)])]
+        let usage = TokenUsage(inputTokens: 7, outputTokens: 3)
+        let response = InferenceResponse(
+            content: "partial answer",
+            toolCalls: [toolCall],
+            finishReason: .toolCall,
+            usage: usage,
+            transcriptMessages: transcript
+        )
+
+        let updates = try await collect(streamFinishedToolTurn { response })
+
+        #expect(updates.count == 4)
+        #expect(updates[0] == .outputChunk("partial answer"))
+        #expect(updates[1] == .toolCallsCompleted([toolCall]))
+        #expect(updates[2] == .usage(usage))
+        #expect(updates[3] == .finishedTurn(response))
+    }
+
+    @Test("Omits empty content and finishedTurn when there is no inner transcript")
+    func omitsEmptySegments() async throws {
+        let response = InferenceResponse(content: "", toolCalls: [], finishReason: .completed)
+
+        let updates = try await collect(streamFinishedToolTurn { response })
+
+        #expect(updates.isEmpty)
+    }
+
+    @Test("Propagates generation errors to the stream consumer")
+    func propagatesErrors() async {
+        struct Boom: Error {}
+
+        await #expect(throws: Boom.self) {
+            try await collect(streamFinishedToolTurn { throw Boom() })
+        }
+    }
+}


### PR DESCRIPTION
## What

`FoundationModelsInferenceProvider.streamWithToolCalls` re-implemented, inline and byte-for-byte, the same degradation the default provider ladder performs in `streamFinishedToolTurn`:

```swift
// duplicated in two adapters
if let content = response.content, !content.isEmpty { yield(.outputChunk(content)) }
if !response.toolCalls.isEmpty { yield(.toolCallsCompleted(response.toolCalls)) }
if let usage = response.usage { yield(.usage(usage)) }
if !response.transcriptMessages.isEmpty { yield(.finishedTurn(response)) }
continuation.finish()
```

Three invariants — update ordering, usage placement, finishedTurn gating on the owned-loop transcript — with zero local enforcement, one copy per adapter.

## Change

- Promote `streamFinishedToolTurn` from a private helper of the default ladder to a package-level shared toolkit with a documented ordering contract (in `ConversationInferenceProvider.swift`, next to the ladder it serves).
- Point the Foundation Models adapter at it; its `streamWithToolCalls` now declares intent only.
- Adapters ship transport + codec; emission order is enforced in exactly one place. New adapters stop re-learning the degradation rules.

## Verification

- New `FinishedTurnStreamEmissionTests`: canonical ordering (outputChunk → toolCallsCompleted → usage → finishedTurn), omission rules for empty content / missing inner transcript, error propagation to the consumer. ✅
- Full suite: 2,115 tests, 1 failure — the pre-existing `API catalog header` freshness issue (176 vs 177 scanned files), identical on clean main; unrelated.
- SwiftLint + SwiftFormat clean on changed files.