### PR TITLE
arch(T1): inject clock/randomness into resilience enforcement

### DIFF
--- a/Sources/Swarm/Resilience/CircuitBreaker.swift
+++ b/Sources/Swarm/Resilience/CircuitBreaker.swift
@@ -5,6 +5,40 @@
 
 import Foundation
 
+// MARK: - BreakerClock
+
+/// Provides the current instant used by circuit breaker state transitions.
+///
+/// The default clock reads the wall clock. Tests inject fixed or stepped
+/// instants to drive open/half-open/closed transitions deterministically
+/// without real waiting.
+///
+/// Example:
+/// ```swift
+/// let clock = BreakerClock(now: { fixedDate })
+/// let breaker = CircuitBreaker(name: "test", clock: clock)
+/// ```
+public struct BreakerClock: Sendable {
+    // MARK: Private
+
+    private let provider: @Sendable () -> Date
+
+    // MARK: - Initialization
+
+    /// Creates a clock backed by a custom instant provider.
+    /// - Parameter now: Closure producing the current instant (default: `Date()`).
+    public init(now: @escaping @Sendable () -> Date = { Date() }) {
+        self.provider = now
+    }
+
+    // MARK: - Public API
+
+    /// Returns the current instant.
+    public func now() -> Date {
+        provider()
+    }
+}
+
 // MARK: - CircuitBreaker
 
 /// Actor-based circuit breaker for preventing cascading failures.
@@ -70,18 +104,21 @@ public actor CircuitBreaker {
     ///   - successThreshold: Number of consecutive successes to close from half-open (default: 2).
     ///   - resetTimeout: Time in seconds before attempting recovery (default: 60.0).
     ///   - halfOpenMaxRequests: Maximum concurrent requests in half-open state (default: 1).
+    ///   - clock: Time source for state transitions (default: wall clock).
     public init(
         name: String,
         failureThreshold: Int = 5,
         successThreshold: Int = 2,
         resetTimeout: TimeInterval = 60.0,
-        halfOpenMaxRequests: Int = 1
+        halfOpenMaxRequests: Int = 1,
+        clock: BreakerClock = BreakerClock()
     ) {
         self.name = name
         self.failureThreshold = max(1, failureThreshold)
         self.successThreshold = max(1, successThreshold)
         self.resetTimeout = max(0, resetTimeout)
         self.halfOpenMaxRequests = max(1, halfOpenMaxRequests)
+        self.clock = clock
     }
 
     // MARK: - Public API
@@ -132,7 +169,7 @@ public actor CircuitBreaker {
 
     /// Manually opens the circuit breaker.
     public func trip() async {
-        let openUntil = Date().addingTimeInterval(resetTimeout)
+        let openUntil = clock.now().addingTimeInterval(resetTimeout)
         state = .open(until: openUntil)
         consecutiveSuccesses = 0
     }
@@ -170,6 +207,9 @@ public actor CircuitBreaker {
 
     /// Timestamp of last failure.
     private var lastFailureTime: Date?
+
+    /// Time source driving state transitions.
+    private let clock: BreakerClock
 
     // MARK: - Private Helpers
 
@@ -211,18 +251,18 @@ public actor CircuitBreaker {
         totalFailures += 1
         consecutiveFailures += 1
         consecutiveSuccesses = 0
-        lastFailureTime = Date()
+        lastFailureTime = clock.now()
 
         switch state {
         case .closed:
             if consecutiveFailures >= failureThreshold {
                 // Transition to open
-                let openUntil = Date().addingTimeInterval(resetTimeout)
+                let openUntil = clock.now().addingTimeInterval(resetTimeout)
                 state = .open(until: openUntil)
             }
         case .halfOpen:
             // Any failure in half-open transitions back to open
-            let openUntil = Date().addingTimeInterval(resetTimeout)
+            let openUntil = clock.now().addingTimeInterval(resetTimeout)
             state = .open(until: openUntil)
         case .open:
             // Already open, no state change needed
@@ -236,7 +276,7 @@ public actor CircuitBreaker {
             return
         }
 
-        if Date() >= until {
+        if clock.now() >= until {
             // Transition to half-open
             state = .halfOpen
             consecutiveSuccesses = 0

--- a/Sources/Swarm/Resilience/RateLimiter.swift
+++ b/Sources/Swarm/Resilience/RateLimiter.swift
@@ -5,6 +5,46 @@
 
 import Foundation
 
+// MARK: - RateLimiterClock
+
+/// Time source driving token refill and acquisition waits for `RateLimiter`.
+///
+/// The default reads the continuous clock and sleeps with `Task.sleep`.
+/// Tests inject fixed or stepped instants plus a no-op (or clock-advancing)
+/// sleep to exercise refill math deterministically without real waiting.
+public struct RateLimiterClock: Sendable {
+    // MARK: Private
+
+    private let nowProvider: @Sendable () -> ContinuousClock.Instant
+    private let sleepHandler: @Sendable (Duration) async throws -> Void
+
+    // MARK: - Initialization
+
+    /// Creates a clock backed by custom instant and sleep handlers.
+    /// - Parameters:
+    ///   - now: Closure producing the current instant (default: `ContinuousClock.now`).
+    ///   - sleep: Async suspension handler (default: `Task.sleep(for:)`).
+    public init(
+        now: @escaping @Sendable () -> ContinuousClock.Instant = { ContinuousClock.now },
+        sleep: @escaping @Sendable (Duration) async throws -> Void = { try await Task.sleep(for: $0) }
+    ) {
+        self.nowProvider = now
+        self.sleepHandler = sleep
+    }
+
+    // MARK: - Public API
+
+    /// Returns the current instant.
+    public func now() -> ContinuousClock.Instant {
+        nowProvider()
+    }
+
+    /// Suspends for the requested duration.
+    public func sleep(for duration: Duration) async throws {
+        try await sleepHandler(duration)
+    }
+}
+
 // MARK: - RateLimiter
 
 /// Token bucket rate limiter for API calls
@@ -37,16 +77,31 @@ public actor RateLimiter {
     }
 
     /// Create rate limiter with requests per minute
-    public init(maxRequestsPerMinute: Int) {
+    /// - Parameters:
+    ///   - maxRequestsPerMinute: Requests allowed per minute.
+    ///   - clock: Time source for refill and acquisition waits (default: wall clock).
+    public init(
+        maxRequestsPerMinute: Int,
+        clock: RateLimiterClock = RateLimiterClock()
+    ) {
         let normalizedMaxRequests = max(1, maxRequestsPerMinute)
         maxTokens = normalizedMaxRequests
         refillRate = max(1.0 / 60.0, Double(normalizedMaxRequests) / 60.0)
         availableTokens = Double(normalizedMaxRequests)
-        lastRefillTime = .now
+        lastRefillTime = clock.now()
+        self.clock = clock
     }
 
     /// Create rate limiter with custom token bucket parameters
-    public init(maxTokens: Int, refillRatePerSecond: Double) {
+    /// - Parameters:
+    ///   - maxTokens: Bucket capacity.
+    ///   - refillRatePerSecond: Tokens added per second.
+    ///   - clock: Time source for refill and acquisition waits (default: wall clock).
+    public init(
+        maxTokens: Int,
+        refillRatePerSecond: Double,
+        clock: RateLimiterClock = RateLimiterClock()
+    ) {
         let normalizedMaxTokens = max(1, maxTokens)
         let normalizedRefillRate = refillRatePerSecond.isFinite && refillRatePerSecond > 0
             ? refillRatePerSecond
@@ -55,7 +110,8 @@ public actor RateLimiter {
         self.maxTokens = normalizedMaxTokens
         refillRate = normalizedRefillRate
         availableTokens = Double(normalizedMaxTokens)
-        lastRefillTime = .now
+        lastRefillTime = clock.now()
+        self.clock = clock
     }
 
     /// Acquire a token, waiting if necessary
@@ -66,7 +122,7 @@ public actor RateLimiter {
         while availableTokens < 1 {
             let rawWaitTime = (1 - availableTokens) / refillRate
             let waitTime = rawWaitTime.isFinite && rawWaitTime > 0 ? rawWaitTime : 0
-            try await Task.sleep(for: .seconds(waitTime))
+            try await clock.sleep(for: .seconds(waitTime))
             try Task.checkCancellation()
             refill()
         }
@@ -87,7 +143,7 @@ public actor RateLimiter {
     /// Reset the limiter to full capacity
     public func reset() {
         availableTokens = Double(maxTokens)
-        lastRefillTime = .now
+        lastRefillTime = clock.now()
     }
 
     // MARK: Private
@@ -97,8 +153,11 @@ public actor RateLimiter {
     private var availableTokens: Double
     private var lastRefillTime: ContinuousClock.Instant
 
+    /// Time source driving refill and acquisition waits.
+    private let clock: RateLimiterClock
+
     private func refill() {
-        let now = ContinuousClock.now
+        let now = clock.now()
         let elapsed = now - lastRefillTime
         let tokensToAdd = elapsed.seconds * refillRate
         availableTokens = min(Double(maxTokens), availableTokens + tokensToAdd)

--- a/Sources/Swarm/Resilience/RetryPolicy.swift
+++ b/Sources/Swarm/Resilience/RetryPolicy.swift
@@ -49,6 +49,38 @@ extension ResilienceError: CustomDebugStringConvertible {
     }
 }
 
+// MARK: - RetryRandomSource
+
+/// Randomness source used by jittered backoff strategies.
+///
+/// The default draws uniformly via `Double.random(in:)`. Tests inject a
+/// deterministic source to exercise jitter branches exactly.
+public struct RetryRandomSource: Sendable {
+    // MARK: Private
+
+    private let provider: @Sendable (ClosedRange<Double>) -> Double
+
+    // MARK: - Initialization
+
+    /// Creates a randomness source backed by a custom draw handler.
+    /// - Parameter randomIn: Closure drawing one uniform sample from the range
+    ///   (default: `Double.random(in:)`).
+    public init(
+        randomIn: @escaping @Sendable (ClosedRange<Double>) -> Double = { Double.random(in: $0) }
+    ) {
+        self.provider = randomIn
+    }
+
+    // MARK: - Public API
+
+    /// Draws one uniform sample from the given range.
+    /// - Parameter range: The closed range to draw from.
+    /// - Returns: The sampled value.
+    public func randomIn(_ range: ClosedRange<Double>) -> Double {
+        provider(range)
+    }
+}
+
 // MARK: - BackoffStrategy
 
 /// Strategies for calculating retry delays.
@@ -56,9 +88,15 @@ public enum BackoffStrategy: Sendable {
     // MARK: Public
 
     /// Calculate the delay for a given retry attempt.
-    /// - Parameter attempt: The attempt number (1-indexed).
+    /// - Parameters:
+    ///   - attempt: The attempt number (1-indexed).
+    ///   - randomSource: Source of randomness for jittered strategies
+    ///     (default: uniform `Double.random`).
     /// - Returns: The delay in seconds before the next retry.
-    public func delay(forAttempt attempt: Int) -> TimeInterval {
+    public func delay(
+        forAttempt attempt: Int,
+        randomSource: RetryRandomSource = RetryRandomSource()
+    ) -> TimeInterval {
         switch self {
         case let .fixed(delay):
             return delay
@@ -75,14 +113,14 @@ public enum BackoffStrategy: Sendable {
             let exponentialDelay = base * pow(multiplier, Double(attempt - 1))
             let cappedDelay = min(exponentialDelay, maxDelay)
             // Add random jitter between 0 and the calculated delay
-            let jitter = Double.random(in: 0...cappedDelay)
+            let jitter = randomSource.randomIn(0...cappedDelay)
             return jitter
 
         case let .decorrelatedJitter(base, maxDelay):
             // Decorrelated jitter: sleep = min(cap, random_between(base, sleep * 3))
             // For the first attempt, use base as the previous sleep
             let previousSleep = attempt == 1 ? base : base * pow(3.0, Double(attempt - 2))
-            let delay = Double.random(in: base...(previousSleep * 3.0))
+            let delay = randomSource.randomIn(base...(previousSleep * 3.0))
             return min(delay, maxDelay)
 
         case .immediate:
@@ -206,12 +244,19 @@ public struct RetryPolicy: Sendable {
     // MARK: - Execution
 
     /// Executes an operation with retry logic.
-    /// - Parameter operation: The async operation to execute.
+    /// - Parameters:
+    ///   - operation: The async operation to execute.
+    ///   - sleep: Suspension handler applied between retries, receiving the
+    ///     sanitized backoff delay in nanoseconds (default: `Task.sleep`).
+    ///   - randomSource: Randomness fed to jittered backoff strategies
+    ///     (default: uniform `Double.random`).
     /// - Returns: The result of the operation.
     /// - Throws: `ResilienceError.retriesExhausted` if all attempts fail, or the original error if retries are
     /// disabled.
     public func execute<T: Sendable>(
-        _ operation: @Sendable () async throws -> T
+        _ operation: @Sendable () async throws -> T,
+        sleep: @escaping @Sendable (UInt64) async throws -> Void = { try await Task.sleep(nanoseconds: $0) },
+        randomSource: RetryRandomSource = RetryRandomSource()
     ) async throws -> T {
         var retryCount = 0
         var lastError: Error?
@@ -241,9 +286,9 @@ public struct RetryPolicy: Sendable {
                 await onRetry?(retryCount, error)
 
                 // Calculate and apply backoff delay
-                let delay = sanitizeBackoffDelay(backoff.delay(forAttempt: retryCount))
+                let delay = sanitizeBackoffDelay(backoff.delay(forAttempt: retryCount, randomSource: randomSource))
                 if delay > 0 {
-                    try await Task.sleep(nanoseconds: delay)
+                    try await sleep(delay)
                 }
             }
         }

--- a/Tests/SwarmTests/Resilience/ResilienceTests+CircuitBreaker.swift
+++ b/Tests/SwarmTests/Resilience/ResilienceTests+CircuitBreaker.swift
@@ -118,10 +118,13 @@ struct CircuitBreakerTests {
 
     @Test("Circuit transitions to halfOpen after timeout")
     func circuitTransitionsToHalfOpen() async throws {
+        let now = SteppedDate()
+        let start = now.current
         let breaker = CircuitBreaker(
             name: "test",
             failureThreshold: 2,
-            resetTimeout: 0.1 // Short timeout for testing
+            resetTimeout: 0.1,
+            clock: BreakerClock(now: { now.current })
         )
 
         // Open the circuit
@@ -135,21 +138,23 @@ struct CircuitBreakerTests {
             }
         }
 
-        // Verify circuit is open
+        // Verify circuit is open until exactly start + resetTimeout
         var state = await breaker.currentState()
-        if case .open = state {
-            // Good
-        } else {
-            Issue.record("Expected circuit to be open")
+        #expect(state == .open(until: start.addingTimeInterval(0.1)))
+
+        // Before the window elapses, requests are rejected and the circuit stays open
+        await #expect(throws: ResilienceError.self) {
+            _ = try await breaker.execute {
+                "too early"
+            }
         }
+        state = await breaker.currentState()
+        #expect(state == .open(until: start.addingTimeInterval(0.1)))
 
-        // Wait for timeout
-        try await Task.sleep(nanoseconds: 150_000_000) // 0.15 seconds
-
-        // Trigger state check by attempting execution
+        // Advance exactly to the boundary and trigger the state check via execution
+        now.advance(by: 0.1)
         do {
             _ = try await breaker.execute {
-                // This will check state and transition to half-open
                 "test"
             }
         } catch {
@@ -157,20 +162,22 @@ struct CircuitBreakerTests {
         }
 
         state = await breaker.currentState()
-        // Should be halfOpen or closed (if the test operation succeeded)
-        #expect(state == .halfOpen || state == .closed)
+        // One success counts toward successThreshold (2), so the circuit stays halfOpen
+        #expect(state == .halfOpen)
     }
 
     // MARK: - Circuit Closing Tests
 
     @Test("Circuit closes after successThreshold successes in halfOpen")
     func circuitClosesAfterSuccesses() async throws {
+        let now = SteppedDate()
         let breaker = CircuitBreaker(
             name: "test",
             failureThreshold: 2,
             successThreshold: 2,
             resetTimeout: 0.1,
-            halfOpenMaxRequests: 5
+            halfOpenMaxRequests: 5,
+            clock: BreakerClock(now: { now.current })
         )
 
         // Open the circuit
@@ -184,8 +191,8 @@ struct CircuitBreakerTests {
             }
         }
 
-        // Wait for timeout to transition to half-open
-        try await Task.sleep(nanoseconds: 150_000_000)
+        // Advance past the timeout to transition to half-open
+        now.advance(by: 0.15)
 
         // Execute successful operations to close circuit
         for _ in 1...2 {
@@ -200,11 +207,13 @@ struct CircuitBreakerTests {
 
     @Test("Single success in halfOpen keeps circuit halfOpen")
     func singleSuccessInHalfOpen() async throws {
+        let now = SteppedDate()
         let breaker = CircuitBreaker(
             name: "test",
             failureThreshold: 2,
             successThreshold: 3,
-            resetTimeout: 0.1
+            resetTimeout: 0.1,
+            clock: BreakerClock(now: { now.current })
         )
 
         // Open circuit
@@ -214,8 +223,8 @@ struct CircuitBreakerTests {
             } catch {}
         }
 
-        // Wait and transition to half-open
-        try await Task.sleep(nanoseconds: 150_000_000)
+        // Advance past the timeout to transition to half-open
+        now.advance(by: 0.15)
 
         // One success
         _ = try await breaker.execute { "success" }
@@ -323,11 +332,13 @@ struct CircuitBreakerTests {
 
     @Test("HalfOpen state limits concurrent requests")
     func halfOpenRequestLimit() async throws {
+        let now = SteppedDate()
         let breaker = CircuitBreaker(
             name: "test",
             failureThreshold: 2,
             resetTimeout: 0.1,
-            halfOpenMaxRequests: 1
+            halfOpenMaxRequests: 1,
+            clock: BreakerClock(now: { now.current })
         )
 
         // Open circuit
@@ -337,19 +348,23 @@ struct CircuitBreakerTests {
             } catch {}
         }
 
-        // Wait for half-open transition
-        try await Task.sleep(nanoseconds: 150_000_000)
+        // Advance past the timeout so the next request transitions to half-open
+        now.advance(by: 0.15)
 
-        // First request should be allowed
+        let (enteredStream, enteredContinuation) = AsyncStream<Void>.makeStream()
+        let (releaseStream, releaseContinuation) = AsyncStream<Void>.makeStream()
+
+        // First request should be allowed; hold it in flight inside half-open
         let task = Task { @Sendable in
             try await breaker.execute {
-                try await Task.sleep(nanoseconds: 100_000_000) // Slow operation
+                enteredContinuation.yield()
+                await releaseStream.first { _ in true }
                 return "success"
             }
         }
 
-        // Give it time to start
-        try await Task.sleep(nanoseconds: 10_000_000)
+        // Deterministically wait until the first request is in flight
+        await enteredStream.first { _ in true }
 
         // Second concurrent request should be blocked
         do {
@@ -365,8 +380,96 @@ struct CircuitBreakerTests {
             }
         }
 
-        // Clean up
-        _ = try await task.value
+        // Release the held request and let it succeed
+        releaseContinuation.yield()
+        let result = try await task.value
+        #expect(result == "success")
+
+        // One success counts toward successThreshold (default 2): still halfOpen
+        let state = await breaker.currentState()
+        #expect(state == .halfOpen)
+    }
+
+    // MARK: - Deterministic Time Tests
+
+    @Test("Manual trip computes open window from injected clock")
+    func manualTripUsesInjectedClock() async throws {
+        let now = SteppedDate(Date(timeIntervalSince1970: 5_000))
+        let start = now.current
+        let breaker = CircuitBreaker(
+            name: "test",
+            resetTimeout: 30.0,
+            clock: BreakerClock(now: { now.current })
+        )
+
+        await breaker.trip()
+
+        let state = await breaker.currentState()
+        #expect(state == .open(until: start.addingTimeInterval(30.0)))
+    }
+
+    @Test("Half-open probe failure re-opens from injected instant")
+    func halfOpenProbeFailureReopensFromInjectedNow() async throws {
+        let now = SteppedDate(Date(timeIntervalSince1970: 6_000))
+        let breaker = CircuitBreaker(
+            name: "test",
+            failureThreshold: 2,
+            resetTimeout: 10.0,
+            clock: BreakerClock(now: { now.current })
+        )
+
+        // Open the circuit
+        for _ in 1...2 {
+            do {
+                _ = try await breaker.execute { throw TestError.network }
+            } catch {}
+        }
+
+        // Advance past the window and fail the half-open probe
+        now.advance(by: 11.0)
+        let probedAt = now.current
+        do {
+            _ = try await breaker.execute { throw TestError.network }
+            Issue.record("Failing probe should rethrow its error")
+        } catch {}
+
+        // Re-open deadline must come from the injected now, not the wall clock
+        let state = await breaker.currentState()
+        #expect(state == .open(until: probedAt.addingTimeInterval(10.0)))
+    }
+
+    @Test("Boundary exactly at open deadline transitions to halfOpen")
+    func boundaryExactlyAtDeadlineTransitionsToHalfOpen() async throws {
+        let now = SteppedDate(Date(timeIntervalSince1970: 7_000))
+        let breaker = CircuitBreaker(
+            name: "test",
+            failureThreshold: 1,
+            resetTimeout: 5.0,
+            clock: BreakerClock(now: { now.current })
+        )
+
+        do {
+            _ = try await breaker.execute { throw TestError.network }
+        } catch {}
+        guard case let .open(until: deadline) = await breaker.currentState() else {
+            Issue.record("Expected open state after threshold failure")
+            return
+        }
+
+        // One tick below the deadline: still open
+        now.advance(by: 4.999)
+        await #expect(throws: ResilienceError.self) {
+            _ = try await breaker.execute { "rejected" }
+        }
+        let stillOpen = await breaker.currentState()
+        #expect(stillOpen == .open(until: deadline))
+
+        // Exactly at the deadline (`now >= until`): transition fires
+        now.advance(by: 0.001)
+        _ = try await breaker.execute { "probe" }
+        let state = await breaker.currentState()
+        // successThreshold defaults to 2, so a single success stays halfOpen
+        #expect(state == .halfOpen)
     }
 }
 

--- a/Tests/SwarmTests/Resilience/ResilienceTests+RateLimiter.swift
+++ b/Tests/SwarmTests/Resilience/ResilienceTests+RateLimiter.swift
@@ -19,12 +19,110 @@ struct RateLimiterTests {
 
     @Test("Invalid token bucket parameters are sanitized")
     func invalidTokenBucketParametersAreSanitized() async throws {
-        let limiter = RateLimiter(maxTokens: -10, refillRatePerSecond: 0)
+        let time = SteppedInstant()
+        let limiter = RateLimiter(maxTokens: -10, refillRatePerSecond: 0, clock: time.limiterClock())
 
         // First token should always be available after sanitization.
         #expect(await limiter.tryAcquire() == true)
 
         // Refill path should remain safe and not produce invalid sleep math.
+        // The injected clock advances during waits, so this returns instantly
+        // instead of sleeping one real second.
         try await limiter.acquire()
+    }
+
+    // MARK: - Deterministic Time Tests
+
+    @Test("Partial refills below one token do not permit acquisition")
+    func partialRefillsBelowOneTokenDoNotPermitAcquisition() async {
+        let time = SteppedInstant()
+        let limiter = RateLimiter(
+            maxTokens: 2,
+            refillRatePerSecond: 1.0,
+            clock: time.limiterClock()
+        )
+
+        // Drain the bucket
+        #expect(await limiter.tryAcquire() == true)
+        #expect(await limiter.tryAcquire() == true)
+        #expect(await limiter.available == 0)
+
+        // Quarter-second steps accumulate fractional tokens that stay below one
+        for _ in 1...3 {
+            time.advance(by: .seconds(0.25))
+            #expect(await limiter.available == 0)
+            #expect(await limiter.tryAcquire() == false)
+        }
+
+        // The fourth quarter second completes exactly one whole token
+        time.advance(by: .seconds(0.25))
+        #expect(await limiter.available == 1)
+        #expect(await limiter.tryAcquire() == true)
+    }
+
+    @Test("Refill never exceeds bucket capacity")
+    func refillCapsAtCapacity() async {
+        let time = SteppedInstant()
+        let limiter = RateLimiter(
+            maxTokens: 3,
+            refillRatePerSecond: 2.0,
+            clock: time.limiterClock()
+        )
+
+        // Drain, then advance far beyond the time needed to refill to capacity
+        #expect(await limiter.tryAcquire() == true)
+        #expect(await limiter.tryAcquire() == true)
+        #expect(await limiter.tryAcquire() == true)
+        time.advance(by: .seconds(10_000))
+
+        #expect(await limiter.available == 3)
+    }
+
+    @Test("acquire bridges empty bucket via injected sleeps with zero real delay")
+    func acquireBridgesEmptyBucketViaInjectedSleeps() async throws {
+        let time = SteppedInstant()
+        let recorder = SleepRecorder()
+        let clock = RateLimiterClock(
+            now: { time.current },
+            sleep: { duration in
+                await recorder.record(UInt64(duration.timeInterval * 1_000_000_000))
+                time.advance(by: duration)
+            }
+        )
+        let limiter = RateLimiter(maxTokens: 2, refillRatePerSecond: 1.0, clock: clock)
+
+        // Drain so acquisition must wait for a refill
+        #expect(await limiter.tryAcquire() == true)
+        #expect(await limiter.tryAcquire() == true)
+
+        try await limiter.acquire()
+
+        // Exactly one one-second wait bridged the gap to the next token
+        let sleeps = await recorder.getAll()
+        #expect(sleeps.count == 1)
+        #expect(sleeps.first == 1_000_000_000)
+
+        // The bridged token was consumed by the acquisition
+        #expect(await limiter.available == 0)
+    }
+
+    @Test("acquire consumes instantly without sleeping when tokens exist")
+    func acquireWithoutWaitDoesNotSleep() async throws {
+        let time = SteppedInstant()
+        let recorder = SleepRecorder()
+        let clock = RateLimiterClock(
+            now: { time.current },
+            sleep: { duration in
+                await recorder.record(UInt64(duration.timeInterval * 1_000_000_000))
+                time.advance(by: duration)
+            }
+        )
+        let limiter = RateLimiter(maxTokens: 2, refillRatePerSecond: 1.0, clock: clock)
+
+        try await limiter.acquire()
+
+        let sleeps = await recorder.getAll()
+        #expect(sleeps.isEmpty)
+        #expect(await limiter.available == 1)
     }
 }

--- a/Tests/SwarmTests/Resilience/ResilienceTests+Retry.swift
+++ b/Tests/SwarmTests/Resilience/ResilienceTests+Retry.swift
@@ -171,6 +171,161 @@ struct RetryPolicyTests {
         #expect(strategy.delay(forAttempt: 5) == 50.0)
     }
 
+    // MARK: - Deterministic Jitter Tests
+
+    @Test("exponentialWithJitter upper-bound source returns capped exponential delays")
+    func jitterUpperBoundReturnsCappedExponentialDelays() {
+        let strategy = BackoffStrategy.exponentialWithJitter(base: 1.0, multiplier: 2.0, maxDelay: 8.0)
+        let source = RetryRandomSource(randomIn: { $0.upperBound })
+
+        #expect(strategy.delay(forAttempt: 1, randomSource: source) == 1.0)
+        #expect(strategy.delay(forAttempt: 2, randomSource: source) == 2.0)
+        #expect(strategy.delay(forAttempt: 3, randomSource: source) == 4.0)
+        #expect(strategy.delay(forAttempt: 4, randomSource: source) == 8.0)
+        // Past the cap the draw range tops out at maxDelay
+        #expect(strategy.delay(forAttempt: 5, randomSource: source) == 8.0)
+    }
+
+    @Test("exponentialWithJitter lower-bound source collapses to zero delay")
+    func jitterLowerBoundCollapsesToZeroDelay() {
+        let strategy = BackoffStrategy.exponentialWithJitter(base: 1.0, multiplier: 2.0, maxDelay: 60.0)
+        let source = RetryRandomSource(randomIn: { $0.lowerBound })
+
+        for attempt in 1...5 {
+            #expect(strategy.delay(forAttempt: attempt, randomSource: source) == 0.0)
+        }
+    }
+
+    @Test("exponentialWithJitter midpoint source returns exact midpoints")
+    func jitterMidpointReturnsExactMidpoints() {
+        let strategy = BackoffStrategy.exponentialWithJitter(base: 1.0, multiplier: 2.0, maxDelay: 8.0)
+        let source = RetryRandomSource(randomIn: { ($0.lowerBound + $0.upperBound) / 2 })
+
+        #expect(strategy.delay(forAttempt: 1, randomSource: source) == 0.5)
+        #expect(strategy.delay(forAttempt: 2, randomSource: source) == 1.0)
+        #expect(strategy.delay(forAttempt: 3, randomSource: source) == 2.0)
+        #expect(strategy.delay(forAttempt: 4, randomSource: source) == 4.0)
+    }
+
+    @Test("decorrelatedJitter draws from ranges derived from injected randomness")
+    func decorrelatedJitterRangesFollowFormula() {
+        let strategy = BackoffStrategy.decorrelatedJitter(base: 1.0, maxDelay: 100.0)
+        let ranges = SyncRecorder<ClosedRange<Double>>()
+        let source = RetryRandomSource(randomIn: { range in
+            ranges.record(range)
+            return range.upperBound
+        })
+
+        // previousSleep grows by a factor of 3 per attempt after the first
+        #expect(strategy.delay(forAttempt: 1, randomSource: source) == 3.0)
+        #expect(strategy.delay(forAttempt: 2, randomSource: source) == 3.0)
+        #expect(strategy.delay(forAttempt: 3, randomSource: source) == 9.0)
+        #expect(strategy.delay(forAttempt: 4, randomSource: source) == 27.0)
+        #expect(strategy.delay(forAttempt: 5, randomSource: source) == 81.0)
+
+        let recorded = ranges.all
+        #expect(recorded.count == 5)
+        #expect(recorded[0] == 1.0...3.0)
+        #expect(recorded[1] == 1.0...3.0)
+        #expect(recorded[2] == 1.0...9.0)
+        #expect(recorded[3] == 1.0...27.0)
+        #expect(recorded[4] == 1.0...81.0)
+    }
+
+    @Test("decorrelatedJitter lower-bound source returns base and respects maxDelay")
+    func decorrelatedJitterLowerBoundAndCap() {
+        let strategy = BackoffStrategy.decorrelatedJitter(base: 1.0, maxDelay: 10.0)
+        let source = RetryRandomSource(randomIn: { $0.lowerBound })
+
+        for attempt in 1...6 {
+            #expect(strategy.delay(forAttempt: attempt, randomSource: source) == 1.0)
+        }
+
+        // Upper bound past maxDelay is clamped by min(delay, maxDelay)
+        let cappedSource = RetryRandomSource(randomIn: { $0.upperBound })
+        #expect(strategy.delay(forAttempt: 4, randomSource: cappedSource) == 10.0)
+        #expect(strategy.delay(forAttempt: 5, randomSource: cappedSource) == 10.0)
+    }
+
+    @Test("Default random source draws within strategy bounds")
+    func defaultRandomSourceStaysWithinBounds() {
+        // GUD-001: the default source must keep drawing uniform samples from
+        // exactly the pre-change ranges.
+        let jitter = BackoffStrategy.exponentialWithJitter(base: 1.0, multiplier: 1.0, maxDelay: 1.0)
+        var jitterSamples: Set<Double> = []
+        for _ in 0..<500 {
+            let value = jitter.delay(forAttempt: 1)
+            #expect(value >= 0.0 && value <= 1.0)
+            jitterSamples.insert(value)
+        }
+
+        let decorrelated = BackoffStrategy.decorrelatedJitter(base: 1.0, maxDelay: 100.0)
+        var decorrelatedSamples: Set<Double> = []
+        for _ in 0..<500 {
+            let value = decorrelated.delay(forAttempt: 1)
+            #expect(value >= 1.0 && value <= 3.0)
+            decorrelatedSamples.insert(value)
+        }
+
+        // Continuous uniform sampling cannot realistically repeat one value
+        #expect(jitterSamples.count > 1)
+        #expect(decorrelatedSamples.count > 1)
+    }
+
+    @Test("Retry applies deterministic jittered backoff via injected sleep")
+    func retryAppliesDeterministicJitteredBackoff() async throws {
+        let counter = TestCounter()
+        let recorder = SleepRecorder()
+        let policy = RetryPolicy(
+            maxAttempts: 2,
+            backoff: .exponentialWithJitter(base: 1.0, multiplier: 2.0, maxDelay: 60.0)
+        )
+
+        let result = try await policy.execute(
+            {
+                let attempt = await counter.increment()
+                if attempt < 3 {
+                    throw TestError.transient
+                }
+                return "recovered"
+            },
+            sleep: { nanoseconds in
+                await recorder.record(nanoseconds)
+            },
+            randomSource: RetryRandomSource(randomIn: { $0.upperBound })
+        )
+
+        #expect(result == "recovered")
+        #expect(await counter.get() == 3)
+
+        // Attempt 1 sleeps 1s (jittered cap), attempt 2 sleeps 2s; zero real time passes
+        let sleeps = await recorder.getAll()
+        #expect(sleeps == [1_000_000_000, 2_000_000_000])
+    }
+
+    @Test("Zero-delay backoff skips the sleep handler entirely")
+    func zeroDelayBackoffSkipsSleep() async throws {
+        let counter = TestCounter()
+        let recorder = SleepRecorder()
+        let policy = RetryPolicy(maxAttempts: 2, backoff: .immediate)
+
+        do {
+            _ = try await policy.execute(
+                {
+                    _ = await counter.increment()
+                    throw TestError.transient
+                },
+                sleep: { nanoseconds in
+                    await recorder.record(nanoseconds)
+                }
+            )
+            Issue.record("Expected retriesExhausted")
+        } catch {}
+
+        #expect(await counter.get() == 3)
+        #expect(await recorder.getAll().isEmpty)
+    }
+
     // MARK: - shouldRetry Predicate Tests
 
     @Test("shouldRetry predicate controls retry behavior")

--- a/Tests/SwarmTests/Resilience/ResilienceTests.swift
+++ b/Tests/SwarmTests/Resilience/ResilienceTests.swift
@@ -6,7 +6,112 @@
 
 import Foundation
 @testable import Swarm
+import Synchronization
 import Testing
+
+// MARK: - SteppedDate
+
+/// Mutex-guarded mutable date for driving injected breaker clocks.
+final class SteppedDate: Sendable {
+    // MARK: Private
+
+    private let value: Mutex<Date>
+
+    // MARK: - Initialization
+
+    init(_ start: Date = Date(timeIntervalSince1970: 1_000)) {
+        value = Mutex(start)
+    }
+
+    // MARK: Internal
+
+    var current: Date { value.withLock { $0 } }
+
+    func advance(by interval: TimeInterval) {
+        value.withLock { $0 = $0.addingTimeInterval(interval) }
+    }
+}
+
+// MARK: - SteppedInstant
+
+/// Mutex-guarded mutable instant for driving injected rate limiter clocks.
+///
+/// The sleep handler advances the instant instead of suspending, so refill
+/// math across acquisition waits runs deterministically with zero real delay.
+final class SteppedInstant: Sendable {
+    // MARK: Private
+
+    private let value: Mutex<ContinuousClock.Instant>
+
+    // MARK: - Initialization
+
+    /// Starts at the current continuous-clock instant; only `advance(by:)`
+    /// moves it, keeping every step deterministic.
+    init() {
+        value = Mutex(ContinuousClock.now)
+    }
+
+    init(_ start: ContinuousClock.Instant) {
+        value = Mutex(start)
+    }
+
+    // MARK: Internal
+
+    var current: ContinuousClock.Instant { value.withLock { $0 } }
+
+    func advance(by duration: Duration) {
+        value.withLock { $0 = $0.advanced(by: duration) }
+    }
+
+    /// A rate limiter clock whose sleeps advance this instant instantly.
+    func limiterClock() -> RateLimiterClock {
+        RateLimiterClock(
+            now: { [self] in current },
+            sleep: { [self] duration in
+                advance(by: duration)
+            }
+        )
+    }
+
+    /// A rate limiter clock whose sleeps neither suspend nor advance time.
+    func frozenLimiterClock() -> RateLimiterClock {
+        RateLimiterClock(now: { [self] in current }, sleep: { _ in })
+    }
+}
+
+// MARK: - SyncRecorder
+
+/// Mutex-guarded value recorder usable from synchronous closures.
+final class SyncRecorder<T: Sendable>: Sendable {
+    // MARK: Private
+
+    private let items: Mutex<[T]> = Mutex([])
+
+    // MARK: Internal
+
+    func record(_ item: T) {
+        items.withLock { $0.append(item) }
+    }
+
+    var all: [T] { items.withLock { $0 } }
+}
+
+// MARK: - SleepRecorder
+
+/// Records sanitized backoff delays handed to an injected retry sleep handler.
+actor SleepRecorder {
+    // MARK: Internal
+
+    func record(_ nanoseconds: UInt64) {
+        durations.append(nanoseconds)
+    }
+
+    func getAll() -> [UInt64] { durations }
+
+    // MARK: Private
+
+    private var durations: [UInt64] = []
+}
 
 // MARK: - TestError
 

--- a/docs/reference/api-catalog.md
+++ b/docs/reference/api-catalog.md
@@ -2367,7 +2367,10 @@ Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for
 | 56 | var | public | CircuitBreaker.successThreshold | `public let successThreshold: Int` |
 | 59 | var | public | CircuitBreaker.resetTimeout | `public let resetTimeout: TimeInterval` |
 | 62 | var | public | CircuitBreaker.halfOpenMaxRequests | `public let halfOpenMaxRequests: Int` |
-| 73 | func | public | CircuitBreaker.init(name:failureThreshold:successThreshold:resetTimeout:halfOpenMaxRequests:) | `public init(name: String, failureThreshold: Int = 5, successThreshold: Int = 2, resetTimeout: TimeInterval = 60.0, halfOpenMaxRequests: Int = 1)` |
+| 21 | struct | public | BreakerClock | `public struct BreakerClock: Sendable` |
+| 30 | func | public | BreakerClock.init(now:) | `public init(now: @escaping @Sendable () -> Date = { Date() })` |
+| 38 | func | public | BreakerClock.now() | `public func now() -> Date` |
+| 73 | func | public | CircuitBreaker.init(name:failureThreshold:successThreshold:resetTimeout:halfOpenMaxRequests:clock:) | `public init(name: String, failureThreshold: Int = 5, successThreshold: Int = 2, resetTimeout: TimeInterval = 60.0, halfOpenMaxRequests: Int = 1, clock: BreakerClock = BreakerClock())` |
 | 93 | func | public | CircuitBreaker.execute(_:) | `public func execute<T>(_ operation: () async throws -> T) async throws -> T where T : Sendable` |
 | 121 | func | public | CircuitBreaker.currentState() | `public func currentState() -> CircuitBreaker.State` |
 | 126 | func | public | CircuitBreaker.reset() | `public func reset() async` |
@@ -2433,8 +2436,11 @@ Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for
 |------|------|--------|------|-----------|
 | 30 | class | public | RateLimiter | `public actor RateLimiter` |
 | 34 | var | public | RateLimiter.available | `public var available: Int { get }` |
-| 40 | func | public | RateLimiter.init(maxRequestsPerMinute:) | `public init(maxRequestsPerMinute: Int)` |
-| 49 | func | public | RateLimiter.init(maxTokens:refillRatePerSecond:) | `public init(maxTokens: Int, refillRatePerSecond: Double)` |
+| 15 | struct | public | RateLimiterClock | `public struct RateLimiterClock: Sendable` |
+| 27 | func | public | RateLimiterClock.init(now:sleep:) | `public init(now: @escaping @Sendable () -> ContinuousClock.Instant = { ContinuousClock.now }, sleep: @escaping @Sendable (Duration) async throws -> Void = { try await Task.sleep(for: $0) })` |
+| 38 | func | public | RateLimiterClock.now() | `public func now() -> ContinuousClock.Instant` |
+| 40 | func | public | RateLimiter.init(maxRequestsPerMinute:clock:) | `public init(maxRequestsPerMinute: Int, clock: RateLimiterClock = RateLimiterClock())` |
+| 49 | func | public | RateLimiter.init(maxTokens:refillRatePerSecond:clock:) | `public init(maxTokens: Int, refillRatePerSecond: Double, clock: RateLimiterClock = RateLimiterClock())` |
 | 62 | func | public | RateLimiter.acquire() | `public func acquire() async throws` |
 | 78 | func | public | RateLimiter.tryAcquire() | `public func tryAcquire() -> Bool` |
 | 88 | func | public | RateLimiter.reset() | `public func reset()` |
@@ -2476,7 +2482,7 @@ Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for
 | 25 | var | public | ResilienceError.errorDescription | `public var errorDescription: String? { get }` |
 | 40 | var | public | ResilienceError.debugDescription | `public var debugDescription: String { get }` |
 | 55 | enum | public | BackoffStrategy | `public enum BackoffStrategy` |
-| 61 | func | public | BackoffStrategy.delay(forAttempt:) | `public func delay(forAttempt attempt: Int) -> TimeInterval` |
+| 61 | func | public | BackoffStrategy.delay(forAttempt:randomSource:) | `public func delay(forAttempt attempt: Int, randomSource: RetryRandomSource = RetryRandomSource()) -> TimeInterval` |
 | 97 | case | public | BackoffStrategy.fixed(delay:) | `public case fixed(delay: TimeInterval)` |
 | 100 | case | public | BackoffStrategy.linear(initial:increment:maxDelay:) | `public case linear(initial: TimeInterval, increment: TimeInterval, maxDelay: TimeInterval)` |
 | 103 | case | public | BackoffStrategy.exponential(base:multiplier:maxDelay:) | `public case exponential(base: TimeInterval, multiplier: Double, maxDelay: TimeInterval)` |
@@ -2494,7 +2500,10 @@ Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for
 | 181 | var | public | RetryPolicy.shouldRetry | `public let shouldRetry: (any Error) -> Bool` |
 | 184 | var | public | RetryPolicy.onRetry | `public let onRetry: ((Int, any Error) async -> Void)?` |
 | 194 | func | public | RetryPolicy.init(maxAttempts:backoff:shouldRetry:onRetry:) | `public init(maxAttempts: Int = 3, backoff: BackoffStrategy = .exponential(base: 1.0, multiplier: 2.0, maxDelay: 60.0), shouldRetry: @escaping (any Error) -> Bool = { _ in true }, onRetry: ((Int, any Error) async -> Void)? = nil)` |
-| 213 | func | public | RetryPolicy.execute(_:) | `public func execute<T>(_ operation: () async throws -> T) async throws -> T where T : Sendable` |
+| 58 | struct | public | RetryRandomSource | `public struct RetryRandomSource: Sendable` |
+| 65 | func | public | RetryRandomSource.init(randomIn:) | `public init(randomIn: @escaping @Sendable (ClosedRange<Double>) -> Double = { Double.random(in: $0) })` |
+| 76 | func | public | RetryRandomSource.randomIn(_:) | `public func randomIn(_ range: ClosedRange<Double>) -> Double` |
+| 213 | func | public | RetryPolicy.execute(_:sleep:randomSource:) | `public func execute<T>(_ operation: @Sendable () async throws -> T, sleep: @escaping @Sendable (UInt64) async throws -> Void = { try await Task.sleep(nanoseconds: $0) }, randomSource: RetryRandomSource = RetryRandomSource()) async throws -> T` |
 | 271 | func | public | RetryPolicy.==(_:_:) | `public static func == (lhs: RetryPolicy, rhs: RetryPolicy) -> Bool` |
 
 ## 9. Workflow

--- a/docs/reference/api-catalog.md
+++ b/docs/reference/api-catalog.md
@@ -2369,8 +2369,8 @@ Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for
 | 62 | var | public | CircuitBreaker.halfOpenMaxRequests | `public let halfOpenMaxRequests: Int` |
 | 21 | struct | public | BreakerClock | `public struct BreakerClock: Sendable` |
 | 30 | func | public | BreakerClock.init(now:) | `public init(now: @escaping @Sendable () -> Date = { Date() })` |
-| 38 | func | public | BreakerClock.now() | `public func now() -> Date` |
-| 73 | func | public | CircuitBreaker.init(name:failureThreshold:successThreshold:resetTimeout:halfOpenMaxRequests:clock:) | `public init(name: String, failureThreshold: Int = 5, successThreshold: Int = 2, resetTimeout: TimeInterval = 60.0, halfOpenMaxRequests: Int = 1, clock: BreakerClock = BreakerClock())` |
+| 37 | func | public | BreakerClock.now() | `public func now() -> Date` |
+| 108 | func | public | CircuitBreaker.init(name:failureThreshold:successThreshold:resetTimeout:halfOpenMaxRequests:clock:) | `public init(name: String, failureThreshold: Int = 5, successThreshold: Int = 2, resetTimeout: TimeInterval = 60.0, halfOpenMaxRequests: Int = 1, clock: BreakerClock = BreakerClock())` |
 | 93 | func | public | CircuitBreaker.execute(_:) | `public func execute<T>(_ operation: () async throws -> T) async throws -> T where T : Sendable` |
 | 121 | func | public | CircuitBreaker.currentState() | `public func currentState() -> CircuitBreaker.State` |
 | 126 | func | public | CircuitBreaker.reset() | `public func reset() async` |
@@ -2439,8 +2439,9 @@ Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for
 | 15 | struct | public | RateLimiterClock | `public struct RateLimiterClock: Sendable` |
 | 27 | func | public | RateLimiterClock.init(now:sleep:) | `public init(now: @escaping @Sendable () -> ContinuousClock.Instant = { ContinuousClock.now }, sleep: @escaping @Sendable (Duration) async throws -> Void = { try await Task.sleep(for: $0) })` |
 | 38 | func | public | RateLimiterClock.now() | `public func now() -> ContinuousClock.Instant` |
-| 40 | func | public | RateLimiter.init(maxRequestsPerMinute:clock:) | `public init(maxRequestsPerMinute: Int, clock: RateLimiterClock = RateLimiterClock())` |
-| 49 | func | public | RateLimiter.init(maxTokens:refillRatePerSecond:clock:) | `public init(maxTokens: Int, refillRatePerSecond: Double, clock: RateLimiterClock = RateLimiterClock())` |
+| 43 | func | public | RateLimiterClock.sleep(for:) | `public func sleep(for duration: Duration) async throws` |
+| 83 | func | public | RateLimiter.init(maxRequestsPerMinute:clock:) | `public init(maxRequestsPerMinute: Int, clock: RateLimiterClock = RateLimiterClock())` |
+| 100 | func | public | RateLimiter.init(maxTokens:refillRatePerSecond:clock:) | `public init(maxTokens: Int, refillRatePerSecond: Double, clock: RateLimiterClock = RateLimiterClock())` |
 | 62 | func | public | RateLimiter.acquire() | `public func acquire() async throws` |
 | 78 | func | public | RateLimiter.tryAcquire() | `public func tryAcquire() -> Bool` |
 | 88 | func | public | RateLimiter.reset() | `public func reset()` |
@@ -2482,7 +2483,7 @@ Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for
 | 25 | var | public | ResilienceError.errorDescription | `public var errorDescription: String? { get }` |
 | 40 | var | public | ResilienceError.debugDescription | `public var debugDescription: String { get }` |
 | 55 | enum | public | BackoffStrategy | `public enum BackoffStrategy` |
-| 61 | func | public | BackoffStrategy.delay(forAttempt:randomSource:) | `public func delay(forAttempt attempt: Int, randomSource: RetryRandomSource = RetryRandomSource()) -> TimeInterval` |
+| 96 | func | public | BackoffStrategy.delay(forAttempt:randomSource:) | `public func delay(forAttempt attempt: Int, randomSource: RetryRandomSource = RetryRandomSource()) -> TimeInterval` |
 | 97 | case | public | BackoffStrategy.fixed(delay:) | `public case fixed(delay: TimeInterval)` |
 | 100 | case | public | BackoffStrategy.linear(initial:increment:maxDelay:) | `public case linear(initial: TimeInterval, increment: TimeInterval, maxDelay: TimeInterval)` |
 | 103 | case | public | BackoffStrategy.exponential(base:multiplier:maxDelay:) | `public case exponential(base: TimeInterval, multiplier: Double, maxDelay: TimeInterval)` |
@@ -2501,9 +2502,9 @@ Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for
 | 184 | var | public | RetryPolicy.onRetry | `public let onRetry: ((Int, any Error) async -> Void)?` |
 | 194 | func | public | RetryPolicy.init(maxAttempts:backoff:shouldRetry:onRetry:) | `public init(maxAttempts: Int = 3, backoff: BackoffStrategy = .exponential(base: 1.0, multiplier: 2.0, maxDelay: 60.0), shouldRetry: @escaping (any Error) -> Bool = { _ in true }, onRetry: ((Int, any Error) async -> Void)? = nil)` |
 | 58 | struct | public | RetryRandomSource | `public struct RetryRandomSource: Sendable` |
-| 65 | func | public | RetryRandomSource.init(randomIn:) | `public init(randomIn: @escaping @Sendable (ClosedRange<Double>) -> Double = { Double.random(in: $0) })` |
-| 76 | func | public | RetryRandomSource.randomIn(_:) | `public func randomIn(_ range: ClosedRange<Double>) -> Double` |
-| 213 | func | public | RetryPolicy.execute(_:sleep:randomSource:) | `public func execute<T>(_ operation: @Sendable () async throws -> T, sleep: @escaping @Sendable (UInt64) async throws -> Void = { try await Task.sleep(nanoseconds: $0) }, randomSource: RetryRandomSource = RetryRandomSource()) async throws -> T` |
+| 68 | func | public | RetryRandomSource.init(randomIn:) | `public init(randomIn: @escaping @Sendable (ClosedRange<Double>) -> Double = { Double.random(in: $0) })` |
+| 79 | func | public | RetryRandomSource.randomIn(_:) | `public func randomIn(_ range: ClosedRange<Double>) -> Double` |
+| 256 | func | public | RetryPolicy.execute(_:sleep:randomSource:) | `public func execute<T>(_ operation: @Sendable () async throws -> T, sleep: @escaping @Sendable (UInt64) async throws -> Void = { try await Task.sleep(nanoseconds: $0) }, randomSource: RetryRandomSource = RetryRandomSource()) async throws -> T where T : Sendable` |
 | 271 | func | public | RetryPolicy.==(_:_:) | `public static func == (lhs: RetryPolicy, rhs: RetryPolicy) -> Bool` |
 
 ## 9. Workflow


### PR DESCRIPTION
Ticket T1 of spec `spec-architecture-functional-core-e3a92541` (swift-functional-codebase-evolution → swift-architecture-pipeline).

**What**
- `BreakerClock` / `RateLimiterClock` / `RetryRandomSource` seams (public, fully defaulted inits) injected into CircuitBreaker / RateLimiter / RetryPolicy enforcement
- Delay computation is now a pure function of policy + attempt + injected RNG; `Double.random` remains the default (distributions unchanged)
- All real-clock sleeps removed from resilience tests: 74 tests pass in ~0.01s (was ≥600ms of waits); previously-skipped token-bucket refill edges now covered
- docs/reference/api-catalog.md refreshed for the additive signatures

**Verification**: lean build+tests ✅ · swift build --traits Integrations ✅ · dependent suites (AgentResilienceWiring/TurnKernel/ProviderOwnedToolLoop) 35/35 ✅

**Reviews**: swift-pr-review ×2 (fresh-context reviewer-fix pass + final pass) — merge-ready, no open findings.

Behavior parity with defaults verified line-by-line against base.