### PR TITLE
arch(T3): injectable clock + pure refill math in RateLimiter

### DIFF
--- a/Sources/Swarm/Resilience/RateLimiter.swift
+++ b/Sources/Swarm/Resilience/RateLimiter.swift
@@ -38,15 +38,62 @@ public actor RateLimiter {
 
     /// Create rate limiter with requests per minute
     public init(maxRequestsPerMinute: Int) {
-        let normalizedMaxRequests = max(1, maxRequestsPerMinute)
-        maxTokens = normalizedMaxRequests
-        refillRate = max(1.0 / 60.0, Double(normalizedMaxRequests) / 60.0)
-        availableTokens = Double(normalizedMaxRequests)
-        lastRefillTime = .now
+        self.init(
+            maxRequestsPerMinute: maxRequestsPerMinute,
+            clock: LiveSwarmClock.live
+        )
     }
 
     /// Create rate limiter with custom token bucket parameters
     public init(maxTokens: Int, refillRatePerSecond: Double) {
+        self.init(
+            maxTokens: maxTokens,
+            refillRatePerSecond: refillRatePerSecond,
+            clock: LiveSwarmClock.live
+        )
+    }
+
+    // MARK: - Initialization
+
+    /// Creates a new rate limiter driven by an injected time source.
+    ///
+    /// Injecting a virtual clock makes refill timing deterministic for tests;
+    /// production callers use the default initializers backed by the live
+    /// clock. Declared under `ColonyInternal` because `SwarmClock` is an SPI
+    /// protocol and cannot appear in an unannotated public signature.
+    /// - Parameters:
+    ///   - maxRequestsPerMinute: Bucket capacity in requests per minute.
+    ///   - clock: Time source driving refill timestamps and waits;
+    ///     pass `nil` to use the live clock.
+    @_spi(ColonyInternal)
+    public init(maxRequestsPerMinute: Int, clock: (any SwarmClock)?) {
+        let normalizedMaxRequests = max(1, maxRequestsPerMinute)
+        maxTokens = normalizedMaxRequests
+        refillRate = max(1.0 / 60.0, Double(normalizedMaxRequests) / 60.0)
+        availableTokens = Double(normalizedMaxRequests)
+
+        let resolvedClock = clock ?? LiveSwarmClock.live
+        self.clock = resolvedClock
+        lastRefillTime = resolvedClock.nowNanoseconds()
+    }
+
+    /// Creates a new rate limiter with custom bucket parameters and an
+    /// injected time source.
+    ///
+    /// Declared under `ColonyInternal` because `SwarmClock` is an SPI protocol
+    /// and cannot appear in an unannotated public signature.
+    /// - Parameters:
+    ///   - maxTokens: Bucket capacity; values below 1 normalize to 1.
+    ///   - refillRatePerSecond: Tokens per second; non-finite or non-positive
+    ///     rates normalize to 1.
+    ///   - clock: Time source driving refill timestamps and waits;
+    ///     pass `nil` to use the live clock.
+    @_spi(ColonyInternal)
+    public init(
+        maxTokens: Int,
+        refillRatePerSecond: Double,
+        clock: (any SwarmClock)?
+    ) {
         let normalizedMaxTokens = max(1, maxTokens)
         let normalizedRefillRate = refillRatePerSecond.isFinite && refillRatePerSecond > 0
             ? refillRatePerSecond
@@ -55,7 +102,10 @@ public actor RateLimiter {
         self.maxTokens = normalizedMaxTokens
         refillRate = normalizedRefillRate
         availableTokens = Double(normalizedMaxTokens)
-        lastRefillTime = .now
+
+        let resolvedClock = clock ?? LiveSwarmClock.live
+        self.clock = resolvedClock
+        lastRefillTime = resolvedClock.nowNanoseconds()
     }
 
     /// Acquire a token, waiting if necessary
@@ -64,9 +114,11 @@ public actor RateLimiter {
         refill()
 
         while availableTokens < 1 {
-            let rawWaitTime = (1 - availableTokens) / refillRate
-            let waitTime = rawWaitTime.isFinite && rawWaitTime > 0 ? rawWaitTime : 0
-            try await Task.sleep(for: .seconds(waitTime))
+            let waitTime = TokenBucketMath.waitSeconds(
+                forDeficit: 1 - availableTokens,
+                refillRate: refillRate
+            )
+            try await clock.sleep(nanoseconds: Duration.seconds(waitTime).swarmNanoseconds)
             try Task.checkCancellation()
             refill()
         }
@@ -87,28 +139,65 @@ public actor RateLimiter {
     /// Reset the limiter to full capacity
     public func reset() {
         availableTokens = Double(maxTokens)
-        lastRefillTime = .now
+        lastRefillTime = clock.nowNanoseconds()
     }
 
     // MARK: Private
 
+    /// Injected time source; every refill timestamp and wait reads through it.
+    private let clock: any SwarmClock
+
     private let maxTokens: Int
     private let refillRate: Double // tokens per second
     private var availableTokens: Double
-    private var lastRefillTime: ContinuousClock.Instant
+    private var lastRefillTime: UInt64
 
     private func refill() {
-        let now = ContinuousClock.now
-        let elapsed = now - lastRefillTime
-        let tokensToAdd = elapsed.seconds * refillRate
-        availableTokens = min(Double(maxTokens), availableTokens + tokensToAdd)
+        let now = clock.nowNanoseconds()
+        availableTokens = TokenBucketMath.refilled(
+            tokens: availableTokens,
+            elapsedSeconds: TokenBucketMath.elapsedSeconds(from: lastRefillTime, to: now),
+            refillRate: refillRate,
+            maxTokens: maxTokens
+        )
         lastRefillTime = now
     }
 }
 
-private extension Duration {
-    var seconds: Double {
-        let (seconds, attoseconds) = components
-        return Double(seconds) + Double(attoseconds) / 1_000_000_000_000_000_000
+// MARK: - TokenBucketMath
+
+/// Pure refill and wait-time math for the token bucket.
+///
+/// Functions are static and side-effect free so every rule is unit-testable
+/// without actor code or a live clock. Behavior mirrors the original inline
+/// logic exactly, including clamping at capacity and the finite/positive
+/// guards on computed wait times.
+enum TokenBucketMath {
+    /// Post-refill token count after adding `elapsedSeconds * refillRate`
+    /// tokens, capped at bucket capacity.
+    ///
+    /// A negative elapsed interval (clock moved backwards) removes tokens at
+    /// the same rate, matching the original signed-duration arithmetic.
+    static func refilled(
+        tokens: Double,
+        elapsedSeconds: Double,
+        refillRate: Double,
+        maxTokens: Int
+    ) -> Double {
+        min(Double(maxTokens), tokens + elapsedSeconds * refillRate)
+    }
+
+    /// Seconds to wait until `deficit` additional tokens have accumulated,
+    /// or `0` when the raw quotient is non-finite or non-positive — preserving
+    /// the original guard so pathological inputs never produce invalid sleeps.
+    static func waitSeconds(forDeficit deficit: Double, refillRate: Double) -> Double {
+        let rawWaitTime = deficit / refillRate
+        return rawWaitTime.isFinite && rawWaitTime > 0 ? rawWaitTime : 0
+    }
+
+    /// Signed elapsed seconds between two nanosecond readings on one clock's
+    /// timeline (`endNanoseconds - startNanoseconds`).
+    static func elapsedSeconds(from startNanoseconds: UInt64, to endNanoseconds: UInt64) -> Double {
+        Double(Int64(bitPattern: endNanoseconds &- startNanoseconds)) / 1_000_000_000
     }
 }

--- a/Tests/SwarmTests/Resilience/ResilienceTests+RateLimiter.swift
+++ b/Tests/SwarmTests/Resilience/ResilienceTests+RateLimiter.swift
@@ -2,13 +2,33 @@
 // Swarm Framework
 //
 // Tests for RateLimiter edge cases and safety constraints.
+// Refill timing is driven entirely by VirtualClock (no real sleeping).
 
 import Foundation
-@testable import Swarm
+@_spi(ColonyInternal) @testable import Swarm
 import Testing
+
+// MARK: - RateLimiterTests
 
 @Suite("RateLimiter Tests")
 struct RateLimiterTests {
+    /// Creates a limiter driven by a fresh virtual clock starting at nanosecond 0,
+    /// so refill math can be asserted against exact injected instants.
+    private func makeVirtualLimiter(
+        maxTokens: Int,
+        refillRatePerSecond: Double
+    ) -> (limiter: RateLimiter, clock: VirtualClock) {
+        let clock = VirtualClock()
+        let limiter = RateLimiter(
+            maxTokens: maxTokens,
+            refillRatePerSecond: refillRatePerSecond,
+            clock: clock
+        )
+        return (limiter, clock)
+    }
+
+    // MARK: - Sanitization Tests
+
     @Test("Invalid maxRequestsPerMinute is sanitized")
     func invalidMaxRequestsPerMinuteIsSanitized() async {
         let limiter = RateLimiter(maxRequestsPerMinute: 0)
@@ -26,5 +46,240 @@ struct RateLimiterTests {
 
         // Refill path should remain safe and not produce invalid sleep math.
         try await limiter.acquire()
+    }
+
+    @Test("Nil clock falls back to the live clock")
+    func nilClockFallsBackToLiveClock() async {
+        let limiter = RateLimiter(maxTokens: 2, refillRatePerSecond: 1.0, clock: nil)
+        #expect(await limiter.available == 2)
+        #expect(await limiter.tryAcquire() == true)
+    }
+
+    // MARK: - Virtual Clock Refill Tests
+
+    @Test("Bucket starts full and stays capped regardless of elapsed time")
+    func bucketStartsFullAndStaysCapped() async {
+        let (limiter, clock) = makeVirtualLimiter(maxTokens: 3, refillRatePerSecond: 1.0)
+
+        clock.advance(by: 60_000_000_000)
+        #expect(await limiter.available == 3)
+        #expect(await limiter.tryAcquire() == true)
+        #expect(await limiter.available == 2)
+    }
+
+    @Test("Refill grants tokens at exactly the configured virtual instants")
+    func refillGrantsAtExactInstants() async {
+        let (limiter, clock) = makeVirtualLimiter(maxTokens: 2, refillRatePerSecond: 1.0)
+
+        // Drain the bucket completely.
+        #expect(await limiter.tryAcquire() == true)
+        #expect(await limiter.tryAcquire() == true)
+        #expect(await limiter.available == 0)
+
+        // Half a second at 1 token/s yields half a token: still blocked.
+        clock.advance(by: 500_000_000)
+        #expect(await limiter.available == 0)
+        #expect(await limiter.tryAcquire() == false)
+
+        // At exactly 1 s one full token has accumulated.
+        clock.advance(to: 1_000_000_000)
+        #expect(await limiter.tryAcquire() == true)
+
+        // Immediately after, the remainder (0.5 s worth) is insufficient.
+        #expect(await limiter.tryAcquire() == false)
+
+        // At exactly 2 s total, the second token has accumulated.
+        clock.advance(to: 2_000_000_000)
+        #expect(await limiter.tryAcquire() == true)
+        #expect(await limiter.available == 0)
+    }
+
+    @Test("Refill caps at maxTokens after long idle periods")
+    func refillCapsAtMaxTokens() async {
+        let (limiter, clock) = makeVirtualLimiter(maxTokens: 4, refillRatePerSecond: 2.0)
+
+        #expect(await limiter.tryAcquire() == true)
+        #expect(await limiter.tryAcquire() == true)
+        #expect(await limiter.available == 2)
+
+        // 100 s at 2 tokens/s far exceeds capacity; refill must clamp at 4.
+        clock.advance(by: 100_000_000_000)
+        #expect(await limiter.available == 4)
+
+        // All four tokens are spendable after the capped refill.
+        for _ in 1...4 {
+            #expect(await limiter.tryAcquire() == true)
+        }
+        #expect(await limiter.tryAcquire() == false)
+    }
+
+    @Test("acquire() waits through the injected clock with zero real sleeping")
+    func acquireWaitsThroughInjectedClock() async throws {
+        let (limiter, clock) = makeVirtualLimiter(maxTokens: 1, refillRatePerSecond: 2.0)
+
+        #expect(await limiter.tryAcquire() == true)
+
+        let wallStart = ContinuousClock.now
+        try await limiter.acquire()
+
+        // Deficit 1.0 at 2 tokens/s requires exactly 0.5 s of virtual sleep;
+        // VirtualClock completes it instantly and advances itself.
+        #expect(clock.recordedSleeps == [500_000_000])
+        let elapsed = ContinuousClock.now - wallStart
+        // A real 0.5 s sleep would exceed this bound even on a loaded runner.
+        #expect(elapsed < .milliseconds(250))
+
+        // Bucket is empty again after consumption.
+        #expect(await limiter.available == 0)
+    }
+
+    @Test("Consecutive acquires each record their exact virtual wait")
+    func consecutiveAcquiresRecordExactWaits() async throws {
+        let (limiter, clock) = makeVirtualLimiter(maxTokens: 1, refillRatePerSecond: 1.0)
+
+        #expect(await limiter.tryAcquire() == true)
+        try await limiter.acquire()
+        try await limiter.acquire()
+
+        // Each refill needs a full second at 1 token/s.
+        #expect(clock.recordedSleeps == [1_000_000_000, 1_000_000_000])
+        #expect(clock.now == 2_000_000_000)
+    }
+
+    @Test("reset() restores full capacity on the injected timeline")
+    func resetRestoresFullCapacityOnInjectedTimeline() async {
+        let (limiter, clock) = makeVirtualLimiter(maxTokens: 3, refillRatePerSecond: 1.0)
+
+        clock.advance(by: 30_000_000_000)
+        #expect(await limiter.tryAcquire() == true)
+        #expect(await limiter.available == 2)
+
+        await limiter.reset()
+        #expect(await limiter.available == 3)
+        #expect(await limiter.tryAcquire() == true)
+        #expect(await limiter.available == 2)
+    }
+
+    @Test("acquire() stays cancellation-aware between injected waits")
+    func acquireRemainsCancellationAwareBetweenWaits() async throws {
+        // A clock whose sleeps never advance time keeps acquire() looping in
+        // its wait branch, so cancellation must come from the loop itself.
+        final class FrozenClock: SwarmClock, @unchecked Sendable {
+            private let lock = NSLock()
+            private var sleeps: [UInt64] = []
+
+            var recordedSleeps: [UInt64] {
+                lock.withLock { sleeps }
+            }
+
+            func nowNanoseconds() -> UInt64 { 0 }
+
+            func sleep(nanoseconds duration: UInt64) async throws {
+                lock.withLock { sleeps.append(duration) }
+                try Task.checkCancellation()
+            }
+        }
+
+        let frozen = FrozenClock()
+        let limiter = RateLimiter(maxTokens: 1, refillRatePerSecond: 1.0, clock: frozen)
+
+        #expect(await limiter.tryAcquire() == true)
+
+        let task = Task {
+            try await limiter.acquire()
+        }
+        // Yield until the waiter has entered (and slept inside) the loop.
+        while await frozen.recordedSleeps.isEmpty {
+            await Task.yield()
+        }
+        task.cancel()
+
+        do {
+            try await task.value
+            Issue.record("Expected cancelled acquire to throw CancellationError")
+        } catch is CancellationError {
+            // Expected: propagated between injected waits.
+        }
+    }
+}
+
+// MARK: - TokenBucketMath Tests
+
+@Suite("TokenBucketMath Tests")
+private struct TokenBucketMathTests {
+    // MARK: refilled
+
+    @Test("Zero elapsed time leaves tokens unchanged")
+    func zeroElapsedLeavesTokensUnchanged() {
+        #expect(
+            TokenBucketMath.refilled(tokens: 2.5, elapsedSeconds: 0, refillRate: 3.0, maxTokens: 10)
+                == 2.5
+        )
+    }
+
+    @Test("Elapsed time adds elapsed times rate tokens")
+    func elapsedAddsRateScaledTokens() {
+        #expect(
+            TokenBucketMath.refilled(tokens: 1.0, elapsedSeconds: 2.5, refillRate: 4.0, maxTokens: 20)
+                == 11.0
+        )
+    }
+
+    @Test("Refill clamps at maxTokens")
+    func refillClampsAtMaxTokens() {
+        #expect(
+            TokenBucketMath.refilled(tokens: 8.0, elapsedSeconds: 10, refillRate: 5.0, maxTokens: 9)
+                == 9.0
+        )
+        #expect(
+            TokenBucketMath.refilled(tokens: 9.0, elapsedSeconds: 60, refillRate: 1.0, maxTokens: 9)
+                == 9.0
+        )
+    }
+
+    @Test("Negative elapsed removes tokens at the refill rate")
+    func negativeElapsedRemovesTokens() {
+        #expect(
+            TokenBucketMath.refilled(tokens: 5.0, elapsedSeconds: -2.0, refillRate: 1.5, maxTokens: 10)
+                == 2.0
+        )
+    }
+
+    // MARK: waitSeconds
+
+    @Test("Wait time is deficit divided by rate")
+    func waitTimeIsDeficitOverRate() {
+        #expect(TokenBucketMath.waitSeconds(forDeficit: 0.5, refillRate: 2.0) == 0.25)
+        #expect(TokenBucketMath.waitSeconds(forDeficit: 1.0, refillRate: 4.0) == 0.25)
+    }
+
+    @Test("Non-positive deficits yield zero wait")
+    func nonPositiveDeficitsYieldZeroWait() {
+        #expect(TokenBucketMath.waitSeconds(forDeficit: 0, refillRate: 2.0) == 0)
+        #expect(TokenBucketMath.waitSeconds(forDeficit: -1.5, refillRate: 2.0) == 0)
+    }
+
+    @Test("Non-finite raw quotients yield zero wait")
+    func nonFiniteQuotientsYieldZeroWait() {
+        // Division by a non-finite deficit or rate must never produce an
+        // invalid sleep duration.
+        #expect(TokenBucketMath.waitSeconds(forDeficit: .infinity, refillRate: 2.0) == 0)
+        #expect(TokenBucketMath.waitSeconds(forDeficit: .nan, refillRate: 2.0) == 0)
+        #expect(TokenBucketMath.waitSeconds(forDeficit: 1.0, refillRate: .infinity) == 0)
+        #expect(TokenBucketMath.waitSeconds(forDeficit: 1.0, refillRate: 0) == 0)
+        #expect(TokenBucketMath.waitSeconds(forDeficit: 1.0, refillRate: .nan) == 0)
+    }
+
+    // MARK: elapsedSeconds
+
+    @Test("Elapsed seconds converts nanosecond deltas forward and backward")
+    func elapsedConvertsNanosecondDeltas() {
+        #expect(
+            TokenBucketMath.elapsedSeconds(from: 1_000_000_000, to: 2_500_000_000) == 1.5
+        )
+        #expect(TokenBucketMath.elapsedSeconds(from: 500, to: 500) == 0)
+        #expect(
+            TokenBucketMath.elapsedSeconds(from: 2_000_000_000, to: 1_500_000_000) == -0.5
+        )
     }
 }

--- a/docs/reference/api-catalog.md
+++ b/docs/reference/api-catalog.md
@@ -3,7 +3,7 @@
 Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for high-risk public rows on 2026-07-28 (Conduit hard-removed in 0.6). MCP client rows refreshed 2026-08-14. OpenAI-compatible provider rows added 2026-08-14.
 
 - Scope: all `.swift` files under `Sources/Swarm/`, excluding `Internal/GraphRuntime/`
-- Source files scanned: 176
+- Source files scanned: 179
 - Public/open symbols cataloged: 2510
 
 ## 1. Swarm (entry point)


### PR DESCRIPTION
Spec \`spec-architecture-resilience-clock-runenv\` ticket T3 (stacked on T1, PR #169). Candidate 01.

- Both inits gain SPI clock param (nil → LiveSwarmClock); refill/wait math extracted as pure \`TokenBucketMath\` preserving exact guard semantics
- acquire() waits route through injected clock; cancellation preserved
- Tests: exact virtual-instant refill boundaries, recorded-sleep assertions with wall-clock bound, frozen-clock cancellation probe

AC-003 satisfied. Reviews: swift-pr-review round-1 (clean; pre-existing degenerate busy-loop noted byte-identical to base) + final pass (clean).