### PR TITLE
arch(T2): normalize guardrail runner to single decision core

### DIFF
--- a/Sources/Swarm/Guardrails/GuardrailRunner.swift
+++ b/Sources/Swarm/Guardrails/GuardrailRunner.swift
@@ -213,13 +213,10 @@ private struct GuardrailTimeoutError: Error, LocalizedError, Sendable {
 /// single sequential executor and a single parallel executor serve every
 /// guardrail kind.
 private struct GuardrailUnit: Sendable {
-    /// Kind of guardrail being executed. Drives observer event payloads and
-    /// selects the tripwire error case.
-    let kind: GuardrailType
-
-    /// Subject referenced by tripwire errors: the agent name for `.output`,
-    /// the tool name for `.toolInput`/`.toolOutput`, unused for `.input`.
-    let subjectName: String
+    /// The guardrail kind paired with the subject its tripwire errors reference.
+    /// Modeling kind and subject as one value makes a mismatched pairing
+    /// unrepresentable (e.g. an `.input` unit carrying a tool name).
+    let subject: Subject
 
     /// Name of the guardrail itself, used in results and errors.
     let name: String
@@ -229,6 +226,26 @@ private struct GuardrailUnit: Sendable {
 
     /// Runs this guardrail's validation once.
     let validate: @Sendable () async throws -> GuardrailResult
+
+    /// Kind of guardrail being executed. Drives observer event payloads.
+    var kind: GuardrailType {
+        switch subject {
+        case .input: .input
+        case .output: .output
+        case .toolInput: .toolInput
+        case .toolOutput: .toolOutput
+        }
+    }
+
+    /// Subject referenced by tripwire errors, tied to the guardrail kind:
+    /// nothing for `.input`, the agent name for `.output`, and the tool name
+    /// for `.toolInput`/`.toolOutput`.
+    enum Subject: Sendable {
+        case input
+        case output(agentName: String)
+        case toolInput(toolName: String)
+        case toolOutput(toolName: String)
+    }
 }
 
 // MARK: - GuardrailRunner
@@ -246,9 +263,10 @@ private struct GuardrailUnit: Sendable {
 /// - **Stop on first**: Immediately throw when a tripwire is triggered
 /// - **Run all**: Execute all guardrails, then throw if any tripwired
 ///
-/// **Note:** When running in parallel mode, the order of results in the returned
-/// array may not match the order of guardrails in the input array due to the
-/// non-deterministic nature of concurrent execution.
+/// **Note:** Parallel mode executes guardrails concurrently and sorts completed
+/// results back into input order before returning. Under stop-on-first-tripwire
+/// semantics, the error thrown corresponds to whichever guardrail finished
+/// first, which may differ from input order.
 ///
 /// **Example:**
 /// ```swift
@@ -313,8 +331,7 @@ public actor GuardrailRunner {
 
     /// Single tripwire error-construction table across all guardrail kinds.
     private static func tripwireError(
-        kind: GuardrailType,
-        subjectName: String,
+        subject: GuardrailUnit.Subject,
         guardrailName: String,
         result: GuardrailResult
     ) -> GuardrailError? {
@@ -322,31 +339,31 @@ public actor GuardrailRunner {
         case .passed:
             nil
         case let .tripwire(message, outputInfo, _):
-            switch kind {
+            switch subject {
             case .input:
                 .inputTripwireTriggered(
                     guardrailName: guardrailName,
                     message: message,
                     outputInfo: outputInfo
                 )
-            case .output:
+            case let .output(agentName):
                 .outputTripwireTriggered(
                     guardrailName: guardrailName,
-                    agentName: subjectName,
+                    agentName: agentName,
                     message: message,
                     outputInfo: outputInfo
                 )
-            case .toolInput:
+            case let .toolInput(toolName):
                 .toolInputTripwireTriggered(
                     guardrailName: guardrailName,
-                    toolName: subjectName,
+                    toolName: toolName,
                     message: message,
                     outputInfo: outputInfo
                 )
-            case .toolOutput:
+            case let .toolOutput(toolName):
                 .toolOutputTripwireTriggered(
                     guardrailName: guardrailName,
-                    toolName: subjectName,
+                    toolName: toolName,
                     message: message,
                     outputInfo: outputInfo
                 )
@@ -415,8 +432,7 @@ public actor GuardrailRunner {
     ) async throws -> [GuardrailExecutionResult] {
         try await execute(guardrails.map { guardrail in
             GuardrailUnit(
-                kind: .input,
-                subjectName: "",
+                subject: .input,
                 name: guardrail.name,
                 observerContext: context,
                 validate: { try await guardrail.validate(input, context: context) }
@@ -450,8 +466,7 @@ public actor GuardrailRunner {
         let agentName = agent.configuration.name
         return try await execute(guardrails.map { guardrail in
             GuardrailUnit(
-                kind: .output,
-                subjectName: agentName,
+                subject: .output(agentName: agentName),
                 name: guardrail.name,
                 observerContext: context,
                 validate: { try await guardrail.validate(output, agent: agent, context: context) }
@@ -481,8 +496,7 @@ public actor GuardrailRunner {
         let toolName = data.tool.name
         return try await execute(guardrails.map { guardrail in
             GuardrailUnit(
-                kind: .toolInput,
-                subjectName: toolName,
+                subject: .toolInput(toolName: toolName),
                 name: guardrail.name,
                 observerContext: data.context,
                 validate: { try await guardrail.validate(data) }
@@ -514,8 +528,7 @@ public actor GuardrailRunner {
         let toolName = data.tool.name
         return try await execute(guardrails.map { guardrail in
             GuardrailUnit(
-                kind: .toolOutput,
-                subjectName: toolName,
+                subject: .toolOutput(toolName: toolName),
                 name: guardrail.name,
                 observerContext: data.context,
                 validate: { try await guardrail.validate(data, output: output) }
@@ -552,8 +565,7 @@ extension GuardrailRunner {
                 results.append(executionResult)
 
                 if let error = Self.tripwireError(
-                    kind: unit.kind,
-                    subjectName: unit.subjectName,
+                    subject: unit.subject,
                     guardrailName: unit.name,
                     result: result
                 ) {
@@ -580,8 +592,7 @@ extension GuardrailRunner {
         // Check if any tripwires were triggered (when not stopping on first)
         if let tripwired = zip(units, results).first(where: { $0.1.didTriggerTripwire }),
            let error = Self.tripwireError(
-               kind: tripwired.0.kind,
-               subjectName: tripwired.0.subjectName,
+               subject: tripwired.0.subject,
                guardrailName: tripwired.1.guardrailName,
                result: tripwired.1.result
            ) {
@@ -624,8 +635,7 @@ extension GuardrailRunner {
                 let unit = units[index]
                 if configuration.stopOnFirstTripwire,
                    let error = Self.tripwireError(
-                       kind: unit.kind,
-                       subjectName: unit.subjectName,
+                       subject: unit.subject,
                        guardrailName: executionResult.guardrailName,
                        result: executionResult.result
                    ) {
@@ -657,8 +667,7 @@ extension GuardrailRunner {
                     )
                 }
                 if let error = Self.tripwireError(
-                    kind: firstTripwire.0.kind,
-                    subjectName: firstTripwire.0.subjectName,
+                    subject: firstTripwire.0.subject,
                     guardrailName: firstTripwire.1.guardrailName,
                     result: firstTripwire.1.result
                 ) {

--- a/Sources/Swarm/Guardrails/GuardrailRunner.swift
+++ b/Sources/Swarm/Guardrails/GuardrailRunner.swift
@@ -204,6 +204,33 @@ private struct GuardrailTimeoutError: Error, LocalizedError, Sendable {
     }
 }
 
+// MARK: - GuardrailUnit
+
+/// One normalized guardrail execution unit, independent of guardrail kind.
+///
+/// Kind-specific differences (how validation is invoked, which tripwire error
+/// is constructed, what the observer receives) collapse into this unit so a
+/// single sequential executor and a single parallel executor serve every
+/// guardrail kind.
+private struct GuardrailUnit: Sendable {
+    /// Kind of guardrail being executed. Drives observer event payloads and
+    /// selects the tripwire error case.
+    let kind: GuardrailType
+
+    /// Subject referenced by tripwire errors: the agent name for `.output`,
+    /// the tool name for `.toolInput`/`.toolOutput`, unused for `.input`.
+    let subjectName: String
+
+    /// Name of the guardrail itself, used in results and errors.
+    let name: String
+
+    /// Context forwarded to observer events.
+    let observerContext: AgentContext?
+
+    /// Runs this guardrail's validation once.
+    let validate: @Sendable () async throws -> GuardrailResult
+}
+
 // MARK: - GuardrailRunner
 
 /// Actor for thread-safe guardrail execution.
@@ -284,7 +311,10 @@ public actor GuardrailRunner {
         }
     }
 
-    private func inputTripwireError(
+    /// Single tripwire error-construction table across all guardrail kinds.
+    private static func tripwireError(
+        kind: GuardrailType,
+        subjectName: String,
         guardrailName: String,
         result: GuardrailResult
     ) -> GuardrailError? {
@@ -292,65 +322,35 @@ public actor GuardrailRunner {
         case .passed:
             nil
         case let .tripwire(message, outputInfo, _):
-            .inputTripwireTriggered(
-                guardrailName: guardrailName,
-                message: message,
-                outputInfo: outputInfo
-            )
-        }
-    }
-
-    private func outputTripwireError(
-        guardrailName: String,
-        agentName: String,
-        result: GuardrailResult
-    ) -> GuardrailError? {
-        switch result {
-        case .passed:
-            nil
-        case let .tripwire(message, outputInfo, _):
-            .outputTripwireTriggered(
-                guardrailName: guardrailName,
-                agentName: agentName,
-                message: message,
-                outputInfo: outputInfo
-            )
-        }
-    }
-
-    private func toolInputTripwireError(
-        guardrailName: String,
-        toolName: String,
-        result: GuardrailResult
-    ) -> GuardrailError? {
-        switch result {
-        case .passed:
-            nil
-        case let .tripwire(message, outputInfo, _):
-            .toolInputTripwireTriggered(
-                guardrailName: guardrailName,
-                toolName: toolName,
-                message: message,
-                outputInfo: outputInfo
-            )
-        }
-    }
-
-    private func toolOutputTripwireError(
-        guardrailName: String,
-        toolName: String,
-        result: GuardrailResult
-    ) -> GuardrailError? {
-        switch result {
-        case .passed:
-            nil
-        case let .tripwire(message, outputInfo, _):
-            .toolOutputTripwireTriggered(
-                guardrailName: guardrailName,
-                toolName: toolName,
-                message: message,
-                outputInfo: outputInfo
-            )
+            switch kind {
+            case .input:
+                .inputTripwireTriggered(
+                    guardrailName: guardrailName,
+                    message: message,
+                    outputInfo: outputInfo
+                )
+            case .output:
+                .outputTripwireTriggered(
+                    guardrailName: guardrailName,
+                    agentName: subjectName,
+                    message: message,
+                    outputInfo: outputInfo
+                )
+            case .toolInput:
+                .toolInputTripwireTriggered(
+                    guardrailName: guardrailName,
+                    toolName: subjectName,
+                    message: message,
+                    outputInfo: outputInfo
+                )
+            case .toolOutput:
+                .toolOutputTripwireTriggered(
+                    guardrailName: guardrailName,
+                    toolName: subjectName,
+                    message: message,
+                    outputInfo: outputInfo
+                )
+            }
         }
     }
 
@@ -413,11 +413,15 @@ public actor GuardrailRunner {
         input: String,
         context: AgentContext?
     ) async throws -> [GuardrailExecutionResult] {
-        if configuration.runInParallel {
-            try await runInputGuardrailsParallel(guardrails, input: input, context: context)
-        } else {
-            try await runInputGuardrailsSequential(guardrails, input: input, context: context)
-        }
+        try await execute(guardrails.map { guardrail in
+            GuardrailUnit(
+                kind: .input,
+                subjectName: "",
+                name: guardrail.name,
+                observerContext: context,
+                validate: { try await guardrail.validate(input, context: context) }
+            )
+        })
     }
 
     // MARK: - Output Guardrails
@@ -443,11 +447,16 @@ public actor GuardrailRunner {
         agent: any AgentRuntime,
         context: AgentContext?
     ) async throws -> [GuardrailExecutionResult] {
-        if configuration.runInParallel {
-            try await runOutputGuardrailsParallel(guardrails, output: output, agent: agent, context: context)
-        } else {
-            try await runOutputGuardrailsSequential(guardrails, output: output, agent: agent, context: context)
-        }
+        let agentName = agent.configuration.name
+        return try await execute(guardrails.map { guardrail in
+            GuardrailUnit(
+                kind: .output,
+                subjectName: agentName,
+                name: guardrail.name,
+                observerContext: context,
+                validate: { try await guardrail.validate(output, agent: agent, context: context) }
+            )
+        })
     }
 
     // MARK: - Tool Input Guardrails
@@ -469,11 +478,16 @@ public actor GuardrailRunner {
         _ guardrails: [any ToolInputGuardrail],
         data: ToolGuardrailData
     ) async throws -> [GuardrailExecutionResult] {
-        if configuration.runInParallel {
-            try await runToolInputGuardrailsParallel(guardrails, data: data)
-        } else {
-            try await runToolInputGuardrailsSequential(guardrails, data: data)
-        }
+        let toolName = data.tool.name
+        return try await execute(guardrails.map { guardrail in
+            GuardrailUnit(
+                kind: .toolInput,
+                subjectName: toolName,
+                name: guardrail.name,
+                observerContext: data.context,
+                validate: { try await guardrail.validate(data) }
+            )
+        })
     }
 
     // MARK: - Tool Output Guardrails
@@ -497,101 +511,57 @@ public actor GuardrailRunner {
         data: ToolGuardrailData,
         output: SendableValue
     ) async throws -> [GuardrailExecutionResult] {
+        let toolName = data.tool.name
+        return try await execute(guardrails.map { guardrail in
+            GuardrailUnit(
+                kind: .toolOutput,
+                subjectName: toolName,
+                name: guardrail.name,
+                observerContext: data.context,
+                validate: { try await guardrail.validate(data, output: output) }
+            )
+        })
+    }
+}
+
+// MARK: - GuardrailRunner + Normalized Decision Core
+
+extension GuardrailRunner {
+    /// Dispatches normalized units through the single sequential or parallel
+    /// executor selected by the configuration.
+    private func execute(_ units: [GuardrailUnit]) async throws -> [GuardrailExecutionResult] {
         if configuration.runInParallel {
-            try await runToolOutputGuardrailsParallel(guardrails, data: data, output: output)
-        } else {
-            try await runToolOutputGuardrailsSequential(guardrails, data: data, output: output)
+            return try await runParallel(units)
         }
+        return try await runSequential(units)
     }
-}
 
-// MARK: - GuardrailRunner + Sequential Execution
-
-extension GuardrailRunner {
-    func runInputGuardrailsSequential(
-        _ guardrails: [any InputGuardrail],
-        input: String,
-        context: AgentContext?
-    ) async throws -> [GuardrailExecutionResult] {
+    /// Executes every unit one-by-one in order.
+    private func runSequential(_ units: [GuardrailUnit]) async throws -> [GuardrailExecutionResult] {
         var results: [GuardrailExecutionResult] = []
 
-        for guardrail in guardrails {
+        for unit in units {
             try Task.checkCancellation()
 
             do {
-                let result = try await validateWithTimeout(guardrailName: guardrail.name) {
-                    try await guardrail.validate(input, context: context)
-                }
+                let result = try await validateWithTimeout(guardrailName: unit.name, operation: unit.validate)
                 let executionResult = GuardrailExecutionResult(
-                    guardrailName: guardrail.name,
+                    guardrailName: unit.name,
                     result: result
                 )
                 results.append(executionResult)
 
-                if let error = inputTripwireError(guardrailName: guardrail.name, result: result) {
-                    await emitGuardrailEvent(
-                        guardrailName: guardrail.name,
-                        guardrailType: .input,
-                        result: result,
-                        context: context
-                    )
-                    if configuration.stopOnFirstTripwire {
-                        throw error
-                    }
-                }
-            } catch let error as GuardrailError {
-                throw error
-            } catch {
-                throw GuardrailError.executionFailed(
-                    guardrailName: guardrail.name,
-                    underlyingError: error.localizedDescription
-                )
-            }
-        }
-
-        // Check if any tripwires were triggered (when not stopping on first)
-        if let tripwiredResult = results.first(where: \.didTriggerTripwire),
-           let error = inputTripwireError(
-               guardrailName: tripwiredResult.guardrailName,
-               result: tripwiredResult.result
-           ) {
-            throw error
-        }
-
-        return results
-    }
-
-    func runOutputGuardrailsSequential(
-        _ guardrails: [any OutputGuardrail],
-        output: String,
-        agent: any AgentRuntime,
-        context: AgentContext?
-    ) async throws -> [GuardrailExecutionResult] {
-        var results: [GuardrailExecutionResult] = []
-
-        for guardrail in guardrails {
-            try Task.checkCancellation()
-
-            do {
-                let result = try await validateWithTimeout(guardrailName: guardrail.name) {
-                    try await guardrail.validate(output, agent: agent, context: context)
-                }
-                let executionResult = GuardrailExecutionResult(
-                    guardrailName: guardrail.name,
-                    result: result
-                )
-                results.append(executionResult)
-
-                if let error = outputTripwireError(
-                    guardrailName: guardrail.name,
-                    agentName: agent.configuration.name,
+                if let error = Self.tripwireError(
+                    kind: unit.kind,
+                    subjectName: unit.subjectName,
+                    guardrailName: unit.name,
                     result: result
                 ) {
                     await emitGuardrailEvent(
-                        guardrailName: guardrail.name,
-                        guardrailType: .output,
+                        guardrailName: unit.name,
+                        guardrailType: unit.kind,
                         result: result,
-                        context: context
+                        context: unit.observerContext
                     )
                     if configuration.stopOnFirstTripwire {
                         throw error
@@ -601,18 +571,19 @@ extension GuardrailRunner {
                 throw error
             } catch {
                 throw GuardrailError.executionFailed(
-                    guardrailName: guardrail.name,
+                    guardrailName: unit.name,
                     underlyingError: error.localizedDescription
                 )
             }
         }
 
         // Check if any tripwires were triggered (when not stopping on first)
-        if let tripwiredResult = results.first(where: \.didTriggerTripwire),
-           let error = outputTripwireError(
-               guardrailName: tripwiredResult.guardrailName,
-               agentName: agent.configuration.name,
-               result: tripwiredResult.result
+        if let tripwired = zip(units, results).first(where: { $0.1.didTriggerTripwire }),
+           let error = Self.tripwireError(
+               kind: tripwired.0.kind,
+               subjectName: tripwired.0.subjectName,
+               guardrailName: tripwired.1.guardrailName,
+               result: tripwired.1.result
            ) {
             throw error
         }
@@ -620,442 +591,83 @@ extension GuardrailRunner {
         return results
     }
 
-    func runToolInputGuardrailsSequential(
-        _ guardrails: [any ToolInputGuardrail],
-        data: ToolGuardrailData
-    ) async throws -> [GuardrailExecutionResult] {
-        var results: [GuardrailExecutionResult] = []
+    /// Executes every unit concurrently and returns results in input order.
+    private func runParallel(_ units: [GuardrailUnit]) async throws -> [GuardrailExecutionResult] {
+        try Task.checkCancellation()
 
-        for guardrail in guardrails {
-            try Task.checkCancellation()
+        return try await withThrowingTaskGroup(of: (Int, GuardrailExecutionResult).self) { group in
+            var indexedResults: [(Int, GuardrailExecutionResult)] = []
+            indexedResults.reserveCapacity(units.count)
 
-            do {
-                let result = try await validateWithTimeout(guardrailName: guardrail.name) {
-                    try await guardrail.validate(data)
+            // Add all units to the task group
+            for (index, unit) in units.enumerated() {
+                group.addTask {
+                    do {
+                        let result = try await self.validateWithTimeout(guardrailName: unit.name, operation: unit.validate)
+                        return (index, GuardrailExecutionResult(
+                            guardrailName: unit.name,
+                            result: result
+                        ))
+                    } catch let error as GuardrailError {
+                        throw error
+                    } catch {
+                        throw GuardrailError.executionFailed(
+                            guardrailName: unit.name,
+                            underlyingError: error.localizedDescription
+                        )
+                    }
                 }
-                let executionResult = GuardrailExecutionResult(
-                    guardrailName: guardrail.name,
-                    result: result
-                )
-                results.append(executionResult)
+            }
 
-                if let error = toolInputTripwireError(
-                    guardrailName: guardrail.name,
-                    toolName: data.tool.name,
-                    result: result
+            // Collect results
+            for try await (index, executionResult) in group {
+                let unit = units[index]
+                if configuration.stopOnFirstTripwire,
+                   let error = Self.tripwireError(
+                       kind: unit.kind,
+                       subjectName: unit.subjectName,
+                       guardrailName: executionResult.guardrailName,
+                       result: executionResult.result
+                   ) {
+                    await emitGuardrailEvent(
+                        guardrailName: executionResult.guardrailName,
+                        guardrailType: unit.kind,
+                        result: executionResult.result,
+                        context: unit.observerContext
+                    )
+                    // Cancel remaining tasks
+                    group.cancelAll()
+                    throw error
+                }
+                indexedResults.append((index, executionResult))
+            }
+
+            indexedResults.sort { $0.0 < $1.0 }
+            let orderedUnits = indexedResults.map { units[$0.0] }
+            let results = indexedResults.map(\.1)
+
+            // Check if any tripwires were triggered (when not stopping on first)
+            if let firstTripwire = zip(orderedUnits, results).first(where: { $0.1.didTriggerTripwire }) {
+                for (unit, executionResult) in zip(orderedUnits, results) where executionResult.didTriggerTripwire {
+                    await emitGuardrailEvent(
+                        guardrailName: executionResult.guardrailName,
+                        guardrailType: unit.kind,
+                        result: executionResult.result,
+                        context: unit.observerContext
+                    )
+                }
+                if let error = Self.tripwireError(
+                    kind: firstTripwire.0.kind,
+                    subjectName: firstTripwire.0.subjectName,
+                    guardrailName: firstTripwire.1.guardrailName,
+                    result: firstTripwire.1.result
                 ) {
-                    await emitGuardrailEvent(
-                        guardrailName: guardrail.name,
-                        guardrailType: .toolInput,
-                        result: result,
-                        context: data.context
-                    )
-                    if configuration.stopOnFirstTripwire {
-                        throw error
-                    }
-                }
-            } catch let error as GuardrailError {
-                throw error
-            } catch {
-                throw GuardrailError.executionFailed(
-                    guardrailName: guardrail.name,
-                    underlyingError: error.localizedDescription
-                )
-            }
-        }
-
-        // Check if any tripwires were triggered (when not stopping on first)
-        if let tripwiredResult = results.first(where: \.didTriggerTripwire),
-           let error = toolInputTripwireError(
-               guardrailName: tripwiredResult.guardrailName,
-               toolName: data.tool.name,
-               result: tripwiredResult.result
-           ) {
-            throw error
-        }
-
-        return results
-    }
-
-    func runToolOutputGuardrailsSequential(
-        _ guardrails: [any ToolOutputGuardrail],
-        data: ToolGuardrailData,
-        output: SendableValue
-    ) async throws -> [GuardrailExecutionResult] {
-        var results: [GuardrailExecutionResult] = []
-
-        for guardrail in guardrails {
-            try Task.checkCancellation()
-
-            do {
-                let result = try await validateWithTimeout(guardrailName: guardrail.name) {
-                    try await guardrail.validate(data, output: output)
-                }
-                let executionResult = GuardrailExecutionResult(
-                    guardrailName: guardrail.name,
-                    result: result
-                )
-                results.append(executionResult)
-
-                if let error = toolOutputTripwireError(
-                    guardrailName: guardrail.name,
-                    toolName: data.tool.name,
-                    result: result
-                ) {
-                    await emitGuardrailEvent(
-                        guardrailName: guardrail.name,
-                        guardrailType: .toolOutput,
-                        result: result,
-                        context: data.context
-                    )
-                    if configuration.stopOnFirstTripwire {
-                        throw error
-                    }
-                }
-            } catch let error as GuardrailError {
-                throw error
-            } catch {
-                throw GuardrailError.executionFailed(
-                    guardrailName: guardrail.name,
-                    underlyingError: error.localizedDescription
-                )
-            }
-        }
-
-        // Check if any tripwires were triggered (when not stopping on first)
-        if let tripwiredResult = results.first(where: \.didTriggerTripwire),
-           let error = toolOutputTripwireError(
-               guardrailName: tripwiredResult.guardrailName,
-               toolName: data.tool.name,
-               result: tripwiredResult.result
-           ) {
-            throw error
-        }
-
-        return results
-    }
-}
-
-// MARK: - GuardrailRunner + Parallel Execution
-
-extension GuardrailRunner {
-    func runInputGuardrailsParallel(
-        _ guardrails: [any InputGuardrail],
-        input: String,
-        context: AgentContext?
-    ) async throws -> [GuardrailExecutionResult] {
-        try Task.checkCancellation()
-
-        return try await withThrowingTaskGroup(of: (Int, GuardrailExecutionResult).self) { group in
-            var indexedResults: [(Int, GuardrailExecutionResult)] = []
-            indexedResults.reserveCapacity(guardrails.count)
-
-            // Add all guardrails to the task group
-            for (index, guardrail) in guardrails.enumerated() {
-                group.addTask {
-                    do {
-                        let result = try await self.validateWithTimeout(guardrailName: guardrail.name) {
-                            try await guardrail.validate(input, context: context)
-                        }
-                        return (index, GuardrailExecutionResult(
-                            guardrailName: guardrail.name,
-                            result: result
-                        ))
-                    } catch let error as GuardrailError {
-                        throw error
-                    } catch {
-                        throw GuardrailError.executionFailed(
-                            guardrailName: guardrail.name,
-                            underlyingError: error.localizedDescription
-                        )
-                    }
-                }
-            }
-
-            // Collect results
-            for try await (index, executionResult) in group {
-                if configuration.stopOnFirstTripwire,
-                   let error = inputTripwireError(
-                       guardrailName: executionResult.guardrailName,
-                       result: executionResult.result
-                   ) {
-                    await emitGuardrailEvent(
-                        guardrailName: executionResult.guardrailName,
-                        guardrailType: .input,
-                        result: executionResult.result,
-                        context: context
-                    )
-                    // Cancel remaining tasks
-                    group.cancelAll()
                     throw error
                 }
-                indexedResults.append((index, executionResult))
-            }
-
-            indexedResults.sort { $0.0 < $1.0 }
-            let results = indexedResults.map(\.1)
-
-            // Check if any tripwires were triggered (when not stopping on first)
-            if let tripwiredResult = results.first(where: \.didTriggerTripwire),
-               let error = inputTripwireError(
-                   guardrailName: tripwiredResult.guardrailName,
-                   result: tripwiredResult.result
-               ) {
-                for result in results where result.didTriggerTripwire {
-                    await emitGuardrailEvent(
-                        guardrailName: result.guardrailName,
-                        guardrailType: .input,
-                        result: result.result,
-                        context: context
-                    )
-                }
-                throw error
-            }
-
-            return results
-        }
-    }
-
-    func runOutputGuardrailsParallel(
-        _ guardrails: [any OutputGuardrail],
-        output: String,
-        agent: any AgentRuntime,
-        context: AgentContext?
-    ) async throws -> [GuardrailExecutionResult] {
-        try Task.checkCancellation()
-
-        let agentName = agent.configuration.name
-
-        return try await withThrowingTaskGroup(of: (Int, GuardrailExecutionResult).self) { group in
-            var indexedResults: [(Int, GuardrailExecutionResult)] = []
-            indexedResults.reserveCapacity(guardrails.count)
-
-            // Add all guardrails to the task group
-            for (index, guardrail) in guardrails.enumerated() {
-                group.addTask {
-                    do {
-                        let result = try await self.validateWithTimeout(guardrailName: guardrail.name) {
-                            try await guardrail.validate(output, agent: agent, context: context)
-                        }
-                        return (index, GuardrailExecutionResult(
-                            guardrailName: guardrail.name,
-                            result: result
-                        ))
-                    } catch let error as GuardrailError {
-                        throw error
-                    } catch {
-                        throw GuardrailError.executionFailed(
-                            guardrailName: guardrail.name,
-                            underlyingError: error.localizedDescription
-                        )
-                    }
-                }
-            }
-
-            // Collect results
-            for try await (index, executionResult) in group {
-                if configuration.stopOnFirstTripwire,
-                   let error = outputTripwireError(
-                       guardrailName: executionResult.guardrailName,
-                       agentName: agentName,
-                       result: executionResult.result
-                   ) {
-                    await emitGuardrailEvent(
-                        guardrailName: executionResult.guardrailName,
-                        guardrailType: .output,
-                        result: executionResult.result,
-                        context: context
-                    )
-                    // Cancel remaining tasks
-                    group.cancelAll()
-                    throw error
-                }
-                indexedResults.append((index, executionResult))
-            }
-
-            indexedResults.sort { $0.0 < $1.0 }
-            let results = indexedResults.map(\.1)
-
-            // Check if any tripwires were triggered (when not stopping on first)
-            if let tripwiredResult = results.first(where: \.didTriggerTripwire),
-               let error = outputTripwireError(
-                   guardrailName: tripwiredResult.guardrailName,
-                   agentName: agentName,
-                   result: tripwiredResult.result
-               ) {
-                for result in results where result.didTriggerTripwire {
-                    await emitGuardrailEvent(
-                        guardrailName: result.guardrailName,
-                        guardrailType: .output,
-                        result: result.result,
-                        context: context
-                    )
-                }
-                throw error
-            }
-
-            return results
-        }
-    }
-
-    func runToolInputGuardrailsParallel(
-        _ guardrails: [any ToolInputGuardrail],
-        data: ToolGuardrailData
-    ) async throws -> [GuardrailExecutionResult] {
-        try Task.checkCancellation()
-
-        let toolName = data.tool.name
-
-        return try await withThrowingTaskGroup(of: (Int, GuardrailExecutionResult).self) { group in
-            var indexedResults: [(Int, GuardrailExecutionResult)] = []
-            indexedResults.reserveCapacity(guardrails.count)
-
-            // Add all guardrails to the task group
-            for (index, guardrail) in guardrails.enumerated() {
-                group.addTask {
-                    do {
-                        let result = try await self.validateWithTimeout(guardrailName: guardrail.name) {
-                            try await guardrail.validate(data)
-                        }
-                        return (index, GuardrailExecutionResult(
-                            guardrailName: guardrail.name,
-                            result: result
-                        ))
-                    } catch let error as GuardrailError {
-                        throw error
-                    } catch {
-                        throw GuardrailError.executionFailed(
-                            guardrailName: guardrail.name,
-                            underlyingError: error.localizedDescription
-                        )
-                    }
-                }
-            }
-
-            // Collect results
-            for try await (index, executionResult) in group {
-                if configuration.stopOnFirstTripwire,
-                   let error = toolInputTripwireError(
-                       guardrailName: executionResult.guardrailName,
-                       toolName: toolName,
-                       result: executionResult.result
-                   ) {
-                    await emitGuardrailEvent(
-                        guardrailName: executionResult.guardrailName,
-                        guardrailType: .toolInput,
-                        result: executionResult.result,
-                        context: data.context
-                    )
-                    // Cancel remaining tasks
-                    group.cancelAll()
-                    throw error
-                }
-                indexedResults.append((index, executionResult))
-            }
-
-            indexedResults.sort { $0.0 < $1.0 }
-            let results = indexedResults.map(\.1)
-
-            // Check if any tripwires were triggered (when not stopping on first)
-            if let tripwiredResult = results.first(where: \.didTriggerTripwire),
-               let error = toolInputTripwireError(
-                   guardrailName: tripwiredResult.guardrailName,
-                   toolName: toolName,
-                   result: tripwiredResult.result
-               ) {
-                for result in results where result.didTriggerTripwire {
-                    await emitGuardrailEvent(
-                        guardrailName: result.guardrailName,
-                        guardrailType: .toolInput,
-                        result: result.result,
-                        context: data.context
-                    )
-                }
-                throw error
-            }
-
-            return results
-        }
-    }
-
-    func runToolOutputGuardrailsParallel(
-        _ guardrails: [any ToolOutputGuardrail],
-        data: ToolGuardrailData,
-        output: SendableValue
-    ) async throws -> [GuardrailExecutionResult] {
-        try Task.checkCancellation()
-
-        let toolName = data.tool.name
-
-        return try await withThrowingTaskGroup(of: (Int, GuardrailExecutionResult).self) { group in
-            var indexedResults: [(Int, GuardrailExecutionResult)] = []
-            indexedResults.reserveCapacity(guardrails.count)
-
-            // Add all guardrails to the task group
-            for (index, guardrail) in guardrails.enumerated() {
-                group.addTask {
-                    do {
-                        let result = try await self.validateWithTimeout(guardrailName: guardrail.name) {
-                            try await guardrail.validate(data, output: output)
-                        }
-                        return (index, GuardrailExecutionResult(
-                            guardrailName: guardrail.name,
-                            result: result
-                        ))
-                    } catch let error as GuardrailError {
-                        throw error
-                    } catch {
-                        throw GuardrailError.executionFailed(
-                            guardrailName: guardrail.name,
-                            underlyingError: error.localizedDescription
-                        )
-                    }
-                }
-            }
-
-            // Collect results
-            for try await (index, executionResult) in group {
-                if configuration.stopOnFirstTripwire,
-                   let error = toolOutputTripwireError(
-                       guardrailName: executionResult.guardrailName,
-                       toolName: toolName,
-                       result: executionResult.result
-                   ) {
-                    await emitGuardrailEvent(
-                        guardrailName: executionResult.guardrailName,
-                        guardrailType: .toolOutput,
-                        result: executionResult.result,
-                        context: data.context
-                    )
-                    // Cancel remaining tasks
-                    group.cancelAll()
-                    throw error
-                }
-                indexedResults.append((index, executionResult))
-            }
-
-            indexedResults.sort { $0.0 < $1.0 }
-            let results = indexedResults.map(\.1)
-
-            // Check if any tripwires were triggered (when not stopping on first)
-            if let tripwiredResult = results.first(where: \.didTriggerTripwire),
-               let error = toolOutputTripwireError(
-                   guardrailName: tripwiredResult.guardrailName,
-                   toolName: toolName,
-                   result: tripwiredResult.result
-               ) {
-                for result in results where result.didTriggerTripwire {
-                    await emitGuardrailEvent(
-                        guardrailName: result.guardrailName,
-                        guardrailType: .toolOutput,
-                        result: result.result,
-                        context: data.context
-                    )
-                }
-                throw error
             }
 
             return results
         }
     }
 }
+

--- a/Sources/Swarm/Guardrails/OutputGuardrail.swift
+++ b/Sources/Swarm/Guardrails/OutputGuardrail.swift
@@ -321,7 +321,41 @@ public struct OutputGuard: OutputGuardrail, Sendable {
         try await handler(output, agent, context)
     }
 
+    /// Evaluates this guard's predicate without an agent runtime.
+    ///
+    /// Built-in guards such as ``maxLength(_:name:)`` never read the agent or
+    /// context parameters; this internal entry point lets their predicates be
+    /// exercised directly without constructing any ``AgentRuntime``.
+    func evaluate(_ output: String) async throws -> GuardrailResult {
+        try await handler(output, NullAgentRuntime.shared, nil)
+    }
+
     private let handler: OutputValidationHandler
+}
+
+// MARK: - NullAgentRuntime
+
+/// An inert ``AgentRuntime`` satisfying validation handlers that require an
+/// agent argument but never read one.
+struct NullAgentRuntime: AgentRuntime {
+    /// Shared inert instance.
+    static let shared = NullAgentRuntime()
+
+    nonisolated let configuration = AgentConfiguration(name: "null-agent")
+    nonisolated let tools: [any AnyJSONTool] = []
+    nonisolated let instructions = ""
+
+    private init() {}
+
+    func run(_: String, session _: (any Session)? = nil, observer _: (any AgentObserver)? = nil) async throws -> AgentResult {
+        AgentResult(output: "")
+    }
+
+    nonisolated func stream(_: String, session _: (any Session)? = nil, observer _: (any AgentObserver)? = nil) -> AsyncThrowingStream<AgentEvent, Error> {
+        AsyncThrowingStream { $0.finish() }
+    }
+
+    func cancel() async {}
 }
 
 // MARK: - OutputGuard Static Factories

--- a/Tests/SwarmTests/Guardrails/BuiltinGuardPredicateTests.swift
+++ b/Tests/SwarmTests/Guardrails/BuiltinGuardPredicateTests.swift
@@ -1,0 +1,125 @@
+// BuiltinGuardPredicateTests.swift
+// SwarmTests
+//
+// Exercises the built-in guards (notEmpty, maxLength, custom) as pure
+// predicates at the protocol level, without constructing any AgentRuntime.
+
+import Foundation
+@testable import Swarm
+import Testing
+
+@Suite("Built-in Guard Predicates")
+struct BuiltinGuardPredicateTests {
+    // MARK: - InputGuard.notEmpty
+
+    @Test("InputGuard.notEmpty trips empty and whitespace-only input")
+    func notEmptyTripsOnBlankInput() async throws {
+        let guardrail = InputGuard.notEmpty()
+
+        #expect(guardrail.name == "NotEmptyGuardrail")
+
+        for blank in ["", "   ", "\n\t "] {
+            let result = try await guardrail.validate(blank, context: nil)
+            #expect(result.tripwireTriggered)
+            #expect(result.message == "Input cannot be empty")
+        }
+    }
+
+    @Test("InputGuard.notEmpty passes input containing non-whitespace characters")
+    func notEmptyPassesRealInput() async throws {
+        let result = try await InputGuard.notEmpty().validate("  hello \n", context: nil)
+        #expect(!result.tripwireTriggered)
+    }
+
+    // MARK: - InputGuard.maxLength
+
+    @Test("InputGuard.maxLength passes at the limit and trips past it with metadata")
+    func maxLengthBoundaryAndPayload() async throws {
+        let guardrail = InputGuard.maxLength(5)
+
+        #expect(guardrail.name == "MaxLengthGuardrail")
+
+        let atLimit = try await guardrail.validate("12345", context: nil)
+        #expect(!atLimit.tripwireTriggered)
+
+        let overLimit = try await guardrail.validate("123456", context: nil)
+        #expect(overLimit.tripwireTriggered)
+        #expect(overLimit.message == "Input exceeds maximum length of 5")
+        #expect(overLimit.metadata["length"]?.intValue == 6)
+        #expect(overLimit.metadata["limit"]?.intValue == 5)
+    }
+
+    @Test("InputGuard.maxLength honors a custom name")
+    func maxLengthCustomName() async throws {
+        #expect(InputGuard.maxLength(10, name: "TweetLimit").name == "TweetLimit")
+    }
+
+    // MARK: - InputGuard.custom
+
+    @Test("InputGuard.custom evaluates the provided closure")
+    func customClosureEvaluation() async throws {
+        let guardrail = InputGuard.custom("no_secrets") { input in
+            input.contains("hunter2")
+                ? .tripwire(message: "secret detected", outputInfo: .string(input))
+                : .passed()
+        }
+
+        let clean = try await guardrail.validate("all good", context: nil)
+        #expect(!clean.tripwireTriggered)
+
+        let dirty = try await guardrail.validate("password is hunter2", context: nil)
+        #expect(dirty.tripwireTriggered)
+        #expect(dirty.message == "secret detected")
+        #expect(dirty.outputInfo == .string("password is hunter2"))
+    }
+
+    // MARK: - OutputGuard.maxLength
+
+    @Test("OutputGuard.maxLength passes within the limit and trips past it with metadata")
+    func outputMaxLengthBoundaryAndPayload() async throws {
+        let guardrail = OutputGuard.maxLength(4)
+
+        #expect(guardrail.name == "MaxOutputLengthGuardrail")
+
+        let atLimit = try await guardrail.evaluate("abcd")
+        #expect(!atLimit.tripwireTriggered)
+
+        let overLimit = try await guardrail.evaluate("abcde")
+        #expect(overLimit.tripwireTriggered)
+        #expect(overLimit.message == "Output exceeds maximum length of 4")
+        #expect(overLimit.metadata["length"]?.intValue == 5)
+        #expect(overLimit.metadata["limit"]?.intValue == 4)
+    }
+
+    @Test("OutputGuard.maxLength honors a custom name")
+    func outputMaxLengthCustomName() async throws {
+        #expect(OutputGuard.maxLength(280, name: "TwitterLimit").name == "TwitterLimit")
+    }
+
+    // MARK: - OutputGuard.custom
+
+    @Test("OutputGuard.custom evaluates the provided closure")
+    func outputCustomClosureEvaluation() async throws {
+        let guardrail = OutputGuard.custom("no_phone_numbers") { output in
+            output.hasPrefix("+") ? .tripwire(message: "phone number detected") : .passed()
+        }
+
+        let text = try await guardrail.evaluate("just words")
+        #expect(!text.tripwireTriggered)
+
+        let phone = try await guardrail.evaluate("+15551234567")
+        #expect(phone.tripwireTriggered)
+        #expect(phone.message == "phone number detected")
+    }
+
+    // MARK: - Protocol Extension Factories
+
+    @Test("Protocol extension factories build heterogeneous guardrail arrays")
+    func protocolExtensionFactories() {
+        let inputs: [any InputGuardrail] = [.maxLength(10), .notEmpty()]
+        #expect(inputs.map(\.name) == ["MaxLengthGuardrail", "NotEmptyGuardrail"])
+
+        let outputs: [any OutputGuardrail] = [.maxLength(100)]
+        #expect(outputs.map(\.name) == ["MaxOutputLengthGuardrail"])
+    }
+}

--- a/Tests/SwarmTests/Guardrails/GuardrailRunnerGoldenTests.swift
+++ b/Tests/SwarmTests/Guardrails/GuardrailRunnerGoldenTests.swift
@@ -44,6 +44,47 @@ private actor RecordingObserver: AgentObserver {
 
 private struct KaboomError: Error {}
 
+/// One-shot gate used to suspend validations at a deterministic point.
+private final class ReleaseGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+    private var released = false
+
+    func waitForRelease() async {
+        await withCheckedContinuation { continuation in
+            lock.lock()
+            if released {
+                lock.unlock()
+                continuation.resume()
+            } else {
+                waiters.append(continuation)
+                lock.unlock()
+            }
+        }
+    }
+
+    func releaseAll() {
+        lock.lock()
+        released = true
+        let waiters = waiters
+        self.waiters = []
+        lock.unlock()
+        for waiter in waiters {
+            waiter.resume()
+        }
+    }
+}
+
+private func waitForEntries(_ log: ExecutionLog, count: Int) async throws {
+    for _ in 0..<2500 {
+        if await log.snapshot().count >= count {
+            return
+        }
+        try await Task.sleep(for: .milliseconds(2))
+    }
+    Issue.record("Timed out waiting for \(count) guardrail entries")
+}
+
 // MARK: - Sequential Golden Tests
 
 @Suite("Guardrail Runner Sequential Goldens")
@@ -195,6 +236,40 @@ struct GuardrailRunnerSequentialGoldens {
                 message: "too big",
                 outputInfo: nil
             ))
+        }
+    }
+
+    @Test("Sequential mid-run cancellation aborts remaining guardrails with raw CancellationError")
+    func sequentialMidRunCancellation() async throws {
+        let gate = ReleaseGate()
+        let log = ExecutionLog()
+        let first = InputGuard("first_waiter") { _, _ in
+            await log.record("first_waiter")
+            await gate.waitForRelease()
+            return .passed(message: "first ok")
+        }
+        let second = InputGuard("second_never") { _, _ in
+            await log.record("second_never")
+            return .passed(message: "second ok")
+        }
+        let runner = GuardrailRunner(
+            configuration: GuardrailRunnerConfiguration(stopOnFirstTripwire: true, timeout: nil)
+        )
+
+        let task = Task {
+            try await runner.runInputGuardrails([first, second], input: "x", context: nil)
+        }
+        try await waitForEntries(log, count: 1)
+        task.cancel()
+        gate.releaseAll()
+
+        do {
+            _ = try await task.value
+            Issue.record("Expected CancellationError")
+        } catch is CancellationError {
+            #expect(await log.snapshot() == ["first_waiter"])
+        } catch {
+            Issue.record("Unexpected error type: \(error)")
         }
     }
 
@@ -393,6 +468,34 @@ struct GuardrailRunnerParallelGoldens {
 
         let events = await observer.events
         #expect(events == [RecordingObserver.Event(name: "deny_all", type: .toolInput, message: "denied")])
+    }
+
+    @Test("Parallel mid-flight cancellation lets spawned guardrails finish and returns ordered results")
+    func parallelMidFlightCancellationStillCompletes() async throws {
+        let gate = ReleaseGate()
+        let log = ExecutionLog()
+        let slow = InputGuard("slow_waiter") { _, _ in
+            await log.record("slow_waiter")
+            await gate.waitForRelease()
+            return .passed(message: "survived")
+        }
+        let quick = InputGuard("quick_pass") { _, _ in
+            await log.record("quick_pass")
+            return .passed(message: "quick ok")
+        }
+        let runner = GuardrailRunner(
+            configuration: GuardrailRunnerConfiguration(runInParallel: true, timeout: nil)
+        )
+
+        let task = Task {
+            try await runner.runInputGuardrails([slow, quick], input: "x", context: nil)
+        }
+        try await waitForEntries(log, count: 2)
+        task.cancel()
+        gate.releaseAll()
+
+        let results = try await task.value
+        #expect(results.map(\.guardrailName) == ["slow_waiter", "quick_pass"])
     }
 
     @Test("Parallel non-GuardrailError is wrapped as executionFailed for every kind")

--- a/Tests/SwarmTests/Guardrails/GuardrailRunnerGoldenTests.swift
+++ b/Tests/SwarmTests/Guardrails/GuardrailRunnerGoldenTests.swift
@@ -1,0 +1,467 @@
+// GuardrailRunnerGoldenTests.swift
+// SwarmTests
+//
+// Golden tests pinning byte-identical runner behavior (order, short-circuit,
+// error payloads, error precedence) across all four guardrail kinds in both
+// sequential and parallel execution styles.
+
+import Foundation
+@testable import Swarm
+import Testing
+
+// MARK: - Fixtures
+
+private actor ExecutionLog {
+    private(set) var entries: [String] = []
+
+    func record(_ name: String) {
+        entries.append(name)
+    }
+
+    func snapshot() -> [String] {
+        entries
+    }
+}
+
+private actor RecordingObserver: AgentObserver {
+    struct Event: Sendable, Equatable {
+        let name: String
+        let type: GuardrailType
+        let message: String?
+    }
+
+    private(set) var events: [Event] = []
+
+    func onGuardrailTriggered(
+        context _: AgentContext?,
+        guardrailName: String,
+        guardrailType: GuardrailType,
+        result: GuardrailResult
+    ) async {
+        events.append(Event(name: guardrailName, type: guardrailType, message: result.message))
+    }
+}
+
+private struct KaboomError: Error {}
+
+// MARK: - Sequential Golden Tests
+
+@Suite("Guardrail Runner Sequential Goldens")
+struct GuardrailRunnerSequentialGoldens {
+    @Test("Sequential input short-circuit throws first tripwire payload and skips later guards")
+    func sequentialInputShortCircuit() async throws {
+        let log = ExecutionLog()
+        let first = InputGuard("first_blocker") { _, _ in
+            await log.record("first_blocker")
+            return .tripwire(
+                message: "first blocked",
+                outputInfo: .dictionary(["code": .string("F001")])
+            )
+        }
+        let second = InputGuard("second_blocker") { _, _ in
+            await log.record("second_blocker")
+            return .tripwire(message: "second blocked")
+        }
+        let runner = GuardrailRunner()
+
+        do {
+            _ = try await runner.runInputGuardrails([first, second], input: "x", context: nil)
+            Issue.record("Expected GuardrailError")
+        } catch let error as GuardrailError {
+            #expect(error == .inputTripwireTriggered(
+                guardrailName: "first_blocker",
+                message: "first blocked",
+                outputInfo: .dictionary(["code": .string("F001")])
+            ))
+        }
+        #expect(await log.snapshot() == ["first_blocker"])
+    }
+
+    @Test("Sequential run-all returns results in order and throws first tripwired by index")
+    func sequentialRunAllFirstByIndexWins() async throws {
+        let observer = RecordingObserver()
+        let pass = InputGuard("pass_guard") { _, _ in
+            .passed(message: "fine")
+        }
+        let tripA = InputGuard("trip_a") { _, _ in
+            .tripwire(message: "a blocked", outputInfo: .dictionary(["id": .int(1)]))
+        }
+        let tripB = InputGuard("trip_b") { _, _ in
+            .tripwire(message: "b blocked", outputInfo: .dictionary(["id": .int(2)]))
+        }
+        let runner = GuardrailRunner(
+            configuration: GuardrailRunnerConfiguration(stopOnFirstTripwire: false),
+            observer: observer
+        )
+
+        do {
+            _ = try await runner.runInputGuardrails([pass, tripA, tripB], input: "x", context: nil)
+            Issue.record("Expected GuardrailError")
+        } catch let error as GuardrailError {
+            #expect(error == .inputTripwireTriggered(
+                guardrailName: "trip_a",
+                message: "a blocked",
+                outputInfo: .dictionary(["id": .int(1)])
+            ))
+        }
+
+        let events = await observer.events
+        #expect(events == [
+            RecordingObserver.Event(name: "trip_a", type: .input, message: "a blocked"),
+            RecordingObserver.Event(name: "trip_b", type: .input, message: "b blocked"),
+        ])
+    }
+
+    @Test("Sequential output tripwire payload carries agent name")
+    func sequentialOutputTripwirePayload() async throws {
+        let agent = MockAgent(configuration: AgentConfiguration(name: "golden-agent"))
+        let guardrail = OutputGuard("length_watch") { output, _, _ in
+            output.count > 3 ? .tripwire(
+                message: "too long",
+                outputInfo: .dictionary(["len": .int(output.count)])
+            ) : .passed()
+        }
+        let runner = GuardrailRunner()
+
+        do {
+            _ = try await runner.runOutputGuardrails([guardrail], output: "toolong", agent: agent, context: nil)
+            Issue.record("Expected GuardrailError")
+        } catch let error as GuardrailError {
+            #expect(error == .outputTripwireTriggered(
+                guardrailName: "length_watch",
+                agentName: "golden-agent",
+                message: "too long",
+                outputInfo: .dictionary(["len": .int(7)])
+            ))
+        }
+    }
+
+    @Test("Sequential tool input tripwire payload carries tool name and data context")
+    func sequentialToolInputTripwirePayload() async throws {
+        let observer = RecordingObserver()
+        let context = AgentContext(input: "tool request")
+        let data = ToolGuardrailData(
+            tool: MockTool(name: "lookup"),
+            arguments: [:],
+            agent: MockAgent(),
+            context: context
+        )
+        let guardrail = ClosureToolInputGuardrail(name: "arg_watcher") { _ in
+            .tripwire(message: "bad args", outputInfo: .dictionary(["field": .string("q")]))
+        }
+        let runner = GuardrailRunner(observer: observer)
+
+        do {
+            _ = try await runner.runToolInputGuardrails([guardrail], data: data)
+            Issue.record("Expected GuardrailError")
+        } catch let error as GuardrailError {
+            #expect(error == .toolInputTripwireTriggered(
+                guardrailName: "arg_watcher",
+                toolName: "lookup",
+                message: "bad args",
+                outputInfo: .dictionary(["field": .string("q")])
+            ))
+        }
+
+        let events = await observer.events
+        #expect(events == [
+            RecordingObserver.Event(name: "arg_watcher", type: .toolInput, message: "bad args")
+        ])
+    }
+
+    @Test("Sequential tool output run-all collects results and throws first tool-output tripwire")
+    func sequentialToolOutputRunAll() async throws {
+        let data = ToolGuardrailData(tool: MockTool(name: "lookup"), arguments: [:], agent: MockAgent(), context: nil)
+        let pass = ClosureToolOutputGuardrail(name: "shape_check") { _, _ in
+            .passed(message: "shape ok")
+        }
+        let tripA = ClosureToolOutputGuardrail(name: "size_check") { _, _ in
+            .tripwire(message: "too big")
+        }
+        let tripB = ClosureToolOutputGuardrail(name: "pii_check") { _, _ in
+            .tripwire(message: "pii found")
+        }
+        let runner = GuardrailRunner(
+            configuration: GuardrailRunnerConfiguration(stopOnFirstTripwire: false)
+        )
+
+        do {
+            _ = try await runner.runToolOutputGuardrails([pass, tripA, tripB], data: data, output: .string("payload"))
+            Issue.record("Expected GuardrailError")
+        } catch let error as GuardrailError {
+            #expect(error == .toolOutputTripwireTriggered(
+                guardrailName: "size_check",
+                toolName: "lookup",
+                message: "too big",
+                outputInfo: nil
+            ))
+        }
+    }
+
+    @Test("Sequential non-GuardrailError is wrapped as executionFailed for every kind")
+    func sequentialExecutionFailedWrapping() async throws {
+        let boom = InputGuard("in_boom") { _, _ in throw KaboomError() }
+        let runner = GuardrailRunner()
+        let agent = MockAgent(configuration: AgentConfiguration(name: "wrap-agent"))
+
+        do {
+            _ = try await runner.runInputGuardrails([boom], input: "x", context: nil)
+            Issue.record("Expected GuardrailError")
+        } catch let error as GuardrailError {
+            guard case let .executionFailed(name, underlying) = error else {
+                Issue.record("Unexpected case: \(error)")
+                return
+            }
+            #expect(name == "in_boom")
+            #expect(underlying.contains("KaboomError"))
+        }
+
+        let outBoom = OutputGuard("out_boom") { _, _, _ in throw KaboomError() }
+        do {
+            _ = try await runner.runOutputGuardrails([outBoom], output: "x", agent: agent, context: nil)
+            Issue.record("Expected GuardrailError")
+        } catch let error as GuardrailError {
+            guard case let .executionFailed(name, underlying) = error else {
+                Issue.record("Unexpected case: \(error)")
+                return
+            }
+            #expect(name == "out_boom")
+            #expect(underlying.contains("KaboomError"))
+        }
+
+        let toolInBoom = ClosureToolInputGuardrail(name: "tin_boom") { _ in throw KaboomError() }
+        let data = ToolGuardrailData(tool: MockTool(name: "lookup"), arguments: [:], agent: agent, context: nil)
+        do {
+            _ = try await runner.runToolInputGuardrails([toolInBoom], data: data)
+            Issue.record("Expected GuardrailError")
+        } catch let error as GuardrailError {
+            guard case let .executionFailed(name, underlying) = error else {
+                Issue.record("Unexpected case: \(error)")
+                return
+            }
+            #expect(name == "tin_boom")
+            #expect(underlying.contains("KaboomError"))
+        }
+
+        let toolOutBoom = ClosureToolOutputGuardrail(name: "tout_boom") { _, _ in throw KaboomError() }
+        do {
+            _ = try await runner.runToolOutputGuardrails([toolOutBoom], data: data, output: .string("x"))
+            Issue.record("Expected GuardrailError")
+        } catch let error as GuardrailError {
+            guard case let .executionFailed(name, underlying) = error else {
+                Issue.record("Unexpected case: \(error)")
+                return
+            }
+            #expect(name == "tout_boom")
+            #expect(underlying.contains("KaboomError"))
+        }
+    }
+}
+
+// MARK: - Parallel Golden Tests
+
+@Suite("Guardrail Runner Parallel Goldens")
+struct GuardrailRunnerParallelGoldens {
+    @Test("Parallel stop-on-first throws first completed tripwire with exact payload")
+    func parallelStopOnFirstCompletedWins() async throws {
+        let fastTrip = OutputGuard("fast_trip") { _, _, _ in
+            .tripwire(message: "fast blocked", outputInfo: .dictionary(["which": .string("fast")]))
+        }
+        let slowPass = OutputGuard("slow_pass") { _, _, _ in
+            try? await Task.sleep(for: .milliseconds(80))
+            return .passed(message: "late but fine")
+        }
+        let agent = MockAgent(configuration: AgentConfiguration(name: "par-agent"))
+        let runner = GuardrailRunner(configuration: .parallel)
+
+        do {
+            _ = try await runner.runOutputGuardrails(
+                [slowPass, fastTrip],
+                output: "x",
+                agent: agent,
+                context: nil
+            )
+            Issue.record("Expected GuardrailError")
+        } catch let error as GuardrailError {
+            #expect(error == .outputTripwireTriggered(
+                guardrailName: "fast_trip",
+                agentName: "par-agent",
+                message: "fast blocked",
+                outputInfo: .dictionary(["which": .string("fast")])
+            ))
+        }
+    }
+
+    @Test("Parallel run-all preserves index-order results and first-by-index error precedence")
+    func parallelRunAllIndexOrderPrecedence() async throws {
+        let observer = RecordingObserver()
+        let slowPass = InputGuard("slow_pass") { _, _ in
+            try? await Task.sleep(for: .milliseconds(60))
+            return .passed(message: "slow ok")
+        }
+        let fastPass = InputGuard("fast_pass") { _, _ in
+            .passed(message: "fast ok")
+        }
+        let lateTrip = InputGuard("late_trip") { _, _ in
+            try? await Task.sleep(for: .milliseconds(30))
+            return .tripwire(message: "late blocked")
+        }
+        let earlyTrip = InputGuard("early_trip") { _, _ in
+            .tripwire(message: "early blocked")
+        }
+        let runner = GuardrailRunner(
+            configuration: GuardrailRunnerConfiguration(runInParallel: true, stopOnFirstTripwire: false),
+            observer: observer
+        )
+
+        do {
+            _ = try await runner.runInputGuardrails([slowPass, fastPass, lateTrip, earlyTrip], input: "x", context: nil)
+            Issue.record("Expected GuardrailError")
+        } catch let error as GuardrailError {
+            #expect(error == .inputTripwireTriggered(
+                guardrailName: "late_trip",
+                message: "late blocked",
+                outputInfo: nil
+            ))
+        }
+
+        let events = await observer.events
+        #expect(events == [
+            RecordingObserver.Event(name: "late_trip", type: .input, message: "late blocked"),
+            RecordingObserver.Event(name: "early_trip", type: .input, message: "early blocked"),
+        ])
+    }
+
+    @Test("Parallel passing sequence returns results in input order for every kind")
+    func parallelPassingResultsInInputOrderPerKind() async throws {
+        let runner = GuardrailRunner(
+            configuration: GuardrailRunnerConfiguration(runInParallel: true)
+        )
+        let agent = MockAgent(configuration: AgentConfiguration(name: "order-agent"))
+        let data = ToolGuardrailData(tool: MockTool(name: "lookup"), arguments: [:], agent: agent, context: nil)
+
+        let inputs: [any InputGuardrail] = [
+            InputGuard("i_one") { _, _ in .passed(message: "one") },
+            InputGuard("i_two") { _, _ in try? await Task.sleep(for: .milliseconds(20)); return .passed(message: "two") },
+        ]
+        #expect(try await runner.runInputGuardrails(inputs, input: "x", context: nil).map(\.guardrailName) == ["i_one", "i_two"])
+
+        let outputs: [any OutputGuardrail] = [
+            OutputGuard("o_one") { _, _, _ in .passed(message: "one") },
+            OutputGuard("o_two") { _, _, _ in try? await Task.sleep(for: .milliseconds(20)); return .passed(message: "two") },
+        ]
+        #expect(try await runner.runOutputGuardrails(outputs, output: "x", agent: agent, context: nil).map(\.guardrailName) == ["o_one", "o_two"])
+
+        let toolInputs: [any ToolInputGuardrail] = [
+            ClosureToolInputGuardrail(name: "ti_one") { _ in .passed(message: "one") },
+            ClosureToolInputGuardrail(name: "ti_two") { _ in try? await Task.sleep(for: .milliseconds(20)); return .passed(message: "two") },
+        ]
+        #expect(try await runner.runToolInputGuardrails(toolInputs, data: data).map(\.guardrailName) == ["ti_one", "ti_two"])
+
+        let toolOutputs: [any ToolOutputGuardrail] = [
+            ClosureToolOutputGuardrail(name: "to_one") { _, _ in .passed(message: "one") },
+            ClosureToolOutputGuardrail(name: "to_two") { _, _ in try? await Task.sleep(for: .milliseconds(20)); return .passed(message: "two") },
+        ]
+        #expect(try await runner.runToolOutputGuardrails(toolOutputs, data: data, output: .string("y")).map(\.guardrailName) == ["to_one", "to_two"])
+    }
+
+    @Test("Parallel tool input stop-on-first emits single event and exact tool payload")
+    func parallelToolInputStopOnFirst() async throws {
+        let observer = RecordingObserver()
+        let data = ToolGuardrailData(
+            tool: MockTool(name: "search"),
+            arguments: [:],
+            agent: MockAgent(),
+            context: AgentContext(input: "parallel tools")
+        )
+        let blocker = ClosureToolInputGuardrail(name: "deny_all") { _ in
+            .tripwire(message: "denied")
+        }
+        let runner = GuardrailRunner(configuration: .parallel, observer: observer)
+
+        do {
+            _ = try await runner.runToolInputGuardrails([blocker], data: data)
+            Issue.record("Expected GuardrailError")
+        } catch let error as GuardrailError {
+            #expect(error == .toolInputTripwireTriggered(
+                guardrailName: "deny_all",
+                toolName: "search",
+                message: "denied",
+                outputInfo: nil
+            ))
+        }
+
+        let events = await observer.events
+        #expect(events == [RecordingObserver.Event(name: "deny_all", type: .toolInput, message: "denied")])
+    }
+
+    @Test("Parallel non-GuardrailError is wrapped as executionFailed for every kind")
+    func parallelExecutionFailedWrapping() async throws {
+        let runner = GuardrailRunner(configuration: .parallel)
+        let agent = MockAgent(configuration: AgentConfiguration(name: "par-wrap"))
+        let data = ToolGuardrailData(tool: MockTool(name: "lookup"), arguments: [:], agent: agent, context: nil)
+
+        do {
+            _ = try await runner.runInputGuardrails([InputGuard("pin_boom") { _, _ in throw KaboomError() }], input: "x", context: nil)
+            Issue.record("Expected GuardrailError")
+        } catch let error as GuardrailError {
+            guard case let .executionFailed(name, underlying) = error else {
+                Issue.record("Unexpected case: \(error)")
+                return
+            }
+            #expect(name == "pin_boom")
+            #expect(underlying.contains("KaboomError"))
+        }
+
+        do {
+            _ = try await runner.runOutputGuardrails([OutputGuard("pout_boom") { _, _, _ in throw KaboomError() }], output: "x", agent: agent, context: nil)
+            Issue.record("Expected GuardrailError")
+        } catch let error as GuardrailError {
+            guard case let .executionFailed(name, underlying) = error else {
+                Issue.record("Unexpected case: \(error)")
+                return
+            }
+            #expect(name == "pout_boom")
+            #expect(underlying.contains("KaboomError"))
+        }
+
+        do {
+            _ = try await runner.runToolInputGuardrails([ClosureToolInputGuardrail(name: "ptin_boom") { _ in throw KaboomError() }], data: data)
+            Issue.record("Expected GuardrailError")
+        } catch let error as GuardrailError {
+            guard case let .executionFailed(name, underlying) = error else {
+                Issue.record("Unexpected case: \(error)")
+                return
+            }
+            #expect(name == "ptin_boom")
+            #expect(underlying.contains("KaboomError"))
+        }
+
+        do {
+            _ = try await runner.runToolOutputGuardrails([ClosureToolOutputGuardrail(name: "ptout_boom") { _, _ in throw KaboomError() }], data: data, output: .string("x"))
+            Issue.record("Expected GuardrailError")
+        } catch let error as GuardrailError {
+            guard case let .executionFailed(name, underlying) = error else {
+                Issue.record("Unexpected case: \(error)")
+                return
+            }
+            #expect(name == "ptout_boom")
+            #expect(underlying.contains("KaboomError"))
+        }
+    }
+
+    @Test("Empty guardrail arrays return empty results in both styles for every kind")
+    func emptyArraysReturnEmptyResults() async throws {
+        let sequential = GuardrailRunner()
+        let parallel = GuardrailRunner(configuration: .parallel)
+        let agent = MockAgent()
+        let data = ToolGuardrailData(tool: MockTool(), arguments: [:], agent: agent, context: nil)
+
+        for runner in [sequential, parallel] {
+            #expect(try await runner.runInputGuardrails([], input: "x", context: nil).isEmpty)
+            #expect(try await runner.runOutputGuardrails([], output: "x", agent: agent, context: nil).isEmpty)
+            #expect(try await runner.runToolInputGuardrails([], data: data).isEmpty)
+            #expect(try await runner.runToolOutputGuardrails([], data: data, output: .string("x")).isEmpty)
+        }
+    }
+}


### PR DESCRIPTION
Ticket T2 of spec `spec-architecture-functional-core-e3a92541` (swift-functional-codebase-evolution → swift-architecture-pipeline).

**What**
- GuardrailRunner: 8 duplicated per-kind×style loops (4 kinds × sequential/parallel, ~850 LOC) → one normalized `GuardrailUnit` model + exactly one `runSequential` and one `runParallel` executor + single `tripwireError(kind:)` table
- Public protocols and all public method signatures unchanged (byte-identical requirement blocks verified against base)
- Built-in guards (maxLength/notEmpty/custom) now testable without constructing any AgentRuntime (internal `NullAgentRuntime` + `OutputGuard.evaluate` seam)
- 12 golden tests written against BASE before refactoring; mutation-checked; 172/172 guardrail tests pass
- Net −388 LOC in the runner

**Verification**: lean build ✅ · goldens pass on base AND head ✅ · full Guardrail suite ✅

**Reviews**: swift-pr-review ×2 (fresh-context reviewer-fix pass + final pass) — merge-ready, no open findings.