### PR TITLE
arch(T2): injectable clock + pure FSM transitions in CircuitBreaker

### DIFF
--- a/Sources/Swarm/Resilience/CircuitBreaker.swift
+++ b/Sources/Swarm/Resilience/CircuitBreaker.swift
@@ -77,11 +77,47 @@ public actor CircuitBreaker {
         resetTimeout: TimeInterval = 60.0,
         halfOpenMaxRequests: Int = 1
     ) {
+        self.init(
+            name: name,
+            failureThreshold: failureThreshold,
+            successThreshold: successThreshold,
+            resetTimeout: resetTimeout,
+            halfOpenMaxRequests: halfOpenMaxRequests,
+            clock: LiveSwarmClock.live
+        )
+    }
+
+    /// Creates a new circuit breaker driven by an injected time source.
+    ///
+    /// Injecting a virtual clock makes open-window deadlines deterministic for
+    /// tests; production callers use the default initializer backed by the
+    /// live clock. Declared under `ColonyInternal` because `SwarmClock` is an
+    /// SPI protocol and cannot appear in an unannotated public signature.
+    /// - Parameters:
+    ///   - name: Unique name for this breaker.
+    ///   - failureThreshold: Number of consecutive failures before opening.
+    ///   - successThreshold: Number of consecutive successes to close from half-open.
+    ///   - resetTimeout: Time in seconds before attempting recovery.
+    ///   - halfOpenMaxRequests: Maximum concurrent requests in half-open state.
+    ///   - clock: Time source driving open-window deadlines and timestamps;
+    ///     pass `nil` to use the live clock.
+    @_spi(ColonyInternal)
+    public init(
+        name: String,
+        failureThreshold: Int,
+        successThreshold: Int,
+        resetTimeout: TimeInterval,
+        halfOpenMaxRequests: Int,
+        clock: (any SwarmClock)?
+    ) {
         self.name = name
         self.failureThreshold = max(1, failureThreshold)
         self.successThreshold = max(1, successThreshold)
         self.resetTimeout = max(0, resetTimeout)
         self.halfOpenMaxRequests = max(1, halfOpenMaxRequests)
+        let resolvedClock = clock ?? LiveSwarmClock.live
+        self.clock = resolvedClock
+        self.clockBridge = CircuitBreakerClockBridge(clock: resolvedClock)
     }
 
     // MARK: - Public API
@@ -132,9 +168,11 @@ public actor CircuitBreaker {
 
     /// Manually opens the circuit breaker.
     public func trip() async {
-        let openUntil = Date().addingTimeInterval(resetTimeout)
-        state = .open(until: openUntil)
-        consecutiveSuccesses = 0
+        fsmSnapshot = CircuitBreakerTransitions.tripped(
+            fsmSnapshot,
+            resetTimeout: resetTimeout,
+            now: currentDate()
+        )
     }
 
     /// Returns statistics about this circuit breaker.
@@ -149,6 +187,13 @@ public actor CircuitBreaker {
     }
 
     // MARK: Private
+
+    /// Injected time source; every deadline and timestamp reads through it.
+    private let clock: any SwarmClock
+
+    /// Maps injected-clock readings onto the `Date` timeline of the public state.
+    /// Internal (not private) so tests can assert exact instants against the anchor.
+    let clockBridge: CircuitBreakerClockBridge
 
     /// Current state of the circuit breaker.
     private var state: State = .closed
@@ -171,6 +216,30 @@ public actor CircuitBreaker {
     /// Timestamp of last failure.
     private var lastFailureTime: Date?
 
+    /// Transition-relevant state as a pure-FSM snapshot, bridged to the stored fields.
+    private var fsmSnapshot: CircuitBreakerTransitions.Snapshot {
+        get {
+            .init(
+                state: state,
+                consecutiveFailures: consecutiveFailures,
+                consecutiveSuccesses: consecutiveSuccesses
+            )
+        }
+        set {
+            state = newValue.state
+            consecutiveFailures = newValue.consecutiveFailures
+            consecutiveSuccesses = newValue.consecutiveSuccesses
+        }
+    }
+
+    /// Current instant on the breaker's `Date` timeline, read through the injected clock.
+    ///
+    /// This conversion is part of the clock↔`Date` adapter (AC-007): all breaker
+    /// time math flows through here instead of raw wall-clock reads.
+    private func currentDate() -> Date {
+        clockBridge.date(atNanoseconds: clock.nowNanoseconds())
+    }
+
     // MARK: - Private Helpers
 
     /// Executes the operation and handles state transitions based on success/failure.
@@ -190,58 +259,193 @@ public actor CircuitBreaker {
     /// Records a successful operation and handles state transitions.
     private func recordSuccess() async {
         totalSuccesses += 1
-        consecutiveFailures = 0
-
-        switch state {
-        case .halfOpen:
-            consecutiveSuccesses += 1
-            if consecutiveSuccesses >= successThreshold {
-                // Transition to closed
-                state = .closed
-                consecutiveSuccesses = 0
-            }
-        case .closed,
-             .open:
-            consecutiveSuccesses = 0
-        }
+        fsmSnapshot = CircuitBreakerTransitions.success(fsmSnapshot, successThreshold: successThreshold)
     }
 
     /// Records a failed operation and handles state transitions.
     private func recordFailure() async {
         totalFailures += 1
-        consecutiveFailures += 1
-        consecutiveSuccesses = 0
-        lastFailureTime = Date()
-
-        switch state {
-        case .closed:
-            if consecutiveFailures >= failureThreshold {
-                // Transition to open
-                let openUntil = Date().addingTimeInterval(resetTimeout)
-                state = .open(until: openUntil)
-            }
-        case .halfOpen:
-            // Any failure in half-open transitions back to open
-            let openUntil = Date().addingTimeInterval(resetTimeout)
-            state = .open(until: openUntil)
-        case .open:
-            // Already open, no state change needed
-            break
-        }
+        let now = currentDate()
+        lastFailureTime = now
+        fsmSnapshot = CircuitBreakerTransitions.failure(
+            fsmSnapshot,
+            failureThreshold: failureThreshold,
+            resetTimeout: resetTimeout,
+            now: now
+        )
     }
 
     /// Checks if the circuit should transition from open to half-open based on timeout.
     private func checkAndTransitionState() async throws {
-        guard case let .open(until) = state else {
-            return
-        }
-
-        if Date() >= until {
-            // Transition to half-open
-            state = .halfOpen
-            consecutiveSuccesses = 0
+        if let transitioned = CircuitBreakerTransitions.timeoutCheck(fsmSnapshot, now: currentDate()) {
+            fsmSnapshot = transitioned
             halfOpenRequestsInFlight = 0
         }
+    }
+}
+
+// MARK: - Clock Bridge
+
+/// Maps monotonic `SwarmClock` nanoseconds onto the `Date` timeline used by
+/// the breaker's public state (`State.open(until:)`, `Statistics.lastFailureTime`).
+///
+/// This is the clock↔`Date` adapter (AC-007): construction captures a single
+/// wall-clock anchor paired with the injected clock's reading; every later
+/// conversion derives purely from injected-clock readings via
+/// `date(atNanoseconds:)`.
+struct CircuitBreakerClockBridge: Sendable {
+    /// Injected-clock reading captured at construction.
+    let anchorNanoseconds: UInt64
+
+    /// Wall-clock instant corresponding to `anchorNanoseconds`.
+    let anchorDate: Date
+
+    /// Creates a bridge from an explicit anchor pair (test-friendly).
+    init(anchorNanoseconds: UInt64, anchorDate: Date) {
+        self.anchorNanoseconds = anchorNanoseconds
+        self.anchorDate = anchorDate
+    }
+
+    /// Anchors one raw wall-clock read to the injected clock's current reading.
+    init(clock: any SwarmClock) {
+        self.init(anchorNanoseconds: clock.nowNanoseconds(), anchorDate: Date())
+    }
+
+    /// Converts an injected-clock reading into its `Date` timeline instant.
+    func date(atNanoseconds nanoseconds: UInt64) -> Date {
+        let delta = Int64(bitPattern: nanoseconds &- anchorNanoseconds)
+        return anchorDate.addingTimeInterval(Double(delta) / 1_000_000_000)
+    }
+}
+
+// MARK: - Pure FSM Transitions
+
+/// Pure transition math for the circuit-breaker state machine.
+///
+/// Functions are static and side-effect free: each takes the full pre-event
+/// snapshot plus configuration and event instant, returning the post-event
+/// snapshot or `nil` when nothing changes. Keeping them off the actor makes
+/// every transition rule unit-testable without executing actor code or reading
+/// a clock. Behavior mirrors the original inline logic exactly:
+/// - Failure in closed state trips once consecutive failures reach the threshold.
+/// - Any failure in half-open reopens the window from that instant.
+/// - Tripping while open extends the window from the new event's instant.
+/// - Success in half-open closes only after the success threshold is met.
+enum CircuitBreakerTransitions {
+    /// Complete transition-relevant state of a breaker.
+    struct Snapshot: Equatable, Sendable {
+        /// Current breaker state.
+        var state: CircuitBreaker.State
+
+        /// Consecutive failure count driving trip thresholds.
+        var consecutiveFailures = 0
+
+        /// Consecutive success count driving half-open recovery.
+        var consecutiveSuccesses = 0
+
+        /// Creates a snapshot.
+        init(
+            state: CircuitBreaker.State,
+            consecutiveFailures: Int = 0,
+            consecutiveSuccesses: Int = 0
+        ) {
+            self.state = state
+            self.consecutiveFailures = consecutiveFailures
+            self.consecutiveSuccesses = consecutiveSuccesses
+        }
+    }
+
+    /// Applies one failed operation outcome.
+    ///
+    /// - Parameters:
+    ///   - before: Pre-failure snapshot.
+    ///   - failureThreshold: Consecutive failures required to trip from closed.
+    ///   - resetTimeout: Open-window length applied when tripping/reopening.
+    ///   - now: Failure instant; anchors any new `.open(until:)` deadline.
+    static func failure(
+        _ before: Snapshot,
+        failureThreshold: Int,
+        resetTimeout: TimeInterval,
+        now: Date
+    ) -> Snapshot {
+        var after = before
+        after.consecutiveFailures += 1
+        after.consecutiveSuccesses = 0
+
+        switch before.state {
+        case .closed:
+            if after.consecutiveFailures >= failureThreshold {
+                // Transition to open
+                after.state = .open(until: now.addingTimeInterval(resetTimeout))
+            }
+        case .halfOpen:
+            // Any failure in half-open transitions back to open
+            after.state = .open(until: now.addingTimeInterval(resetTimeout))
+        case .open:
+            // Already open, no state change needed
+            break
+        }
+        return after
+    }
+
+    /// Applies one successful operation outcome.
+    ///
+    /// - Parameters:
+    ///   - before: Pre-success snapshot.
+    ///   - successThreshold: Consecutive half-open successes required to close.
+    static func success(_ before: Snapshot, successThreshold: Int) -> Snapshot {
+        var after = before
+        after.consecutiveFailures = 0
+
+        switch before.state {
+        case .halfOpen:
+            after.consecutiveSuccesses += 1
+            if after.consecutiveSuccesses >= successThreshold {
+                // Transition to closed
+                after.state = .closed
+                after.consecutiveSuccesses = 0
+            }
+        case .closed,
+             .open:
+            after.consecutiveSuccesses = 0
+        }
+        return after
+    }
+
+    /// Applies a manual trip.
+    ///
+    /// Opens the window from `now`, extending it even if already open;
+    /// resets the half-open success streak without touching failures.
+    ///
+    /// - Parameters:
+    ///   - before: Pre-trip snapshot.
+    ///   - resetTimeout: Open-window length.
+    ///   - now: Trip instant; anchors the new `.open(until:)` deadline.
+    static func tripped(
+        _ before: Snapshot,
+        resetTimeout: TimeInterval,
+        now: Date
+    ) -> Snapshot {
+        var after = before
+        after.state = .open(until: now.addingTimeInterval(resetTimeout))
+        after.consecutiveSuccesses = 0
+        return after
+    }
+
+    /// Applies the open-timeout check performed before each execution.
+    ///
+    /// Returns the post-transition snapshot when the open window has elapsed by
+    /// `now` (`now >= until`), moving to half-open and resetting the success
+    /// streak; returns `nil` when no transition occurs.
+    static func timeoutCheck(_ before: Snapshot, now: Date) -> Snapshot? {
+        guard case let .open(until) = before.state, now >= until else {
+            return nil
+        }
+
+        var after = before
+        after.state = .halfOpen
+        after.consecutiveSuccesses = 0
+        return after
     }
 }
 

--- a/Tests/SwarmTests/Resilience/ResilienceTests+CircuitBreaker.swift
+++ b/Tests/SwarmTests/Resilience/ResilienceTests+CircuitBreaker.swift
@@ -2,15 +2,46 @@
 // Swarm Framework
 //
 // Tests for CircuitBreaker resilience component using Swift Testing framework.
+// Transition timing is driven entirely by VirtualClock (no real sleeping).
 
 import Foundation
-@testable import Swarm
+@_spi(ColonyInternal) @testable import Swarm
 import Testing
 
 // MARK: - CircuitBreakerTests
 
 @Suite("CircuitBreaker Tests")
 struct CircuitBreakerTests {
+    /// Creates a breaker driven by a fresh virtual clock starting at nanosecond 0.
+    ///
+    /// Construction anchors the breaker's Date timeline at the current wall
+    /// clock paired with nanosecond 0, so every injected instant converts via
+    /// `anchorDate.addingTimeInterval(nanoseconds / 1e9)`.
+    private func makeVirtualBreaker(
+        name: String = "test",
+        failureThreshold: Int,
+        successThreshold: Int = 2,
+        resetTimeout: TimeInterval,
+        halfOpenMaxRequests: Int = 1
+    ) -> (breaker: CircuitBreaker, clock: VirtualClock) {
+        let clock = VirtualClock()
+        let breaker = CircuitBreaker(
+            name: name,
+            failureThreshold: failureThreshold,
+            successThreshold: successThreshold,
+            resetTimeout: resetTimeout,
+            halfOpenMaxRequests: halfOpenMaxRequests,
+            clock: clock
+        )
+        return (breaker, clock)
+    }
+
+    /// The `Date` the breaker assigns to the given virtual-clock reading.
+    private func date(_ breaker: CircuitBreaker, atNanoseconds nanoseconds: UInt64) async -> Date {
+        let bridge = await breaker.clockBridge
+        return bridge.date(atNanoseconds: nanoseconds)
+    }
+
     // MARK: - Initial State Tests
 
     @Test("Initial state is closed")
@@ -55,6 +86,32 @@ struct CircuitBreakerTests {
         } else {
             Issue.record("Expected circuit to be open, got \(state)")
         }
+    }
+
+    @Test("Circuit opens at the exact injected instant")
+    func circuitOpensAtExactInjectedInstant() async throws {
+        let (breaker, clock) = makeVirtualBreaker(
+            name: "test",
+            failureThreshold: 3,
+            resetTimeout: 60.0
+        )
+
+        // All three failures stamp at virtual time 10 s.
+        clock.advance(by: 10_000_000_000)
+
+        for _ in 1...3 {
+            do {
+                _ = try await breaker.execute {
+                    throw TestError.network
+                }
+            } catch {
+                // Expected
+            }
+        }
+
+        let expectedUntil = await date(breaker, atNanoseconds: 10_000_000_000).addingTimeInterval(60.0)
+        let state = await breaker.currentState()
+        #expect(state == .open(until: expectedUntil))
     }
 
     @Test("Circuit remains closed below failureThreshold")
@@ -116,15 +173,15 @@ struct CircuitBreakerTests {
 
     // MARK: - Half-Open Transition Tests
 
-    @Test("Circuit transitions to halfOpen after timeout")
+    @Test("Circuit transitions to halfOpen at the exact injected instant")
     func circuitTransitionsToHalfOpen() async throws {
-        let breaker = CircuitBreaker(
+        let (breaker, clock) = makeVirtualBreaker(
             name: "test",
             failureThreshold: 2,
-            resetTimeout: 0.1 // Short timeout for testing
+            resetTimeout: 60.0
         )
 
-        // Open the circuit
+        // Open the circuit at virtual time 0
         for _ in 1...2 {
             do {
                 _ = try await breaker.execute {
@@ -135,41 +192,52 @@ struct CircuitBreakerTests {
             }
         }
 
-        // Verify circuit is open
+        let expectedUntil = await date(breaker, atNanoseconds: 0).addingTimeInterval(60.0)
+
+        // Verify circuit is open with the exact window
         var state = await breaker.currentState()
-        if case .open = state {
-            // Good
-        } else {
-            Issue.record("Expected circuit to be open")
-        }
+        #expect(state == .open(until: expectedUntil))
 
-        // Wait for timeout
-        try await Task.sleep(nanoseconds: 150_000_000) // 0.15 seconds
-
-        // Trigger state check by attempting execution
+        // Just before the window elapses: still open, requests blocked.
+        // Margin is 1 ms because Date's Double storage resolves ~100 ns at
+        // present-day epochs; finer probes round onto the boundary itself.
+        clock.advance(to: 60_000_000_000 - 1_000_000)
         do {
             _ = try await breaker.execute {
-                // This will check state and transition to half-open
-                "test"
+                "too early"
             }
-        } catch {
-            // May fail depending on timing
+            Issue.record("Request before the deadline should have been blocked")
+        } catch let error as ResilienceError {
+            guard case .circuitBreakerOpen = error else {
+                Issue.record("Expected circuitBreakerOpen, got \(error)")
+                return
+            }
         }
 
         state = await breaker.currentState()
-        // Should be halfOpen or closed (if the test operation succeeded)
-        #expect(state == .halfOpen || state == .closed)
+        #expect(state == .open(until: expectedUntil))
+
+        // Advance to exactly the injected deadline: transition fires
+        clock.advance(to: 60_000_000_000)
+        let result = try await breaker.execute {
+            "recovered"
+        }
+        #expect(result == "recovered")
+
+        state = await breaker.currentState()
+        // Success streak (1 of 2) keeps the circuit half-open
+        #expect(state == .halfOpen)
     }
 
     // MARK: - Circuit Closing Tests
 
     @Test("Circuit closes after successThreshold successes in halfOpen")
     func circuitClosesAfterSuccesses() async throws {
-        let breaker = CircuitBreaker(
+        let (breaker, clock) = makeVirtualBreaker(
             name: "test",
             failureThreshold: 2,
             successThreshold: 2,
-            resetTimeout: 0.1,
+            resetTimeout: 60.0,
             halfOpenMaxRequests: 5
         )
 
@@ -184,8 +252,8 @@ struct CircuitBreakerTests {
             }
         }
 
-        // Wait for timeout to transition to half-open
-        try await Task.sleep(nanoseconds: 150_000_000)
+        // Jump instantly to the exact half-open transition instant
+        clock.advance(to: 60_000_000_000)
 
         // Execute successful operations to close circuit
         for _ in 1...2 {
@@ -200,11 +268,11 @@ struct CircuitBreakerTests {
 
     @Test("Single success in halfOpen keeps circuit halfOpen")
     func singleSuccessInHalfOpen() async throws {
-        let breaker = CircuitBreaker(
+        let (breaker, clock) = makeVirtualBreaker(
             name: "test",
             failureThreshold: 2,
             successThreshold: 3,
-            resetTimeout: 0.1
+            resetTimeout: 60.0
         )
 
         // Open circuit
@@ -214,8 +282,8 @@ struct CircuitBreakerTests {
             } catch {}
         }
 
-        // Wait and transition to half-open
-        try await Task.sleep(nanoseconds: 150_000_000)
+        // Jump instantly past the open window into half-open
+        clock.advance(to: 60_000_000_000)
 
         // One success
         _ = try await breaker.execute { "success" }
@@ -271,6 +339,23 @@ struct CircuitBreakerTests {
         }
     }
 
+    @Test("Second trip extends the window from the second call's instant")
+    func secondTripExtendsWindowFromLatestInstant() async throws {
+        let (breaker, clock) = makeVirtualBreaker(name: "test", failureThreshold: 2, resetTimeout: 60.0)
+
+        // First trip at virtual time 10 s
+        clock.advance(to: 10_000_000_000)
+        await breaker.trip()
+        var state = await breaker.currentState()
+        #expect(state == .open(until: await date(breaker, atNanoseconds: 10_000_000_000).addingTimeInterval(60.0)))
+
+        // Second trip at virtual time 20 s must re-anchor the window there
+        clock.advance(to: 20_000_000_000)
+        await breaker.trip()
+        state = await breaker.currentState()
+        #expect(state == .open(until: await date(breaker, atNanoseconds: 20_000_000_000).addingTimeInterval(60.0)))
+    }
+
     // MARK: - Statistics Tests
 
     @Test("Statistics track success and failure counts")
@@ -302,6 +387,29 @@ struct CircuitBreakerTests {
         #expect(stats.lastFailureTime != nil)
     }
 
+    @Test("Statistics lastFailureTime stamps from the injected clock")
+    func statisticsLastFailureTimeUsesInjectedClock() async throws {
+        let (breaker, clock) = makeVirtualBreaker(
+            name: "test",
+            failureThreshold: 5,
+            resetTimeout: 60.0
+        )
+
+        // Failure stamped at virtual time 42 s
+        clock.advance(to: 42_000_000_000)
+        do {
+            _ = try await breaker.execute {
+                throw TestError.network
+            }
+        } catch {
+            // Expected
+        }
+
+        let stats = await breaker.statistics()
+        let expectedFailureInstant = await date(breaker, atNanoseconds: 42_000_000_000)
+        #expect(stats.lastFailureTime == expectedFailureInstant)
+    }
+
     @Test("Statistics calculate success rate correctly")
     func testSuccessRate() async throws {
         let breaker = CircuitBreaker(name: "test")
@@ -323,10 +431,10 @@ struct CircuitBreakerTests {
 
     @Test("HalfOpen state limits concurrent requests")
     func halfOpenRequestLimit() async throws {
-        let breaker = CircuitBreaker(
+        let (breaker, clock) = makeVirtualBreaker(
             name: "test",
             failureThreshold: 2,
-            resetTimeout: 0.1,
+            resetTimeout: 60.0,
             halfOpenMaxRequests: 1
         )
 
@@ -337,19 +445,24 @@ struct CircuitBreakerTests {
             } catch {}
         }
 
-        // Wait for half-open transition
-        try await Task.sleep(nanoseconds: 150_000_000)
+        // Jump to the exact half-open transition instant
+        clock.advance(to: 60_000_000_000)
 
-        // First request should be allowed
-        let task = Task { @Sendable in
+        // Deterministic in-flight coordination: the first half-open operation
+        // signals entry, then suspends until released by this test.
+        let started = AsyncLatch()
+        let release = AsyncLatch()
+
+        let task = Task {
             try await breaker.execute {
-                try await Task.sleep(nanoseconds: 100_000_000) // Slow operation
+                started.open()
+                await release.wait()
                 return "success"
             }
         }
 
-        // Give it time to start
-        try await Task.sleep(nanoseconds: 10_000_000)
+        // Proceed only once the first request holds the half-open slot.
+        await started.wait()
 
         // Second concurrent request should be blocked
         do {
@@ -366,11 +479,189 @@ struct CircuitBreakerTests {
         }
 
         // Clean up
+        release.open()
         _ = try await task.value
     }
 }
 
-// MARK: - CircuitBreakerRegistryTests
+// MARK: - Pure Transition Math Tests
+
+@Suite("CircuitBreaker Transition Math Tests")
+struct CircuitBreakerTransitionMathTests {
+    /// Fixed reference instant for deterministic expectations.
+    private let reference = Date(timeIntervalSince1970: 1_000_000)
+
+    private func snapshot(
+        state: CircuitBreaker.State = .closed,
+        consecutiveFailures: Int = 0,
+        consecutiveSuccesses: Int = 0
+    ) -> CircuitBreakerTransitions.Snapshot {
+        .init(
+            state: state,
+            consecutiveFailures: consecutiveFailures,
+            consecutiveSuccesses: consecutiveSuccesses
+        )
+    }
+
+    @Test("Failure below threshold keeps the circuit closed")
+    func failureBelowThresholdKeepsClosed() {
+        let after = CircuitBreakerTransitions.failure(
+            snapshot(consecutiveFailures: 1),
+            failureThreshold: 3,
+            resetTimeout: 60.0,
+            now: reference
+        )
+
+        #expect(after.state == .closed)
+        #expect(after.consecutiveFailures == 2)
+        #expect(after.consecutiveSuccesses == 0)
+    }
+
+    @Test("Failure at threshold opens with the exact deadline")
+    func failureAtThresholdOpensWithExactDeadline() {
+        let after = CircuitBreakerTransitions.failure(
+            snapshot(consecutiveFailures: 2),
+            failureThreshold: 3,
+            resetTimeout: 90.0,
+            now: reference
+        )
+
+        #expect(after.state == .open(until: reference.addingTimeInterval(90.0)))
+        #expect(after.consecutiveFailures == 3)
+    }
+
+    @Test("Failure while open leaves the window untouched")
+    func failureWhileOpenLeavesWindowUntouched() {
+        let originalUntil = reference.addingTimeInterval(30.0)
+        let after = CircuitBreakerTransitions.failure(
+            snapshot(state: .open(until: originalUntil), consecutiveFailures: 4),
+            failureThreshold: 3,
+            resetTimeout: 90.0,
+            now: reference.addingTimeInterval(40.0)
+        )
+
+        #expect(after.state == .open(until: originalUntil))
+        #expect(after.consecutiveFailures == 5)
+    }
+
+    @Test("Any failure in halfOpen reopens from that failure's instant")
+    func failureInHalfOpenReopensFromFailureInstant() {
+        let failureInstant = reference.addingTimeInterval(75.0)
+        let after = CircuitBreakerTransitions.failure(
+            snapshot(state: .halfOpen),
+            failureThreshold: 3,
+            resetTimeout: 90.0,
+            now: failureInstant
+        )
+
+        #expect(after.state == .open(until: failureInstant.addingTimeInterval(90.0)))
+    }
+
+    @Test("Success in halfOpen accumulates and closes at the threshold")
+    func successInHalfOpenAccumulatesAndCloses() {
+        let afterFirst = CircuitBreakerTransitions.success(snapshot(state: .halfOpen), successThreshold: 2)
+        #expect(afterFirst.state == .halfOpen)
+        #expect(afterFirst.consecutiveSuccesses == 1)
+
+        let afterSecond = CircuitBreakerTransitions.success(afterFirst, successThreshold: 2)
+        #expect(afterSecond.state == .closed)
+        #expect(afterSecond.consecutiveSuccesses == 0)
+        #expect(afterSecond.consecutiveFailures == 0)
+    }
+
+    @Test("Success outside halfOpen resets the success streak")
+    func successOutsideHalfOpenResetsStreak() {
+        let after = CircuitBreakerTransitions.success(
+            snapshot(state: .open(until: reference), consecutiveSuccesses: 1),
+            successThreshold: 2
+        )
+        #expect(after.state == .open(until: reference))
+        #expect(after.consecutiveSuccesses == 0)
+    }
+
+    @Test("Manual trip opens the window from the given instant")
+    func trippedOpensFromGivenInstant() {
+        let after = CircuitBreakerTransitions.tripped(
+            snapshot(consecutiveFailures: 7, consecutiveSuccesses: 1),
+            resetTimeout: 45.0,
+            now: reference
+        )
+
+        #expect(after.state == .open(until: reference.addingTimeInterval(45.0)))
+        #expect(after.consecutiveSuccesses == 0)
+        // Tripping does not erase the failure streak, matching legacy behavior.
+        #expect(after.consecutiveFailures == 7)
+    }
+
+    @Test("Manual trip while open extends the window from the new instant")
+    func trippedWhileOpenExtendsWindow() {
+        let firstWindow = CircuitBreakerTransitions.tripped(
+            snapshot(),
+            resetTimeout: 60.0,
+            now: reference
+        )
+
+        let secondInstant = reference.addingTimeInterval(25.0)
+        let extended = CircuitBreakerTransitions.tripped(
+            firstWindow,
+            resetTimeout: 60.0,
+            now: secondInstant
+        )
+
+        // Window extends from the second call's now, not stacked onto the old one.
+        #expect(firstWindow.state == .open(until: reference.addingTimeInterval(60.0)))
+        #expect(extended.state == .open(until: secondInstant.addingTimeInterval(60.0)))
+    }
+
+    @Test("Timeout check returns nil before the deadline")
+    func timeoutCheckBeforeDeadlineReturnsNil() {
+        let open = snapshot(state: .open(until: reference.addingTimeInterval(60.0)))
+        let early = CircuitBreakerTransitions.timeoutCheck(open, now: reference.addingTimeInterval(59.999))
+
+        #expect(early == nil)
+
+        let closed = snapshot(state: .closed)
+        #expect(CircuitBreakerTransitions.timeoutCheck(closed, now: reference.addingTimeInterval(999)) == nil)
+
+        let halfOpen = snapshot(state: .halfOpen)
+        #expect(CircuitBreakerTransitions.timeoutCheck(halfOpen, now: reference) == nil)
+    }
+
+    @Test("Timeout check at the deadline moves to halfOpen and resets the streak")
+    func timeoutCheckAtDeadlineTransitionsToHalfOpen() {
+        let open = snapshot(
+            state: .open(until: reference.addingTimeInterval(60.0)),
+            consecutiveFailures: 3,
+            consecutiveSuccesses: 1
+        )
+
+        let transitioned = CircuitBreakerTransitions.timeoutCheck(open, now: reference.addingTimeInterval(60.0))
+
+        #expect(transitioned != nil)
+        #expect(transitioned?.state == .halfOpen)
+        #expect(transitioned?.consecutiveSuccesses == 0)
+        // Failure streak survives the half-open probe window.
+        #expect(transitioned?.consecutiveFailures == 3)
+    }
+}
+
+// MARK: - Clock Bridge Tests
+
+@Suite("CircuitBreaker Clock Bridge Tests")
+struct CircuitBreakerClockBridgeTests {
+    @Test("Anchor instant maps to itself; deltas convert to seconds")
+    func anchorAndDeltaMapping() {
+        let anchorDate = Date(timeIntervalSince1970: 777_777)
+        let bridge = CircuitBreakerClockBridge(anchorNanoseconds: 500, anchorDate: anchorDate)
+
+        #expect(bridge.anchorNanoseconds == 500)
+        #expect(bridge.date(atNanoseconds: 500) == anchorDate)
+        #expect(bridge.date(atNanoseconds: 1_000_000_500) == anchorDate.addingTimeInterval(1.0))
+        #expect(bridge.date(atNanoseconds: 0) == anchorDate.addingTimeInterval(-0.000_000_5))
+    }
+}
+
+// MARK: - CircuitBreakerRegistry Tests
 
 @Suite("CircuitBreakerRegistry Tests")
 struct CircuitBreakerRegistryTests {
@@ -440,5 +731,41 @@ struct CircuitBreakerRegistryTests {
 
         #expect(state1 == .closed)
         #expect(state2 == .closed)
+    }
+}
+
+// MARK: - AsyncLatch
+
+/// One-shot async gate for deterministic coordination of in-flight operations.
+///
+/// `wait()` suspends until `open()` is called (or resumes immediately when
+/// already open), letting tests pin ordering without real sleeping.
+private final class AsyncLatch: @unchecked Sendable {
+    private let lock = NSLock()
+    private var opened = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    /// Opens the gate and resumes all suspended waiters.
+    func open() {
+        lock.lock()
+        opened = true
+        let pending = waiters
+        waiters.removeAll()
+        lock.unlock()
+        pending.forEach { $0.resume() }
+    }
+
+    /// Suspends until the gate is open.
+    func wait() async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            lock.lock()
+            if opened {
+                lock.unlock()
+                continuation.resume()
+                return
+            }
+            waiters.append(continuation)
+            lock.unlock()
+        }
     }
 }

--- a/docs/reference/api-catalog.md
+++ b/docs/reference/api-catalog.md
@@ -3,7 +3,7 @@
 Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for high-risk public rows on 2026-07-28 (Conduit hard-removed in 0.6). MCP client rows refreshed 2026-08-14. OpenAI-compatible provider rows added 2026-08-14.
 
 - Scope: all `.swift` files under `Sources/Swarm/`, excluding `Internal/GraphRuntime/`
-- Source files scanned: 176
+- Source files scanned: 179
 - Public/open symbols cataloged: 2510
 
 ## 1. Swarm (entry point)


### PR DESCRIPTION
Spec \`spec-architecture-resilience-clock-runenv\` ticket T2 (stacked on T1, PR #169). Candidate 01.

- Additive SPI init \`clock: (any SwarmClock)?\` (nil → live); original public init untouched
- All internal \`Date()\` reads routed through injected clock; sole raw read left is inside the clock↔Date bridge anchor
- FSM transitions extracted to pure \`CircuitBreakerTransitions\` helpers (failure/success/tripped/timeoutCheck) — behavior byte-parity vs base verified line-by-line by reviewer
- Four real-sleep transition tests converted to VirtualClock exact-instant probes; pure-FSM suite added

AC-001/AC-007 satisfied. Reviews: swift-pr-review round-1 (clean) + final pass (clean).