### PR TITLE
arch(T3): resolve agent collaborators into explicit turn dependencies

### DIFF
--- a/Sources/Swarm/Agents/Agent.swift
+++ b/Sources/Swarm/Agents/Agent.swift
@@ -837,16 +837,6 @@ public struct Agent: AgentRuntime, Sendable {
         }
     }
 
-    private func resolvedActiveTracer() -> (any Tracer)? {
-        AgentDependencyResolver.activeTracer(
-            explicitTracer: tracer,
-            environmentTracer: AgentEnvironmentValues.current.tracer,
-            defaultTracingEnabled: configuration.defaultTracingEnabled,
-            autoAttachMetricsCollector: configuration.autoAttachMetricsCollector,
-            metricsCollector: metricsCollector
-        )
-    }
-
     private func runInternal(
         _ input: String,
         session: (any Session)? = nil,
@@ -857,16 +847,14 @@ public struct Agent: AgentRuntime, Sendable {
             throw AgentError.invalidInput(reason: "Input cannot be empty")
         }
 
-        let activeTracer = resolvedActiveTracer()
-        let activeMemory = resolvedMemory()
-        let memoryHooks = activeMemory.map { MemoryHooks.resolved(from: $0) } ?? .empty
-        let trackedSessionMemory = activeMemory.flatMap { memory in
-            resolvedTrackedSessionMemory(from: memory, defaultMemory: defaultMemory)
-        }
+        let dependencies = try await resolveTurnDependencies()
+        let activeTracer = dependencies.tracer
+        let activeMemory = dependencies.memory
+        let memoryHooks = dependencies.memoryHooks
         var defaultMemoryRunKey: ObjectIdentifier?
 
         if let session,
-           let trackedSessionMemory
+           let trackedSessionMemory = dependencies.trackedSessionMemory
         {
             let memoryKey = memoryObjectIdentifier(trackedSessionMemory)
             defaultMemoryRunKey = memoryKey
@@ -879,7 +867,6 @@ public struct Agent: AgentRuntime, Sendable {
             tracer: activeTracer,
             agentName: configuration.name.isEmpty ? "Agent" : configuration.name
         )
-        let runtimeToolRegistry = try await resolvedToolRegistry()
         await tracing.traceStart(input: input)
 
         // Notify observer of agent start
@@ -924,9 +911,9 @@ public struct Agent: AgentRuntime, Sendable {
             let userMessage = SwarmTranscriptCodec.encodeMessage(role: .user, content: input)
 
             // Execute the tool calling loop with session context
-            let provider = try await resolvedInferenceProvider()
+            let provider = dependencies.provider
             let executionContext = AgentContext(input: input)
-            let runtimeEnvironment = runtimeEnvironment(for: provider)
+            let runtimeEnvironment = runtimeEnvironment(for: provider, snapshot: dependencies.environmentSnapshot)
             let ownsToolLoop = provider.capabilities.contains(.providerOwnedToolLoop)
             let executionGate = ownsToolLoop ? ProviderOwnedLoopGate() : nil
             let pendingHandoff = OwnedLoopPendingHandoff()
@@ -934,8 +921,7 @@ public struct Agent: AgentRuntime, Sendable {
             let toolLoopOutcome = try await AgentEnvironmentValues.$current.withValue(runtimeEnvironment) {
                 try await executeToolCallingLoop(
                     input: input,
-                    toolRegistry: runtimeToolRegistry,
-                    provider: provider,
+                    dependencies: dependencies,
                     sessionHistory: sessionHistory,
                     session: session,
                     resultBuilder: resultBuilder,
@@ -973,7 +959,7 @@ public struct Agent: AgentRuntime, Sendable {
                 if let transcriptHash = try? persistedTranscript.transcriptHash() {
                     _ = resultBuilder.setMetadata(Self.transcriptHashMetadataKey, .string(transcriptHash))
                 }
-            } else if let activeMemory, shouldPersistNoSessionTurn(to: activeMemory) {
+            } else if let activeMemory, dependencies.shouldPersistNoSessionTurnToDefaultMemory {
                 await persistNoSessionTurn(
                     userMessage: userMessage,
                     transcriptMessages: toolLoopOutcome.transcriptMessages,
@@ -1017,39 +1003,33 @@ public struct Agent: AgentRuntime, Sendable {
         }
     }
 
-    // MARK: - Inference Provider Resolution
+    // MARK: - Turn Dependency Resolution
 
-    private func resolvedInferenceProvider() async throws -> any InferenceProvider {
-        try await AgentDependencyResolver.inferenceProvider(
-            privacyRequired: configuration.inferencePolicy?.privacyRequired == true,
+    /// Gathers every resolution channel for one turn — explicit configuration,
+    /// the TaskLocal environment snapshot, package globals, and the agent's
+    /// base tools — and resolves them exactly once into an
+    /// ``AgentTurnDependencies`` value.
+    private func resolveTurnDependencies() async throws -> AgentTurnDependencies {
+        let query = AgentTurnDependencyQuery(
+            configuration: configuration,
             explicitProvider: inferenceProvider,
-            environment: AgentEnvironmentValues.current,
-            runEnvironment: runEnvironment
-        )
-    }
-
-    private func resolvedMembraneAdapter() -> (any MembraneAgentAdapter)? {
-        AgentDependencyResolver.membraneAdapter(in: AgentEnvironmentValues.current)
-    }
-
-    private func runtimeEnvironment(for provider: any InferenceProvider) -> AgentEnvironment {
-        AgentDependencyResolver.runtimeEnvironment(AgentEnvironmentValues.current, addingTokenCounterFrom: provider)
-    }
-
-    private func resolvedMemory() -> (any Memory)? {
-        AgentDependencyResolver.memory(
             explicitMemory: memory,
-            environmentMemory: AgentEnvironmentValues.current.memory,
-            defaultMemory: defaultMemory
+            defaultMemory: defaultMemory,
+            explicitTracer: tracer,
+            metricsCollector: metricsCollector,
+            baseTools: await toolRegistry.allTools,
+            environment: AgentEnvironmentValues.current,
+            globalProvider: await runEnvironment.defaultProvider(),
+            globalWebSearch: await runEnvironment.webConfiguration()
         )
+        return try AgentTurnDependencyResolver.resolve(query)
     }
 
-    private func shouldPersistNoSessionTurn(to activeMemory: any Memory) -> Bool {
-        guard let defaultMemory else {
-            return false
-        }
-
-        return memoriesAreSameInstance(activeMemory, defaultMemory)
+    private func runtimeEnvironment(
+        for provider: any InferenceProvider,
+        snapshot: AgentEnvironment
+    ) -> AgentEnvironment {
+        AgentDependencyResolver.runtimeEnvironment(snapshot, addingTokenCounterFrom: provider)
     }
 
     private func persistNoSessionTurn(
@@ -1091,14 +1071,6 @@ public struct Agent: AgentRuntime, Sendable {
         // Lean builds, or Integrations on non-Apple (no ContextCore link).
         return SlidingWindowMemory()
         #endif
-    }
-
-    private func resolvedToolRegistry() async throws -> ToolRegistry {
-        try await AgentDependencyResolver.toolRegistry(
-            baseTools: await toolRegistry.allTools,
-            taskLocalWebSearch: AgentEnvironmentValues.current.webSearch,
-            runEnvironment: runEnvironment
-        )
     }
 
     private func resolvedInferenceOptions(
@@ -1205,8 +1177,7 @@ public struct Agent: AgentRuntime, Sendable {
 
     private func executeToolCallingLoop(
         input: String,
-        toolRegistry: ToolRegistry,
-        provider: any InferenceProvider,
+        dependencies: AgentTurnDependencies,
         sessionHistory: [MemoryMessage] = [],
         session: (any Session)?,
         resultBuilder: AgentResult.Builder,
@@ -1217,6 +1188,8 @@ public struct Agent: AgentRuntime, Sendable {
         executionGate: ProviderOwnedLoopGate?,
         pendingHandoff: OwnedLoopPendingHandoff
     ) async throws -> ToolLoopOutcome {
+        let toolRegistry = dependencies.toolRegistry
+        let provider = dependencies.provider
         var iteration = 0
         let startTime = ContinuousClock.now
         var inferenceOptions = await resolvedInferenceOptions(session: session, provider: provider)
@@ -1224,9 +1197,13 @@ public struct Agent: AgentRuntime, Sendable {
             inferenceOptions.structuredOutput = structuredOutputRequest
         }
         inferenceOptions.conversationId = session?.sessionId ?? UUID().uuidString
+        inferenceOptions = optionsWithMembraneRuntimeSettings(
+            inferenceOptions,
+            membrane: dependencies.membraneEnvironment
+        )
 
         // Retrieve relevant context from memory (enables RAG for VectorMemory)
-        let activeMemory = resolvedMemory()
+        let activeMemory = dependencies.memory
         var memoryContext = ""
         if let mem = activeMemory {
             let contextProfile = configuration.effectiveContextProfile
@@ -1260,7 +1237,7 @@ public struct Agent: AgentRuntime, Sendable {
         let enableStreaming = configuration.enableStreaming && observer != nil
         let capabilities = providerCapabilities(for: provider)
         let useToolStreaming = enableStreaming && capabilities.contains(.streamingToolCalls)
-        let membraneAdapter = resolvedMembraneAdapter()
+        let membraneAdapter = dependencies.membraneAdapter
 
         while iteration < configuration.maxIterations {
             iteration += 1
@@ -1418,6 +1395,8 @@ public struct Agent: AgentRuntime, Sendable {
                     let handoffOutcome = try await completeOwnedLoopHandoff(
                         request,
                         toolRegistry: toolRegistry,
+                        memory: activeMemory,
+                        membraneAdapter: membraneAdapter,
                         conversationHistory: conversationHistory,
                         transcriptMessages: &transcriptMessages,
                         resultBuilder: resultBuilder,
@@ -1433,6 +1412,8 @@ public struct Agent: AgentRuntime, Sendable {
                         let handoffOutcome = try await completeOwnedLoopHandoff(
                             OwnedLoopHandoffRequest(name: pending.name, arguments: pending.arguments),
                             toolRegistry: toolRegistry,
+                            memory: activeMemory,
+                            membraneAdapter: membraneAdapter,
                             conversationHistory: conversationHistory,
                             transcriptMessages: &transcriptMessages,
                             resultBuilder: resultBuilder,
@@ -1477,6 +1458,7 @@ public struct Agent: AgentRuntime, Sendable {
                     let handoffResult = try await processToolCallsWithHandoffs(
                         response: response,
                         toolRegistry: toolRegistry,
+                        memory: activeMemory,
                         conversationHistory: &conversationHistory,
                         transcriptMessages: &transcriptMessages,
                         resultBuilder: resultBuilder,
@@ -1640,7 +1622,7 @@ public struct Agent: AgentRuntime, Sendable {
     ) async throws -> FinalAssistantResponse {
         await observer?.notifyLLMStart(context: nil, agent: self, systemPrompt: systemPrompt, inputMessages: messages)
 
-        let options = optionsWithMembraneRuntimeSettings(inferenceOptions)
+        let options = inferenceOptions
         let content: String
         let structuredOutput: StructuredOutputResult?
         if let request = options.structuredOutput {
@@ -1676,6 +1658,7 @@ public struct Agent: AgentRuntime, Sendable {
     private func executeSingleToolCall(
         parsedCall: InferenceResponse.ParsedToolCall,
         toolRegistry: ToolRegistry,
+        memory: (any Memory)?,
         conversationHistory: inout [ConversationMessage],
         transcriptMessages: inout [MemoryMessage],
         resultBuilder: AgentResult.Builder,
@@ -1685,7 +1668,7 @@ public struct Agent: AgentRuntime, Sendable {
         membraneAdapter: (any MembraneAgentAdapter)?,
         startTime: ContinuousClock.Instant
     ) async throws {
-        let activeMemory = resolvedMemory()
+        let activeMemory = memory
 
         // Handoff I/O lives in `processToolCallsWithHandoffs`. A `.handoff` kind
         // here is the missing-configuration fallback and must not take the
@@ -1957,6 +1940,7 @@ public struct Agent: AgentRuntime, Sendable {
     private func processToolCallsWithHandoffs(
         response: InferenceResponse,
         toolRegistry: ToolRegistry,
+        memory: (any Memory)?,
         conversationHistory: inout [ConversationMessage],
         transcriptMessages: inout [MemoryMessage],
         resultBuilder: AgentResult.Builder,
@@ -1993,6 +1977,7 @@ public struct Agent: AgentRuntime, Sendable {
                     try await executeSingleToolCall(
                         parsedCall: parsedCall,
                         toolRegistry: toolRegistry,
+                        memory: memory,
                         conversationHistory: &conversationHistory,
                         transcriptMessages: &transcriptMessages,
                         resultBuilder: resultBuilder,
@@ -2187,6 +2172,7 @@ public struct Agent: AgentRuntime, Sendable {
                 try await executeSingleToolCall(
                     parsedCall: parsedCall,
                     toolRegistry: toolRegistry,
+                    memory: memory,
                     conversationHistory: &conversationHistory,
                     transcriptMessages: &transcriptMessages,
                     resultBuilder: resultBuilder,
@@ -2334,8 +2320,7 @@ public struct Agent: AgentRuntime, Sendable {
         emitOutputTokens: Bool = false,
         toolExecutor: ToolCallExecutor? = nil
     ) async throws -> InferenceResponse {
-        var options = inferenceOptions
-        options = optionsWithMembraneRuntimeSettings(options)
+        let options = inferenceOptions
 
         // Notify observer of LLM start
         await observer?.notifyLLMStart(context: nil, agent: self, systemPrompt: systemPrompt, inputMessages: messages)
@@ -2369,8 +2354,7 @@ public struct Agent: AgentRuntime, Sendable {
         observer: (any AgentObserver)? = nil,
         toolExecutor: ToolCallExecutor? = nil
     ) async throws -> InferenceResponse {
-        var options = inferenceOptions
-        options = optionsWithMembraneRuntimeSettings(options)
+        let options = inferenceOptions
 
         await observer?.notifyLLMStart(context: nil, agent: self, systemPrompt: systemPrompt, inputMessages: messages)
 
@@ -2430,8 +2414,11 @@ public struct Agent: AgentRuntime, Sendable {
         )
     }
 
-    func optionsWithMembraneRuntimeSettings(_ base: InferenceOptions) -> InferenceOptions {
-        guard let membrane = AgentEnvironmentValues.current.membrane, membrane.isEnabled else {
+    func optionsWithMembraneRuntimeSettings(
+        _ base: InferenceOptions,
+        membrane: MembraneEnvironment?
+    ) -> InferenceOptions {
+        guard let membrane, membrane.isEnabled else {
             return base
         }
 
@@ -2503,6 +2490,8 @@ public struct Agent: AgentRuntime, Sendable {
     private func completeOwnedLoopHandoff(
         _ request: OwnedLoopHandoffRequest,
         toolRegistry: ToolRegistry,
+        memory: (any Memory)?,
+        membraneAdapter: (any MembraneAgentAdapter)?,
         conversationHistory: [ConversationMessage],
         transcriptMessages: inout [MemoryMessage],
         resultBuilder: AgentResult.Builder,
@@ -2526,12 +2515,13 @@ public struct Agent: AgentRuntime, Sendable {
         let handoffOutput = try await processToolCallsWithHandoffs(
             response: response,
             toolRegistry: toolRegistry,
+            memory: memory,
             conversationHistory: &history,
             transcriptMessages: &transcriptMessages,
             resultBuilder: resultBuilder,
             observer: observer,
             tracing: tracing,
-            membraneAdapter: resolvedMembraneAdapter(),
+            membraneAdapter: membraneAdapter,
             context: context,
             startTime: startTime
         )

--- a/Sources/Swarm/Agents/AgentTurnDependencies.swift
+++ b/Sources/Swarm/Agents/AgentTurnDependencies.swift
@@ -1,0 +1,246 @@
+// AgentTurnDependencies.swift
+// Swarm Framework
+//
+// Explicit per-turn collaborator resolution for Agent.
+
+import Foundation
+
+/// The collaborators chosen for one agent turn.
+///
+/// ``Agent`` resolves this value exactly once at the start of every run, and
+/// the turn loop plus its helpers read only from it. Identity-sensitive
+/// decisions — whether the resolved memory is the package default, which
+/// memory layer owns session tracking — are computed here against the resolved
+/// instances instead of being re-derived mid-loop.
+struct AgentTurnDependencies: Sendable {
+    /// Inference provider that won resolution for this turn.
+    let provider: any InferenceProvider
+
+    /// Memory for this turn. `nil` remains legal (stateless turn).
+    let memory: (any Memory)?
+
+    /// Optional memory behavior derived from ``memory``.
+    let memoryHooks: MemoryHooks
+
+    /// Memory layer that owns session isolation for this turn: the agent's
+    /// default memory when the resolved memory is that instance, otherwise the
+    /// resolved memory's tracked session layer.
+    let trackedSessionMemory: (any Memory)?
+
+    /// Whether a session-less turn persists into the resolved memory. True
+    /// exactly when the resolved memory is the agent's default memory instance.
+    let shouldPersistNoSessionTurnToDefaultMemory: Bool
+
+    /// Tracer chain for this turn: explicit tracer or environment tracer,
+    /// falling back to the configured default, composed with the auto-attached
+    /// metrics collector when enabled.
+    let tracer: (any Tracer)?
+
+    /// Tool registry for this turn, including any ambient web-search tool.
+    let toolRegistry: ToolRegistry
+
+    /// Membrane planning/transform adapter for this turn, `nil` when membrane
+    /// is disabled in the environment.
+    let membraneAdapter: (any MembraneAgentAdapter)?
+
+    /// Raw membrane environment used to derive inference runtime settings.
+    let membraneEnvironment: MembraneEnvironment?
+
+    /// Environment snapshot captured when this turn's dependencies resolved.
+    /// Nested execution re-binds it (with provider-derived token counters) via
+    /// the existing TaskLocal propagation.
+    let environmentSnapshot: AgentEnvironment
+}
+
+/// Direct inputs to collaborator resolution for one agent turn.
+///
+/// Async channel reads (`Swarm.defaultProvider`, `Swarm.webConfiguration`,
+/// the agent's base tools) are gathered by the caller before resolution.
+/// Resolution itself is synchronous, so winner precedence can be asserted from
+/// direct inputs without TaskLocal choreography.
+struct AgentTurnDependencyQuery {
+    var configuration: AgentConfiguration
+    var explicitProvider: (any InferenceProvider)?
+    var explicitMemory: (any Memory)?
+    var defaultMemory: (any Memory)?
+    var explicitTracer: (any Tracer)?
+    var metricsCollector: MetricsCollector?
+    var baseTools: [any AnyJSONTool]
+    var environment: AgentEnvironment
+    var globalProvider: (any InferenceProvider)?
+    var globalWebSearch: WebSearchTool.Configuration?
+    var foundationModelsProvider: @Sendable () -> (any InferenceProvider)?
+
+    init(
+        configuration: AgentConfiguration,
+        explicitProvider: (any InferenceProvider)? = nil,
+        explicitMemory: (any Memory)? = nil,
+        defaultMemory: (any Memory)? = nil,
+        explicitTracer: (any Tracer)? = nil,
+        metricsCollector: MetricsCollector? = nil,
+        baseTools: [any AnyJSONTool] = [],
+        environment: AgentEnvironment = AgentEnvironment(),
+        globalProvider: (any InferenceProvider)? = nil,
+        globalWebSearch: WebSearchTool.Configuration? = nil,
+        foundationModelsProvider: @escaping @Sendable () -> (any InferenceProvider)? = { DefaultInferenceProviderFactory.makeFoundationModelsProviderIfAvailable() }
+    ) {
+        self.configuration = configuration
+        self.explicitProvider = explicitProvider
+        self.explicitMemory = explicitMemory
+        self.defaultMemory = defaultMemory
+        self.explicitTracer = explicitTracer
+        self.metricsCollector = metricsCollector
+        self.baseTools = baseTools
+        self.environment = environment
+        self.globalProvider = globalProvider
+        self.globalWebSearch = globalWebSearch
+        self.foundationModelsProvider = foundationModelsProvider
+    }
+}
+
+/// Single resolution point turning an ``AgentTurnDependencyQuery`` into
+/// ``AgentTurnDependencies``.
+///
+/// Normal-policy provider precedence:
+/// explicit → environment → `Swarm.defaultProvider` → Foundation Models → throw.
+///
+/// Privacy-required policy reranks to:
+/// Foundation Models → private explicit → private environment → private global
+/// → throw. Non-private providers are filtered out; Foundation Models is
+/// accepted as on-device private inference.
+enum AgentTurnDependencyResolver {
+    static func resolve(_ query: AgentTurnDependencyQuery) throws -> AgentTurnDependencies {
+        let memory = resolveMemory(query)
+        let shouldPersistNoSessionTurn = memory.map { memory in
+            guard let defaultMemory = query.defaultMemory else { return false }
+            return memoriesAreSameInstance(memory, defaultMemory)
+        } ?? false
+
+        return AgentTurnDependencies(
+            provider: try resolveProvider(query),
+            memory: memory,
+            memoryHooks: memory.map { MemoryHooks.resolved(from: $0) } ?? .empty,
+            trackedSessionMemory: memory.flatMap {
+                resolvedTrackedSessionMemory(from: $0, defaultMemory: query.defaultMemory)
+            },
+            shouldPersistNoSessionTurnToDefaultMemory: shouldPersistNoSessionTurn,
+            tracer: resolveTracer(query),
+            toolRegistry: try resolveToolRegistry(query),
+            membraneAdapter: resolveMembraneAdapter(query),
+            membraneEnvironment: query.environment.membrane,
+            environmentSnapshot: query.environment
+        )
+    }
+
+    private static func resolveProvider(_ query: AgentTurnDependencyQuery) throws -> any InferenceProvider {
+        if query.configuration.inferencePolicy?.privacyRequired == true {
+            if let foundationModelsProvider = query.foundationModelsProvider() {
+                return transformed(foundationModelsProvider, query)
+            }
+
+            let ambientProviders = [
+                query.explicitProvider,
+                query.environment.inferenceProvider,
+                query.globalProvider,
+            ]
+            for candidate in ambientProviders {
+                guard let candidate else { continue }
+                if isPrivateInference(candidate) {
+                    return transformed(candidate, query)
+                }
+            }
+
+            throw AgentError.inferenceProviderUnavailable(
+                reason: """
+                AgentConfiguration.inferencePolicy.privacyRequired is true, but no private inference provider is available.
+
+                Use Apple Foundation Models on a supported device, or configure a provider that reports \
+                InferenceProviderCapabilities.privateInference via `await Swarm.configure(provider: ...)`.
+                """
+            )
+        }
+
+        let candidates = [
+            query.explicitProvider,
+            query.environment.inferenceProvider,
+            query.globalProvider,
+        ]
+        for candidate in candidates {
+            if let candidate {
+                return transformed(candidate, query)
+            }
+        }
+
+        if let foundationModelsProvider = query.foundationModelsProvider() {
+            return transformed(foundationModelsProvider, query)
+        }
+
+        throw AgentError.inferenceProviderUnavailable(
+            reason: """
+            No inference provider configured and Apple Foundation Models are unavailable.
+
+            Configure a provider globally via `await Swarm.configure(provider: ...)` \
+            or pass one explicitly to Agent(...).
+            """
+        )
+    }
+
+    private static func isPrivateInference(_ provider: any InferenceProvider) -> Bool {
+        InferenceProviderCapabilities.resolved(for: provider).contains(.privateInference)
+    }
+
+    private static func transformed(
+        _ provider: any InferenceProvider,
+        _ query: AgentTurnDependencyQuery
+    ) -> any InferenceProvider {
+        guard let transform = query.environment.inferenceProviderTransform else {
+            return provider
+        }
+        return transform(provider)
+    }
+
+    private static func resolveMemory(_ query: AgentTurnDependencyQuery) -> (any Memory)? {
+        query.explicitMemory ?? query.environment.memory ?? query.defaultMemory
+    }
+
+    private static func resolveTracer(_ query: AgentTurnDependencyQuery) -> (any Tracer)? {
+        let configured = query.explicitTracer ?? query.environment.tracer
+        let fallback = query.configuration.defaultTracingEnabled
+            ? SwiftLogTracer(minimumLevel: .debug)
+            : nil
+        let base = configured ?? fallback
+
+        guard query.configuration.autoAttachMetricsCollector, let collector = query.metricsCollector else {
+            return base
+        }
+
+        if let base {
+            if let existing = base as? MetricsCollector, existing === collector {
+                return collector
+            }
+            return CompositeTracer(tracers: [base, collector])
+        }
+        return collector
+    }
+
+    private static func resolveToolRegistry(_ query: AgentTurnDependencyQuery) throws -> ToolRegistry {
+        var tools = query.baseTools
+        #if SWARM_INTEGRATIONS
+        if !tools.contains(where: { $0.name == "websearch" }) {
+            let ambientWeb = query.environment.webSearch ?? query.globalWebSearch
+            if let ambientWeb, ambientWeb.enabled {
+                tools.append(WebSearchTool(configuration: ambientWeb))
+            }
+        }
+        #endif
+        return try ToolRegistry(tools: tools)
+    }
+
+    private static func resolveMembraneAdapter(_ query: AgentTurnDependencyQuery) -> (any MembraneAgentAdapter)? {
+        let membrane = query.environment.membrane ?? .enabled
+        guard membrane.isEnabled else {
+            return nil
+        }
+        return membrane.adapter ?? DefaultMembraneAgentAdapter(configuration: membrane.configuration)
+    }
+}

--- a/Tests/SwarmTests/Agents/AgentTurnDependenciesTests.swift
+++ b/Tests/SwarmTests/Agents/AgentTurnDependenciesTests.swift
@@ -1,0 +1,399 @@
+// AgentTurnDependenciesTests.swift
+// SwarmTests
+//
+// Direct-input tests for per-turn Agent collaborator resolution.
+
+import Foundation
+@testable import Swarm
+import Testing
+
+@Suite("Agent Turn Dependencies")
+struct AgentTurnDependenciesTests {
+    // MARK: - Provider Winner Order (normal policy)
+
+    @Test("Normal policy prefers explicit provider over environment, global, and Foundation Models")
+    func explicitProviderWins() throws {
+        let explicit = MockInferenceProvider(responses: ["explicit"])
+        let environment = MockInferenceProvider(responses: ["environment"])
+        let global = MockInferenceProvider(responses: ["global"])
+        let foundationModels = MockInferenceProvider(responses: ["foundation-models"])
+
+        let dependencies = try AgentTurnDependencyResolver.resolve(
+            query(
+                explicitProvider: explicit,
+                environmentProvider: environment,
+                globalProvider: global,
+                foundationModels: foundationModels
+            )
+        )
+
+        #expect(sameInstance(dependencies.provider, explicit))
+    }
+
+    @Test("Normal policy falls back through environment, global, then Foundation Models")
+    func normalPolicyFallbackOrder() throws {
+        let environment = MockInferenceProvider(responses: ["environment"])
+        let global = MockInferenceProvider(responses: ["global"])
+        let foundationModels = MockInferenceProvider(responses: ["foundation-models"])
+
+        let fromEnvironment = try AgentTurnDependencyResolver.resolve(
+            query(environmentProvider: environment, globalProvider: global, foundationModels: foundationModels)
+        )
+        #expect(sameInstance(fromEnvironment.provider, environment))
+
+        let fromGlobal = try AgentTurnDependencyResolver.resolve(
+            query(globalProvider: global, foundationModels: foundationModels)
+        )
+        #expect(sameInstance(fromGlobal.provider, global))
+
+        let fromFoundationModels = try AgentTurnDependencyResolver.resolve(
+            query(foundationModels: foundationModels)
+        )
+        #expect(sameInstance(fromFoundationModels.provider, foundationModels))
+    }
+
+    @Test("Normal policy throws when no channel offers a provider")
+    func normalPolicyThrowsWithoutAnyProvider() {
+        #expect(throws: AgentError.self) {
+            _ = try AgentTurnDependencyResolver.resolve(query(foundationModels: nil))
+        }
+    }
+
+    // MARK: - Provider Winner Order (privacy-required policy)
+
+    @Test("Privacy-required reranks Foundation Models ahead of private ambient providers")
+    func privacyRequiredPrefersFoundationModels() throws {
+        let foundationModels = MockInferenceProvider(
+            responses: ["foundation-models"],
+            capabilities: [.privateInference]
+        )
+        let explicitPrivate = MockInferenceProvider(
+            responses: ["explicit"],
+            capabilities: [.privateInference]
+        )
+
+        let dependencies = try AgentTurnDependencyResolver.resolve(
+            query(
+                configuration: AgentConfiguration.default.inferencePolicy(InferencePolicy(privacyRequired: true)),
+                explicitProvider: explicitPrivate,
+                foundationModels: foundationModels
+            )
+        )
+
+        #expect(sameInstance(dependencies.provider, foundationModels))
+    }
+
+    @Test("Privacy-required skips non-private providers and keeps private order")
+    func privacyRequiredFiltersNonPrivateProviders() throws {
+        let configuration = AgentConfiguration.default.inferencePolicy(InferencePolicy(privacyRequired: true))
+        let nonPrivateExplicit = MockInferenceProvider(responses: ["non-private-explicit"])
+        let nonPrivateEnvironment = MockInferenceProvider(responses: ["non-private-environment"])
+        let privateGlobal = MockInferenceProvider(
+            responses: ["private-global"],
+            capabilities: [.privateInference]
+        )
+
+        let dependencies = try AgentTurnDependencyResolver.resolve(query(
+            configuration: configuration,
+            explicitProvider: nonPrivateExplicit,
+            environmentProvider: nonPrivateEnvironment,
+            globalProvider: privateGlobal,
+            foundationModels: nil
+        ))
+
+        #expect(sameInstance(dependencies.provider, privateGlobal))
+    }
+
+    @Test("Privacy-required throws when no private provider exists")
+    func privacyRequiredThrowsWithoutPrivateProvider() {
+        let configuration = AgentConfiguration.default.inferencePolicy(InferencePolicy(privacyRequired: true))
+
+        #expect(throws: AgentError.self) {
+            _ = try AgentTurnDependencyResolver.resolve(
+                query(configuration: configuration, explicitProvider: MockInferenceProvider(), foundationModels: nil)
+            )
+        }
+    }
+
+    // MARK: - Provider transform
+
+    @Test("Environment transform applies to the winning provider")
+    func transformAppliesToWinner() throws {
+        let explicit = MockInferenceProvider(responses: ["explicit"])
+        let transformed = MockInferenceProvider(responses: ["transformed"])
+        var environment = AgentEnvironment()
+        environment.inferenceProviderTransform = { _ in transformed }
+
+        let dependencies = try AgentTurnDependencyResolver.resolve(
+            query(explicitProvider: explicit, environment: environment, foundationModels: nil)
+        )
+
+        #expect(sameInstance(dependencies.provider, transformed))
+    }
+
+    // MARK: - Memory winner order and identity decisions
+
+    @Test("Memory precedence is explicit, then environment, then default")
+    func memoryPrecedence() throws {
+        let explicit = SlidingWindowMemory()
+        let environmentMemory = SlidingWindowMemory()
+        let defaultMemory = SlidingWindowMemory()
+        var environment = AgentEnvironment()
+        environment.memory = environmentMemory
+
+        let fromExplicit = try resolve(explicitMemory: explicit, defaultMemory: defaultMemory)
+        #expect(sameInstance(fromExplicit.memory!, explicit))
+
+        let fromEnvironment = try resolve(defaultMemory: defaultMemory, environment: environment)
+        #expect(sameInstance(fromEnvironment.memory!, environmentMemory))
+
+        let fromDefault = try resolve(defaultMemory: defaultMemory)
+        #expect(sameInstance(fromDefault.memory!, defaultMemory))
+
+        let stateless = try resolve(defaultMemory: nil, environment: AgentEnvironment())
+        #expect(stateless.memory == nil)
+    }
+
+    @Test("Session-less persistence records identity against the resolved memory")
+    func sessionlessPersistenceIdentityDecision() throws {
+        let defaultMemory = SlidingWindowMemory()
+
+        let sameInstance = try resolve(explicitMemory: defaultMemory, defaultMemory: defaultMemory)
+        #expect(sameInstance.shouldPersistNoSessionTurnToDefaultMemory)
+        #expect(identical(sameInstance.trackedSessionMemory, defaultMemory as (any Memory)?))
+
+        let differentInstance = try resolve(
+            explicitMemory: SlidingWindowMemory(),
+            defaultMemory: defaultMemory
+        )
+        #expect(!differentInstance.shouldPersistNoSessionTurnToDefaultMemory)
+        #expect(differentInstance.trackedSessionMemory == nil)
+    }
+
+    // MARK: - Tracer resolution
+
+    @Test("Tracer prefers explicit tracer and composes the auto-attached collector")
+    func tracerComposition() throws {
+        let tracer = SwiftLogTracer(minimumLevel: .debug)
+        let collector = MetricsCollector()
+
+        let composed = try resolve(
+            configuration: .default.autoAttachMetricsCollector(true),
+            explicitTracer: tracer,
+            metricsCollector: collector
+        )
+        #expect(composed.tracer is CompositeTracer)
+
+        let collectorAsTracer = try resolve(
+            configuration: .default.autoAttachMetricsCollector(true),
+            explicitTracer: collector,
+            metricsCollector: collector
+        )
+        #expect(identical(collectorAsTracer.tracer, collector as (any Tracer)?))
+
+        let withoutCollector = try resolve(
+            configuration: .default.autoAttachMetricsCollector(false),
+            explicitTracer: tracer,
+            metricsCollector: nil
+        )
+        #expect(identical(withoutCollector.tracer, tracer as (any Tracer)?))
+    }
+
+    @Test("Default tracing fallback produces a tracer only when configured")
+    func defaultTracingFallback() throws {
+        let enabled = try resolve(configuration: .default.defaultTracingEnabled(true), explicitTracer: nil)
+        #expect(enabled.tracer != nil)
+
+        let disabled = try resolve(configuration: .default.defaultTracingEnabled(false), explicitTracer: nil)
+        #expect(disabled.tracer == nil)
+    }
+
+    // MARK: - Determinism
+
+    @Test("Repeated resolution with identical inputs yields identical winners")
+    func resolutionIsDeterministic() async throws {
+        let memory = SlidingWindowMemory()
+        let provider = MockInferenceProvider(responses: ["winner"])
+        let tracer = SwiftLogTracer(minimumLevel: .debug)
+        let tool = StubTurnDependencyTool(name: "echo")
+
+        let first = try resolve(explicitProvider: provider, explicitMemory: memory, explicitTracer: tracer, baseTools: [tool])
+        let second = try resolve(explicitProvider: provider, explicitMemory: memory, explicitTracer: tracer, baseTools: [tool])
+
+        #expect(sameInstance(first.provider, second.provider))
+        #expect(identical(first.memory, second.memory))
+        #expect(identical(first.tracer, second.tracer))
+
+        let firstNames = Set(await first.toolRegistry.toolNames)
+        let secondNames = Set(await second.toolRegistry.toolNames)
+        #expect(firstNames == secondNames)
+    }
+
+    // MARK: - Tool registry
+
+    @Test("Resolved tool registry keeps the agent's base tools")
+    func toolRegistryPreservesBaseTools() async throws {
+        let toolA = StubTurnDependencyTool(name: "alpha")
+        let toolB = StubTurnDependencyTool(name: "beta")
+
+        let dependencies = try resolve(baseTools: [toolA, toolB])
+        let names = Set(await dependencies.toolRegistry.toolNames)
+
+        #expect(names == ["alpha", "beta"])
+    }
+
+    #if SWARM_INTEGRATIONS
+    @Test("Ambient web search injects once with environment precedence over global")
+    func webSearchInjectionPrecedence() async throws {
+        let environmentWeb = WebSearchTool.Configuration(enabled: true)
+        let globalWeb = WebSearchTool.Configuration(enabled: false)
+        var environment = AgentEnvironment()
+        environment.webSearch = environmentWeb
+
+        let fromEnvironment = try resolve(baseTools: [], environment: environment, globalWebSearch: globalWeb)
+        var names = await Set(fromEnvironment.toolRegistry.toolNames)
+        #expect(names == ["websearch"])
+
+        let fromGlobal = try resolve(baseTools: [], globalWebSearch: globalWeb)
+        names = await Set(fromGlobal.toolRegistry.toolNames)
+        #expect(names.isEmpty)
+
+        let alreadyAttached = try resolve(
+            baseTools: [StubTurnDependencyTool(name: "websearch")],
+            environment: environment
+        )
+        names = await Set(alreadyAttached.toolRegistry.toolNames)
+        #expect(names == ["websearch"])
+    }
+    #endif
+
+    // MARK: - Membrane resolution
+
+    @Test("Membrane adapter defaults to enabled and honors disabled environments")
+    func membraneResolution() throws {
+        let defaultsEnabled = try resolve(environment: AgentEnvironment())
+        #expect(defaultsEnabled.membraneAdapter != nil)
+        #expect(defaultsEnabled.membraneEnvironment?.isEnabled == true)
+
+        var absentMembrane = AgentEnvironment()
+        absentMembrane.membrane = nil
+        let defaulted = try resolve(environment: absentMembrane)
+        #expect(defaulted.membraneAdapter != nil)
+        #expect(defaulted.membraneEnvironment == nil)
+
+        let disabled = try resolve(environment: AgentEnvironment(membrane: .disabled))
+        #expect(disabled.membraneAdapter == nil)
+        #expect(disabled.membraneEnvironment?.isEnabled == false)
+    }
+
+    // MARK: - Helpers
+
+    private func query(
+        configuration: AgentConfiguration = .default,
+        explicitProvider: (any InferenceProvider)? = nil,
+        explicitMemory: (any Memory)? = nil,
+        defaultMemory: (any Memory)? = nil,
+        explicitTracer: (any Tracer)? = nil,
+        metricsCollector: MetricsCollector? = nil,
+        baseTools: [any AnyJSONTool] = [],
+        environment: AgentEnvironment = AgentEnvironment(),
+        environmentProvider: (any InferenceProvider)? = nil,
+        environmentMemory: (any Memory)? = nil,
+        globalProvider: (any InferenceProvider)? = nil,
+        globalWebSearch: WebSearchTool.Configuration? = nil,
+        foundationModels: (any InferenceProvider)?
+    ) -> AgentTurnDependencyQuery {
+        var resolvedEnvironment = environment
+        if let environmentProvider {
+            resolvedEnvironment.inferenceProvider = environmentProvider
+        }
+        if let environmentMemory {
+            resolvedEnvironment.memory = environmentMemory
+        }
+        return AgentTurnDependencyQuery(
+            configuration: configuration,
+            explicitProvider: explicitProvider,
+            explicitMemory: explicitMemory,
+            defaultMemory: defaultMemory,
+            explicitTracer: explicitTracer,
+            metricsCollector: metricsCollector,
+            baseTools: baseTools,
+            environment: resolvedEnvironment,
+            globalProvider: globalProvider,
+            globalWebSearch: globalWebSearch,
+            foundationModelsProvider: { foundationModels }
+        )
+    }
+
+    private func resolve(
+        configuration: AgentConfiguration = .default,
+        explicitProvider providedProvider: (any InferenceProvider)? = nil,
+        explicitMemory: (any Memory)? = nil,
+        defaultMemory: (any Memory)? = nil,
+        explicitTracer: (any Tracer)? = nil,
+        metricsCollector: MetricsCollector? = nil,
+        baseTools: [any AnyJSONTool] = [],
+        environment: AgentEnvironment = AgentEnvironment(),
+        environmentProvider: (any InferenceProvider)? = nil,
+        globalProvider: (any InferenceProvider)? = nil,
+        globalWebSearch: WebSearchTool.Configuration? = nil
+    ) throws -> AgentTurnDependencies {
+        try AgentTurnDependencyResolver.resolve(
+            query(
+                configuration: configuration,
+                explicitProvider: providedProvider ?? MockInferenceProvider(responses: ["resolve-helper"]),
+                explicitMemory: explicitMemory,
+                defaultMemory: defaultMemory,
+                explicitTracer: explicitTracer,
+                metricsCollector: metricsCollector,
+                baseTools: baseTools,
+                environment: environment,
+                environmentProvider: environmentProvider,
+                globalProvider: globalProvider,
+                globalWebSearch: globalWebSearch,
+                foundationModels: nil
+            )
+        )
+    }
+
+    private func sameInstance(_ lhs: some Any, _ rhs: some Any) -> Bool {
+        ObjectIdentifier(lhs as AnyObject) == ObjectIdentifier(rhs as AnyObject)
+    }
+
+    private func identical(_ lhs: (any Memory)?, _ rhs: (any Memory)?) -> Bool {
+        switch (lhs, rhs) {
+        case let (lhs?, rhs?):
+            return sameInstance(lhs, rhs)
+        case (nil, nil):
+            return true
+        default:
+            return false
+        }
+    }
+
+    private func identical(_ lhs: (any Tracer)?, _ rhs: (any Tracer)?) -> Bool {
+        switch (lhs, rhs) {
+        case let (lhs?, rhs?):
+            return sameInstance(lhs, rhs)
+        case (nil, nil):
+            return true
+        default:
+            return false
+        }
+    }
+}
+
+/// Minimal JSON tool used to populate resolved registries.
+private struct StubTurnDependencyTool: AnyJSONTool {
+    let name: String
+    let description = "stub"
+    let parameters: [ToolParameter] = []
+
+    init(name: String) {
+        self.name = name
+    }
+
+    func execute(arguments: [String: SendableValue]) async throws -> SendableValue {
+        .string("ok")
+    }
+}

--- a/docs/reference/api-catalog.md
+++ b/docs/reference/api-catalog.md
@@ -3,7 +3,7 @@
 Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for high-risk public rows on 2026-07-28 (Conduit hard-removed in 0.6). MCP client rows refreshed 2026-08-14. OpenAI-compatible provider rows added 2026-08-14.
 
 - Scope: all `.swift` files under `Sources/Swarm/`, excluding `Internal/GraphRuntime/`
-- Source files scanned: 185
+- Source files scanned: 186
 - Public/open symbols cataloged: 2325
 
 ## 1. Swarm (entry point)


### PR DESCRIPTION
Ticket T3 of spec `spec-architecture-functional-core-e3a92541` (swift-functional-codebase-evolution → swift-architecture-pipeline).

**What**
- New internal `AgentTurnDependencyResolver` resolves provider/memory/tracer/tools/membrane ONCE per turn into an immutable `AgentTurnDependencies` value; run-loop helpers read only the value (no mid-loop ambient lookups)
- Both winner orders encoded explicitly: normal (explicit → environment → global → FoundationModels) and privacy-required (FM → private(explicit→env→global)); verbatim error messages preserved
- Identity checks (`memoriesAreSameInstance`, ObjectIdentifier session-tracker key, tracer pointer-equality) moved into the resolver against resolved values
- `makeDefaultMemory(isRunningTests:)` internal injectable overload; public static unchanged
- Public APIs (`Swarm.defaultProvider`, `.environment(...)`) untouched; Agent.swift net −105 LOC

**Declared deviations (adversarially reviewed, accepted)**: D1 — resolution failure now surfaces before session begin/clear (fail-fast, strictly safer; observer error events for provider misconfiguration no longer emitted). D2 — one extra side-effect-free actor read per lean turn.

**Verification**: lean build ✅ · 329 agent tests / 56 suites ✅ (15-16 new precedence/determinism tests) · Integrations build ✅

**Reviews**: swift-adversarial-pr-review ×2 (fresh-context pass + final pass) — merge-ready, D1/D2 accepted with evidence.