### PR TITLE
Typed metadata keys across result/trace seams (spec T1)

### DIFF
--- a/Sources/Swarm/Core/AgentResult.swift
+++ b/Sources/Swarm/Core/AgentResult.swift
@@ -265,7 +265,6 @@ public extension AgentResult {
     /// The runtime engine that produced this result, if recorded.
     /// Returns `"graph"` when the graph runtime was used, `"native"` otherwise.
     var runtimeEngine: String? {
-        guard case let .string(value) = metadata["runtime.engine"] else { return nil }
-        return value
+        metadata[.runtimeEngine]
     }
 }

--- a/Sources/Swarm/Core/MetadataKey.swift
+++ b/Sources/Swarm/Core/MetadataKey.swift
@@ -85,8 +85,11 @@ public extension MetadataKey where Value == Int {
 }
 
 public extension MetadataKey where Value == Double {
-    /// Step duration in milliseconds recorded on trace events.
-    static let durationMs = MetadataKey("durationMs")
+    /// Duration in milliseconds recorded on trace events (`duration_ms`).
+    ///
+    /// Written by ``TracingHelper`` spans and `@Traceable` results; readers
+    /// share this symbol instead of repeating the raw string.
+    static let durationMs = MetadataKey("duration_ms")
 }
 
 // MARK: - Tool Outcome Keys
@@ -95,8 +98,8 @@ public extension MetadataKey where Value == Bool {
     /// Tool invocation outcome written as a Boolean payload (never
     /// `"true"`/`"false"` strings) on result and trace metadata.
     ///
-    /// Graph-runtime stream events carry their stringly counterpart in
-    /// ``StreamEventMetadata/success`` until those payloads migrate.
+    /// Graph-runtime stream events carry their stringly counterpart under the
+    /// same `"success"` name until those payloads migrate.
     static let toolSuccess = MetadataKey("success")
 }
 
@@ -107,25 +110,29 @@ public extension MetadataKey where Value == Bool {
 /// These events serialize as `[String: String]`, so every field here is a
 /// ``MetadataKey``-keyed read over a plain string dictionary. See `GraphAgent`
 /// for the consumer side of these payloads.
-public enum StreamEventMetadata {
+///
+/// Internal because both the producer (`ChatGraph`) and the consumer
+/// (`GraphAgent`) live in this module; promote to public if external graph
+/// nodes ever need to emit compatible events.
+enum StreamEventMetadata {
     /// Model identifier reported when a model invocation starts.
-    public static let model = MetadataKey<String>("model")
+    static let model = MetadataKey<String>("model")
 
     /// Incremental text chunk reported while a model streams.
-    public static let text = MetadataKey<String>("text")
+    static let text = MetadataKey<String>("text")
 
     /// Tool name reported when a tool invocation starts or finishes.
-    public static let name = MetadataKey<String>("name")
+    static let name = MetadataKey<String>("name")
 
     /// Tool invocation outcome (`"true"`/`"false"`) reported when a tool
     /// invocation finishes.
-    public static let success = MetadataKey<String>("success")
+    static let success = MetadataKey<String>("success")
 
     /// Provider tool-call identifier correlating invocations across events.
-    public static let toolCallID = MetadataKey<String>("toolCallID")
+    static let toolCallID = MetadataKey<String>("toolCallID")
 
     /// Tool output reported when a successful tool invocation finishes.
-    public static let output = MetadataKey<String>("output")
+    static let output = MetadataKey<String>("output")
 }
 
 // MARK: - Typed Metadata Access

--- a/Sources/Swarm/Core/MetadataKey.swift
+++ b/Sources/Swarm/Core/MetadataKey.swift
@@ -172,9 +172,14 @@ public extension Dictionary where Key == String, Value == SendableValue {
     }
 }
 
-public extension Dictionary where Key == String, Value == String {
+extension Dictionary where Key == String, Value == String {
     /// Reads the value stored under the key's stable name from a plain string
     /// dictionary, such as graph-runtime stream event payloads.
+    ///
+    /// Internal because the only keys defined for these dictionaries
+    /// (`StreamEventMetadata`) are internal module plumbing; promote this
+    /// accessor alongside that enum if external producers ever need typed
+    /// access to stream payloads.
     subscript(key: MetadataKey<String>) -> String? {
         get { self[key.name] }
         set { self[key.name] = newValue }

--- a/Sources/Swarm/Core/MetadataKey.swift
+++ b/Sources/Swarm/Core/MetadataKey.swift
@@ -1,0 +1,175 @@
+// MetadataKey.swift
+// Swarm Framework
+//
+// Compiler-checked keys for result and trace metadata dictionaries.
+
+import Foundation
+
+// MARK: - MetadataKey
+
+/// A compiler-checked key pairing a stable string name with a value type.
+///
+/// Producers and consumers of a ``AgentResult/metadata`` or
+/// ``TraceEvent/metadata`` entry share one `MetadataKey` symbol so the stored
+/// payload type is verified at compile time instead of by string convention.
+/// Keys serialize to their ``name``; the persisted dictionary remains
+/// `[String: SendableValue]`, so raw-string access keeps working alongside
+/// typed access.
+///
+/// Example:
+/// ```swift
+/// var metadata: [String: SendableValue] = [:]
+/// metadata[.runtimeEngine] = "graph"
+///
+/// let engine: String? = metadata[.runtimeEngine]  // same key symbol
+/// ```
+public struct MetadataKey<Value: Sendable>: Hashable, Sendable {
+    // MARK: Public
+
+    /// The stable serialized name written into the metadata dictionary.
+    ///
+    /// This string must not change across releases: persisted results,
+    /// traces, and checkpoints store it verbatim.
+    public let name: String
+
+    /// Creates a key with a stable serialized name.
+    ///
+    /// - Parameter name: String written into the dictionary. Prefer declaring
+    ///   one shared constant instead of constructing ad-hoc keys at call sites.
+    public init(_ name: String) {
+        self.name = name
+    }
+}
+
+// MARK: - Result Runtime Keys
+
+public extension MetadataKey where Value == String {
+    /// Runtime engine recorded on ``AgentResult`` (`"graph"` or `"native"`).
+    static let runtimeEngine = MetadataKey("runtime.engine")
+}
+
+// MARK: - Workflow Keys
+
+public extension MetadataKey where Value == Bool {
+    /// Whether a workflow fallback step ran its backup agent.
+    static let fallbackUsed = MetadataKey("workflow.fallback.used")
+}
+
+public extension MetadataKey where Value == String {
+    /// Description of the error that forced a workflow fallback to its backup.
+    static let fallbackError = MetadataKey("workflow.fallback.error")
+}
+
+// MARK: - Token Usage Keys
+
+public extension MetadataKey where Value == Int {
+    /// Provider-reported input tokens on `agentComplete` trace events.
+    static let inputTokens = MetadataKey("input_tokens")
+
+    /// Provider-reported output tokens on `agentComplete` trace events.
+    static let outputTokens = MetadataKey("output_tokens")
+
+    /// Provider-reported total tokens on `agentComplete` trace events.
+    static let totalTokens = MetadataKey("total_tokens")
+
+    /// Legacy alias of ``totalTokens`` kept for older readers that consume the
+    /// pre-namespaced `"tokenCount"` entry.
+    static let legacyTokenCount = MetadataKey("tokenCount")
+}
+
+// MARK: - Step Timing Keys
+
+public extension MetadataKey where Value == Int {
+    /// Zero-based step index recorded on trace events emitted per step.
+    static let stepNumber = MetadataKey("stepNumber")
+}
+
+public extension MetadataKey where Value == Double {
+    /// Step duration in milliseconds recorded on trace events.
+    static let durationMs = MetadataKey("durationMs")
+}
+
+// MARK: - Tool Outcome Keys
+
+public extension MetadataKey where Value == Bool {
+    /// Tool invocation outcome written as a Boolean payload (never
+    /// `"true"`/`"false"` strings) on result and trace metadata.
+    ///
+    /// Graph-runtime stream events carry their stringly counterpart in
+    /// ``StreamEventMetadata/success`` until those payloads migrate.
+    static let toolSuccess = MetadataKey("success")
+}
+
+// MARK: - Stream Event Keys
+
+/// Payload field names carried by graph-runtime stream events.
+///
+/// These events serialize as `[String: String]`, so every field here is a
+/// ``MetadataKey``-keyed read over a plain string dictionary. See `GraphAgent`
+/// for the consumer side of these payloads.
+public enum StreamEventMetadata {
+    /// Model identifier reported when a model invocation starts.
+    public static let model = MetadataKey<String>("model")
+
+    /// Incremental text chunk reported while a model streams.
+    public static let text = MetadataKey<String>("text")
+
+    /// Tool name reported when a tool invocation starts or finishes.
+    public static let name = MetadataKey<String>("name")
+
+    /// Tool invocation outcome (`"true"`/`"false"`) reported when a tool
+    /// invocation finishes.
+    public static let success = MetadataKey<String>("success")
+
+    /// Provider tool-call identifier correlating invocations across events.
+    public static let toolCallID = MetadataKey<String>("toolCallID")
+
+    /// Tool output reported when a successful tool invocation finishes.
+    public static let output = MetadataKey<String>("output")
+}
+
+// MARK: - Typed Metadata Access
+
+public extension Dictionary where Key == String, Value == SendableValue {
+    /// Reads the value stored under the key's stable name as a `String`.
+    ///
+    /// Returns nil when the entry is absent or holds a non-string payload.
+    subscript(key: MetadataKey<String>) -> String? {
+        get { self[key.name]?.stringValue }
+        set { self[key.name] = newValue.map { SendableValue($0) } }
+    }
+
+    /// Reads the value stored under the key's stable name as an `Int`.
+    ///
+    /// Returns nil when the entry is absent or holds a non-integer payload.
+    subscript(key: MetadataKey<Int>) -> Int? {
+        get { self[key.name]?.intValue }
+        set { self[key.name] = newValue.map { SendableValue($0) } }
+    }
+
+    /// Reads the value stored under the key's stable name as a `Double`.
+    ///
+    /// Returns nil when the entry is absent or holds neither a `.double` nor
+    /// an `.int` payload.
+    subscript(key: MetadataKey<Double>) -> Double? {
+        get { self[key.name]?.doubleValue }
+        set { self[key.name] = newValue.map { SendableValue($0) } }
+    }
+
+    /// Reads the value stored under the key's stable name as a `Bool`.
+    ///
+    /// Returns nil when the entry is absent or holds a non-Boolean payload.
+    subscript(key: MetadataKey<Bool>) -> Bool? {
+        get { self[key.name]?.boolValue }
+        set { self[key.name] = newValue.map { SendableValue($0) } }
+    }
+}
+
+public extension Dictionary where Key == String, Value == String {
+    /// Reads the value stored under the key's stable name from a plain string
+    /// dictionary, such as graph-runtime stream event payloads.
+    subscript(key: MetadataKey<String>) -> String? {
+        get { self[key.name] }
+        set { self[key.name] = newValue }
+    }
+}

--- a/Sources/Swarm/Core/RuntimeMetadata.swift
+++ b/Sources/Swarm/Core/RuntimeMetadata.swift
@@ -6,7 +6,9 @@
 import Foundation
 
 enum RuntimeMetadata {
-    static let runtimeEngineKey = "runtime.engine"
+    /// Derived from the canonical typed key so the writer and reader sides of
+    /// the runtime-engine seam cannot drift apart.
+    static let runtimeEngineKey = MetadataKey<String>.runtimeEngine.name
     static let graphRuntimeEngineName = "graph"
     static let nativeRuntimeEngineName = "native"
 }

--- a/Sources/Swarm/Internal/GraphRuntime/GraphAgent.swift
+++ b/Sources/Swarm/Internal/GraphRuntime/GraphAgent.swift
@@ -324,22 +324,22 @@ struct GraphAgent: AgentRuntime, Sendable {
     private static func mapCustomDebugEvent(name: String, event: HiveEvent) -> AgentEvent? {
         switch name {
         case "modelInvocationStarted":
-            return .observation(.llmStarted(model: event.metadata["model"], promptTokens: nil))
+            return .observation(.llmStarted(model: event.metadata[StreamEventMetadata.model], promptTokens: nil))
         case "modelToken":
-            return .output(.token(event.metadata["text"] ?? ""))
+            return .output(.token(event.metadata[StreamEventMetadata.text] ?? ""))
         case "modelInvocationFinished":
             return .observation(.llmCompleted(model: nil, promptTokens: nil, completionTokens: nil, duration: 0))
         case "toolInvocationStarted":
-            let toolName = event.metadata["name"] ?? "tool"
+            let toolName = event.metadata[StreamEventMetadata.name] ?? "tool"
             let call = toolCall(from: event, toolName: toolName)
             return .tool(.started(call: call))
         case "toolInvocationFinished":
-            let toolName = event.metadata["name"] ?? "tool"
+            let toolName = event.metadata[StreamEventMetadata.name] ?? "tool"
             let call = toolCall(from: event, toolName: toolName)
-            if event.metadata["success"] == "true" {
+            if event.metadata[StreamEventMetadata.success] == "true" {
                 let result = ToolResult.success(
                     callId: call.id,
-                    output: event.metadata["output"].map(SendableValue.string) ?? .null,
+                    output: event.metadata[StreamEventMetadata.output].map(SendableValue.init) ?? .null,
                     duration: .zero
                 )
                 return .tool(.completed(call: call, result: result))
@@ -352,7 +352,7 @@ struct GraphAgent: AgentRuntime, Sendable {
     }
 
     private static func toolCall(from event: HiveEvent, toolName: String) -> ToolCall {
-        let providerCallId = event.metadata["toolCallID"]
+        let providerCallId = event.metadata[StreamEventMetadata.toolCallID]
         let stableID = stableUUID(
             for: providerCallId ?? "\(event.id.eventIndex)|\(event.id.stepIndex.map(String.init) ?? "nil")|\(toolName)"
         )

--- a/Sources/Swarm/Internal/GraphRuntime/GraphAgent.swift
+++ b/Sources/Swarm/Internal/GraphRuntime/GraphAgent.swift
@@ -339,7 +339,7 @@ struct GraphAgent: AgentRuntime, Sendable {
             if event.metadata[StreamEventMetadata.success] == "true" {
                 let result = ToolResult.success(
                     callId: call.id,
-                    output: event.metadata[StreamEventMetadata.output].map(SendableValue.init) ?? .null,
+                    output: event.metadata[StreamEventMetadata.output].map { SendableValue($0) } ?? .null,
                     duration: .zero
                 )
                 return .tool(.completed(call: call, result: result))

--- a/Sources/Swarm/Observability/MetricsCollector.swift
+++ b/Sources/Swarm/Observability/MetricsCollector.swift
@@ -305,10 +305,10 @@ public actor MetricsCollector: Tracer {
                 let duration = event.timestamp.timeIntervalSince(startTime)
                 executionDurations.append(duration)
             }
-            if let input = event.metadata["input_tokens"]?.intValue {
+            if let input = event.metadata[.inputTokens] {
                 inputTokens += input
             }
-            if let output = event.metadata["output_tokens"]?.intValue {
+            if let output = event.metadata[.outputTokens] {
                 outputTokens += output
             }
             spanStartTimes.removeValue(forKey: event.spanId)

--- a/Sources/Swarm/Observability/SwiftLogTracer.swift
+++ b/Sources/Swarm/Observability/SwiftLogTracer.swift
@@ -121,7 +121,7 @@ public actor SwiftLogTracer: Tracer {
         }
 
         // Extract stepNumber from metadata if present
-        if let stepNumber = event.metadata["stepNumber"]?.intValue {
+        if let stepNumber = event.metadata[.stepNumber] {
             metadata["step"] = "\(stepNumber)"
         }
 
@@ -130,7 +130,7 @@ public actor SwiftLogTracer: Tracer {
         }
 
         // Extract tokenCount from metadata if present
-        if let tokenCount = event.metadata["tokenCount"]?.intValue {
+        if let tokenCount = event.metadata[.legacyTokenCount] {
             metadata["tokens"] = "\(tokenCount)"
         }
 

--- a/Sources/Swarm/Observability/TracingHelper.swift
+++ b/Sources/Swarm/Observability/TracingHelper.swift
@@ -100,11 +100,11 @@ public struct TracingHelper: Sendable {
             message: "LegacyAgent \(agentName) completed",
             metadata: {
                 var metadata: [String: SendableValue] = [
-                    "duration_ms": .double(duration.milliseconds),
                     "iterations": .int(result.iterationCount),
                     "tool_calls_count": .int(result.toolCalls.count),
                     "output_length": .int(result.output.count)
                 ]
+                metadata[.durationMs] = duration.milliseconds
                 if let usage = tokenUsage {
                     metadata[.inputTokens] = usage.inputTokens
                     metadata[.outputTokens] = usage.outputTokens
@@ -129,11 +129,14 @@ public struct TracingHelper: Sendable {
             kind: .agentError,
             level: .error,
             message: "LegacyAgent \(agentName) error: \(error.localizedDescription)",
-            metadata: [
-                "duration_ms": .double(duration.milliseconds),
-                "error_type": .string(String(describing: type(of: error))),
-                "error_message": .string(error.localizedDescription)
-            ],
+            metadata: {
+                var metadata: [String: SendableValue] = [
+                    "error_type": .string(String(describing: type(of: error))),
+                    "error_message": .string(error.localizedDescription)
+                ]
+                metadata[.durationMs] = duration.milliseconds
+                return metadata
+            }(),
             agentName: agentName,
             error: ErrorInfo(from: error)
         ))
@@ -253,11 +256,14 @@ public struct TracingHelper: Sendable {
             kind: .toolResult,
             level: .debug,
             message: "Tool result: \(name)",
-            metadata: [
-                "tool_name": .string(name),
-                "result_length": .int(result.count),
-                "duration_ms": .double(duration.milliseconds)
-            ],
+            metadata: {
+                var metadata: [String: SendableValue] = [
+                    "tool_name": .string(name),
+                    "result_length": .int(result.count)
+                ]
+                metadata[.durationMs] = duration.milliseconds
+                return metadata
+            }(),
             agentName: agentName,
             toolName: name
         ))

--- a/Sources/Swarm/Observability/TracingHelper.swift
+++ b/Sources/Swarm/Observability/TracingHelper.swift
@@ -106,10 +106,10 @@ public struct TracingHelper: Sendable {
                     "output_length": .int(result.output.count)
                 ]
                 if let usage = tokenUsage {
-                    metadata["input_tokens"] = .int(usage.inputTokens)
-                    metadata["output_tokens"] = .int(usage.outputTokens)
-                    metadata["total_tokens"] = .int(usage.totalTokens)
-                    metadata["tokenCount"] = .int(usage.totalTokens)
+                    metadata[.inputTokens] = usage.inputTokens
+                    metadata[.outputTokens] = usage.outputTokens
+                    metadata[.totalTokens] = usage.totalTokens
+                    metadata[.legacyTokenCount] = usage.totalTokens
                 }
                 return metadata
             }(),

--- a/Sources/Swarm/Workflow/Workflow.swift
+++ b/Sources/Swarm/Workflow/Workflow.swift
@@ -642,9 +642,9 @@ public struct Workflow: Sendable {
 
             let fallbackResult = try await backup.run(input, session: nil, observer: observer)
             var metadata = fallbackResult.metadata
-            metadata["workflow.fallback.used"] = .bool(true)
+            metadata[.fallbackUsed] = true
             if let lastError {
-                metadata["workflow.fallback.error"] = .string(String(describing: lastError))
+                metadata[.fallbackError] = String(describing: lastError)
             }
             return AgentResult(
                 output: fallbackResult.output,

--- a/Tests/SwarmTests/Core/MetadataKeyTests.swift
+++ b/Tests/SwarmTests/Core/MetadataKeyTests.swift
@@ -38,7 +38,7 @@ struct MetadataKeyTests {
         metadata[.durationMs] = 12.5
 
         #expect(metadata[.durationMs] == 12.5)
-        #expect(metadata["durationMs"] == .double(12.5))
+        #expect(metadata["duration_ms"] == .double(12.5))
     }
 
     @Test("bool key round-trips through result metadata")
@@ -95,7 +95,7 @@ struct MetadataKeyTests {
         #expect(MetadataKey<Int>.totalTokens.name == "total_tokens")
         #expect(MetadataKey<Int>.legacyTokenCount.name == "tokenCount")
         #expect(MetadataKey<Int>.stepNumber.name == "stepNumber")
-        #expect(MetadataKey<Double>.durationMs.name == "durationMs")
+        #expect(MetadataKey<Double>.durationMs.name == "duration_ms")
         #expect(MetadataKey<Bool>.toolSuccess.name == "success")
         #expect(StreamEventMetadata.model.name == "model")
         #expect(StreamEventMetadata.text.name == "text")
@@ -146,7 +146,7 @@ struct MetadataKeyTests {
         #expect(metadata[.inputTokens] == nil)
         #expect(metadata[.stepNumber] == nil)
 
-        metadata["durationMs"] = .int(5)
+        metadata["duration_ms"] = .int(5)
         // Double reads accept integer payloads via SendableValue.doubleValue.
         #expect(metadata[.durationMs] == 5.0)
     }

--- a/Tests/SwarmTests/Core/MetadataKeyTests.swift
+++ b/Tests/SwarmTests/Core/MetadataKeyTests.swift
@@ -103,6 +103,9 @@ struct MetadataKeyTests {
         #expect(StreamEventMetadata.success.name == "success")
         #expect(StreamEventMetadata.toolCallID.name == "toolCallID")
         #expect(StreamEventMetadata.output.name == "output")
+
+        // The legacy writer constant stays tied to the canonical typed key.
+        #expect(RuntimeMetadata.runtimeEngineKey == MetadataKey<String>.runtimeEngine.name)
     }
 
     @Test("typed write overwrites and nil assignment removes the entry")
@@ -169,6 +172,29 @@ struct MetadataKeyTests {
         seen.insert(MetadataKey<Int>("input_tokens"))
 
         #expect(seen.count == 1)
+    }
+
+    // MARK: - Cross-Type Collision Tests
+
+    @Test("same-name keys with different value types share storage and mismatched reads are nil")
+    func sameNameDifferentValueTypeCollision() {
+        var metadata: [String: SendableValue] = [:]
+        let boolView = MetadataKey<Bool>("input_tokens")
+
+        // The wrongly-typed key writes through the same wire name.
+        metadata[boolView] = true
+        #expect(metadata["input_tokens"] == .bool(true))
+
+        // The canonical Int key reads the non-int payload as nil, not a
+        // coerced or defaulted value.
+        #expect(metadata[.inputTokens] == nil)
+
+        // A typed write through the canonical key overwrites the colliding
+        // entry, after which the Bool view's read is nil.
+        metadata[.inputTokens] = 9
+        #expect(metadata["input_tokens"] == .int(9))
+        #expect(metadata[.inputTokens] == 9)
+        #expect(metadata[boolView] == nil)
     }
 }
 

--- a/Tests/SwarmTests/Core/MetadataKeyTests.swift
+++ b/Tests/SwarmTests/Core/MetadataKeyTests.swift
@@ -1,0 +1,199 @@
+// MetadataKeyTests.swift
+// SwarmTests
+//
+// Tests for MetadataKey typed metadata access across result and trace seams.
+
+import Foundation
+@testable import Swarm
+import Testing
+
+// MARK: - MetadataKeyTests
+
+@Suite("MetadataKey Tests")
+struct MetadataKeyTests {
+
+    // MARK: - Round-Trip Tests
+
+    @Test("string key round-trips through result metadata")
+    func stringKeyRoundTrip() {
+        var metadata: [String: SendableValue] = [:]
+        metadata[.runtimeEngine] = "graph"
+
+        #expect(metadata[.runtimeEngine] == "graph")
+        #expect(metadata["runtime.engine"] == .string("graph"))
+    }
+
+    @Test("integer key round-trips through trace metadata")
+    func integerKeyRoundTrip() {
+        var metadata: [String: SendableValue] = [:]
+        metadata[.inputTokens] = 11
+
+        #expect(metadata[.inputTokens] == 11)
+        #expect(metadata["input_tokens"] == .int(11))
+    }
+
+    @Test("double key round-trips through trace metadata")
+    func doubleKeyRoundTrip() {
+        var metadata: [String: SendableValue] = [:]
+        metadata[.durationMs] = 12.5
+
+        #expect(metadata[.durationMs] == 12.5)
+        #expect(metadata["durationMs"] == .double(12.5))
+    }
+
+    @Test("bool key round-trips through result metadata")
+    func boolKeyRoundTrip() {
+        var metadata: [String: SendableValue] = [:]
+        metadata[.fallbackUsed] = true
+
+        #expect(metadata[.fallbackUsed] == true)
+        #expect(metadata["workflow.fallback.used"] == .bool(true))
+    }
+
+    @Test("tool success writes a bool payload, not strings")
+    func toolSuccessWritesBoolPayload() {
+        var metadata: [String: SendableValue] = [:]
+        metadata[.toolSuccess] = true
+        #expect(metadata["success"] == .bool(true))
+
+        metadata[.toolSuccess] = false
+        #expect(metadata["success"] == .bool(false))
+        #expect(metadata[.toolSuccess] == false)
+    }
+
+    @Test("stream event keys round-trip through string dictionaries")
+    func streamEventKeysRoundTrip() {
+        var payload: [String: String] = [:]
+        payload[StreamEventMetadata.model] = "gpt-test"
+        payload[StreamEventMetadata.text] = "chunk"
+        payload[StreamEventMetadata.name] = "echo"
+        payload[StreamEventMetadata.success] = "true"
+        payload[StreamEventMetadata.toolCallID] = "call-1"
+        payload[StreamEventMetadata.output] = "ok"
+
+        #expect(payload[StreamEventMetadata.model] == "gpt-test")
+        #expect(payload[StreamEventMetadata.text] == "chunk")
+        #expect(payload[StreamEventMetadata.name] == "echo")
+        #expect(payload[StreamEventMetadata.success] == "true")
+        #expect(payload[StreamEventMetadata.toolCallID] == "call-1")
+        #expect(payload[StreamEventMetadata.output] == "ok")
+
+        // Raw-string reads observe the same entries.
+        #expect(payload["model"] == "gpt-test")
+        #expect(payload["toolCallID"] == "call-1")
+    }
+
+    // MARK: - Serialized Form Tests
+
+    @Test("key constants keep their serialized names")
+    func keyConstantsKeepSerializedNames() {
+        #expect(MetadataKey<String>.runtimeEngine.name == "runtime.engine")
+        #expect(MetadataKey<Bool>.fallbackUsed.name == "workflow.fallback.used")
+        #expect(MetadataKey<String>.fallbackError.name == "workflow.fallback.error")
+        #expect(MetadataKey<Int>.inputTokens.name == "input_tokens")
+        #expect(MetadataKey<Int>.outputTokens.name == "output_tokens")
+        #expect(MetadataKey<Int>.totalTokens.name == "total_tokens")
+        #expect(MetadataKey<Int>.legacyTokenCount.name == "tokenCount")
+        #expect(MetadataKey<Int>.stepNumber.name == "stepNumber")
+        #expect(MetadataKey<Double>.durationMs.name == "durationMs")
+        #expect(MetadataKey<Bool>.toolSuccess.name == "success")
+        #expect(StreamEventMetadata.model.name == "model")
+        #expect(StreamEventMetadata.text.name == "text")
+        #expect(StreamEventMetadata.name.name == "name")
+        #expect(StreamEventMetadata.success.name == "success")
+        #expect(StreamEventMetadata.toolCallID.name == "toolCallID")
+        #expect(StreamEventMetadata.output.name == "output")
+    }
+
+    @Test("typed write overwrites and nil assignment removes the entry")
+    func typedWriteOverwritesAndNilRemoves() {
+        var metadata: [String: SendableValue] = [:]
+        metadata[.totalTokens] = 1
+        metadata[.totalTokens] = 2
+        #expect(metadata["total_tokens"] == .int(2))
+
+        metadata[.totalTokens] = nil
+        #expect(metadata["total_tokens"] == nil)
+    }
+
+    // MARK: - Legacy Raw-String Interop Tests
+
+    @Test("legacy tokenCount raw-string read observes typed legacy write")
+    func legacyRawStringReadObservesTypedWrite() {
+        var metadata: [String: SendableValue] = [:]
+        metadata[.legacyTokenCount] = 120
+
+        #expect(metadata["tokenCount"]?.intValue == 120)
+    }
+
+    @Test("raw-string write observes typed read")
+    func rawStringWriteObservesTypedRead() {
+        var metadata: [String: SendableValue] = [
+            "workflow.fallback.used": .bool(true),
+            "stepNumber": .int(3)
+        ]
+
+        #expect(metadata[.fallbackUsed] == true)
+        #expect(metadata[.stepNumber] == 3)
+    }
+
+    // MARK: - Payload Mismatch Tests
+
+    @Test("typed read returns nil for absent or mismatched payloads")
+    func typedReadReturnsNilForAbsentOrMismatchedPayloads() {
+        var metadata: [String: SendableValue] = ["stepNumber": .string("three")]
+
+        #expect(metadata[.inputTokens] == nil)
+        #expect(metadata[.stepNumber] == nil)
+
+        metadata["durationMs"] = .int(5)
+        // Double reads accept integer payloads via SendableValue.doubleValue.
+        #expect(metadata[.durationMs] == 5.0)
+    }
+
+    // MARK: - Hashable Tests
+
+    @Test("keys with equal name and value type are equal")
+    func keysWithEqualNameAndTypeAreEqual() {
+        let constructed = MetadataKey<Int>("input_tokens")
+
+        #expect(constructed == .inputTokens)
+        #expect(constructed.hashValue == MetadataKey<Int>.inputTokens.hashValue)
+        #expect(constructed != .outputTokens)
+    }
+
+    @Test("keys deduplicate inside sets")
+    func keysDeduplicateInsideSets() {
+        var seen = Set<MetadataKey<Int>>()
+        seen.insert(.inputTokens)
+        seen.insert(MetadataKey<Int>("input_tokens"))
+
+        #expect(seen.count == 1)
+    }
+}
+
+// MARK: - AgentResult Runtime Engine Access Tests
+
+@Suite("AgentResult.runtimeEngine Typed Key Tests")
+struct AgentResultRuntimeEngineTypedKeyTests {
+
+    @Test("accessor reads a value written through the typed key")
+    func accessorReadsTypedKeyWrite() {
+        var metadata: [String: SendableValue] = [:]
+        metadata[.runtimeEngine] = "graph"
+
+        let result = AgentResult(output: "hi", metadata: metadata)
+
+        #expect(result.runtimeEngine == "graph")
+    }
+
+    @Test("accessor keeps reading legacy raw-string writes")
+    func accessorReadsLegacyRawWrite() {
+        let result = AgentResult(
+            output: "hi",
+            metadata: ["runtime.engine": .string("native")]
+        )
+
+        #expect(result.runtimeEngine == "native")
+    }
+}

--- a/Tests/SwarmTests/Observability/MetadataRoundTripTests.swift
+++ b/Tests/SwarmTests/Observability/MetadataRoundTripTests.swift
@@ -42,6 +42,9 @@ struct MetadataRoundTripTests {
         #expect(event.metadata["total_tokens"] == .int(18))
         #expect(event.metadata["tokenCount"] == .int(18))
 
+        // The typed duration key observes the helper's duration_ms write.
+        #expect(event.metadata[.durationMs] == event.metadata["duration_ms"]?.doubleValue)
+
         // The same event feeds MetricsCollector through the typed keys.
         let collector = MetricsCollector()
         let spanId = event.spanId

--- a/Tests/SwarmTests/Observability/MetadataRoundTripTests.swift
+++ b/Tests/SwarmTests/Observability/MetadataRoundTripTests.swift
@@ -1,0 +1,117 @@
+// MetadataRoundTripTests.swift
+// SwarmTests
+//
+// End-to-end typed metadata round trips across TracingHelper, MetricsCollector,
+// and Workflow fallback seams.
+
+import Foundation
+@testable import Swarm
+import Testing
+
+// MARK: - MetadataRoundTripTests
+
+@Suite("Metadata Round-Trip Tests")
+struct MetadataRoundTripTests {
+
+    // MARK: - TracingHelper → TraceEvent → MetricsCollector Tests
+
+    @Test("TracingHelper token writes round-trip through raw strings and metrics")
+    func tracingHelperTokenWritesRoundTrip() async {
+        let spy = SpyTracer()
+        let helper = TracingHelper(tracer: spy, agentName: "TypedAgent")
+        let result = AgentResult(output: "done")
+
+        await helper.traceComplete(
+            result: result,
+            tokenUsage: TokenUsage(inputTokens: 11, outputTokens: 7)
+        )
+
+        let events = await spy.tracedEvents
+        #expect(events.count == 1)
+        guard let event = events.first else { return }
+
+        // Typed reads share the producer's key symbols.
+        #expect(event.metadata[.inputTokens] == 11)
+        #expect(event.metadata[.outputTokens] == 7)
+        #expect(event.metadata[.totalTokens] == 18)
+        #expect(event.metadata[.legacyTokenCount] == 18)
+
+        // Serialized form keeps the stable string names and .int payloads.
+        #expect(event.metadata["input_tokens"] == .int(11))
+        #expect(event.metadata["output_tokens"] == .int(7))
+        #expect(event.metadata["total_tokens"] == .int(18))
+        #expect(event.metadata["tokenCount"] == .int(18))
+
+        // The same event feeds MetricsCollector through the typed keys.
+        let collector = MetricsCollector()
+        let spanId = event.spanId
+        let traceId = event.traceId
+        await collector.trace(.agentStart(traceId: traceId, spanId: spanId, agentName: "TypedAgent"))
+        await collector.trace(event)
+
+        let snapshot = await collector.snapshot()
+        #expect(snapshot.inputTokens == 11)
+        #expect(snapshot.outputTokens == 7)
+        #expect(snapshot.totalTokens == 18)
+    }
+
+    @Test("TracingHelper omits token keys when usage is absent")
+    func tracingHelperOmitsTokenKeysWithoutUsage() async {
+        let spy = SpyTracer()
+        let helper = TracingHelper(tracer: spy, agentName: "TypedAgent")
+
+        await helper.traceComplete(result: AgentResult(output: "done"), tokenUsage: nil)
+
+        let events = await spy.tracedEvents
+        guard let event = events.first else { return }
+
+        #expect(event.metadata[.inputTokens] == nil)
+        #expect(event.metadata[.outputTokens] == nil)
+        #expect(event.metadata[.totalTokens] == nil)
+        #expect(event.metadata[.legacyTokenCount] == nil)
+    }
+
+    // MARK: - Workflow Fallback Tests
+
+    @Test("workflow fallback writes typed metadata readable through raw strings")
+    func workflowFallbackMetadataRoundTrip() async throws {
+        let result = try await Workflow()
+            .durable
+            .fallback(primary: AlwaysFailingAgent(), to: MockAgentRuntime(response: "backup"), retries: 1)
+            .run("input")
+
+        #expect(result.output == "backup")
+
+        // Typed reads share the writer's key symbols.
+        #expect(result.metadata[.fallbackUsed] == true)
+        #expect(result.metadata[.fallbackError]?.isEmpty == false)
+
+        // Serialized form stays identical to the pre-typed format.
+        #expect(result.metadata["workflow.fallback.used"] == .bool(true))
+        #expect(result.metadata["workflow.fallback.error"]?.stringValue?.isEmpty == false)
+    }
+}
+
+// MARK: - Fixtures
+
+/// Agent runtime that always fails so workflows exercise their fallback path.
+private actor AlwaysFailingAgent: AgentRuntime {
+    nonisolated let tools: [any AnyJSONTool] = []
+    nonisolated let instructions: String = "AlwaysFailingAgent"
+    nonisolated let configuration = AgentConfiguration(name: "AlwaysFailingAgent")
+    nonisolated let handoffs: [AnyHandoffConfiguration] = []
+
+    func run(_ input: String, session: (any Session)?, observer: (any AgentObserver)?) async throws -> AgentResult {
+        throw AgentError.internalError(reason: "forced failure")
+    }
+
+    nonisolated func stream(
+        _ input: String,
+        session: (any Session)?,
+        observer: (any AgentObserver)?
+    ) -> AsyncThrowingStream<AgentEvent, Error> {
+        AsyncThrowingStream { $0.finish(throwing: AgentError.internalError(reason: "forced failure")) }
+    }
+
+    func cancel() async {}
+}


### PR DESCRIPTION
## Ticket T1 — spec `spec-architecture-typed-seams` (local-only internal spec)

Replaces magic-string coordination on `[String: SendableValue]` metadata dicts with a compiler-checked `MetadataKey<Value>` newtype + typed accessors. Serialized form stays `[String: SendableValue]`.

### What
- NEW `Sources/Swarm/Core/MetadataKey.swift`: `public struct MetadataKey<Value: Sendable>: Hashable, Sendable` + namespaced keys (`runtimeEngine`, `fallbackUsed/Error`, token trio, legacy `tokenCount`, `stepNumber`, `durationMs` → real wire key `"duration_ms"`, bool `toolSuccess`) and typed subscripts over the metadata dictionaries.
- Producers/consumers now share one symbol: TracingHelper, MetricsCollector, SwiftLogTracer, GraphAgent (`StreamEventMetadata`, internal), Workflow fallback flags, `AgentResult.runtimeEngine`.
- Additive only; raw-string access still compiles; zero payload/key-string changes on the wire.

### Verification
- Lean lane: `SWARM_OMIT_INTEGRATION_TARGETS=1 swift build --product Swarm` green, 0 new warnings.
- Full: 1977 tests, single failure is the pre-existing `DocumentationFreshnessTests` catalog-count staleness (fixed by the docs-sync ticket that follows this one).
- New Swift Testing suites: MetadataKeyTests + MetadataRoundTripTests (18 tests).

### Reviews (fresh-context per pipeline)
1. Reviewer A — `swift-pr-review`: fixed durationMs dead-key repoint/wire, scoped StreamEventMetadata internal, doc-link fix (ce7d0863).
2. Final pass — `swift-pr-review`: all fixes verified stays-fixed; dismissals upheld; no new commits required.

### Known follow-ups (out of scope here)
- SwarmMacros `TraceableMacro` raw `"duration_ms"` sites → one-line migration onto the typed key.
- Hive `[String:String]` event seam stringly `"success"` stays byte-identical; future writer migration is one line per site via `StreamEventMetadata`.
