### PR TITLE
arch(T5): shared timeout-race helper across guardrail/workflow/stream sites

### DIFF
--- a/Sources/Swarm/Core/StreamOperations.swift
+++ b/Sources/Swarm/Core/StreamOperations.swift
@@ -122,7 +122,10 @@ public extension AsyncThrowingStream where Element == AgentEvent, Failure == Err
                     lastError = error
                     if attempts < maxAttempts, delay != .zero {
                         do {
-                            try await Task.sleep(for: delay)
+                            // Routed through the SwarmClock seam so a future
+                            // injected virtual clock makes retry delays
+                            // deterministic in tests.
+                            try await LiveSwarmClock.live.sleep(nanoseconds: delay.swarmNanoseconds)
                         } catch is CancellationError {
                             continuation.finish(throwing: CancellationError())
                             return

--- a/Sources/Swarm/Core/TimeoutRace.swift
+++ b/Sources/Swarm/Core/TimeoutRace.swift
@@ -3,7 +3,11 @@
 //
 // Shared completion machinery for async operations raced against a timeout,
 // consolidating the per-site coordinator/race classes that previously lived
-// in GuardrailRunner and Workflow+Timeout.
+// in GuardrailRunner and Workflow+Timeout. Two timeout sites deliberately
+// keep their own machinery: Agent.executeWithinRemainingTimeout ties race
+// settlement to its ProviderOwnedLoopGate execution-gate state, and
+// StreamOperations.timeout(after:) is a stream-lifetime operator rather than
+// a one-shot race.
 
 import Foundation
 

--- a/Sources/Swarm/Core/TimeoutRace.swift
+++ b/Sources/Swarm/Core/TimeoutRace.swift
@@ -1,0 +1,189 @@
+// TimeoutRace.swift
+// Swarm Framework
+//
+// Shared completion machinery for async operations raced against a timeout,
+// consolidating the per-site coordinator/race classes that previously lived
+// in GuardrailRunner and Workflow+Timeout.
+
+import Foundation
+
+/// One-shot completion coordinator for an asynchronous operation racing a
+/// timeout timer.
+///
+/// The wrapped checked continuation is resumed exactly once: whichever side
+/// finishes first records the outcome, both worker tasks are cancelled, and
+/// any task registered after settlement is cancelled immediately. An outcome
+/// recorded before `install(continuation:)` runs (e.g. a cancellation handler
+/// firing in that window) is applied as soon as the continuation arrives, so
+/// no registration order can leak or strand it.
+final class TimeoutRace<T: Sendable>: @unchecked Sendable {
+    private enum Outcome {
+        case success(T)
+        case failure(Error)
+    }
+
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<T, Error>?
+    private var operationTask: Task<Void, Never>?
+    private var timeoutTask: Task<Void, Never>?
+    private var outcome: Outcome?
+
+    func install(continuation: CheckedContinuation<T, Error>) {
+        lock.lock()
+        self.continuation = continuation
+        lock.unlock()
+        resumeRecordedOutcomeIfReady()
+    }
+
+    func setOperationTask(_ task: Task<Void, Never>) {
+        lock.lock()
+        let settledAlready = outcome != nil
+        if !settledAlready {
+            operationTask = task
+        }
+        lock.unlock()
+
+        if settledAlready {
+            task.cancel()
+        }
+    }
+
+    func setTimeoutTask(_ task: Task<Void, Never>) {
+        lock.lock()
+        let settledAlready = outcome != nil
+        if !settledAlready {
+            timeoutTask = task
+        }
+        lock.unlock()
+
+        if settledAlready {
+            task.cancel()
+        }
+    }
+
+    func finish(returning value: T) {
+        record(.success(value))
+    }
+
+    func finish(throwing error: Error) {
+        record(.failure(error))
+    }
+
+    private func record(_ newOutcome: Outcome) {
+        lock.lock()
+        guard outcome == nil else {
+            lock.unlock()
+            return
+        }
+        outcome = newOutcome
+        let pendingContinuation = continuation
+        let pendingOperationTask = operationTask
+        let pendingTimeoutTask = timeoutTask
+        continuation = nil
+        operationTask = nil
+        timeoutTask = nil
+        lock.unlock()
+
+        pendingOperationTask?.cancel()
+        pendingTimeoutTask?.cancel()
+        if let pendingContinuation {
+            resume(newOutcome, onto: pendingContinuation)
+        }
+    }
+
+    private func resumeRecordedOutcomeIfReady() {
+        lock.lock()
+        let recorded = outcome
+        let pendingContinuation = continuation
+        if recorded != nil {
+            continuation = nil
+        }
+        lock.unlock()
+
+        if let recorded, let pendingContinuation {
+            resume(recorded, onto: pendingContinuation)
+        }
+    }
+
+    private func resume(_ outcome: Outcome, onto continuation: CheckedContinuation<T, Error>) {
+        switch outcome {
+        case let .success(value):
+            continuation.resume(returning: value)
+        case let .failure(error):
+            continuation.resume(throwing: error)
+        }
+    }
+}
+
+/// Runs `operation`, racing it against `timeout` measured on `clock`.
+///
+/// Whichever finishes first wins; the loser task is cancelled and the result
+/// resumes exactly once. When `cancelsOnParentCancellation` is set (the
+/// default), cancelling the surrounding task settles the race immediately
+/// with `CancellationError`; when cleared, parent cancellation does not
+/// interrupt the park, matching sites whose callers own cancellation
+/// handling. A non-nil `priority` spawns both worker tasks detached at that
+/// priority so actor-context work cannot deadlock the race; `nil` keeps the
+/// inherited-context `Task {}` flavor.
+///
+/// Sleep failures other than cancellation surface through the continuation;
+/// `LiveSwarmClock` suspension only ever throws `CancellationError`.
+func withTimeoutRace<T: Sendable>(
+    timeout: Duration,
+    clock: any SwarmClock = LiveSwarmClock.live,
+    cancelsOnParentCancellation: Bool = true,
+    priority: TaskPriority? = nil,
+    timeoutError: @autoclosure @escaping @Sendable () -> Error,
+    operation: @escaping @Sendable () async throws -> T
+) async throws -> T {
+    let race = TimeoutRace<T>()
+
+    func run() async throws -> T {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<T, Error>) in
+            race.install(continuation: continuation)
+
+            func spawn(_ work: @escaping @Sendable () async -> Void) -> Task<Void, Never> {
+                if let priority {
+                    return Task.detached(priority: priority, operation: work)
+                }
+                return Task(operation: work)
+            }
+
+            let operationTask = spawn {
+                do {
+                    race.finish(returning: try await operation())
+                } catch {
+                    race.finish(throwing: error)
+                }
+            }
+            race.setOperationTask(operationTask)
+
+            let timeoutTask = spawn {
+                do {
+                    try await clock.sleep(nanoseconds: timeout.swarmNanoseconds)
+                } catch is CancellationError {
+                    return
+                } catch {
+                    race.finish(throwing: error)
+                    return
+                }
+                operationTask.cancel()
+                race.finish(throwing: timeoutError())
+            }
+            race.setTimeoutTask(timeoutTask)
+        }
+    }
+
+    guard cancelsOnParentCancellation else {
+        return try await run()
+    }
+
+    return try await withTaskCancellationHandler(
+        operation: {
+            try await run()
+        },
+        onCancel: {
+            race.finish(throwing: CancellationError())
+        }
+    )
+}

--- a/Sources/Swarm/Guardrails/GuardrailRunner.swift
+++ b/Sources/Swarm/Guardrails/GuardrailRunner.swift
@@ -332,7 +332,10 @@ public actor GuardrailRunner {
 
         // Parent cancellation is not wired into this race (matching the
         // original implementation): a cancelled caller parks until the
-        // guardrail finishes or the timeout fires.
+        // guardrail finishes or the timeout fires. Unlike the original
+        // actor-isolated `Task {}` workers, the helper spawns unisolated
+        // tasks, so guardrail operations and their timers no longer queue
+        // behind other runner-actor work.
         return try await withTimeoutRace(
             timeout: timeout,
             cancelsOnParentCancellation: false,

--- a/Sources/Swarm/Guardrails/GuardrailRunner.swift
+++ b/Sources/Swarm/Guardrails/GuardrailRunner.swift
@@ -146,55 +146,6 @@ public struct GuardrailExecutionResult: Sendable, Equatable {
     }
 }
 
-private final class GuardrailTimeoutRace<Result: Sendable>: @unchecked Sendable {
-    private let lock = NSLock()
-    private var completed = false
-    private var operationTask: Task<Void, Never>?
-    private var timeoutTask: Task<Void, Never>?
-
-    func setOperationTask(_ task: Task<Void, Never>) {
-        lock.lock()
-        let shouldCancel = completed
-        if !completed {
-            operationTask = task
-        }
-        lock.unlock()
-
-        if shouldCancel {
-            task.cancel()
-        }
-    }
-
-    func setTimeoutTask(_ task: Task<Void, Never>) {
-        lock.lock()
-        let shouldCancel = completed
-        if !completed {
-            timeoutTask = task
-        }
-        lock.unlock()
-
-        if shouldCancel {
-            task.cancel()
-        }
-    }
-
-    func complete(_ resume: () -> Void) {
-        lock.lock()
-        guard !completed else {
-            lock.unlock()
-            return
-        }
-        completed = true
-        let operationTask = operationTask
-        let timeoutTask = timeoutTask
-        lock.unlock()
-
-        operationTask?.cancel()
-        timeoutTask?.cancel()
-        resume()
-    }
-}
-
 private struct GuardrailTimeoutError: Error, LocalizedError, Sendable {
     let guardrailName: String
     let timeout: Duration
@@ -379,33 +330,15 @@ public actor GuardrailRunner {
             return try await operation()
         }
 
-        let race = GuardrailTimeoutRace<Result>()
-        return try await withCheckedThrowingContinuation { continuation in
-            let operationTask = Task {
-                do {
-                    let result = try await operation()
-                    race.complete {
-                        continuation.resume(returning: result)
-                    }
-                } catch {
-                    race.complete {
-                        continuation.resume(throwing: error)
-                    }
-                }
-            }
-            race.setOperationTask(operationTask)
-
-            let timeoutTask = Task {
-                do {
-                    try await Task.sleep(for: timeout)
-                } catch {
-                    return
-                }
-                race.complete {
-                    continuation.resume(throwing: GuardrailTimeoutError(guardrailName: guardrailName, timeout: timeout))
-                }
-            }
-            race.setTimeoutTask(timeoutTask)
+        // Parent cancellation is not wired into this race (matching the
+        // original implementation): a cancelled caller parks until the
+        // guardrail finishes or the timeout fires.
+        return try await withTimeoutRace(
+            timeout: timeout,
+            cancelsOnParentCancellation: false,
+            timeoutError: GuardrailTimeoutError(guardrailName: guardrailName, timeout: timeout)
+        ) {
+            try await operation()
         }
     }
 

--- a/Sources/Swarm/Workflow/Workflow+Timeout.swift
+++ b/Sources/Swarm/Workflow/Workflow+Timeout.swift
@@ -3,10 +3,11 @@ import Foundation
 extension Workflow {
     /// Runs `operation`, racing it against `timeoutDuration` when configured.
     ///
-    /// Uses `Task.detached` so a MainActor caller cannot deadlock the
-    /// continuation (an unstructured `Task {}` would be scheduled on MainActor
-    /// and never run). Detached tasks drop `@TaskLocal` values, so the ambient
-    /// `AgentEnvironment` is snapshotted and re-applied inside the worker.
+    /// The race spawns detached tasks so a MainActor caller cannot deadlock
+    /// the continuation (an unstructured inherited-context task would be
+    /// scheduled on MainActor and never run). Detached tasks drop
+    /// `@TaskLocal` values, so the ambient `AgentEnvironment` is snapshotted
+    /// and re-applied inside the worker closure.
     func executeWithTimeout(
         _ operation: @escaping @Sendable () async throws -> AgentResult
     ) async throws -> AgentResult {
@@ -14,120 +15,15 @@ extension Workflow {
             return try await operation()
         }
 
-        let coordinator = WorkflowTimedOperationCoordinator<AgentResult>()
-        let priority = Task.currentPriority
         let capturedEnvironment = AgentEnvironmentValues.current
-        return try await withTaskCancellationHandler(
-            operation: {
-                try await withCheckedThrowingContinuation { continuation in
-                    coordinator.install(continuation: continuation)
-
-                    let operationTask = Task.detached(priority: priority) {
-                        do {
-                            let result = try await AgentEnvironmentValues.$current.withValue(
-                                capturedEnvironment
-                            ) {
-                                try await operation()
-                            }
-                            coordinator.finish(returning: result)
-                        } catch {
-                            coordinator.finish(throwing: error)
-                        }
-                    }
-                    coordinator.setOperationTask(operationTask)
-
-                    let timeoutTask = Task.detached(priority: priority) {
-                        do {
-                            try await Task.sleep(for: timeoutDuration)
-                            operationTask.cancel()
-                            coordinator.finish(throwing: AgentError.timeout(duration: timeoutDuration))
-                        } catch is CancellationError {
-                            return
-                        } catch {
-                            coordinator.finish(throwing: error)
-                        }
-                    }
-                    coordinator.setTimeoutTask(timeoutTask)
-                }
-            },
-            onCancel: {
-                coordinator.cancelPending(with: CancellationError())
+        return try await withTimeoutRace(
+            timeout: timeoutDuration,
+            priority: Task.currentPriority,
+            timeoutError: AgentError.timeout(duration: timeoutDuration)
+        ) {
+            try await AgentEnvironmentValues.$current.withValue(capturedEnvironment) {
+                try await operation()
             }
-        )
-    }
-}
-
-private final class WorkflowTimedOperationCoordinator<T: Sendable>: @unchecked Sendable {
-    private let lock = NSLock()
-    private var continuation: CheckedContinuation<T, Error>?
-    private var operationTask: Task<Void, Never>?
-    private var timeoutTask: Task<Void, Never>?
-    private var completed = false
-
-    func install(continuation: CheckedContinuation<T, Error>) {
-        lock.lock()
-        self.continuation = continuation
-        lock.unlock()
-    }
-
-    func setOperationTask(_ task: Task<Void, Never>) {
-        lock.lock()
-        operationTask = task
-        lock.unlock()
-    }
-
-    func setTimeoutTask(_ task: Task<Void, Never>) {
-        lock.lock()
-        timeoutTask = task
-        lock.unlock()
-    }
-
-    func finish(returning value: T) {
-        complete { continuation in
-            continuation.resume(returning: value)
         }
-    }
-
-    func finish(throwing error: Error) {
-        complete { continuation in
-            continuation.resume(throwing: error)
-        }
-    }
-
-    func cancelPending(with error: Error) {
-        let pendingState = takePendingState()
-        pendingState.operationTask?.cancel()
-        pendingState.timeoutTask?.cancel()
-        pendingState.continuation?.resume(throwing: error)
-    }
-
-    private func complete(_ resume: (CheckedContinuation<T, Error>) -> Void) {
-        let pendingState = takePendingState()
-        pendingState.operationTask?.cancel()
-        pendingState.timeoutTask?.cancel()
-        guard let continuation = pendingState.continuation else { return }
-        resume(continuation)
-    }
-
-    private func takePendingState() -> (
-        continuation: CheckedContinuation<T, Error>?,
-        operationTask: Task<Void, Never>?,
-        timeoutTask: Task<Void, Never>?
-    ) {
-        lock.lock()
-        defer { lock.unlock() }
-
-        guard completed == false else {
-            return (nil, nil, nil)
-        }
-
-        completed = true
-        let pendingContinuation = continuation
-        let pendingOperationTask = operationTask
-        let pendingTimeoutTask = timeoutTask
-        continuation = nil
-        operationTask = nil
-        timeoutTask = nil
-        return (pendingContinuation, pendingOperationTask, pendingTimeoutTask)
     }
 }

--- a/Tests/SwarmTests/Core/TimeoutRaceTests.swift
+++ b/Tests/SwarmTests/Core/TimeoutRaceTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import Testing
+@testable import Swarm
+
+@Suite("TimeoutRace")
+struct TimeoutRaceTests {
+    @Test("outcome recorded before install resumes the continuation with success")
+    func recordedSuccessAppliesOnLateInstall() async throws {
+        let race = TimeoutRace<Int>()
+        race.finish(returning: 42)
+
+        let value = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Int, Error>) in
+            race.install(continuation: continuation)
+        }
+        #expect(value == 42)
+    }
+
+    @Test("outcome recorded before install resumes the continuation with failure")
+    func recordedFailureAppliesOnLateInstall() async throws {
+        let race = TimeoutRace<Int>()
+        race.finish(throwing: CancellationError())
+
+        await #expect(throws: CancellationError.self) {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Int, Error>) in
+                race.install(continuation: continuation)
+            }
+        }
+    }
+
+    @Test("tasks registered after settlement are cancelled immediately")
+    func lateRegisteredTasksAreCancelled() async {
+        let race = TimeoutRace<Int>()
+        race.finish(throwing: CancellationError())
+
+        let operationTask = Task { _ = try? await Task.sleep(nanoseconds: 5_000_000_000) }
+        race.setOperationTask(operationTask)
+        #expect(operationTask.isCancelled)
+
+        let timeoutTask = Task { _ = try? await Task.sleep(nanoseconds: 5_000_000_000) }
+        race.setTimeoutTask(timeoutTask)
+        #expect(timeoutTask.isCancelled)
+    }
+
+    @Test("first settlement wins under concurrent finish attempts")
+    func firstOutcomeWins() async throws {
+        let race = TimeoutRace<Int>()
+        race.finish(returning: 7)
+        race.finish(throwing: CancellationError())
+        race.finish(returning: 99)
+
+        let value = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Int, Error>) in
+            race.install(continuation: continuation)
+        }
+        #expect(value == 7)
+    }
+
+    @Test("withTimeoutRace settles immediately when the surrounding task is already cancelled")
+    func alreadyCancelledParentSettlesImmediately() async throws {
+        final class SettlementProbe: @unchecked Sendable {
+            private let lock = NSLock()
+            private var _isSettled = false
+            private var _failure: (any Error)?
+
+            var state: (settled: Bool, failure: (any Error)?) {
+                lock.lock()
+                defer { lock.unlock() }
+                return (_isSettled, _failure)
+            }
+
+            func settle(failure: (any Error)?) {
+                lock.lock()
+                _isSettled = true
+                _failure = failure
+                lock.unlock()
+            }
+        }
+
+        let probe = SettlementProbe()
+        let work = Task<Void, Never> {
+            do {
+                _ = try await withTimeoutRace(
+                    timeout: .seconds(30),
+                    timeoutError: AgentError.timeout(duration: .seconds(30))
+                ) {
+                    try await Task.sleep(nanoseconds: 30_000_000_000)
+                }
+                probe.settle(failure: nil)
+            } catch {
+                probe.settle(failure: error)
+            }
+        }
+        work.cancel()
+
+        // Bounded wait so a regression in early-settlement cannot hang the suite;
+        // without the fix only the 30s timer could settle this race.
+        for _ in 0..<100 where !probe.state.settled {
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        let state = probe.state
+        #expect(state.settled, "withTimeoutRace did not settle after parent cancellation")
+
+        work.cancel()
+        _ = await work.result
+
+        guard case true = state.settled else { return }
+        let failure = state.failure
+        #expect(failure is CancellationError, "expected CancellationError, got \(String(describing: failure))")
+    }
+}

--- a/docs/reference/api-catalog.md
+++ b/docs/reference/api-catalog.md
@@ -3,7 +3,7 @@
 Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for high-risk public rows on 2026-07-28 (Conduit hard-removed in 0.6). MCP client rows refreshed 2026-08-14. OpenAI-compatible provider rows added 2026-08-14.
 
 - Scope: all `.swift` files under `Sources/Swarm/`, excluding `Internal/GraphRuntime/`
-- Source files scanned: 179
+- Source files scanned: 180
 - Public/open symbols cataloged: 2510
 
 ## 1. Swarm (entry point)


### PR DESCRIPTION
Spec \`spec-architecture-resilience-clock-runenv\` ticket T5 (stacked on T1, PR #169). Candidate 01 deepening move.

- NEW \`Sources/Swarm/Core/TimeoutRace.swift\`: one-shot completion box + \`withTimeoutRace\` wiring (timer via SwarmClock seam); closes a confirmed install-after-cancel hang window in the old Workflow coordinator
- Adopted at GuardrailRunner.validateWithTimeout (GuardrailTimeoutError unchanged) and Workflow.executeWithTimeout (TaskLocal re-binding preserved inside detached task)
- Deliberately NOT adopted at Agent.executeWithinRemainingTimeout (ProviderOwnedLoopGate settlement coupling) and StreamOperations.timeout(after:) — rationale documented in code
- StreamOperations.retry backoff now routes through the clock seam

AC-004 satisfied at adopted sites. Reviews: swift-pr-review round-1 (P2 regression coverage added: TimeoutRaceTests; P3 isolation-shift comment) + final pass (non-adoption doc fix).