### PR TITLE
Unified phantom-typed AgentContext store (spec T2)

### DIFF
--- a/Sources/Swarm/Core/Execution/AgentContext.swift
+++ b/Sources/Swarm/Core/Execution/AgentContext.swift
@@ -314,8 +314,11 @@ public actor AgentContext {
     /// // Only adds keys that don't exist in current context
     /// ```
     public func merge(from other: AgentContext, overwrite: Bool = false) async {
-        let otherRawValues = await other.rawValues()
-        let otherSlots = await other.valueSlotStore()
+        // Raw and slots must come from one parent hop. ContextKey data used
+        // to live in `values` as a single snapshot; two awaits let another
+        // task mutate `other` in between and drop a replacement or duplicate
+        // it across namespaces so snapshot, getTyped, and removeTyped disagree.
+        let (otherRawValues, otherSlots) = await other.rawValuesAndValueSlots()
 
         // Typed slot names occupy the key for overwrite:false even though
         // they live outside the raw namespace. Copying parent raw under a
@@ -465,19 +468,12 @@ public actor AgentContext {
         slots.hasValuePayload(key)
     }
 
-    /// Returns a copy of this context's raw string-keyed namespace.
-    /// Package-internal; used by `merge(from:)` across actor boundaries.
-    ///
-    /// - Returns: The raw key-value storage.
-    func rawValues() -> [String: SendableValue] {
-        values
-    }
-
-    /// Returns a copy of this context's unified slot store for merging and
-    /// copying. Package-internal; used by `merge(from:)` across actor
-    /// boundaries and by the typed-access helpers in this directory.
-    func valueSlotStore() -> ContextSlotStore {
-        slots
+    /// Returns a copy of this context's raw namespace and typed slot store
+    /// captured together. Package-internal; used by `merge(from:)` so a
+    /// concurrent mutation of the parent cannot tear ContextKey data across
+    /// the two namespaces.
+    func rawValuesAndValueSlots() -> (raw: [String: SendableValue], slots: ContextSlotStore) {
+        (values, slots)
     }
 
     // MARK: Private

--- a/Sources/Swarm/Core/Execution/AgentContext.swift
+++ b/Sources/Swarm/Core/Execution/AgentContext.swift
@@ -324,19 +324,10 @@ public actor AgentContext {
         }
 
         // Merge typed value slots so reads through `getTyped(_:)` observe
-        // merged state. Their encoded payloads also project into the raw
-        // namespace by name, matching where such values lived before typed
-        // storage was unified; projections never displace an existing raw
-        // entry or a same-named local slot unless overwriting. Provided
-        // slots are intentionally not merged; they were historically
-        // instance-specific.
-        let projection = otherSlots.projectedValues()
-        for (name, payload) in projection {
-            if overwrite || (values[name] == nil && !slots.containsValueName(name)) {
-                values[name] = payload
-            }
-        }
-
+        // merged state. Snapshot already projects those slots by name; they
+        // are not copied into the raw namespace, matching `setTyped` and
+        // `copy(additionalValues:)`. Provided slots are intentionally not
+        // merged; they were historically instance-specific.
         slots.mergeValueSlots(from: otherSlots, overwrite: overwrite)
 
         // Merge messages

--- a/Sources/Swarm/Core/Execution/AgentContext.swift
+++ b/Sources/Swarm/Core/Execution/AgentContext.swift
@@ -43,26 +43,37 @@ public enum AgentContextKey: String, Sendable {
 
 /// A protocol for providing typed context to agents and tools.
 ///
-/// Conform to this protocol to create strongly-typed context objects
-/// that can be stored in and retrieved from `AgentContext`, eliminating
-/// stringly-typed dictionary access patterns.
+/// - Deprecated: Store typed values with ``ContextKey`` instead. Define a
+/// `ContextKey<Value>` for your value type and use
+/// ``AgentContext/setTyped(_:value:)`` /
+/// ``AgentContext/getTyped(_:)``, which pair keys and values at compile
+/// time. This protocol remains functional over the unified context store
+/// but will be removed in a future release.
 ///
 /// Example:
 /// ```swift
-/// struct UserContext: AgentContextProviding {
-///     static let contextKey = "user_context"
+/// extension ContextKey where Value == String {
+///     static let userContext = ContextKey("user_context")
+/// }
+///
+/// struct UserContext: Codable, Sendable {
 ///     let userId: String
 ///     let isAdmin: Bool
 /// }
 ///
 /// // Store:
-/// await context.setTyped(UserContext(userId: "123", isAdmin: true))
+/// await context.setTyped(.userContext, value: UserContext(userId: "123", isAdmin: true))
 ///
 /// // Retrieve:
-/// if let user: UserContext = await context.typed(UserContext.self) {
+/// if let user = await context.getTyped(.userContext) {
 ///     print(user.userId)
 /// }
 /// ```
+@available(
+    *,
+    deprecated,
+    message: "Use ContextKey<Value> with setTyped(_:value:)/getTyped(_:) instead"
+)
 public protocol AgentContextProviding: Sendable {
     /// The key used to store this context in the key-value storage.
     static var contextKey: String { get }
@@ -108,16 +119,30 @@ public actor AgentContext {
     nonisolated public let createdAt: Date
 
     /// All current keys in the context.
+    ///
+    /// Includes raw string keys plus the names of any typed slots written
+    /// through `setTyped(_:value:)`.
     public var allKeys: [String] {
-        Array(values.keys)
+        var keys = Array(values.keys)
+        for name in slots.valueNames where values[name] == nil {
+            keys.append(name)
+        }
+        return keys
     }
 
     /// A snapshot copy of all values.
     ///
-    /// Returns a copy of the current key-value storage.
+    /// Returns a copy of the current key-value storage with typed slot
+    /// payloads projected in by name. Raw namespace entries take precedence
+    /// over same-named typed slots; when several typed slots share a name
+    /// across different value types, the most recently written one wins.
     /// Changes to the returned dictionary do not affect the context.
     public var snapshot: [String: SendableValue] {
-        values
+        var projected = values
+        for (name, payload) in slots.projectedValues() where projected[name] == nil {
+            projected[name] = payload
+        }
+        return projected
     }
 
     // MARK: - Initialization
@@ -128,10 +153,24 @@ public actor AgentContext {
     ///   - input: The original input that started orchestration.
     ///   - initialValues: Optional initial key-value pairs. Default: [:]
     public init(input: String, initialValues: [String: SendableValue] = [:]) {
+        self.init(input: input, initialValues: initialValues, slots: ContextSlotStore())
+    }
+
+    /// Creates a new agent context preloaded with typed slots.
+    ///
+    /// Package-internal seed used by `copy(additionalValues:)` to carry
+    /// typed slot state into the new context.
+    ///
+    /// - Parameters:
+    ///   - input: The original input that started orchestration.
+    ///   - initialValues: Initial raw key-value pairs.
+    ///   - slots: Typed slots carried over from a source context.
+    init(input: String, initialValues: [String: SendableValue], slots: ContextSlotStore) {
         originalInput = input
         executionId = TurnEnvironment.live.newUUID()
         createdAt = TurnEnvironment.live.now()
         values = initialValues
+        self.slots = slots
         messages = []
         executionPath = []
 
@@ -268,13 +307,30 @@ public actor AgentContext {
     /// // Only adds keys that don't exist in current context
     /// ```
     public func merge(from other: AgentContext, overwrite: Bool = false) async {
-        let otherSnapshot = await other.snapshot
+        let otherRawValues = await other.rawValues()
+        let otherSlots = await other.valueSlotStore()
 
-        for (key, value) in otherSnapshot {
+        for (key, value) in otherRawValues {
             if overwrite || values[key] == nil {
                 values[key] = value
             }
         }
+
+        // Merge typed value slots so reads through `getTyped(_:)` observe
+        // merged state. Their encoded payloads also project into the raw
+        // namespace by name, matching where such values lived before typed
+        // storage was unified; projections never displace an existing raw
+        // entry or a same-named local slot unless overwriting. Provided
+        // slots are intentionally not merged; they were historically
+        // instance-specific.
+        let projection = otherSlots.projectedValues()
+        for (name, payload) in projection {
+            if overwrite || (values[name] == nil && !slots.containsValueName(name)) {
+                values[name] = payload
+            }
+        }
+
+        slots.mergeValueSlots(from: otherSlots, overwrite: overwrite)
 
         // Merge messages
         let otherMessages = await other.getMessages()
@@ -314,7 +370,14 @@ public actor AgentContext {
             copiedValues[key] = value
         }
 
-        let newContext = AgentContext(input: originalInput, initialValues: copiedValues)
+        // Carry typed value slots so reads through `getTyped(_:)` observe
+        // copied state. Provided slots are intentionally not copied; they
+        // are instance-specific.
+        let newContext = AgentContext(
+            input: originalInput,
+            initialValues: copiedValues,
+            slots: slots.copyingValueSlots()
+        )
 
         // Note: Messages and execution path are not copied to the new context
         // to avoid confusion. They are instance-specific.
@@ -323,24 +386,24 @@ public actor AgentContext {
         return newContext
     }
 
-    // MARK: - Typed Context
+    // MARK: - Typed Context (deprecated shim)
 
     /// Stores a typed context object.
     ///
-    /// The context is stored under its `contextKey` and can be retrieved
-    /// using `typed(_:)`.
+    /// The context is stored in the unified slot store keyed by its concrete
+    /// type and `contextKey`, and can be retrieved using `typed(_:)`.
     ///
     /// - Parameter context: The typed context to store.
     public func setTyped<T: AgentContextProviding>(_ context: T) {
-        typedContexts[T.contextKey] = context
+        slots.setProvided(context)
     }
 
     /// Retrieves a typed context object.
     ///
     /// - Parameter type: The type of context to retrieve.
-    /// - Returns: The stored context, or nil if not found or wrong type.
+    /// - Returns: The stored context, or nil if not found.
     public func typed<T: AgentContextProviding>(_: T.Type) -> T? {
-        typedContexts[T.contextKey] as? T
+        slots.provided(of: T.self)
     }
 
     /// Removes a typed context.
@@ -349,7 +412,7 @@ public actor AgentContext {
     /// - Returns: The removed context, or nil if not found.
     @discardableResult
     public func removeTyped<T: AgentContextProviding>(_: T.Type) -> T? {
-        typedContexts.removeValue(forKey: T.contextKey) as? T
+        slots.removeProvided(of: T.self)
     }
 
     /// Returns true if a typed context of the given type is stored.
@@ -357,7 +420,62 @@ public actor AgentContext {
     /// - Parameter type: The type to check for.
     /// - Returns: Whether a context of this type exists.
     public func hasTyped<T: AgentContextProviding>(_: T.Type) -> Bool {
-        typedContexts[T.contextKey] != nil
+        slots.containsProvided(of: T.self)
+    }
+
+    // MARK: - Slot Storage Bridge (package-internal)
+
+    /// Stores an encoded payload in the slot identified by `key`.
+    /// Package-internal; used by the typed-access helpers in this directory.
+    ///
+    /// - Parameters:
+    ///   - key: The typed key identifying the slot.
+    ///   - payload: The encoded value to store.
+    func setValueSlot<T>(_ key: ContextKey<T>, payload: SendableValue) {
+        slots.setValuePayload(key, payload: payload)
+    }
+
+    /// Returns the encoded payload stored for `key`, if any.
+    /// Package-internal; used by the typed-access helpers in this directory.
+    ///
+    /// - Parameter key: The typed key identifying the slot.
+    /// - Returns: The stored payload, or nil when the slot is empty.
+    func valueSlotPayload<T>(for key: ContextKey<T>) -> SendableValue? {
+        slots.valuePayload(for: key)
+    }
+
+    /// Removes the slot identified by `key`.
+    /// Package-internal; used by the typed-access helpers in this directory.
+    ///
+    /// - Parameter key: The typed key identifying the slot.
+    /// - Returns: The removed payload, or nil when the slot was empty.
+    @discardableResult
+    func removeValueSlot<T>(_ key: ContextKey<T>) -> SendableValue? {
+        slots.removeValuePayload(key)
+    }
+
+    /// Returns whether a slot exists for `key`.
+    /// Package-internal; used by the typed-access helpers in this directory.
+    ///
+    /// - Parameter key: The typed key identifying the slot.
+    /// - Returns: True when the slot holds a value.
+    func hasValueSlot<T>(_ key: ContextKey<T>) -> Bool {
+        slots.hasValuePayload(key)
+    }
+
+    /// Returns a copy of this context's raw string-keyed namespace.
+    /// Package-internal; used by `merge(from:)` across actor boundaries.
+    ///
+    /// - Returns: The raw key-value storage.
+    func rawValues() -> [String: SendableValue] {
+        values
+    }
+
+    /// Returns a copy of this context's unified slot store for merging and
+    /// copying. Package-internal; used by `merge(from:)` across actor
+    /// boundaries and by the typed-access helpers in this directory.
+    func valueSlotStore() -> ContextSlotStore {
+        slots
     }
 
     // MARK: Private
@@ -365,6 +483,9 @@ public actor AgentContext {
     // MARK: - Private Storage
 
     /// Key-value storage for arbitrary data.
+    ///
+    /// This is the raw string-keyed namespace. Typed `ContextKey<Value>`
+    /// values live in `slots` and are projected into snapshots by name.
     private var values: [String: SendableValue]
 
     /// Message history for conversation continuity.
@@ -373,8 +494,10 @@ public actor AgentContext {
     /// List of agent names that have executed.
     private var executionPath: [String]
 
-    /// Typed context storage keyed by context key string.
-    private var typedContexts: [String: any AgentContextProviding] = [:]
+    /// Unified typed slot storage shared by `ContextKey<Value>` accessors
+    /// and the deprecated `AgentContextProviding` shim. See
+    /// `ContextSlotStore`.
+    private var slots: ContextSlotStore
 }
 
 // MARK: CustomStringConvertible

--- a/Sources/Swarm/Core/Execution/AgentContext.swift
+++ b/Sources/Swarm/Core/Execution/AgentContext.swift
@@ -50,6 +50,13 @@ public enum AgentContextKey: String, Sendable {
 /// time. This protocol remains functional over the unified context store
 /// but will be removed in a future release.
 ///
+/// - Migration hazard: `ContextKey<Value>` writes live in a namespace
+/// separate from untyped string storage. Values written through the typed
+/// API are no longer visible to raw reads such as
+/// ``AgentContext/get(_:)`` or string-keyed snapshot entries, so any code
+/// still reading a migrated value by its raw string must switch to
+/// ``AgentContext/getTyped(_:)`` with the same key name.
+///
 /// Example:
 /// ```swift
 /// extension ContextKey where Value == String {

--- a/Sources/Swarm/Core/Execution/AgentContext.swift
+++ b/Sources/Swarm/Core/Execution/AgentContext.swift
@@ -317,8 +317,12 @@ public actor AgentContext {
         let otherRawValues = await other.rawValues()
         let otherSlots = await other.valueSlotStore()
 
+        // Typed slot names occupy the key for overwrite:false even though
+        // they live outside the raw namespace. Copying parent raw under a
+        // live local slot would steal the snapshot (raw wins) and survive
+        // removeTyped as a shadow.
         for (key, value) in otherRawValues {
-            if overwrite || values[key] == nil {
+            if overwrite || (values[key] == nil && !slots.containsValueName(key)) {
                 values[key] = value
             }
         }

--- a/Sources/Swarm/Core/Execution/ContextKey.swift
+++ b/Sources/Swarm/Core/Execution/ContextKey.swift
@@ -127,8 +127,20 @@ public extension ContextKey where Value == Date {
 
 // MARK: - AgentContext Typed Extensions
 
+/// Typed context access over `AgentContext`'s unified slot store.
+///
+/// Keys and values are paired at compile time: a slot is identified by the
+/// key's string name together with its static `Value` type, so two keys
+/// sharing a name across different value types occupy distinct slots and a
+/// read can never observe another key's payload. Values are encoded once on
+/// write and decoded once on read by `ContextValueCodec`; no runtime casting
+/// participates in typed reads.
 public extension AgentContext {
     /// Sets a typed value in the context.
+    ///
+    /// The value is encoded into the unified slot store under this key's
+    /// `(Value type, name)` identity. Untyped string storage is a separate
+    /// raw namespace; raw writes are not visible to typed reads.
     ///
     /// - Parameters:
     ///   - key: The typed context key.
@@ -140,19 +152,14 @@ public extension AgentContext {
     /// await context.setTyped(.isAuthenticated, value: true)
     /// ```
     func setTyped<T: Sendable & Encodable>(_ key: ContextKey<T>, value: T) {
-        do {
-            let sendableValue = try SendableValue(encoding: value)
-            set(key.name, value: sendableValue)
-        } catch {
-            // If encoding fails, store as string representation
-            set(key.name, value: .string(String(describing: value)))
-        }
+        setValueSlot(key, payload: ContextValueCodec.encode(value))
     }
 
     /// Gets a typed value from the context.
     ///
     /// - Parameter key: The typed context key.
-    /// - Returns: The value if found and type matches, nil otherwise.
+    /// - Returns: The stored value decoded as the key's value type, or nil
+    ///   when nothing is stored under this slot.
     ///
     /// Example:
     /// ```swift
@@ -160,45 +167,8 @@ public extension AgentContext {
     /// let isAuth: Bool? = await context.getTyped(.isAuthenticated)
     /// ```
     func getTyped<T: Sendable & Decodable>(_ key: ContextKey<T>) -> T? {
-        guard let sendableValue = get(key.name) else {
-            return nil
-        }
-
-        // Handle primitive types directly
-        if T.self == String.self {
-            return sendableValue.stringValue as? T
-        }
-        if T.self == Int.self {
-            return sendableValue.intValue as? T
-        }
-        if T.self == Double.self {
-            return sendableValue.doubleValue as? T
-        }
-        if T.self == Bool.self {
-            return sendableValue.boolValue as? T
-        }
-
-        // Handle arrays
-        if T.self == [String].self {
-            if let array = sendableValue.arrayValue {
-                let strings = array.compactMap(\.stringValue)
-                return strings as? T
-            }
-        }
-
-        // Handle Date
-        if T.self == Date.self {
-            if let timestamp = sendableValue.doubleValue {
-                return Date(timeIntervalSince1970: timestamp) as? T
-            }
-        }
-
-        // For complex types, try to decode
-        do {
-            return try sendableValue.decode()
-        } catch {
-            return nil
-        }
+        guard let payload = valueSlotPayload(for: key) else { return nil }
+        return ContextValueCodec.decode(payload, as: T.self)
     }
 
     /// Gets a typed value from the context with a default.
@@ -218,6 +188,9 @@ public extension AgentContext {
 
     /// Removes a typed value from the context.
     ///
+    /// Only this key's own slot is removed; same-named slots of other value
+    /// types and raw namespace entries are untouched.
+    ///
     /// - Parameter key: The typed context key.
     ///
     /// Example:
@@ -225,13 +198,13 @@ public extension AgentContext {
     /// await context.removeTyped(.userID)
     /// ```
     func removeTyped(_ key: ContextKey<some Sendable>) {
-        _ = remove(key.name)
+        removeValueSlot(key)
     }
 
     /// Checks if a typed key exists in the context.
     ///
     /// - Parameter key: The typed context key.
-    /// - Returns: True if the key exists.
+    /// - Returns: True if a value exists for this exact slot.
     ///
     /// Example:
     /// ```swift
@@ -240,6 +213,6 @@ public extension AgentContext {
     /// }
     /// ```
     func hasTyped(_ key: ContextKey<some Sendable>) -> Bool {
-        get(key.name) != nil
+        hasValueSlot(key)
     }
 }

--- a/Sources/Swarm/Core/Execution/ContextKey.swift
+++ b/Sources/Swarm/Core/Execution/ContextKey.swift
@@ -12,6 +12,12 @@ import Foundation
 /// `ContextKey` provides compile-time type safety for context values,
 /// eliminating runtime type errors when storing and retrieving data.
 ///
+/// Typed storage is a namespace separate from untyped string storage:
+/// unlike ``MetadataKey`` — whose entries remain visible to raw-string
+/// dictionary access — a value written through
+/// ``AgentContext/setTyped(_:value:)`` is readable only through
+/// ``AgentContext/getTyped(_:)``, not by its string name.
+///
 /// Example:
 /// ```swift
 /// // Define typed keys

--- a/Sources/Swarm/Core/Execution/ContextKey.swift
+++ b/Sources/Swarm/Core/Execution/ContextKey.swift
@@ -159,7 +159,9 @@ public extension AgentContext {
     ///
     /// - Parameter key: The typed context key.
     /// - Returns: The stored value decoded as the key's value type, or nil
-    ///   when nothing is stored under this slot.
+    ///   when nothing is stored under this slot. When the value type is
+    ///   itself Optional, storing `nil` creates a null slot whose read
+    ///   succeeds with a nil payload rather than returning nil for absence.
     ///
     /// Example:
     /// ```swift

--- a/Sources/Swarm/Core/Execution/ContextSlotStore.swift
+++ b/Sources/Swarm/Core/Execution/ContextSlotStore.swift
@@ -214,6 +214,15 @@ struct ContextSlotStore {
         Set(valueSlots.keys.map(\.name)).sorted()
     }
 
+    /// Returns whether any value slot occupies `name`, regardless of the
+    /// owning value type.
+    ///
+    /// - Parameter name: The string name to look up.
+    /// - Returns: True when at least one slot uses this name.
+    func containsValueName(_ name: String) -> Bool {
+        valueSlots.contains { $0.key.name == name }
+    }
+
     // MARK: - Provided Slots (deprecated shim)
 
     /// Stores `instance` in the slot identified by its concrete type and

--- a/Sources/Swarm/Core/Execution/ContextSlotStore.swift
+++ b/Sources/Swarm/Core/Execution/ContextSlotStore.swift
@@ -1,0 +1,250 @@
+// ContextSlotStore.swift
+// Swarm Framework
+//
+// Internal unified slot storage backing `AgentContext`'s typed values.
+
+import Foundation
+
+// MARK: - ContextSlotID
+
+/// Identifies one typed slot inside `AgentContext`'s unified store.
+///
+/// Slot identity combines the static `Value` type of a `ContextKey<Value>`
+/// with the key's string name, so two keys sharing a name but carrying
+/// different value types always occupy distinct slots. Wrong key/value
+/// pairings therefore fail to compile instead of surfacing as silent
+/// runtime nils.
+struct ContextSlotID: Hashable {
+    // MARK: Internal
+
+    /// Runtime identity of the slot's value type.
+    let valueTypeIdentity: ObjectIdentifier
+
+    /// The string name contributed by the key.
+    let name: String
+
+    // MARK: - Initialization
+
+    /// Creates a slot identifier for `valueType` under `name`.
+    ///
+    /// - Parameters:
+    ///   - valueType: The static value type of the accessing key.
+    ///   - name: The string name of the accessing key.
+    init<Value>(valueType: Value.Type, name: String) {
+        valueTypeIdentity = ObjectIdentifier(valueType)
+        self.name = name
+    }
+}
+
+// MARK: - ContextSlotEntry
+
+/// An encoded value stored under a `ContextKey<Value>` slot identity.
+///
+/// Values are encoded once when written and decoded once when read. Keeping
+/// the encoded form lets `snapshot`, `merge(from:)`, and
+/// `copy(additionalValues:)` produce `[String: SendableValue]` at their
+/// boundaries without re-interpreting a stored value under another type.
+struct ContextSlotEntry {
+    // MARK: Public
+
+    /// The encoded representation written for the slot's value type.
+    let payload: SendableValue
+
+    /// Monotonic sequence number used to resolve ties deterministically when
+    /// several same-named slots of different value types project into a
+    /// snapshot; the most recently written slot wins.
+    let writeStamp: Int
+}
+
+// MARK: - ContextSlotStore
+
+/// The single unified store for `AgentContext` typed values.
+///
+/// `ContextKey<Value>` writes land in value slots keyed by
+/// `(Value type identity, key name)`; the deprecated `AgentContextProviding`
+/// shim stores instances in provided slots keyed by
+/// `(concrete type identity, contextKey)`. Untyped string access remains a
+/// separate raw `[String: SendableValue]` namespace owned by `AgentContext`.
+struct ContextSlotStore {
+    // MARK: Private
+
+    /// Typed value slots keyed by value-type identity plus key name.
+    private var valueSlots: [ContextSlotID: ContextSlotEntry] = [:]
+
+    /// Deprecated `AgentContextProviding` instances keyed by concrete type
+    /// identity plus the conformer's `contextKey`.
+    private var providedSlots: [ContextSlotID: any AgentContextProviding] = [:]
+
+    /// Source of monotonically increasing write stamps.
+    private var nextWriteStamp = 0
+
+    // MARK: - Value Slots
+
+    /// Stores `payload` in the slot identified by `key`.
+    ///
+    /// - Parameters:
+    ///   - key: The typed key identifying the slot.
+    ///   - payload: The encoded value to store.
+    mutating func setValuePayload<T>(_ key: ContextKey<T>, payload: SendableValue) {
+        nextWriteStamp += 1
+        let id = ContextSlotID(valueType: T.self, name: key.name)
+        valueSlots[id] = ContextSlotEntry(payload: payload, writeStamp: nextWriteStamp)
+    }
+
+    /// Returns the encoded payload stored for `key`, if any.
+    ///
+    /// - Parameter key: The typed key identifying the slot.
+    /// - Returns: The stored payload, or nil when the slot is empty.
+    func valuePayload<T>(for key: ContextKey<T>) -> SendableValue? {
+        valueSlots[ContextSlotID(valueType: T.self, name: key.name)]?.payload
+    }
+
+    /// Removes the slot identified by `key`.
+    ///
+    /// - Parameter key: The typed key identifying the slot.
+    /// - Returns: The removed payload, or nil when the slot was empty.
+    @discardableResult
+    mutating func removeValuePayload<T>(_ key: ContextKey<T>) -> SendableValue? {
+        valueSlots.removeValue(forKey: ContextSlotID(valueType: T.self, name: key.name))?.payload
+    }
+
+    /// Returns whether a slot exists for `key`.
+    ///
+    /// - Parameter key: The typed key identifying the slot.
+    /// - Returns: True when the slot holds a value.
+    func hasValuePayload<T>(_ key: ContextKey<T>) -> Bool {
+        valueSlots[ContextSlotID(valueType: T.self, name: key.name)] != nil
+    }
+
+    /// Merges value slots from `other` into this store.
+    ///
+    /// - Parameters:
+    ///   - other: The store whose value slots are copied in.
+    ///   - overwrite: When false, existing slots are left untouched.
+    mutating func mergeValueSlots(from other: ContextSlotStore, overwrite: Bool) {
+        for (id, entry) in other.valueSlots {
+            if overwrite || valueSlots[id] == nil {
+                nextWriteStamp += 1
+                valueSlots[id] = ContextSlotEntry(
+                    payload: entry.payload,
+                    writeStamp: nextWriteStamp
+                )
+            }
+        }
+    }
+
+    /// Projects value slots into the string-keyed snapshot form.
+    ///
+    /// When several slots share a name across different value types, the most
+    /// recently written slot wins. Raw namespace entries owned by
+    /// `AgentContext` take precedence during snapshot assembly.
+    ///
+    /// - Returns: Projected payloads keyed by slot name.
+    func projectedValues() -> [String: SendableValue] {
+        var latestByName: [String: (stamp: Int, payload: SendableValue)] = [:]
+        for (id, entry) in valueSlots {
+            if let current = latestByName[id.name], current.stamp > entry.writeStamp {
+                continue
+            }
+            latestByName[id.name] = (entry.writeStamp, entry.payload)
+        }
+        return latestByName.mapValues(\.payload)
+    }
+
+    /// The distinct slot names held in value slots.
+    var valueNames: [String] {
+        Set(valueSlots.keys.map(\.name)).sorted()
+    }
+
+    /// Returns whether any value slot occupies `name`, regardless of the
+    /// owning value type.
+    ///
+    /// - Parameter name: The string name to look up.
+    /// - Returns: True when at least one slot uses this name.
+    func containsValueName(_ name: String) -> Bool {
+        valueSlots.contains { $0.key.name == name }
+    }
+
+    // MARK: - Provided Slots (deprecated shim)
+
+    /// Stores `instance` in the slot identified by its concrete type and
+    /// `AgentContextProviding.contextKey`.
+    ///
+    /// - Parameter instance: The typed context instance to store.
+    mutating func setProvided<T: AgentContextProviding>(_ instance: T) {
+        let id = ContextSlotID(valueType: T.self, name: T.contextKey)
+        providedSlots[id] = instance
+    }
+
+    /// Returns the stored instance for `type`, if any.
+    ///
+    /// The slot identifier pins the concrete type, so the single existential
+    /// crossing below can neither fail nor produce a wrong-typed value; a
+    /// mismatched request simply addresses an empty slot and returns nil.
+    ///
+    /// - Parameter type: The concrete context type to retrieve.
+    /// - Returns: The stored instance, or nil when absent.
+    func provided<T: AgentContextProviding>(of type: T.Type) -> T? {
+        extract(type, from: providedSlots[ContextSlotID(valueType: T.self, name: T.contextKey)])
+    }
+
+    /// Removes and returns the stored instance for `type`, if any.
+    ///
+    /// - Parameter type: The concrete context type to remove.
+    /// - Returns: The removed instance, or nil when absent.
+    @discardableResult
+    mutating func removeProvided<T: AgentContextProviding>(of type: T.Type) -> T? {
+        extract(type, from: providedSlots.removeValue(forKey: ContextSlotID(
+            valueType: T.self,
+            name: T.contextKey
+        )))
+    }
+
+    /// Returns whether a provided slot exists for `type`.
+    ///
+    /// - Parameter type: The concrete context type to look up.
+    /// - Returns: True when an instance of this type is stored.
+    func containsProvided<T: AgentContextProviding>(of type: T.Type) -> Bool {
+        providedSlots[ContextSlotID(valueType: T.self, name: T.contextKey)] != nil
+    }
+
+    // MARK: - Copying
+
+    /// Creates a copy holding only value slots, dropping provided slots.
+    ///
+    /// Provided slots are deliberately excluded: `copy(additionalValues:)`
+    /// historically duplicated only the string-keyed values that typed
+    /// `ContextKey` writes produced, never `AgentContextProviding` instances.
+    ///
+    /// - Returns: A store whose value slots match this store's.
+    func copyingValueSlots() -> ContextSlotStore {
+        var copy = ContextSlotStore()
+        for (id, entry) in valueSlots {
+            copy.nextWriteStamp += 1
+            copy.valueSlots[id] = ContextSlotEntry(
+                payload: entry.payload,
+                writeStamp: copy.nextWriteStamp
+            )
+        }
+        return copy
+    }
+
+    // MARK: Private
+
+    /// Crosses the `any AgentContextProviding` existential boundary after
+    /// slot identity already established the stored instance has type
+    /// `Value`.
+    ///
+    /// This is not a speculative runtime check like the removed string-keyed
+    /// lookup: the slot identifier pins the concrete conformer type, so the
+    /// conversion below can neither fail nor produce a wrong-typed value. It
+    /// exists only because Swift has no way to recover a concrete type from
+    /// an existential without one checked conversion at the storage boundary.
+    private func extract<Value: AgentContextProviding>(
+        _ type: Value.Type,
+        from slot: (any AgentContextProviding)?
+    ) -> Value? {
+        guard let slot else { return nil }
+        return slot as? Value
+    }
+}

--- a/Sources/Swarm/Core/Execution/ContextSlotStore.swift
+++ b/Sources/Swarm/Core/Execution/ContextSlotStore.swift
@@ -122,7 +122,10 @@ struct ContextSlotStore {
     ///   - other: The store whose value slots are copied in.
     ///   - overwrite: When false, existing slots are left untouched.
     mutating func mergeValueSlots(from other: ContextSlotStore, overwrite: Bool) {
-        for (id, entry) in other.valueSlots {
+        // Re-stamp in source-recency order so the relative order that
+        // `projectedValues` resolves ties by survives the merge regardless
+        // of dictionary iteration order.
+        for (id, entry) in other.valueSlots.sorted(by: { $0.value.writeStamp < $1.value.writeStamp }) {
             if overwrite || valueSlots[id] == nil {
                 nextWriteStamp += 1
                 valueSlots[id] = ContextSlotEntry(
@@ -219,7 +222,10 @@ struct ContextSlotStore {
     /// - Returns: A store whose value slots match this store's.
     func copyingValueSlots() -> ContextSlotStore {
         var copy = ContextSlotStore()
-        for (id, entry) in valueSlots {
+        // Re-stamp in source-recency order so a copy projects the same
+        // same-named winner as its source regardless of dictionary
+        // iteration order.
+        for (id, entry) in valueSlots.sorted(by: { $0.value.writeStamp < $1.value.writeStamp }) {
             copy.nextWriteStamp += 1
             copy.valueSlots[id] = ContextSlotEntry(
                 payload: entry.payload,

--- a/Sources/Swarm/Core/Execution/ContextSlotStore.swift
+++ b/Sources/Swarm/Core/Execution/ContextSlotStore.swift
@@ -118,21 +118,76 @@ struct ContextSlotStore {
 
     /// Merges value slots from `other` into this store.
     ///
+    /// Incoming slots are re-stamped in source-recency order so the relative
+    /// order that `projectedValues` resolves ties by survives the merge
+    /// regardless of dictionary iteration order.
+    ///
+    /// When `overwrite` is false, existing slots are left untouched. Incoming
+    /// slots that share a name with a local slot but have a different value
+    /// type are still inserted so typed reads of the incoming type work, but
+    /// they receive a write stamp strictly below the current same-name winner
+    /// so they cannot steal the snapshot projection.
+    ///
     /// - Parameters:
     ///   - other: The store whose value slots are copied in.
-    ///   - overwrite: When false, existing slots are left untouched.
+    ///   - overwrite: When false, existing slots are left untouched and
+    ///     same-name newcomers stay below the local projection winner.
     mutating func mergeValueSlots(from other: ContextSlotStore, overwrite: Bool) {
-        // Re-stamp in source-recency order so the relative order that
-        // `projectedValues` resolves ties by survives the merge regardless
-        // of dictionary iteration order.
-        for (id, entry) in other.valueSlots.sorted(by: { $0.value.writeStamp < $1.value.writeStamp }) {
-            if overwrite || valueSlots[id] == nil {
+        let incoming = other.valueSlots.sorted(by: { $0.value.writeStamp < $1.value.writeStamp })
+
+        if overwrite {
+            for (id, entry) in incoming {
                 nextWriteStamp += 1
                 valueSlots[id] = ContextSlotEntry(
                     payload: entry.payload,
                     writeStamp: nextWriteStamp
                 )
             }
+            return
+        }
+
+        var winnerStampByName: [String: Int] = [:]
+        var usedStampsByName: [String: Set<Int>] = [:]
+        for (id, entry) in valueSlots {
+            usedStampsByName[id.name, default: []].insert(entry.writeStamp)
+            if let current = winnerStampByName[id.name], current >= entry.writeStamp {
+                continue
+            }
+            winnerStampByName[id.name] = entry.writeStamp
+        }
+
+        var newNames: [(id: ContextSlotID, entry: ContextSlotEntry)] = []
+        var belowWinnerByName: [String: [(id: ContextSlotID, entry: ContextSlotEntry)]] = [:]
+        for (id, entry) in incoming {
+            guard valueSlots[id] == nil else { continue }
+            if winnerStampByName[id.name] != nil {
+                belowWinnerByName[id.name, default: []].append((id, entry))
+            } else {
+                newNames.append((id, entry))
+            }
+        }
+
+        for (name, entries) in belowWinnerByName {
+            guard var nextBelow = winnerStampByName[name] else { continue }
+            var used = usedStampsByName[name] ?? []
+            // Newest incoming first so relative recency among newcomers is
+            // preserved, all strictly below the local winner.
+            for (id, entry) in entries.reversed() {
+                nextBelow -= 1
+                while used.contains(nextBelow) {
+                    nextBelow -= 1
+                }
+                valueSlots[id] = ContextSlotEntry(payload: entry.payload, writeStamp: nextBelow)
+                used.insert(nextBelow)
+            }
+        }
+
+        for (id, entry) in newNames {
+            nextWriteStamp += 1
+            valueSlots[id] = ContextSlotEntry(
+                payload: entry.payload,
+                writeStamp: nextWriteStamp
+            )
         }
     }
 
@@ -157,15 +212,6 @@ struct ContextSlotStore {
     /// The distinct slot names held in value slots.
     var valueNames: [String] {
         Set(valueSlots.keys.map(\.name)).sorted()
-    }
-
-    /// Returns whether any value slot occupies `name`, regardless of the
-    /// owning value type.
-    ///
-    /// - Parameter name: The string name to look up.
-    /// - Returns: True when at least one slot uses this name.
-    func containsValueName(_ name: String) -> Bool {
-        valueSlots.contains { $0.key.name == name }
     }
 
     // MARK: - Provided Slots (deprecated shim)

--- a/Sources/Swarm/Core/Execution/ContextValueCodec.swift
+++ b/Sources/Swarm/Core/Execution/ContextValueCodec.swift
@@ -14,6 +14,13 @@ import Foundation
 /// `Codable` machinery alone; no runtime casting decides value identity. The
 /// encoder/decoder pair pins `Date` to seconds-since-1970, which keeps typed
 /// reads of timestamp payloads exact.
+///
+/// Do not substitute ``SendableValue/init(encoding:)`` /
+/// ``SendableValue/decode()`` here: both decide value identity with runtime
+/// casts and carry no `Date` strategy, which reintroduces silent wrong-type
+/// reads and timestamp drift. JSON is the chosen serialization; if another
+/// format ever becomes a requirement, replace this enum wholesale rather
+/// than threading an injected strategy through `AgentContext`.
 enum ContextValueCodec {
     // MARK: - Encoding
 

--- a/Sources/Swarm/Core/Execution/ContextValueCodec.swift
+++ b/Sources/Swarm/Core/Execution/ContextValueCodec.swift
@@ -1,0 +1,54 @@
+// ContextValueCodec.swift
+// Swarm Framework
+//
+// Internal encoding/decoding between typed context values and SendableValue.
+
+import Foundation
+
+// MARK: - ContextValueCodec
+
+/// Converts typed context values to and from their stored
+/// `SendableValue` payloads.
+///
+/// Both directions travel through JSON so the conversion is performed by the
+/// `Codable` machinery alone; no runtime casting decides value identity. The
+/// encoder/decoder pair pins `Date` to seconds-since-1970, which keeps typed
+/// reads of timestamp payloads exact.
+enum ContextValueCodec {
+    // MARK: - Encoding
+
+    /// Encodes `value` into its stored payload form.
+    ///
+    /// - Parameter value: The value written through `setTyped(_:value:)`.
+    /// - Returns: The encoded payload. When encoding fails, the historical
+    ///   fallback — a string description of the value — is returned so a
+    ///   write never throws.
+    static func encode<T: Encodable>(_ value: T) -> SendableValue {
+        do {
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .secondsSince1970
+            let data = try encoder.encode(value)
+            return try JSONDecoder().decode(SendableValue.self, from: data)
+        } catch {
+            return .string(String(describing: value))
+        }
+    }
+
+    // MARK: - Decoding
+
+    /// Decodes `payload` into `T`.
+    ///
+    /// - Parameters:
+    ///   - payload: The stored payload for this slot's value type.
+    ///   - type: The static value type of the reading key.
+    /// - Returns: The decoded value, or nil when the payload cannot be
+    ///   decoded as `T`. A nil result is only reachable when the stored
+    ///   payload does not fit `T`; slot identity already guarantees the
+    ///   request itself addresses the right slot.
+    static func decode<T: Decodable>(_ payload: SendableValue, as type: T.Type) -> T? {
+        guard let data = try? JSONEncoder().encode(payload) else { return nil }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        return try? decoder.decode(T.self, from: data)
+    }
+}

--- a/Tests/SwarmTests/Core/ContextStoreUnificationTests.swift
+++ b/Tests/SwarmTests/Core/ContextStoreUnificationTests.swift
@@ -310,6 +310,21 @@ struct ContextStoreUnificationTests {
         #expect(merged.valuePayload(for: ContextKey<String>("recency_name")) == .string("newest"))
     }
 
+    @Test("store-level merge without overwrite restamps same-name ids below the local winner")
+    func storeMergeDoesNotLetDifferentTypedSameNameStealProjection() {
+        var local = ContextSlotStore()
+        local.setValuePayload(ContextKey<Int>("user_id"), payload: .int(42))
+
+        var incoming = ContextSlotStore()
+        incoming.setValuePayload(ContextKey<String>("user_id"), payload: .string("parent-user"))
+
+        local.mergeValueSlots(from: incoming, overwrite: false)
+
+        #expect(local.projectedValues()["user_id"] == .int(42))
+        #expect(local.valuePayload(for: ContextKey<Int>("user_id")) == .int(42))
+        #expect(local.valuePayload(for: ContextKey<String>("user_id")) == .string("parent-user"))
+    }
+
     // MARK: - Copy Behavior
 
     @Test("copy carries typed values and lands additionalValues in the raw namespace")
@@ -491,5 +506,42 @@ struct ContextStoreUnificationTests {
         // Typed namespace still received the merged slot.
         #expect(await child.getTyped(.userID) == "from-slot")
         #expect(await child.get("user_id") == .string("raw-local"))
+    }
+
+    @Test("merge of typed-only parent then removeTyped leaves no raw shadow")
+    func mergeThenRemoveTypedDoesNotLeaveRawShadow() async throws {
+        let parent = AgentContext(input: "parent")
+        await parent.setTyped(.userID, value: "p-user")
+
+        let child = AgentContext(input: "child")
+        await child.merge(from: parent, overwrite: false)
+
+        #expect(await child.getTyped(.userID) == "p-user")
+        #expect(await child.snapshot["user_id"] == .string("p-user"))
+        // Merge must not copy the projection into raw storage.
+        #expect(await child.get("user_id") == nil)
+
+        await child.removeTyped(.userID)
+        #expect(await child.getTyped(.userID) == nil)
+        #expect(await child.get("user_id") == nil)
+        #expect(await child.snapshot["user_id"] == nil)
+    }
+
+    @Test("merge without overwrite keeps a local typed snapshot winner across value types")
+    func mergeWithoutOverwriteKeepsLocalSameNameSnapshotWinner() async throws {
+        let parent = AgentContext(input: "parent")
+        await parent.setTyped(ContextKey<String>("user_id"), value: "parent-user")
+
+        let child = AgentContext(input: "child")
+        await child.setTyped(ContextKey<Int>("user_id"), value: 42)
+
+        await child.merge(from: parent, overwrite: false)
+
+        #expect(await child.getTyped(ContextKey<Int>("user_id")) == 42)
+        #expect(await child.getTyped(ContextKey<String>("user_id")) == "parent-user")
+        #expect(await child.snapshot["user_id"] == .int(42))
+
+        await child.removeTyped(ContextKey<Int>("user_id"))
+        #expect(await child.snapshot["user_id"] == .string("parent-user"))
     }
 }

--- a/Tests/SwarmTests/Core/ContextStoreUnificationTests.swift
+++ b/Tests/SwarmTests/Core/ContextStoreUnificationTests.swift
@@ -1,0 +1,329 @@
+// ContextStoreUnificationTests.swift
+// SwarmTests
+//
+// Tests for the unified phantom-typed AgentContext store: slot identity,
+// round-trip exactness, namespace separation, snapshot/merge/copy behavior,
+// and the deprecated AgentContextProviding shim.
+
+import Foundation
+import Testing
+@testable import Swarm
+
+// MARK: - Test Fixtures
+
+/// A custom Codable value used to exercise complex typed slots.
+private struct UserProfile: Codable, Equatable, Sendable {
+    let id: String
+    let score: Double
+}
+
+/// A deprecated-protocol conformer used to prove the shim still functions.
+private struct LegacyUserContext: AgentContextProviding {
+    static let contextKey = "legacy_user_context"
+
+    let userId: String
+    let isAdmin: Bool
+}
+
+/// A second deprecated-protocol conformer used to prove shim coexistence.
+private struct LegacySessionContext: AgentContextProviding {
+    static let contextKey = "legacy_session_context"
+
+    let sessionId: String
+}
+
+// MARK: - ContextStoreUnificationTests
+
+@Suite("Context Store Unification")
+struct ContextStoreUnificationTests {
+    // MARK: - Slot Identity
+
+    @Test("same-name keys with different Value types occupy distinct slots")
+    func sameNameDifferentValueTypesDoNotCollide() async throws {
+        let stringKey = ContextKey<String>("shared_name")
+        let intKey = ContextKey<Int>("shared_name")
+        let context = AgentContext(input: "test")
+
+        await context.setTyped(stringKey, value: "hello")
+        await context.setTyped(intKey, value: 42)
+
+        let stringValue = await context.getTyped(stringKey)
+        let intValue = await context.getTyped(intKey)
+        #expect(stringValue == "hello")
+        #expect(intValue == 42)
+    }
+
+    @Test("overwriting one same-named key leaves the other untouched")
+    func overwritingSameNamedKeyDoesNotLeak() async throws {
+        let boolKey = ContextKey<Bool>("shared_name_2")
+        let doubleKey = ContextKey<Double>("shared_name_2")
+        let context = AgentContext(input: "test")
+
+        await context.setTyped(boolKey, value: true)
+        await context.setTyped(doubleKey, value: 1.5)
+        await context.setTyped(boolKey, value: false)
+
+        #expect(await context.getTyped(doubleKey) == 1.5)
+        #expect(await context.getTyped(boolKey) == false)
+    }
+
+    // MARK: - Round-Trip Exactness
+
+    @Test("typed round trip returns the exact stored value for standard keys")
+    func typedRoundTripStandardKeys() async throws {
+        let context = AgentContext(input: "test")
+
+        let stamp = Date(timeIntervalSince1970: 1_793_200_000.123456)
+        await context.setTyped(.userID, value: "user-123")
+        await context.setTyped(.requestCount, value: 7)
+        await context.setTyped(ContextKey<Double>("pi"), value: 3.14)
+        await context.setTyped(.isAuthenticated, value: true)
+        await context.setTyped(.tags, value: ["alpha", "beta"])
+        await context.setTyped(.timestamp, value: stamp)
+        await context.setTyped(
+            ContextKey<UserProfile>("profile"),
+            value: UserProfile(id: "u1", score: 99.5)
+        )
+
+        #expect(await context.getTyped(.userID) == "user-123")
+        #expect(await context.getTyped(.requestCount) == 7)
+        #expect(await context.getTyped(ContextKey<Double>("pi")) == 3.14)
+        #expect(await context.getTyped(.isAuthenticated) == true)
+        #expect(await context.getTyped(.tags) == ["alpha", "beta"])
+        #expect(await context.getTyped(.timestamp) == stamp)
+        #expect(
+            await context.getTyped(ContextKey<UserProfile>("profile"))
+                == UserProfile(id: "u1", score: 99.5)
+        )
+    }
+
+    @Test("Date keys stored via timestamp doubles still decode")
+    func dateFromTimestampPayloadDecodes() async throws {
+        let context = AgentContext(input: "test")
+
+        await context.setTyped(.expiresAt, value: Date(timeIntervalSince1970: 1_900_000_000))
+
+        let decoded = await context.getTyped(.expiresAt)
+        #expect(decoded == Date(timeIntervalSince1970: 1_900_000_000))
+    }
+
+    @Test("getTyped default returns stored value or fallback")
+    func getTypedWithDefault() async throws {
+        let context = AgentContext(input: "test")
+
+        let missing = await context.getTyped(.retryCount, default: 5)
+        #expect(missing == 5)
+
+        await context.setTyped(.retryCount, value: 2)
+        let present = await context.getTyped(.retryCount, default: 5)
+        #expect(present == 2)
+    }
+
+    @Test("removeTyped and hasTyped target only their own slot")
+    func removeAndHasSemantics() async throws {
+        let context = AgentContext(input: "test")
+        await context.setTyped(.userID, value: "u-1")
+        await context.setTyped(ContextKey<Int>("user_id"), value: 9)
+
+        #expect(await context.hasTyped(.userID))
+        await context.removeTyped(.userID)
+        #expect(await context.hasTyped(.userID) == false)
+        // Same name, different Value type keeps its own slot.
+        #expect(await context.getTyped(ContextKey<Int>("user_id")) == 9)
+        #expect(await context.getTyped(.userID) == nil)
+    }
+
+    // MARK: - Namespace Separation
+
+    @Test("typed writes are not visible through untyped reads and vice versa")
+    func typedAndRawNamespacesStaySeparate() async throws {
+        let context = AgentContext(input: "test")
+
+        await context.setTyped(.userID, value: "x")
+        #expect(await context.get("user_id") == nil)
+
+        // A raw write does not touch the typed slot.
+        await context.set("user_id", value: .string("y"))
+        #expect(await context.getTyped(.userID) == "x")
+        #expect(await context.hasTyped(.userID))
+
+        // Removing the typed slot leaves the raw entry intact.
+        await context.removeTyped(.userID)
+        #expect(await context.getTyped(.userID) == nil)
+        #expect(await context.get("user_id") == .string("y"))
+
+        // Raw entries keep flowing through the raw API.
+        #expect(await context.get("user_id") == .string("y"))
+    }
+
+    // MARK: - Snapshot Behavior
+
+    @Test("snapshot projects typed slots by name and preserves raw entries")
+    func snapshotIncludesTypedSlotsAndRawEntries() async throws {
+        let context = AgentContext(input: "hello", initialValues: ["branch": .string("main")])
+        let stamp = Date(timeIntervalSince1970: 1_700_000_000)
+
+        await context.setTyped(.userID, value: "u-9")
+        await context.setTyped(.depth, value: 3)
+        await context.setTyped(.timestamp, value: stamp)
+
+        let snap = await context.snapshot
+        #expect(snap["branch"] == .string("main"))
+        #expect(snap[AgentContextKey.originalInput.rawValue] == .string("hello"))
+        #expect(snap["user_id"] == .string("u-9"))
+        #expect(snap["depth"] == .int(3))
+
+        let timestampPayload = try #require(snap["timestamp"])
+        switch timestampPayload {
+        case let .double(seconds):
+            #expect(Date(timeIntervalSince1970: seconds) == stamp)
+        case let .int(seconds):
+            #expect(Date(timeIntervalSince1970: Double(seconds)) == stamp)
+        default:
+            Issue.record("Expected timestamp payload encoded as a number")
+        }
+    }
+
+    @Test("raw entries win when a raw key collides with a projected slot name")
+    func snapshotRawEntriesTakePrecedence() async throws {
+        let context = AgentContext(input: "test")
+
+        await context.setTyped(.sessionID, value: "from-typed-slot")
+        await context.set("session_id", value: .string("from-raw"))
+
+        let snap = await context.snapshot
+        #expect(snap["session_id"] == .string("from-raw"))
+    }
+
+    @Test("allKeys includes typed slot names alongside raw keys")
+    func allKeysIncludesSlotNames() async throws {
+        let context = AgentContext(input: "test")
+        await context.setTyped(.correlationID, value: "c-1")
+        await context.set("plain", value: .int(1))
+
+        let keys = Set(await context.allKeys)
+        #expect(keys.contains("correlation_id"))
+        #expect(keys.contains("plain"))
+        #expect(keys.contains(AgentContextKey.originalInput.rawValue))
+    }
+
+    // MARK: - Merge Behavior
+
+    @Test("merge carries typed values and respects overwrite flag")
+    func mergeCarriesTypedValues() async throws {
+        let parent = AgentContext(input: "parent")
+        await parent.setTyped(.userID, value: "p-user")
+        await parent.addMessage(MemoryMessage.user("hello"))
+
+        let child = AgentContext(input: "child")
+        await child.setTyped(.userID, value: "c-user")
+        await child.setTyped(.depth, value: 1)
+
+        await child.merge(from: parent, overwrite: false)
+        #expect(await child.getTyped(.userID) == "c-user")
+        #expect(await child.getTyped(.depth) == 1)
+
+        await child.merge(from: parent, overwrite: true)
+        #expect(await child.getTyped(.userID) == "p-user")
+
+        let messages = await child.getMessages()
+        #expect(messages.count == 1)
+        #expect(messages.first?.content == "hello")
+    }
+
+    @Test("merge keeps execution path tracking intact")
+    func mergePreservesExecutionPath() async throws {
+        let parent = AgentContext(input: "parent")
+        await parent.recordExecution(agentName: "Fetcher")
+
+        let child = AgentContext(input: "child")
+        await child.recordExecution(agentName: "Analyzer")
+        await child.merge(from: parent)
+
+        let path = await child.getExecutionPath()
+        #expect(path.contains("Fetcher"))
+        #expect(path.contains("Analyzer"))
+    }
+
+    @Test("merge does not displace a local typed slot with an incoming same-named value")
+    func mergeKeepsLocalSlotWithoutOverwrite() async throws {
+        let parent = AgentContext(input: "parent")
+        await parent.setTyped(.userID, value: "parent-user")
+
+        let child = AgentContext(input: "child")
+        await child.setTyped(.userID, value: "child-user")
+
+        await child.merge(from: parent, overwrite: false)
+        #expect(await child.getTyped(.userID) == "child-user")
+        // The projected payload must not shadow the live slot in snapshots.
+        #expect(await child.snapshot["user_id"] == .string("child-user"))
+
+        await child.merge(from: parent, overwrite: true)
+        #expect(await child.getTyped(.userID) == "parent-user")
+        #expect(await child.snapshot["user_id"] == .string("parent-user"))
+    }
+
+    // MARK: - Copy Behavior
+
+    @Test("copy carries typed values and lands additionalValues in the raw namespace")
+    func copyCarriesTypedValues() async throws {
+        let source = AgentContext(input: "source")
+        await source.setTyped(.userID, value: "copied-user")
+
+        let branch = await source.copy(additionalValues: ["mode": .string("experimental")])
+
+        #expect(await branch.getTyped(.userID) == "copied-user")
+        #expect(await branch.get("mode") == .string("experimental"))
+        #expect(await branch.originalInput == "source")
+
+        // The copy is independent of its source.
+        await branch.setTyped(.userID, value: "changed-in-copy")
+        #expect(await source.getTyped(.userID) == "copied-user")
+    }
+
+    // MARK: - Deprecated AgentContextProviding Shim
+
+    @Test("deprecated AgentContextProviding shim stores and retrieves instances")
+    func providedShimStillFunctions() async throws {
+        let context = AgentContext(input: "test")
+
+        await context.setTyped(LegacyUserContext(userId: "u-42", isAdmin: true))
+        let retrieved = await context.typed(LegacyUserContext.self)
+        #expect(retrieved?.userId == "u-42")
+        #expect(retrieved?.isAdmin == true)
+    }
+
+    @Test("deprecated shim supports has, overwrite, removal, and coexistence")
+    func providedShimHasRemoveCoexist() async throws {
+        let context = AgentContext(input: "test")
+
+        #expect(await context.hasTyped(LegacyUserContext.self) == false)
+        #expect(await context.removeTyped(LegacyUserContext.self) == nil)
+        #expect(await context.typed(LegacyUserContext.self) == nil)
+
+        await context.setTyped(LegacyUserContext(userId: "first", isAdmin: false))
+        await context.setTyped(LegacyUserContext(userId: "second", isAdmin: true))
+        let overwritten = await context.typed(LegacyUserContext.self)
+        #expect(overwritten?.userId == "second")
+
+        await context.setTyped(LegacySessionContext(sessionId: "s-1"))
+        let user = await context.typed(LegacyUserContext.self)
+        let session = await context.typed(LegacySessionContext.self)
+        #expect(user?.userId == "second")
+        #expect(session?.sessionId == "s-1")
+
+        let removed = await context.removeTyped(LegacyUserContext.self)
+        #expect(removed?.userId == "second")
+        #expect(await context.hasTyped(LegacyUserContext.self) == false)
+        #expect(await context.hasTyped(LegacySessionContext.self))
+    }
+
+    @Test("deprecated shim instances do not appear in snapshots")
+    func providedShimStaysOutOfSnapshots() async throws {
+        let context = AgentContext(input: "test")
+        await context.setTyped(LegacyUserContext(userId: "u-1", isAdmin: false))
+
+        let snap = await context.snapshot
+        #expect(snap["legacy_user_context"] == nil)
+    }
+}

--- a/Tests/SwarmTests/Core/ContextStoreUnificationTests.swift
+++ b/Tests/SwarmTests/Core/ContextStoreUnificationTests.swift
@@ -544,4 +544,24 @@ struct ContextStoreUnificationTests {
         await child.removeTyped(ContextKey<Int>("user_id"))
         #expect(await child.snapshot["user_id"] == .string("parent-user"))
     }
+
+    @Test("merge without overwrite does not let parent raw steal a local typed snapshot name")
+    func mergeWithoutOverwriteKeepsLocalTypedNameAgainstParentRaw() async throws {
+        let parent = AgentContext(input: "parent")
+        await parent.set("user_id", value: .string("parent-raw"))
+
+        let child = AgentContext(input: "child")
+        await child.setTyped(ContextKey<Int>("user_id"), value: 42)
+
+        await child.merge(from: parent, overwrite: false)
+
+        #expect(await child.getTyped(ContextKey<Int>("user_id")) == 42)
+        #expect(await child.snapshot["user_id"] == .int(42))
+        #expect(await child.get("user_id") == nil)
+
+        await child.removeTyped(ContextKey<Int>("user_id"))
+        #expect(await child.getTyped(ContextKey<Int>("user_id")) == nil)
+        #expect(await child.get("user_id") == nil)
+        #expect(await child.snapshot["user_id"] == nil)
+    }
 }

--- a/Tests/SwarmTests/Core/ContextStoreUnificationTests.swift
+++ b/Tests/SwarmTests/Core/ContextStoreUnificationTests.swift
@@ -263,6 +263,20 @@ struct ContextStoreUnificationTests {
         #expect(await child.snapshot["user_id"] == .string("parent-user"))
     }
 
+    @Test("merge keeps most-recent same-named slot winning across value types")
+    func mergePreservesSameNamedRecencyAcrossValueTypes() async throws {
+        let parent = AgentContext(input: "parent")
+        await parent.setTyped(ContextKey<Int>("recency_name"), value: 1)
+        await parent.setTyped(ContextKey<String>("recency_name"), value: "newest")
+
+        let child = AgentContext(input: "child")
+        await child.merge(from: parent)
+
+        #expect(await child.snapshot["recency_name"] == .string("newest"))
+        #expect(await child.getTyped(ContextKey<String>("recency_name")) == "newest")
+        #expect(await child.getTyped(ContextKey<Int>("recency_name")) == 1)
+    }
+
     // MARK: - Copy Behavior
 
     @Test("copy carries typed values and lands additionalValues in the raw namespace")
@@ -279,6 +293,18 @@ struct ContextStoreUnificationTests {
         // The copy is independent of its source.
         await branch.setTyped(.userID, value: "changed-in-copy")
         #expect(await source.getTyped(.userID) == "copied-user")
+    }
+
+    @Test("copy keeps most-recent same-named slot winning across value types")
+    func copyPreservesSameNamedRecencyAcrossValueTypes() async throws {
+        let context = AgentContext(input: "test")
+        await context.setTyped(ContextKey<Int>("recency_name"), value: 1)
+        await context.setTyped(ContextKey<String>("recency_name"), value: "newest")
+
+        let branch = await context.copy()
+        #expect(await branch.snapshot["recency_name"] == .string("newest"))
+        #expect(await branch.getTyped(ContextKey<String>("recency_name")) == "newest")
+        #expect(await branch.getTyped(ContextKey<Int>("recency_name")) == 1)
     }
 
     // MARK: - Deprecated AgentContextProviding Shim

--- a/Tests/SwarmTests/Core/ContextStoreUnificationTests.swift
+++ b/Tests/SwarmTests/Core/ContextStoreUnificationTests.swift
@@ -564,4 +564,96 @@ struct ContextStoreUnificationTests {
         #expect(await child.get("user_id") == nil)
         #expect(await child.snapshot["user_id"] == nil)
     }
+
+    @Test("merge captures parent raw and slots together so a typed-to-raw replacement is not dropped")
+    func mergeDoesNotDropReplacementWhenParentMovesTypedToRawBetweenFormerHops() async throws {
+        let parent = AgentContext(input: "parent")
+        await parent.setTyped(.userID, value: "typed")
+
+        // Former merge hops: `rawValues()` then `valueSlotStore()`. Mutating
+        // the parent between them captures empty raw with empty slots and
+        // drops the replacement.
+        let staleRaw = await parent.rawValuesAndValueSlots().raw
+        await parent.removeTyped(.userID)
+        await parent.set("user_id", value: .string("raw-replacement"))
+        let freshSlots = await parent.rawValuesAndValueSlots().slots
+        #expect(staleRaw["user_id"] == nil)
+        #expect(freshSlots.valuePayload(for: .userID) == nil)
+
+        let child = AgentContext(input: "child")
+        await child.merge(from: parent, overwrite: true)
+
+        #expect(await child.get("user_id") == .string("raw-replacement"))
+        #expect(await child.getTyped(.userID) == nil)
+        #expect(await child.snapshot["user_id"] == .string("raw-replacement"))
+        await child.removeTyped(.userID)
+        #expect(await child.get("user_id") == .string("raw-replacement"))
+        #expect(await child.snapshot["user_id"] == .string("raw-replacement"))
+    }
+
+    @Test("merge captures parent raw and slots together so a raw-to-typed replacement is not duplicated")
+    func mergeDoesNotDuplicateReplacementWhenParentMovesRawToTypedBetweenFormerHops() async throws {
+        let parent = AgentContext(input: "parent")
+        await parent.set("user_id", value: .string("raw"))
+
+        let staleRaw = await parent.rawValuesAndValueSlots().raw
+        await parent.remove("user_id")
+        await parent.setTyped(.userID, value: "typed-replacement")
+        let freshSlots = await parent.rawValuesAndValueSlots().slots
+        #expect(staleRaw["user_id"] == .string("raw"))
+        #expect(freshSlots.valuePayload(for: .userID) == .string("typed-replacement"))
+
+        let child = AgentContext(input: "child")
+        await child.merge(from: parent, overwrite: true)
+
+        #expect(await child.get("user_id") == nil)
+        #expect(await child.getTyped(.userID) == "typed-replacement")
+        #expect(await child.snapshot["user_id"] == .string("typed-replacement"))
+        await child.removeTyped(.userID)
+        #expect(await child.getTyped(.userID) == nil)
+        #expect(await child.get("user_id") == nil)
+        #expect(await child.snapshot["user_id"] == nil)
+    }
+
+    @Test("merge does not duplicate a raw-to-typed replacement that races the parent capture")
+    func mergeDoesNotDuplicateWhenParentMovesRawToTypedConcurrently() async throws {
+        // Parent never holds both namespaces during this replacement. A split
+        // capture (rawValues then valueSlotStore) can still copy stale raw
+        // plus the new slot, so snapshot/getTyped/removeTyped disagree.
+        for _ in 0..<40 {
+            let parent = AgentContext(input: "parent")
+            await parent.set("user_id", value: .string("raw"))
+
+            let child = AgentContext(input: "child")
+            await withTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    await child.merge(from: parent, overwrite: true)
+                }
+                group.addTask {
+                    await parent.remove("user_id")
+                    await parent.setTyped(.userID, value: "typed-replacement")
+                }
+            }
+
+            let snap = await child.snapshot["user_id"]
+            let typed = await child.getTyped(.userID)
+            let raw = await child.get("user_id")
+            #expect(raw == nil || typed == nil)
+
+            if typed == "typed-replacement" {
+                #expect(raw == nil)
+                #expect(snap == .string("typed-replacement"))
+                await child.removeTyped(.userID)
+                #expect(await child.get("user_id") == nil)
+                #expect(await child.snapshot["user_id"] == nil)
+            } else if raw == .string("raw") {
+                #expect(typed == nil)
+                #expect(snap == .string("raw"))
+            } else {
+                #expect(typed == nil)
+                #expect(raw == nil)
+                #expect(snap == nil)
+            }
+        }
+    }
 }

--- a/Tests/SwarmTests/Core/ContextStoreUnificationTests.swift
+++ b/Tests/SwarmTests/Core/ContextStoreUnificationTests.swift
@@ -32,6 +32,25 @@ private struct LegacySessionContext: AgentContextProviding {
     let sessionId: String
 }
 
+/// An enum with associated values used to exercise codec round-trips that
+/// must not corrupt case payloads.
+private enum AssociatedValueEnum: Codable, Equatable, Sendable {
+    case count(Int)
+    case label(String)
+}
+
+/// A Codable type whose `encode(to:)` always throws, forcing the codec's
+/// description-string fallback; its synthesized decoder requires a field
+/// the fallback cannot supply, so typed reads of the fallback return nil.
+private struct UnencodableButDecodable: Codable, Sendable {
+    let required: Int
+
+    func encode(to encoder: any Encoder) throws {
+        struct EncodingUnavailable: Error {}
+        throw EncodingUnavailable()
+    }
+}
+
 // MARK: - ContextStoreUnificationTests
 
 @Suite("Context Store Unification")
@@ -365,5 +384,112 @@ struct ContextStoreUnificationTests {
 
         let snap = await context.snapshot
         #expect(snap["legacy_user_context"] == nil)
+    }
+
+    // MARK: - Codec Edge Cases
+
+    @Test("enums with associated values round-trip without corrupting cases")
+    func associatedValueEnumRoundTrips() async throws {
+        let context = AgentContext(input: "test")
+
+        await context.setTyped(ContextKey<AssociatedValueEnum>("en_count"), value: .count(5))
+        await context.setTyped(ContextKey<AssociatedValueEnum>("en_label"), value: .label("x"))
+
+        #expect(await context.getTyped(ContextKey<AssociatedValueEnum>("en_count")) == .count(5))
+        #expect(await context.getTyped(ContextKey<AssociatedValueEnum>("en_label")) == .label("x"))
+    }
+
+    @Test("nested SendableValue containers round-trip")
+    func nestedContainersRoundTrip() async throws {
+        let context = AgentContext(input: "test")
+        let nested: [String: SendableValue] = [
+            "a": .array([.int(1), .string("s")]),
+            "b": .bool(true),
+        ]
+
+        await context.setTyped(ContextKey<[String: SendableValue]>("nest"), value: nested)
+        await context.setTyped(ContextKey<[SendableValue]>("arr"), value: [.double(1.5), .null])
+
+        #expect(await context.getTyped(ContextKey<[String: SendableValue]>("nest")) == nested)
+        #expect(await context.getTyped(ContextKey<[SendableValue]>("arr")) == [.double(1.5), .null])
+    }
+
+    @Test("optional none stores a null slot that reads back as absent")
+    func optionalNoneSlotSemantics() async throws {
+        let key = ContextKey<String?>("opt_none")
+        let context = AgentContext(input: "test")
+
+        await context.setTyped(key, value: nil)
+
+        // The slot exists and projects a null payload; the typed read
+        // succeeds decoding `null` as String?, yielding .some(.none).
+        #expect(await context.hasTyped(key))
+        #expect(await context.snapshot["opt_none"] == .null)
+        let decoded = await context.valueSlotPayload(for: key)
+        #expect(decoded == .null)
+        // A present-optional write still round-trips exactly.
+        let someKey = ContextKey<String?>("opt_some")
+        await context.setTyped(someKey, value: "present")
+        #expect(await context.getTyped(someKey) == "present")
+    }
+
+    @Test("unencodable value falls back to a description string that fails to decode")
+    func unencodableFallsBackToInertStringPayload() async throws {
+        let key = ContextKey<UnencodableButDecodable>("boom")
+        let context = AgentContext(input: "test")
+
+        await context.setTyped(key, value: UnencodableButDecodable(required: 7))
+
+        // Write never throws (fallback stored); the payload is inert for
+        // typed reads: has stays true, the read returns nil, nothing is
+        // corrupted.
+        #expect(await context.hasTyped(key))
+        #expect(await context.getTyped(key) == nil)
+        #expect(await context.snapshot["boom"]?.stringValue?.isEmpty == false)
+    }
+
+    @Test("whole-number doubles collapse to int payloads but read back exact")
+    func wholeDoublePayloadCollapsesNumericallyLosslessly() async throws {
+        let context = AgentContext(input: "test")
+
+        await context.setTyped(ContextKey<Double>("whole"), value: 2.0)
+
+        // JSON cannot distinguish 2 from 2.0, so the projected payload
+        // decodes as an integer; the Double read remains numerically exact.
+        let snap = try #require(await context.snapshot["whole"])
+        guard case .int = snap else {
+            Issue.record("expected integer-shaped payload for whole double, got \(snap)")
+            return
+        }
+        #expect(await context.getTyped(ContextKey<Double>("whole")) == 2.0)
+    }
+
+    @Test("date keys stay exact at sub-second precision and far-future epochs")
+    func dateExtremeValuesStayExact() async throws {
+        let context = AgentContext(input: "test")
+        let tiny = Date(timeIntervalSince1970: 0.000001)
+        let far = Date(timeIntervalSince1970: 4_102_444_800)
+
+        await context.setTyped(.timestamp, value: tiny)
+        await context.setTyped(ContextKey<Date>("far_future"), value: far)
+
+        #expect(await context.getTyped(.timestamp) == tiny)
+        #expect(await context.getTyped(ContextKey<Date>("far_future")) == far)
+    }
+
+    @Test("merge without overwrite keeps raw entry in snapshot while merging the slot")
+    func mergeWithoutOverwriteSeparatesRawEntryFromMergedSlot() async throws {
+        let parent = AgentContext(input: "parent")
+        await parent.setTyped(.userID, value: "from-slot")
+
+        let child = AgentContext(input: "child")
+        await child.set("user_id", value: .string("raw-local"))
+        await child.merge(from: parent, overwrite: false)
+
+        // Snapshot projection: existing raw entry wins.
+        #expect(await child.snapshot["user_id"] == .string("raw-local"))
+        // Typed namespace still received the merged slot.
+        #expect(await child.getTyped(.userID) == "from-slot")
+        #expect(await child.get("user_id") == .string("raw-local"))
     }
 }

--- a/Tests/SwarmTests/Core/ContextStoreUnificationTests.swift
+++ b/Tests/SwarmTests/Core/ContextStoreUnificationTests.swift
@@ -277,6 +277,20 @@ struct ContextStoreUnificationTests {
         #expect(await child.getTyped(ContextKey<Int>("recency_name")) == 1)
     }
 
+    @Test("store-level merge re-stamps incoming slots in source-recency order")
+    func storeMergeRestampsInSourceRecencyOrder() {
+        var source = ContextSlotStore()
+        source.setValuePayload(ContextKey<Int>("recency_name"), payload: .int(1))
+        source.setValuePayload(ContextKey<String>("recency_name"), payload: .string("newest"))
+
+        var merged = ContextSlotStore()
+        merged.mergeValueSlots(from: source, overwrite: false)
+
+        #expect(merged.projectedValues()["recency_name"] == .string("newest"))
+        #expect(merged.valuePayload(for: ContextKey<Int>("recency_name")) == .int(1))
+        #expect(merged.valuePayload(for: ContextKey<String>("recency_name")) == .string("newest"))
+    }
+
     // MARK: - Copy Behavior
 
     @Test("copy carries typed values and lands additionalValues in the raw namespace")

--- a/docs/reference/api-catalog.md
+++ b/docs/reference/api-catalog.md
@@ -3,7 +3,7 @@
 Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for high-risk public rows on 2026-07-28 (Conduit hard-removed in 0.6). MCP client rows refreshed 2026-08-14. OpenAI-compatible provider rows added 2026-08-14.
 
 - Scope: all `.swift` files under `Sources/Swarm/`, excluding `Internal/GraphRuntime/`
-- Source files scanned: 183
+- Source files scanned: 185
 - Public/open symbols cataloged: 2325
 
 ## 1. Swarm (entry point)


### PR DESCRIPTION
## Ticket T2 — spec `spec-architecture-typed-seams` (local-only internal spec)

Unifies `AgentContext`'s two parallel typed-context mechanisms behind phantom-typed `ContextKey<Value>` identity. Wrong key/value pairs stop compiling; silent `as?` nils disappear from typed-store paths.

### What
- NEW `Sources/Swarm/Core/Execution/ContextSlotStore.swift`: unified slot store keyed by `(ObjectIdentifier(Value.Type), key.name)` — same-name/different-type collisions structurally impossible.
- NEW `Sources/Swarm/Core/Execution/ContextValueCodec.swift`: Codable-based encode/decode (`.secondsSince1970` for Date), fixing the old reference-date/1970 epoch mismatch on Date keys.
- `AgentContext.swift`: single store behind unchanged public shapes (`setTyped/getTyped/removeTyped/hasTyped`, snapshot/merge/copy semantics preserved).
- `AgentContextProviding` reimplemented over the store and marked deprecated toward `ContextKey<Value>` (repo-standard deprecation style).

### Verification
- Lean lane build green; full suite 1979 tests with only the known pre-existing `DocumentationFreshnessTests` catalog-count failure (docs-sync ticket fixes it).
- New suite "Context Store Unification": 22 tests incl. collision-impossibility, exact round-trip, namespace separation, merge/copy recency determinism.
- `rg -n "as\? T" Sources/Swarm/Core/Execution/` → zero hits.

### Reviews (fresh-context per pipeline)
1. Reviewer A — `swift-pr-review`: fixed nondeterministic write-stamp ordering in copy/merge re-stamping (871ceff6); audited the one intentional existential crossing in the deprecated shim as provably infallible.
2. Final pass — `swift-pr-review`: R2-01 stays-fixed; added a genuine store-level regression pin that survives comparator inversion, bypassing a raw-namespace projection mask (F2-01, 2db49e6c); all dismissals upheld.

### Notes for reviewers of this PR
- Deprecation warnings at `APIAuditTests.swift:28,38` are expected (existing conformers of the now-deprecated protocol; file intentionally untouched).
- One documented infallible `as? Value` crossing remains inside `ContextSlotStore.extract` for the deprecated shim — slot identity pins the concrete type; detailed rationale in commit history.
