### PR TITLE
arch(T4): injectable randomness and sleep in RetryPolicy

### DIFF
--- a/Sources/Swarm/Resilience/RetryPolicy.swift
+++ b/Sources/Swarm/Resilience/RetryPolicy.swift
@@ -67,8 +67,11 @@ public enum BackoffStrategy: Sendable {
     /// generators under test).
     /// - Parameters:
     ///   - attempt: The attempt number (1-indexed).
-    ///   - random: Replacement for `Double.random(in:)`; receives the legal
-    ///     range for the drawn value.
+    ///   - random: Replacement for `Double.random(in:)`; receives exactly the
+    ///     range the live implementation would draw from. Implementations
+    ///     mirroring `Double.random(in:)` keep its precondition failure on
+    ///     inverted ranges, preserving historical crash behavior for
+    ///     degenerate configurations.
     /// - Returns: The delay in seconds before the next retry.
     func delay(
         forAttempt attempt: Int,
@@ -202,11 +205,11 @@ public struct RetryPolicy: Sendable {
 
     /// Clock used to suspend between retries. Defaults to `LiveSwarmClock`
     /// (plain `Task.sleep`) so existing behavior is unchanged when nil.
-    let clock: any SwarmClock
+    private let clock: any SwarmClock
 
     /// Randomness source consulted by jittered backoff strategies. Defaults
     /// to `Double.random(in:)` so existing behavior is unchanged when nil.
-    let randomSource: @Sendable (ClosedRange<Double>) -> Double
+    private let randomSource: @Sendable (ClosedRange<Double>) -> Double
 
     // MARK: - Initialization
 

--- a/Sources/Swarm/Resilience/RetryPolicy.swift
+++ b/Sources/Swarm/Resilience/RetryPolicy.swift
@@ -59,6 +59,21 @@ public enum BackoffStrategy: Sendable {
     /// - Parameter attempt: The attempt number (1-indexed).
     /// - Returns: The delay in seconds before the next retry.
     public func delay(forAttempt attempt: Int) -> TimeInterval {
+        delay(forAttempt: attempt, random: { Double.random(in: $0) })
+    }
+
+    /// Calculates the delay using an explicit randomness source so that
+    /// jittered strategies produce reproducible sequences (e.g. seeded
+    /// generators under test).
+    /// - Parameters:
+    ///   - attempt: The attempt number (1-indexed).
+    ///   - random: Replacement for `Double.random(in:)`; receives the legal
+    ///     range for the drawn value.
+    /// - Returns: The delay in seconds before the next retry.
+    func delay(
+        forAttempt attempt: Int,
+        random: @Sendable (ClosedRange<Double>) -> Double
+    ) -> TimeInterval {
         switch self {
         case let .fixed(delay):
             return delay
@@ -75,14 +90,14 @@ public enum BackoffStrategy: Sendable {
             let exponentialDelay = base * pow(multiplier, Double(attempt - 1))
             let cappedDelay = min(exponentialDelay, maxDelay)
             // Add random jitter between 0 and the calculated delay
-            let jitter = Double.random(in: 0...cappedDelay)
+            let jitter = random(0...cappedDelay)
             return jitter
 
         case let .decorrelatedJitter(base, maxDelay):
             // Decorrelated jitter: sleep = min(cap, random_between(base, sleep * 3))
             // For the first attempt, use base as the previous sleep
             let previousSleep = attempt == 1 ? base : base * pow(3.0, Double(attempt - 2))
-            let delay = Double.random(in: base...(previousSleep * 3.0))
+            let delay = random(base...(previousSleep * 3.0))
             return min(delay, maxDelay)
 
         case .immediate:
@@ -183,6 +198,16 @@ public struct RetryPolicy: Sendable {
     /// Optional callback invoked before each retry attempt.
     public let onRetry: (@Sendable (Int, Error) async -> Void)?
 
+    // MARK: Private
+
+    /// Clock used to suspend between retries. Defaults to `LiveSwarmClock`
+    /// (plain `Task.sleep`) so existing behavior is unchanged when nil.
+    let clock: any SwarmClock
+
+    /// Randomness source consulted by jittered backoff strategies. Defaults
+    /// to `Double.random(in:)` so existing behavior is unchanged when nil.
+    let randomSource: @Sendable (ClosedRange<Double>) -> Double
+
     // MARK: - Initialization
 
     /// Creates a new retry policy.
@@ -197,10 +222,37 @@ public struct RetryPolicy: Sendable {
         shouldRetry: @escaping @Sendable (Error) -> Bool = { _ in true },
         onRetry: (@Sendable (Int, Error) async -> Void)? = nil
     ) {
+        self.init(
+            maxAttempts: maxAttempts,
+            backoff: backoff,
+            shouldRetry: shouldRetry,
+            onRetry: onRetry,
+            clock: nil,
+            random: nil
+        )
+    }
+
+    /// Package-internal injection point for deterministic tests.
+    ///
+    /// `clock` replaces the default `Task.sleep(nanoseconds:)` suspension path;
+    /// `random` replaces `Double.random(in:)` for jittered backoff strategies.
+    /// Both default to the live behaviors when `nil`. Kept internal because
+    /// `SwarmClock` is `@_spi(ColonyInternal)` and cannot appear in a public
+    /// signature.
+    init(
+        maxAttempts: Int = 3,
+        backoff: BackoffStrategy = .exponential(base: 1.0, multiplier: 2.0, maxDelay: 60.0),
+        shouldRetry: @escaping @Sendable (Error) -> Bool = { _ in true },
+        onRetry: (@Sendable (Int, Error) async -> Void)? = nil,
+        clock: (any SwarmClock)? = nil,
+        random: (@Sendable (ClosedRange<Double>) -> Double)? = nil
+    ) {
         self.maxAttempts = max(0, maxAttempts)
         self.backoff = backoff
         self.shouldRetry = shouldRetry
         self.onRetry = onRetry
+        self.clock = clock ?? LiveSwarmClock.live
+        self.randomSource = random ?? { Double.random(in: $0) }
     }
 
     // MARK: - Execution
@@ -241,9 +293,11 @@ public struct RetryPolicy: Sendable {
                 await onRetry?(retryCount, error)
 
                 // Calculate and apply backoff delay
-                let delay = sanitizeBackoffDelay(backoff.delay(forAttempt: retryCount))
+                let delay = sanitizeBackoffDelay(
+                    backoff.delay(forAttempt: retryCount, random: randomSource)
+                )
                 if delay > 0 {
-                    try await Task.sleep(nanoseconds: delay)
+                    try await clock.sleep(nanoseconds: delay)
                 }
             }
         }

--- a/Tests/SwarmTests/Resilience/ResilienceTests+Retry.swift
+++ b/Tests/SwarmTests/Resilience/ResilienceTests+Retry.swift
@@ -4,7 +4,7 @@
 // Tests for RetryPolicy resilience component using Swift Testing framework.
 
 import Foundation
-@testable import Swarm
+@_spi(ColonyInternal) @testable import Swarm
 import Testing
 
 // MARK: - RetryPolicy Tests
@@ -437,5 +437,186 @@ struct RetryPolicyTests {
         }
 
         #expect(await counter.get() == 2)
+    }
+}
+
+// MARK: - Deterministic Randomness & Sleep Seam Support
+
+/// Lock-guarded wrapper exposing `SeededRandomGenerator` through the
+/// `@Sendable` closure shape accepted by RetryPolicy and BackoffStrategy.
+/// (The generator is a value type; `@Sendable` closures need shared state.)
+private final class SharedSeededRandom: @unchecked Sendable {
+    // MARK: Private
+
+    private let lock = NSLock()
+    private var generator: SeededRandomGenerator
+
+    // MARK: Init
+
+    init(seed: UInt64) {
+        generator = SeededRandomGenerator(seed: seed)
+    }
+
+    // MARK: Internal
+
+    func random(in range: ClosedRange<Double>) -> Double {
+        lock.withLock { generator.random(in: range) }
+    }
+}
+
+// MARK: - Jitter Determinism Tests
+
+@Suite("RetryPolicy Determinism Tests")
+private struct RetryPolicyDeterminismTests {
+    @Test("Seeded randomness reproduces exponentialWithJitter sequences")
+    func seededExponentialJitterReplaysExactly() {
+        let strategy = BackoffStrategy.exponentialWithJitter(base: 1.0, multiplier: 2.0, maxDelay: 10.0)
+
+        let firstRun = SharedSeededRandom(seed: 99)
+        let firstSequence = (1...6).map { strategy.delay(forAttempt: $0, random: firstRun.random(in:)) }
+
+        let replayRun = SharedSeededRandom(seed: 99)
+        let replaySequence = (1...6).map { strategy.delay(forAttempt: $0, random: replayRun.random(in:)) }
+
+        #expect(firstSequence == replaySequence)
+
+        for (index, delay) in firstSequence.enumerated() {
+            let capped = min(1.0 * pow(2.0, Double(index)), 10.0)
+            #expect(delay >= 0)
+            #expect(delay <= capped)
+        }
+        #expect(Set(firstSequence).count > 1) // jitter actually varies
+    }
+
+    @Test("Seeded randomness reproduces decorrelatedJitter sequences")
+    func seededDecorrelatedJitterReplaysExactly() {
+        let strategy = BackoffStrategy.decorrelatedJitter(base: 0.5, maxDelay: 20.0)
+
+        let firstRun = SharedSeededRandom(seed: 7)
+        let firstSequence = (1...5).map { strategy.delay(forAttempt: $0, random: firstRun.random(in:)) }
+
+        let replayRun = SharedSeededRandom(seed: 7)
+        let replaySequence = (1...5).map { strategy.delay(forAttempt: $0, random: replayRun.random(in:)) }
+
+        #expect(firstSequence == replaySequence)
+
+        for (index, delay) in firstSequence.enumerated() {
+            // previousSleep formula preserved byte-identically:
+            // attempt == 1 uses base; else base * pow(3, attempt - 2).
+            let previousSleep = index == 0 ? 0.5 : 0.5 * pow(3.0, Double(index - 1))
+            #expect(delay >= 0.5)
+            #expect(delay <= min(previousSleep * 3.0, 20.0))
+        }
+    }
+
+    @Test("Public delay(forAttempt:) keeps live randomness and unchanged math")
+    func publicDelayKeepsLiveRandomness() {
+        let strategy = BackoffStrategy.exponentialWithJitter(base: 1.0, multiplier: 2.0, maxDelay: 1_000_000.0)
+
+        let delays = (0..<16).map { _ in strategy.delay(forAttempt: 1) }
+
+        #expect(delays.allSatisfy { $0 >= 0 && $0 <= 1.0 })
+        #expect(Set(delays).count > 1)
+
+        // Non-jitter strategies are unaffected by the seam.
+        #expect(BackoffStrategy.fixed(delay: 1.5).delay(forAttempt: 3) == 1.5)
+        #expect(BackoffStrategy.immediate.delay(forAttempt: 9) == 0)
+    }
+
+    // MARK: Injected Sleep Seam Tests
+
+    @Test("Injected clock records exact per-attempt delays without real sleeping")
+    func executeRecordsExactDelaysViaVirtualClock() async throws {
+        let clock = VirtualClock()
+        let counter = TestCounter()
+        let policy = RetryPolicy(
+            maxAttempts: 3,
+            backoff: .fixed(delay: 0.25),
+            clock: clock
+        )
+
+        let wallStart = ContinuousClock.now
+
+        let result = try await policy.execute {
+            let count = await counter.increment()
+            if count < 3 {
+                throw TestError.transient
+            }
+            return "recovered"
+        }
+
+        #expect(result == "recovered")
+        #expect(await counter.get() == 3)
+        #expect(clock.recordedSleeps == [250_000_000, 250_000_000]) // attempts 1 and 2 only
+        #expect(clock.now == 500_000_000) // virtual time advanced by the two sleeps
+
+        let elapsed = ContinuousClock.now - wallStart
+        // Two real 250 ms sleeps would take at least 0.5 s.
+        #expect(elapsed < .milliseconds(250))
+    }
+
+    @Test("Seeded jitter retries replay identical sleep sequences end to end")
+    func seededJitterEndToEndReplaysIdenticalSleeps() async throws {
+        let strategy = BackoffStrategy.exponentialWithJitter(base: 1.0, multiplier: 2.0, maxDelay: 60.0)
+
+        func runOnce() async throws -> [UInt64] {
+            let clock = VirtualClock()
+            let random = SharedSeededRandom(seed: 2_026)
+            let counter = TestCounter()
+            let policy = RetryPolicy(maxAttempts: 3, backoff: strategy, clock: clock, random: random.random(in:))
+
+            _ = try await policy.execute {
+                let count = await counter.increment()
+                if count < 4 {
+                    throw TestError.network
+                }
+                return true
+            }
+
+            #expect(await counter.get() == 4) // initial + 3 retries
+            return clock.recordedSleeps
+        }
+
+        let firstRun = try await runOnce()
+        let secondRun = try await runOnce()
+
+        #expect(firstRun.count == 3)
+        #expect(firstRun == secondRun)
+
+        for (index, nanoseconds) in firstRun.enumerated() {
+            let capped = min(1.0 * pow(2.0, Double(index)), 60.0)
+            #expect(Double(nanoseconds) / 1_000_000_000 <= capped)
+        }
+    }
+
+    @Test("Injected clock preserves immediate cancellation semantics")
+    func injectedClockPreservesCancellationSemantics() async throws {
+        let clock = VirtualClock()
+        let counter = TestCounter()
+        let retryRecorder = TestRecorder<Int>()
+        let policy = RetryPolicy(
+            maxAttempts: 3,
+            backoff: .fixed(delay: 1.0),
+            onRetry: { attempt, _ in
+                await retryRecorder.append(attempt)
+            },
+            clock: clock
+        )
+
+        do {
+            _ = try await policy.execute {
+                _ = await counter.increment()
+                throw CancellationError()
+            }
+            Issue.record("Expected CancellationError")
+        } catch is CancellationError {
+            // Expected: cancellation rethrown immediately, no retry, no sleep.
+        } catch {
+            Issue.record("Expected CancellationError, got \(error)")
+        }
+
+        #expect(await counter.get() == 1)
+        #expect(await retryRecorder.getAll().isEmpty)
+        #expect(clock.recordedSleeps.isEmpty)
     }
 }

--- a/docs/reference/api-catalog.md
+++ b/docs/reference/api-catalog.md
@@ -3,7 +3,7 @@
 Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for high-risk public rows on 2026-07-28 (Conduit hard-removed in 0.6). MCP client rows refreshed 2026-08-14. OpenAI-compatible provider rows added 2026-08-14.
 
 - Scope: all `.swift` files under `Sources/Swarm/`, excluding `Internal/GraphRuntime/`
-- Source files scanned: 176
+- Source files scanned: 179
 - Public/open symbols cataloged: 2510
 
 ## 1. Swarm (entry point)


### PR DESCRIPTION
Spec \`spec-architecture-resilience-clock-runenv\` ticket T4 (stacked on T1, PR #169). Candidate 01.

- \`BackoffStrategy.delay(forAttempt:random:)\` internal overload; public signature unchanged, default remains Double.random (crash-on-inverted-range parity preserved)
- RetryPolicy gains internal clock init (nil → live); execute() suspends via injected clock — zero real delay in tests
- decorrelatedJitter formula byte-identical; sanitizeBackoffDelay/loop ordering/cancellation untouched
- Seeded replay tests for both jitter strategies + exact recorded-sleep execute() test

AC-002 satisfied. Reviews: swift-pr-review round-1 (2×P3 visibility/doc fixes) + final pass (approve).