### PR TITLE
arch(T6): explicit AgentRunEnvironment + extracted dependency resolver

### DIFF
--- a/Sources/Swarm/Agents/Agent.swift
+++ b/Sources/Swarm/Agents/Agent.swift
@@ -264,6 +264,39 @@ public struct Agent: AgentRuntime, Sendable {
         guardrailRunnerConfiguration: GuardrailRunnerConfiguration = .default,
         handoffs: [AnyHandoffConfiguration] = []
     ) throws {
+        try self.init(
+            tools: tools,
+            instructions: instructions,
+            configuration: configuration,
+            memory: memory,
+            inferenceProvider: inferenceProvider,
+            tracer: tracer,
+            inputGuardrails: inputGuardrails,
+            outputGuardrails: outputGuardrails,
+            guardrailRunnerConfiguration: guardrailRunnerConfiguration,
+            handoffs: handoffs,
+            runEnvironment: .live
+        )
+    }
+
+    /// Designated initializer with explicit per-run dependencies.
+    ///
+    /// ``runEnvironment`` defaults to ``AgentRunEnvironment/live`` so agents
+    /// built through public initializers share dedup and session-serialization
+    /// state exactly as they did when these dependencies were process globals.
+    init(
+        tools: [any AnyJSONTool] = [],
+        instructions: String = "",
+        configuration: AgentConfiguration = .default,
+        memory: (any Memory)? = nil,
+        inferenceProvider: (any InferenceProvider)? = nil,
+        tracer: (any Tracer)? = nil,
+        inputGuardrails: [any InputGuardrail] = [],
+        outputGuardrails: [any OutputGuardrail] = [],
+        guardrailRunnerConfiguration: GuardrailRunnerConfiguration = .default,
+        handoffs: [AnyHandoffConfiguration] = [],
+        runEnvironment: AgentRunEnvironment = .live
+    ) throws {
         self.tools = tools
         self.instructions = instructions
         self.configuration = configuration
@@ -283,6 +316,7 @@ public struct Agent: AgentRuntime, Sendable {
             agentName: configuration.name
         )
         inferenceRateLimiter = configuration.resilience.makeRateLimiter()
+        self.runEnvironment = runEnvironment
     }
 
     /// Convenience initializer that takes an unlabeled inference provider.
@@ -638,8 +672,22 @@ public struct Agent: AgentRuntime, Sendable {
     let inferenceCircuitBreaker: CircuitBreaker?
     /// Created from ``AgentConfiguration/resilience`` at init. Copies of this value share the actor.
     let inferenceRateLimiter: RateLimiter?
-    private static let autoResponseTracker = ResponseTracker()
-    private static let defaultMemorySessionTracker = DefaultMemorySessionTracker()
+    /// Per-run dependency bundle (response tracker, default-memory session
+    /// tracker, shared configuration source). Defaults to ``AgentRunEnvironment/live``;
+    /// a separately constructed environment isolates tracker state per agent.
+    let runEnvironment: AgentRunEnvironment
+
+    /// Shared default environment backing agents constructed through public initializers.
+    /// All such agents observe one instance, preserving the former process-global
+    /// sharing semantics across agent copies.
+    static let defaultRunEnvironment = AgentRunEnvironment.live
+
+    /// Former process-global response tracker; delegates to ``defaultRunEnvironment``.
+    static var autoResponseTracker: ResponseTracker { defaultRunEnvironment.responseTracker }
+
+    /// Former process-global default-memory session tracker; delegates to ``defaultRunEnvironment``.
+    static var defaultMemorySessionTracker: DefaultMemorySessionTracker { defaultRunEnvironment.defaultMemorySessionTracker }
+
     private static let responseIDMetadataKey = "response.id"
     private static let transcriptSchemaVersionMetadataKey = "swarm.transcript.schema_version"
     private static let transcriptHashMetadataKey = "swarm.transcript.hash"
@@ -787,101 +835,14 @@ public struct Agent: AgentRuntime, Sendable {
         }
     }
 
-    private actor DefaultMemorySessionTracker {
-        private var sessionIDs: [ObjectIdentifier: String] = [:]
-        private var activeSessionIDs: [ObjectIdentifier: String] = [:]
-        private var activeCounts: [ObjectIdentifier: Int] = [:]
-        // Waiters are keyed by a per-call UUID so a cancellation can target the
-        // exact parked task without disturbing siblings. `endRun()` resumes any
-        // remaining waiters with success; cancellation resumes the targeted
-        // waiter with `CancellationError` and removes it from the map.
-        private var waiters: [ObjectIdentifier: [UUID: CheckedContinuation<Void, Error>]] = [:]
-
-        func beginRun(for key: ObjectIdentifier, sessionID: String) async throws -> Bool {
-            while let activeSessionID = activeSessionIDs[key],
-                  activeSessionID != sessionID
-            {
-                try Task.checkCancellation()
-                try await waitForSessionRelease(key: key)
-            }
-
-            // Final cancellation check after exiting the wait loop. Closes the
-            // race where `endRun` resumes the continuation just as the parent
-            // task is cancelled — without this, the resumed task would proceed
-            // to claim the slot and trigger memory-clear side effects.
-            try Task.checkCancellation()
-
-            let previous = sessionIDs[key]
-            sessionIDs[key] = sessionID
-            activeSessionIDs[key] = sessionID
-            activeCounts[key, default: 0] += 1
-            return previous != sessionID
-        }
-
-        func endRun(for key: ObjectIdentifier) {
-            let remaining = (activeCounts[key] ?? 1) - 1
-            if remaining > 0 {
-                activeCounts[key] = remaining
-                return
-            }
-
-            activeCounts[key] = nil
-            activeSessionIDs[key] = nil
-            let pendingWaiters = waiters.removeValue(forKey: key) ?? [:]
-            for (_, continuation) in pendingWaiters {
-                continuation.resume()
-            }
-        }
-
-        /// Park the calling task until either the active session releases (success)
-        /// or the calling task is cancelled (throws `CancellationError`). Without
-        /// the cancellation arm, a cancelled task would stay parked until the
-        /// holder of the active session calls `endRun()`, then wake up and claim
-        /// the slot — performing memory clears and other side effects before the
-        /// cancellation surfaces deeper in execution.
-        private func waitForSessionRelease(key: ObjectIdentifier) async throws {
-            let waiterID = UUID()
-            try await withTaskCancellationHandler {
-                try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-                    if Task.isCancelled {
-                        continuation.resume(throwing: CancellationError())
-                        return
-                    }
-                    waiters[key, default: [:]][waiterID] = continuation
-                }
-            } onCancel: {
-                Task { await self.cancelWaiter(key: key, id: waiterID) }
-            }
-        }
-
-        private func cancelWaiter(key: ObjectIdentifier, id: UUID) {
-            if let continuation = waiters[key]?.removeValue(forKey: id) {
-                if waiters[key]?.isEmpty == true {
-                    waiters[key] = nil
-                }
-                continuation.resume(throwing: CancellationError())
-            }
-        }
-    }
-
     private func resolvedActiveTracer() -> (any Tracer)? {
-        let configured = tracer ?? AgentEnvironmentValues.current.tracer
-        let fallback = configuration.defaultTracingEnabled
-            ? SwiftLogTracer(minimumLevel: .debug)
-            : nil
-        let base = configured ?? fallback
-
-        guard configuration.autoAttachMetricsCollector, let collector = metricsCollector else {
-            return base
-        }
-
-        if let base {
-            if let existing = base as? MetricsCollector, existing === collector {
-                return collector
-            }
-            return CompositeTracer(tracers: [base, collector])
-        }
-        return collector
+        AgentDependencyResolver.activeTracer(
+            explicitTracer: tracer,
+            environmentTracer: AgentEnvironmentValues.current.tracer,
+            defaultTracingEnabled: configuration.defaultTracingEnabled,
+            autoAttachMetricsCollector: configuration.autoAttachMetricsCollector,
+            metricsCollector: metricsCollector
+        )
     }
 
     private func runInternal(
@@ -907,7 +868,7 @@ public struct Agent: AgentRuntime, Sendable {
         {
             let memoryKey = memoryObjectIdentifier(trackedSessionMemory)
             defaultMemoryRunKey = memoryKey
-            if try await Self.defaultMemorySessionTracker.beginRun(for: memoryKey, sessionID: session.sessionId) {
+            if try await runEnvironment.defaultMemorySessionTracker.beginRun(for: memoryKey, sessionID: session.sessionId) {
                 await trackedSessionMemory.clear()
             }
         }
@@ -1025,7 +986,7 @@ public struct Agent: AgentRuntime, Sendable {
             let result = resultBuilder.build()
             if configuration.autoPreviousResponseId, let session {
                 let response = makeResponse(from: result, responseID: responseID)
-                await Self.autoResponseTracker.recordResponse(response, sessionId: session.sessionId)
+                await runEnvironment.responseTracker.recordResponse(response, sessionId: session.sessionId)
             }
             await tracing.traceComplete(result: result, tokenUsage: resultBuilder.ownTokenUsage())
 
@@ -1036,7 +997,7 @@ public struct Agent: AgentRuntime, Sendable {
                 await endMemorySession()
             }
             if let defaultMemoryRunKey {
-                await Self.defaultMemorySessionTracker.endRun(for: defaultMemoryRunKey)
+                await runEnvironment.defaultMemorySessionTracker.endRun(for: defaultMemoryRunKey)
             }
             return InternalRunResult(agentResult: result, structuredOutput: toolLoopOutcome.structuredOutput)
         } catch {
@@ -1048,7 +1009,7 @@ public struct Agent: AgentRuntime, Sendable {
                 await endMemorySession()
             }
             if let defaultMemoryRunKey {
-                await Self.defaultMemorySessionTracker.endRun(for: defaultMemoryRunKey)
+                await runEnvironment.defaultMemorySessionTracker.endRun(for: defaultMemoryRunKey)
             }
             throw normalizedError
         }
@@ -1057,110 +1018,28 @@ public struct Agent: AgentRuntime, Sendable {
     // MARK: - Inference Provider Resolution
 
     private func resolvedInferenceProvider() async throws -> any InferenceProvider {
-        if configuration.inferencePolicy?.privacyRequired == true {
-            return try await resolvedPrivateInferenceProvider()
-        }
-
-        // 1. Explicit provider on Agent
-        if let inferenceProvider {
-            return transformedInferenceProvider(inferenceProvider)
-        }
-
-        // 2. TaskLocal via .environment()
-        if let environmentProvider = AgentEnvironmentValues.current.inferenceProvider {
-            return transformedInferenceProvider(environmentProvider)
-        }
-
-        // 3. Swarm.defaultProvider (global)
-        if let globalProvider = await Swarm.defaultProvider {
-            return transformedInferenceProvider(globalProvider)
-        }
-
-        // 4. Foundation Models (if available, on Apple platform)
-        if let foundationModelsProvider = DefaultInferenceProviderFactory.makeFoundationModelsProviderIfAvailable() {
-            return transformedInferenceProvider(foundationModelsProvider)
-        }
-
-        // 5. No provider available
-        throw AgentError.inferenceProviderUnavailable(
-            reason: """
-            No inference provider configured and Apple Foundation Models are unavailable.
-
-            Configure a provider globally via `await Swarm.configure(provider: ...)` \
-            or pass one explicitly to Agent(...).
-            """
+        try await AgentDependencyResolver.inferenceProvider(
+            privacyRequired: configuration.inferencePolicy?.privacyRequired == true,
+            explicitProvider: inferenceProvider,
+            environment: AgentEnvironmentValues.current,
+            runEnvironment: runEnvironment
         )
-    }
-
-    private func resolvedPrivateInferenceProvider() async throws -> any InferenceProvider {
-        if let foundationModelsProvider = DefaultInferenceProviderFactory.makeFoundationModelsProviderIfAvailable() {
-            return transformedInferenceProvider(foundationModelsProvider)
-        }
-
-        if let provider = privateInferenceProvider(inferenceProvider) {
-            return transformedInferenceProvider(provider)
-        }
-
-        if let provider = privateInferenceProvider(AgentEnvironmentValues.current.inferenceProvider) {
-            return transformedInferenceProvider(provider)
-        }
-
-        if let globalProvider = await Swarm.defaultProvider,
-           let provider = privateInferenceProvider(globalProvider)
-        {
-            return transformedInferenceProvider(provider)
-        }
-
-        throw AgentError.inferenceProviderUnavailable(
-            reason: """
-            AgentConfiguration.inferencePolicy.privacyRequired is true, but no private inference provider is available.
-
-            Use Apple Foundation Models on a supported device, or configure a provider that reports \
-            InferenceProviderCapabilities.privateInference via `await Swarm.configure(provider: ...)`.
-            """
-        )
-    }
-
-    private func privateInferenceProvider(_ provider: (any InferenceProvider)?) -> (any InferenceProvider)? {
-        guard let provider else {
-            return nil
-        }
-
-        let capabilities = InferenceProviderCapabilities.resolved(for: provider)
-        guard capabilities.contains(.privateInference) else {
-            return nil
-        }
-        return provider
-    }
-
-    private func transformedInferenceProvider(_ provider: any InferenceProvider) -> any InferenceProvider {
-        guard let transform = AgentEnvironmentValues.current.inferenceProviderTransform else {
-            return provider
-        }
-        return transform(provider)
     }
 
     private func resolvedMembraneAdapter() -> (any MembraneAgentAdapter)? {
-        let membrane = AgentEnvironmentValues.current.membrane ?? .enabled
-        guard membrane.isEnabled else {
-            return nil
-        }
-        if let adapter = membrane.adapter {
-            return adapter
-        }
-        return DefaultMembraneAgentAdapter(configuration: membrane.configuration)
+        AgentDependencyResolver.membraneAdapter(in: AgentEnvironmentValues.current)
     }
 
     private func runtimeEnvironment(for provider: any InferenceProvider) -> AgentEnvironment {
-        var environment = AgentEnvironmentValues.current
-        if let tokenCounter = provider.promptTokenCounter {
-            environment.promptTokenCounter = tokenCounter
-        }
-        return environment
+        AgentDependencyResolver.runtimeEnvironment(AgentEnvironmentValues.current, addingTokenCounterFrom: provider)
     }
 
     private func resolvedMemory() -> (any Memory)? {
-        memory ?? AgentEnvironmentValues.current.memory ?? defaultMemory
+        AgentDependencyResolver.memory(
+            explicitMemory: memory,
+            environmentMemory: AgentEnvironmentValues.current.memory,
+            defaultMemory: defaultMemory
+        )
     }
 
     private func shouldPersistNoSessionTurn(to activeMemory: any Memory) -> Bool {
@@ -1210,59 +1089,27 @@ public struct Agent: AgentRuntime, Sendable {
     }
 
     private func resolvedToolRegistry() async throws -> ToolRegistry {
-        let baseTools = await toolRegistry.allTools
-        #if SWARM_INTEGRATIONS
-        guard !baseTools.contains(where: { $0.name == "websearch" }) else {
-            return try ToolRegistry(tools: baseTools)
-        }
-
-        let taskLocalWeb = AgentEnvironmentValues.current.webSearch
-        let ambientWeb = if let taskLocalWeb { taskLocalWeb } else { await Swarm.webConfiguration }
-        guard let ambientWeb,
-              ambientWeb.enabled
-        else {
-            return try ToolRegistry(tools: baseTools)
-        }
-
-        var tools = baseTools
-        tools.append(WebSearchTool(configuration: ambientWeb))
-        return try ToolRegistry(tools: tools)
-        #else
-        return try ToolRegistry(tools: baseTools)
-        #endif
+        try await AgentDependencyResolver.toolRegistry(
+            baseTools: await toolRegistry.allTools,
+            taskLocalWebSearch: AgentEnvironmentValues.current.webSearch,
+            runEnvironment: runEnvironment
+        )
     }
 
     private func resolvedInferenceOptions(
         session: (any Session)?,
         provider: any InferenceProvider
     ) async -> InferenceOptions {
-        var options = configuration.inferenceOptions
-
-        let capabilities = providerCapabilities(for: provider)
-        guard capabilities.contains(.responseContinuation) else {
-            options.previousResponseId = nil
-            return options
-        }
-
-        if let explicit = configuration.previousResponseId?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !explicit.isEmpty {
-            options.previousResponseId = explicit
-            return options
-        }
-
-        guard configuration.autoPreviousResponseId, let session else {
-            return options
-        }
-
-        if let latestResponseID = await Self.autoResponseTracker.getLatestResponseId(for: session.sessionId) {
-            options.previousResponseId = latestResponseID
-        }
-
-        return options
+        await AgentDependencyResolver.inferenceOptions(
+            configuration: configuration,
+            capabilities: providerCapabilities(for: provider),
+            sessionID: session?.sessionId,
+            responseTracker: runEnvironment.responseTracker
+        )
     }
 
     private func providerCapabilities(for provider: any InferenceProvider) -> InferenceProviderCapabilities {
-        InferenceProviderCapabilities.resolved(for: provider)
+        AgentDependencyResolver.providerCapabilities(for: provider)
     }
 
     private func responseID(from result: AgentResult) -> String {

--- a/Sources/Swarm/Agents/AgentDependencyResolver.swift
+++ b/Sources/Swarm/Agents/AgentDependencyResolver.swift
@@ -1,0 +1,280 @@
+// AgentDependencyResolver.swift
+// Swarm Framework
+//
+// Pure resolution functions for per-run agent dependencies.
+
+import Foundation
+
+/// Pure resolution of per-run ``Agent`` dependencies.
+///
+/// Extracted from ``Agent`` so provider, tracer, memory, tool-registry, and
+/// inference-options decisions are unit-testable without running an agent.
+/// Each function receives value snapshots (configuration fields, task-local
+/// ``AgentEnvironment``, ``AgentRunEnvironment``) and returns the resolved
+/// dependency; ``Agent`` call sites remain thin delegations that gather the
+/// ambient inputs at the same points they did before extraction.
+enum AgentDependencyResolver {
+    // MARK: - Tracing
+
+    /// Composes the active tracer chain.
+    ///
+    /// Order: explicit agent tracer, then task-local tracer, then a
+    /// `SwiftLogTracer` fallback when default tracing is enabled. When metric
+    /// auto-attach is on, the collector is composed into (or returned as) the
+    /// resulting chain.
+    static func activeTracer(
+        explicitTracer: (any Tracer)?,
+        environmentTracer: (any Tracer)?,
+        defaultTracingEnabled: Bool,
+        autoAttachMetricsCollector: Bool,
+        metricsCollector: MetricsCollector?
+    ) -> (any Tracer)? {
+        let configured = explicitTracer ?? environmentTracer
+        let fallback = defaultTracingEnabled
+            ? SwiftLogTracer(minimumLevel: .debug)
+            : nil
+        let base = configured ?? fallback
+
+        guard autoAttachMetricsCollector, let collector = metricsCollector else {
+            return base
+        }
+
+        if let base {
+            if let existing = base as? MetricsCollector, existing === collector {
+                return collector
+            }
+            return CompositeTracer(tracers: [base, collector])
+        }
+        return collector
+    }
+
+    // MARK: - Inference Provider
+
+    /// Resolves the provider for a run.
+    ///
+    /// Privacy-required runs accept only on-device or `.privateInference`
+    /// providers; otherwise resolution follows explicit → task-local →
+    /// globally configured → Foundation Models.
+    static func inferenceProvider(
+        privacyRequired: Bool,
+        explicitProvider: (any InferenceProvider)?,
+        environment: AgentEnvironment,
+        runEnvironment: AgentRunEnvironment,
+        foundationModelsProvider: @escaping @Sendable () -> (any InferenceProvider)? = {
+            DefaultInferenceProviderFactory.makeFoundationModelsProviderIfAvailable()
+        }
+    ) async throws -> any InferenceProvider {
+        if privacyRequired {
+            return try await resolvedPrivateInferenceProvider(
+                explicitProvider: explicitProvider,
+                environment: environment,
+                runEnvironment: runEnvironment,
+                foundationModelsProvider: foundationModelsProvider
+            )
+        }
+
+        // 1. Explicit provider on Agent
+        if let explicitProvider {
+            return transformedInferenceProvider(explicitProvider, transform: environment.inferenceProviderTransform)
+        }
+
+        // 2. TaskLocal via .environment()
+        if let environmentProvider = environment.inferenceProvider {
+            return transformedInferenceProvider(environmentProvider, transform: environment.inferenceProviderTransform)
+        }
+
+        // 3. Swarm.defaultProvider (global)
+        if let globalProvider = await runEnvironment.defaultProvider() {
+            return transformedInferenceProvider(globalProvider, transform: environment.inferenceProviderTransform)
+        }
+
+        // 4. Foundation Models (if available, on Apple platform)
+        if let foundationModelsProvider = foundationModelsProvider() {
+            return transformedInferenceProvider(foundationModelsProvider, transform: environment.inferenceProviderTransform)
+        }
+
+        // 5. No provider available
+        throw AgentError.inferenceProviderUnavailable(
+            reason: """
+            No inference provider configured and Apple Foundation Models are unavailable.
+
+            Configure a provider globally via `await Swarm.configure(provider: ...)` \
+            or pass one explicitly to Agent(...).
+            """
+        )
+    }
+
+    private static func resolvedPrivateInferenceProvider(
+        explicitProvider: (any InferenceProvider)?,
+        environment: AgentEnvironment,
+        runEnvironment: AgentRunEnvironment,
+        foundationModelsProvider: @escaping @Sendable () -> (any InferenceProvider)?
+    ) async throws -> any InferenceProvider {
+        if let foundationModelsProvider = foundationModelsProvider() {
+            return transformedInferenceProvider(foundationModelsProvider, transform: environment.inferenceProviderTransform)
+        }
+
+        if let provider = privateInferenceProvider(explicitProvider) {
+            return transformedInferenceProvider(provider, transform: environment.inferenceProviderTransform)
+        }
+
+        if let provider = privateInferenceProvider(environment.inferenceProvider) {
+            return transformedInferenceProvider(provider, transform: environment.inferenceProviderTransform)
+        }
+
+        if let globalProvider = await runEnvironment.defaultProvider(),
+           let provider = privateInferenceProvider(globalProvider)
+        {
+            return transformedInferenceProvider(provider, transform: environment.inferenceProviderTransform)
+        }
+
+        throw AgentError.inferenceProviderUnavailable(
+            reason: """
+            AgentConfiguration.inferencePolicy.privacyRequired is true, but no private inference provider is available.
+
+            Use Apple Foundation Models on a supported device, or configure a provider that reports \
+            InferenceProviderCapabilities.privateInference via `await Swarm.configure(provider: ...)`.
+            """
+        )
+    }
+
+    /// Filters out providers that do not report `.privateInference`.
+    static func privateInferenceProvider(_ provider: (any InferenceProvider)?) -> (any InferenceProvider)? {
+        guard let provider else {
+            return nil
+        }
+
+        let capabilities = InferenceProviderCapabilities.resolved(for: provider)
+        guard capabilities.contains(.privateInference) else {
+            return nil
+        }
+        return provider
+    }
+
+    /// Applies the task-local provider transform, when present.
+    static func transformedInferenceProvider(
+        _ provider: any InferenceProvider,
+        transform: (@Sendable (any InferenceProvider) -> any InferenceProvider)?
+    ) -> any InferenceProvider {
+        guard let transform else {
+            return provider
+        }
+        return transform(provider)
+    }
+
+    /// Effective capability set advertised by a provider.
+    static func providerCapabilities(for provider: any InferenceProvider) -> InferenceProviderCapabilities {
+        InferenceProviderCapabilities.resolved(for: provider)
+    }
+
+    // MARK: - Membrane
+
+    /// Resolves the Membrane planning adapter for a run, when enabled.
+    static func membraneAdapter(in environment: AgentEnvironment) -> (any MembraneAgentAdapter)? {
+        let membrane = environment.membrane ?? .enabled
+        guard membrane.isEnabled else {
+            return nil
+        }
+        if let adapter = membrane.adapter {
+            return adapter
+        }
+        return DefaultMembraneAgentAdapter(configuration: membrane.configuration)
+    }
+
+    // MARK: - Runtime Environment
+
+    /// Merges the provider's prompt token counter into the run environment.
+    static func runtimeEnvironment(
+        _ environment: AgentEnvironment,
+        addingTokenCounterFrom provider: any InferenceProvider
+    ) -> AgentEnvironment {
+        var environment = environment
+        if let tokenCounter = provider.promptTokenCounter {
+            environment.promptTokenCounter = tokenCounter
+        }
+        return environment
+    }
+
+    // MARK: - Memory
+
+    /// Resolves the effective memory for a run.
+    ///
+    /// Precedence: explicit agent memory, then task-local memory, then the
+    /// package default memory created at init.
+    static func memory(
+        explicitMemory: (any Memory)?,
+        environmentMemory: (any Memory)?,
+        defaultMemory: (any Memory)?
+    ) -> (any Memory)? {
+        explicitMemory ?? environmentMemory ?? defaultMemory
+    }
+
+    // MARK: - Tool Registry
+
+    /// Resolves the tool registry for a run.
+    ///
+    /// With the Integrations trait an ambient web-search configuration
+    /// (task-local first, then the shared configuration source) appends a
+    /// `websearch` tool unless the agent already carries one.
+    static func toolRegistry(
+        baseTools: [any AnyJSONTool],
+        taskLocalWebSearch: WebSearchTool.Configuration?,
+        runEnvironment: AgentRunEnvironment
+    ) async throws -> ToolRegistry {
+        #if SWARM_INTEGRATIONS
+        guard !baseTools.contains(where: { $0.name == "websearch" }) else {
+            return try ToolRegistry(tools: baseTools)
+        }
+
+        let ambientWeb = if let taskLocalWebSearch { taskLocalWebSearch } else { await runEnvironment.webConfiguration() }
+        guard let ambientWeb,
+              ambientWeb.enabled
+        else {
+            return try ToolRegistry(tools: baseTools)
+        }
+
+        var tools = baseTools
+        tools.append(WebSearchTool(configuration: ambientWeb))
+        return try ToolRegistry(tools: tools)
+        #else
+        return try ToolRegistry(tools: baseTools)
+        #endif
+    }
+
+    // MARK: - Inference Options
+
+    /// Assembles per-run inference options from configuration and tracker state.
+    ///
+    /// Previous-response continuation applies only to providers advertising
+    /// `.responseContinuation`; an explicit configured ID wins over the
+    /// auto-tracked latest response ID.
+    static func inferenceOptions(
+        configuration: AgentConfiguration,
+        capabilities: InferenceProviderCapabilities,
+        sessionID: String?,
+        responseTracker: ResponseTracker
+    ) async -> InferenceOptions {
+        var options = configuration.inferenceOptions
+
+        guard capabilities.contains(.responseContinuation) else {
+            options.previousResponseId = nil
+            return options
+        }
+
+        if let explicit = configuration.previousResponseId?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !explicit.isEmpty {
+            options.previousResponseId = explicit
+            return options
+        }
+
+        guard configuration.autoPreviousResponseId, let sessionID else {
+            return options
+        }
+
+        if let latestResponseID = await responseTracker.getLatestResponseId(for: sessionID) {
+            options.previousResponseId = latestResponseID
+        }
+
+        return options
+    }
+}

--- a/Sources/Swarm/Agents/AgentRunEnvironment.swift
+++ b/Sources/Swarm/Agents/AgentRunEnvironment.swift
@@ -1,0 +1,154 @@
+// AgentRunEnvironment.swift
+// Swarm Framework
+//
+// Explicit per-run dependency bundle for agents, replacing process globals.
+
+import Foundation
+
+// MARK: - DefaultMemorySessionTracker
+
+/// Serializes runs that share the package default memory.
+///
+/// While a run is active for a memory instance, other runs using the same
+/// memory with a different session park until the active run finishes; runs
+/// reusing the same session proceed without clearing memory.
+actor DefaultMemorySessionTracker {
+    private var sessionIDs: [ObjectIdentifier: String] = [:]
+    private var activeSessionIDs: [ObjectIdentifier: String] = [:]
+    private var activeCounts: [ObjectIdentifier: Int] = [:]
+    // Waiters are keyed by a per-call UUID so a cancellation can target the
+    // exact parked task without disturbing siblings. `endRun()` resumes any
+    // remaining waiters with success; cancellation resumes the targeted
+    // waiter with `CancellationError` and removes it from the map.
+    private var waiters: [ObjectIdentifier: [UUID: CheckedContinuation<Void, Error>]] = [:]
+
+    func beginRun(for key: ObjectIdentifier, sessionID: String) async throws -> Bool {
+        while let activeSessionID = activeSessionIDs[key],
+              activeSessionID != sessionID
+        {
+            try Task.checkCancellation()
+            try await waitForSessionRelease(key: key)
+        }
+
+        // Final cancellation check after exiting the wait loop. Closes the
+        // race where `endRun` resumes the continuation just as the parent
+        // task is cancelled — without this, the resumed task would proceed
+        // to claim the slot and trigger memory-clear side effects.
+        try Task.checkCancellation()
+
+        let previous = sessionIDs[key]
+        sessionIDs[key] = sessionID
+        activeSessionIDs[key] = sessionID
+        activeCounts[key, default: 0] += 1
+        return previous != sessionID
+    }
+
+    func endRun(for key: ObjectIdentifier) {
+        let remaining = (activeCounts[key] ?? 1) - 1
+        if remaining > 0 {
+            activeCounts[key] = remaining
+            return
+        }
+
+        activeCounts[key] = nil
+        activeSessionIDs[key] = nil
+        let pendingWaiters = waiters.removeValue(forKey: key) ?? [:]
+        for (_, continuation) in pendingWaiters {
+            continuation.resume()
+        }
+    }
+
+    /// Park the calling task until either the active session releases (success)
+    /// or the calling task is cancelled (throws `CancellationError`). Without
+    /// the cancellation arm, a cancelled task would stay parked until the
+    /// holder of the active session calls `endRun()`, then wake up and claim
+    /// the slot — performing memory clears and other side effects before the
+    /// cancellation surfaces deeper in execution.
+    private func waitForSessionRelease(key: ObjectIdentifier) async throws {
+        let waiterID = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                if Task.isCancelled {
+                    continuation.resume(throwing: CancellationError())
+                    return
+                }
+                waiters[key, default: [:]][waiterID] = continuation
+            }
+        } onCancel: {
+            Task { await self.cancelWaiter(key: key, id: waiterID) }
+        }
+    }
+
+    private func cancelWaiter(key: ObjectIdentifier, id: UUID) {
+        if let continuation = waiters[key]?.removeValue(forKey: id) {
+            if waiters[key]?.isEmpty == true {
+                waiters[key] = nil
+            }
+            continuation.resume(throwing: CancellationError())
+        }
+    }
+}
+
+// MARK: - AgentRunEnvironment
+
+/// Per-run dependencies previously held in process state.
+///
+/// An ``Agent`` resolves its response tracker, default-memory session
+/// serializer, and shared configuration source through this value instead of
+/// reaching into statics at run time:
+///
+/// - ``live`` (the default) wires to the framework-wide instances, so agents
+///   built through public initializers share dedup and session-serialization
+///   state exactly as they did when these were process globals.
+/// - A separately constructed environment carries freshly created trackers,
+///   giving each agent fully isolated state.
+struct AgentRunEnvironment: Sendable {
+    // MARK: Dependencies
+
+    /// Tracks previous response IDs per session for conversation continuation.
+    let responseTracker: ResponseTracker
+
+    /// Serializes concurrent runs sharing the package default memory.
+    let defaultMemorySessionTracker: DefaultMemorySessionTracker
+
+    private let defaultProviderLookup: @Sendable () async -> (any InferenceProvider)?
+    private let webConfigurationLookup: @Sendable () async -> WebSearchTool.Configuration?
+
+    // MARK: Initialization
+
+    /// Creates an environment.
+    ///
+    /// Defaults produce fresh trackers and read the globally configured
+    /// provider / web-search configuration via ``Swarm/defaultProvider`` and
+    /// ``Swarm/webConfiguration``.
+    init(
+        responseTracker: ResponseTracker = ResponseTracker(),
+        defaultMemorySessionTracker: DefaultMemorySessionTracker = DefaultMemorySessionTracker(),
+        defaultProvider: @escaping @Sendable () async -> (any InferenceProvider)? = { await Swarm.defaultProvider },
+        webConfiguration: @escaping @Sendable () async -> WebSearchTool.Configuration? = { await Swarm.webConfiguration }
+    ) {
+        self.responseTracker = responseTracker
+        self.defaultMemorySessionTracker = defaultMemorySessionTracker
+        self.defaultProviderLookup = defaultProvider
+        self.webConfigurationLookup = webConfiguration
+    }
+
+    // MARK: Shared Configuration Source
+
+    /// The globally configured default provider, if any.
+    func defaultProvider() async -> (any InferenceProvider)? {
+        await defaultProviderLookup()
+    }
+
+    /// The globally configured web-search configuration, if any.
+    func webConfiguration() async -> WebSearchTool.Configuration? {
+        await webConfigurationLookup()
+    }
+
+    // MARK: Default Instance
+
+    /// The shared environment backing every agent constructed without an
+    /// explicit one. All agents reading from this instance observe the same
+    /// tracker state — the observable contract of the former process globals.
+    static let live = AgentRunEnvironment()
+}

--- a/Tests/SwarmTests/Agents/AgentRunEnvironmentTests.swift
+++ b/Tests/SwarmTests/Agents/AgentRunEnvironmentTests.swift
@@ -1,0 +1,647 @@
+// AgentRunEnvironmentTests.swift
+// SwarmTests
+//
+// Proves AgentRunEnvironment isolation semantics (AC-005) and the extracted
+// AgentDependencyResolver decisions.
+
+import Foundation
+import Testing
+@testable import Swarm
+
+// MARK: - Test Doubles
+
+private actor StubTracer: Tracer {
+    func trace(_ event: TraceEvent) {}
+}
+
+private struct BareInferenceProvider: InferenceProvider {
+    func generate(messages: [InferenceMessage], options: InferenceOptions) async throws -> String {
+        "bare"
+    }
+}
+
+private final class LookupCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    func increment() {
+        lock.lock()
+        count += 1
+        lock.unlock()
+    }
+
+    var value: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return count
+    }
+}
+
+private func sameInstance(_ lhs: any InferenceProvider, _ rhs: any InferenceProvider) -> Bool {
+    ObjectIdentifier(lhs as AnyObject) == ObjectIdentifier(rhs as AnyObject)
+}
+
+private func makeAgent(
+    configuration: AgentConfiguration,
+    provider: MockInferenceProvider,
+    environment: AgentRunEnvironment
+) throws -> Agent {
+    try Agent(
+        configuration: configuration,
+        inferenceProvider: provider,
+        runEnvironment: environment
+    )
+}
+
+// MARK: - Environment Isolation & Default Sharing
+
+@Suite("AgentRunEnvironment")
+struct AgentRunEnvironmentTests {
+    private let config = AgentConfiguration.default.autoPreviousResponseId(true)
+
+    @Test("two constructed environments carry fully isolated tracker state")
+    func constructedEnvironmentsAreIsolated() async throws {
+        let first = AgentRunEnvironment()
+        let second = AgentRunEnvironment()
+
+        #expect(first.responseTracker !== second.responseTracker)
+        #expect(first.defaultMemorySessionTracker !== second.defaultMemorySessionTracker)
+
+        let response = AgentResponse(responseId: "first-env-response", output: "hi", agentName: "A")
+        await first.responseTracker.recordResponse(response, sessionId: "isolation-session")
+
+        let leaked = await second.responseTracker.getLatestResponseId(for: "isolation-session")
+        #expect(leaked == nil)
+
+        let own = await first.responseTracker.getLatestResponseId(for: "isolation-session")
+        #expect(own == "first-env-response")
+    }
+
+    @Test("default-configured agents share one environment exactly as the former globals")
+    func defaultAgentsShareLiveEnvironment() throws {
+        let first = try Agent(configuration: .default)
+        let second = try Agent(configuration: .default)
+
+        #expect(first.runEnvironment.responseTracker === second.runEnvironment.responseTracker)
+        #expect(
+            first.runEnvironment.defaultMemorySessionTracker
+                === second.runEnvironment.defaultMemorySessionTracker
+        )
+        #expect(first.runEnvironment.responseTracker === AgentRunEnvironment.live.responseTracker)
+        #expect(
+            first.runEnvironment.defaultMemorySessionTracker
+                === AgentRunEnvironment.live.defaultMemorySessionTracker
+        )
+
+        // Former process-global statics delegate to the shared default instance.
+        #expect(Agent.autoResponseTracker === first.runEnvironment.responseTracker)
+        #expect(Agent.defaultMemorySessionTracker === first.runEnvironment.defaultMemorySessionTracker)
+    }
+
+    @Test("agents using defaults share response tracking across copies")
+    func defaultAgentsShareTrackerStateAcrossRuns() async throws {
+        let sessionID = "shared-default-\(UUID().uuidString)"
+        let session = InMemorySession(sessionId: sessionID)
+        let provider = MockInferenceProvider(
+            responses: ["first reply", "second reply"],
+            capabilities: [.responseContinuation]
+        )
+
+        let first = try Agent(configuration: config, inferenceProvider: provider)
+        let second = try Agent(configuration: config, inferenceProvider: provider)
+
+        let firstResult = try await first.run("first prompt", session: session)
+        _ = try await second.run("second prompt", session: session)
+
+        guard case let .string(firstResponseID)? = firstResult.metadata["response.id"] else {
+            Issue.record("Expected first result metadata to include response.id")
+            return
+        }
+
+        let calls = await provider.generateMessageCalls
+        #expect(calls.count == 2)
+        if calls.count == 2 {
+            #expect(calls[0].options.previousResponseId == nil)
+            #expect(calls[1].options.previousResponseId == firstResponseID)
+        }
+    }
+
+    @Test("agents with distinct environments isolate response tracking across copies")
+    func distinctEnvironmentsIsolateTrackingAcrossRuns() async throws {
+        let sessionID = "isolated-envs-\(UUID().uuidString)"
+        let session = InMemorySession(sessionId: sessionID)
+        let provider = MockInferenceProvider(
+            responses: ["first reply", "second reply"],
+            capabilities: [.responseContinuation]
+        )
+
+        let first = try makeAgent(
+            configuration: config,
+            provider: provider,
+            environment: AgentRunEnvironment()
+        )
+        let second = try makeAgent(
+            configuration: config,
+            provider: provider,
+            environment: AgentRunEnvironment()
+        )
+
+        let firstResult = try await first.run("first prompt", session: session)
+        _ = try await second.run("second prompt", session: session)
+
+        guard case let .string(firstResponseID)? = firstResult.metadata["response.id"] else {
+            Issue.record("Expected first result metadata to include response.id")
+            return
+        }
+        #expect(!firstResponseID.isEmpty)
+
+        let calls = await provider.generateMessageCalls
+        #expect(calls.count == 2)
+        if calls.count == 2 {
+            #expect(calls[0].options.previousResponseId == nil)
+            #expect(calls[1].options.previousResponseId == nil)
+        }
+    }
+
+    @Test("session tracker clears memory only when the session changes")
+    func sessionTrackerClearsOnlyOnSessionChange() async throws {
+        let tracker = DefaultMemorySessionTracker()
+        let key = ObjectIdentifier(NSObject())
+
+        let firstClaim = try await tracker.beginRun(for: key, sessionID: "s1")
+        #expect(firstClaim == true)
+
+        // Same session re-claiming while active must not trigger a memory clear.
+        let reentrantClaim = try await tracker.beginRun(for: key, sessionID: "s1")
+        #expect(reentrantClaim == false)
+
+        await tracker.endRun(for: key)
+        await tracker.endRun(for: key)
+
+        let changedClaim = try await tracker.beginRun(for: key, sessionID: "s2")
+        #expect(changedClaim == true)
+
+        await tracker.endRun(for: key)
+    }
+
+    @Test("session tracker state is isolated between instances")
+    func sessionTrackerStateIsPerInstance() async throws {
+        let first = DefaultMemorySessionTracker()
+        let second = DefaultMemorySessionTracker()
+        let key = ObjectIdentifier(NSObject())
+
+        let firstResult = try await first.beginRun(for: key, sessionID: "shared-session")
+        let secondResult = try await second.beginRun(for: key, sessionID: "shared-session")
+
+        #expect(firstResult == true)
+        #expect(secondResult == true)
+    }
+}
+
+// MARK: - Resolver Decisions
+
+@Suite("AgentDependencyResolver")
+struct AgentDependencyResolverTests {
+    // MARK: Tracer composition
+
+    @Test("active tracer prefers explicit over environment over fallback")
+    func activeTracerPrecedence() {
+        let explicit = StubTracer()
+        let environment = StubTracer()
+
+        let explicitWins = AgentDependencyResolver.activeTracer(
+            explicitTracer: explicit,
+            environmentTracer: environment,
+            defaultTracingEnabled: true,
+            autoAttachMetricsCollector: false,
+            metricsCollector: nil
+        )
+        #expect(explicitWins === explicit)
+
+        let environmentUsed = AgentDependencyResolver.activeTracer(
+            explicitTracer: nil,
+            environmentTracer: environment,
+            defaultTracingEnabled: true,
+            autoAttachMetricsCollector: false,
+            metricsCollector: nil
+        )
+        #expect(environmentUsed === environment)
+    }
+
+    @Test("active tracer falls back to SwiftLog tracer only when default tracing is enabled")
+    func activeTracerFallback() {
+        let fallback = AgentDependencyResolver.activeTracer(
+            explicitTracer: nil,
+            environmentTracer: nil,
+            defaultTracingEnabled: true,
+            autoAttachMetricsCollector: false,
+            metricsCollector: nil
+        )
+        #expect(fallback is SwiftLogTracer)
+
+        let silent = AgentDependencyResolver.activeTracer(
+            explicitTracer: nil,
+            environmentTracer: nil,
+            defaultTracingEnabled: false,
+            autoAttachMetricsCollector: false,
+            metricsCollector: nil
+        )
+        #expect(silent == nil)
+    }
+
+    @Test("metrics collector composes into the tracer chain per auto-attach flag")
+    func activeTracerComposesMetricsCollector() {
+        let base = StubTracer()
+        let collector = MetricsCollector()
+
+        let composed = AgentDependencyResolver.activeTracer(
+            explicitTracer: base,
+            environmentTracer: nil,
+            defaultTracingEnabled: false,
+            autoAttachMetricsCollector: true,
+            metricsCollector: collector
+        )
+        #expect(composed is CompositeTracer)
+
+        let passthrough = AgentDependencyResolver.activeTracer(
+            explicitTracer: collector,
+            environmentTracer: nil,
+            defaultTracingEnabled: false,
+            autoAttachMetricsCollector: true,
+            metricsCollector: collector
+        )
+        #expect(passthrough === collector)
+
+        let collectorOnly = AgentDependencyResolver.activeTracer(
+            explicitTracer: nil,
+            environmentTracer: nil,
+            defaultTracingEnabled: false,
+            autoAttachMetricsCollector: true,
+            metricsCollector: collector
+        )
+        #expect(collectorOnly === collector)
+
+        let detached = AgentDependencyResolver.activeTracer(
+            explicitTracer: base,
+            environmentTracer: nil,
+            defaultTracingEnabled: false,
+            autoAttachMetricsCollector: false,
+            metricsCollector: collector
+        )
+        #expect(detached === base)
+    }
+
+    // MARK: Inference provider resolution
+
+    @Test("non-private resolution prefers explicit, then environment, then global lookup")
+    func providerResolutionOrder() async throws {
+        let explicit = MockInferenceProvider(responses: ["explicit"])
+        let environment = MockInferenceProvider(responses: ["environment"])
+        let global = MockInferenceProvider(responses: ["global"])
+        let emptyEnvironment = AgentEnvironment()
+
+        let fromExplicit = try await AgentDependencyResolver.inferenceProvider(
+            privacyRequired: false,
+            explicitProvider: explicit,
+            environment: emptyEnvironment,
+            runEnvironment: AgentRunEnvironment(defaultProvider: { global })
+        )
+        #expect(sameInstance(fromExplicit, explicit))
+
+        let fromEnvironment = try await AgentDependencyResolver.inferenceProvider(
+            privacyRequired: false,
+            explicitProvider: nil,
+            environment: AgentEnvironment(inferenceProvider: environment),
+            runEnvironment: AgentRunEnvironment(defaultProvider: { global })
+        )
+        #expect(sameInstance(fromEnvironment, environment))
+
+        let fromGlobal = try await AgentDependencyResolver.inferenceProvider(
+            privacyRequired: false,
+            explicitProvider: nil,
+            environment: emptyEnvironment,
+            runEnvironment: AgentRunEnvironment(defaultProvider: { global })
+        )
+        #expect(sameInstance(fromGlobal, global))
+    }
+
+    @Test("global lookup is skipped while an explicit or environment provider exists")
+    func providerGlobalLookupLaziness() async throws {
+        let counter = LookupCounter()
+        let explicit = MockInferenceProvider(responses: ["explicit"])
+        let global = MockInferenceProvider(responses: ["global"])
+
+        _ = try await AgentDependencyResolver.inferenceProvider(
+            privacyRequired: false,
+            explicitProvider: explicit,
+            environment: AgentEnvironment(),
+            runEnvironment: AgentRunEnvironment(defaultProvider: {
+                counter.increment()
+                return global
+            })
+        )
+        #expect(counter.value == 0)
+
+        _ = try await AgentDependencyResolver.inferenceProvider(
+            privacyRequired: false,
+            explicitProvider: nil,
+            environment: AgentEnvironment(),
+            runEnvironment: AgentRunEnvironment(defaultProvider: {
+                counter.increment()
+                return global
+            })
+        )
+        #expect(counter.value == 1)
+    }
+
+    @Test("environment transform wraps whichever provider resolution selects")
+    func providerTransformApplied() async throws {
+        let base = MockInferenceProvider(responses: ["base"])
+        let wrapped = MockInferenceProvider(responses: ["wrapped"])
+        var environment = AgentEnvironment()
+        environment.inferenceProviderTransform = { _ in wrapped }
+
+        let resolved = try await AgentDependencyResolver.inferenceProvider(
+            privacyRequired: false,
+            explicitProvider: base,
+            environment: environment,
+            runEnvironment: AgentRunEnvironment()
+        )
+        #expect(sameInstance(resolved, wrapped))
+    }
+
+    @Test("foundation models fill in only when no configured source resolves")
+    func providerFoundationModelsFallback() async throws {
+        let foundationModels = MockInferenceProvider(responses: ["on-device"])
+
+        let fromFoundationModels = try await AgentDependencyResolver.inferenceProvider(
+            privacyRequired: false,
+            explicitProvider: nil,
+            environment: AgentEnvironment(),
+            runEnvironment: AgentRunEnvironment(defaultProvider: { nil }),
+            foundationModelsProvider: { foundationModels }
+        )
+        #expect(sameInstance(fromFoundationModels, foundationModels))
+    }
+
+    @Test("globally configured provider wins over the foundation models fallback")
+    func providerGlobalBeatsFoundationModels() async throws {
+        let foundationModels = MockInferenceProvider(responses: ["on-device"])
+        let global = MockInferenceProvider(responses: ["global"])
+
+        let resolved = try await AgentDependencyResolver.inferenceProvider(
+            privacyRequired: false,
+            explicitProvider: nil,
+            environment: AgentEnvironment(),
+            runEnvironment: AgentRunEnvironment(defaultProvider: { global }),
+            foundationModelsProvider: { foundationModels }
+        )
+        #expect(sameInstance(resolved, global))
+    }
+
+    @Test("resolution throws when no source can supply a provider")
+    func providerUnavailableThrows() async throws {
+        do {
+            _ = try await AgentDependencyResolver.inferenceProvider(
+                privacyRequired: false,
+                explicitProvider: nil,
+                environment: AgentEnvironment(),
+                runEnvironment: AgentRunEnvironment(defaultProvider: { nil }),
+                foundationModelsProvider: { nil }
+            )
+            Issue.record("Expected inferenceProviderUnavailable")
+        } catch let error as AgentError {
+            guard case .inferenceProviderUnavailable = error else {
+                Issue.record("Unexpected AgentError case: \(error)")
+                return
+            }
+        }
+    }
+
+    // MARK: Privacy filtering
+
+    @Test("privacy filter keeps only providers reporting privateInference")
+    func privacyFilterBranches() {
+        let publicProvider = MockInferenceProvider(responses: ["public"])
+        let privateProvider = MockInferenceProvider(responses: ["private"], capabilities: [.privateInference])
+
+        #expect(AgentDependencyResolver.privateInferenceProvider(nil) == nil)
+        #expect(AgentDependencyResolver.privateInferenceProvider(publicProvider) == nil)
+
+        let kept = AgentDependencyResolver.privateInferenceProvider(privateProvider)
+        #expect(kept != nil)
+        if let kept {
+            #expect(sameInstance(kept, privateProvider))
+        }
+    }
+
+    @Test("privacy-required resolution prefers on-device and filters non-private sources")
+    func privacyRequiredResolutionOrder() async throws {
+        let nonPrivate = MockInferenceProvider(responses: ["non-private"])
+        let privateProvider = MockInferenceProvider(responses: ["private"], capabilities: [.privateInference])
+        let foundationModels = MockInferenceProvider(responses: ["on-device"])
+        let filteredEnvironment = AgentEnvironment(inferenceProvider: nonPrivate)
+
+        let onDeviceWins = try await AgentDependencyResolver.inferenceProvider(
+            privacyRequired: true,
+            explicitProvider: nonPrivate,
+            environment: filteredEnvironment,
+            runEnvironment: AgentRunEnvironment(defaultProvider: { nonPrivate }),
+            foundationModelsProvider: { foundationModels }
+        )
+        #expect(sameInstance(onDeviceWins, foundationModels))
+
+        let explicitPrivateWins = try await AgentDependencyResolver.inferenceProvider(
+            privacyRequired: true,
+            explicitProvider: privateProvider,
+            environment: filteredEnvironment,
+            runEnvironment: AgentRunEnvironment(defaultProvider: { nonPrivate }),
+            foundationModelsProvider: { nil }
+        )
+        #expect(sameInstance(explicitPrivateWins, privateProvider))
+
+        let environmentPrivateWins = try await AgentDependencyResolver.inferenceProvider(
+            privacyRequired: true,
+            explicitProvider: nil,
+            environment: AgentEnvironment(inferenceProvider: privateProvider),
+            runEnvironment: AgentRunEnvironment(defaultProvider: { nonPrivate }),
+            foundationModelsProvider: { nil }
+        )
+        #expect(sameInstance(environmentPrivateWins, privateProvider))
+
+        let globalPrivateWins = try await AgentDependencyResolver.inferenceProvider(
+            privacyRequired: true,
+            explicitProvider: nonPrivate,
+            environment: filteredEnvironment,
+            runEnvironment: AgentRunEnvironment(defaultProvider: { privateProvider }),
+            foundationModelsProvider: { nil }
+        )
+        #expect(sameInstance(globalPrivateWins, privateProvider))
+
+        do {
+            _ = try await AgentDependencyResolver.inferenceProvider(
+                privacyRequired: true,
+                explicitProvider: nonPrivate,
+                environment: filteredEnvironment,
+                runEnvironment: AgentRunEnvironment(defaultProvider: { nonPrivate }),
+                foundationModelsProvider: { nil }
+            )
+            Issue.record("Expected inferenceProviderUnavailable for all-non-private sources")
+        } catch let error as AgentError {
+            guard case .inferenceProviderUnavailable = error else {
+                Issue.record("Unexpected AgentError case: \(error)")
+                return
+            }
+        }
+    }
+
+    // MARK: Memory & runtime environment
+
+    @Test("memory resolution follows explicit, environment, then default precedence")
+    func memoryPrecedence() {
+        let explicit = SlidingWindowMemory()
+        let ambient = SlidingWindowMemory()
+        let fallback = SlidingWindowMemory()
+
+        let usesExplicit = AgentDependencyResolver.memory(
+            explicitMemory: explicit,
+            environmentMemory: ambient,
+            defaultMemory: fallback
+        )
+        #expect(usesExplicit === explicit)
+
+        let usesEnvironment = AgentDependencyResolver.memory(
+            explicitMemory: nil,
+            environmentMemory: ambient,
+            defaultMemory: fallback
+        )
+        #expect(usesEnvironment === ambient)
+
+        let usesDefault = AgentDependencyResolver.memory(
+            explicitMemory: nil,
+            environmentMemory: nil,
+            defaultMemory: fallback
+        )
+        #expect(usesDefault === fallback)
+
+        #expect(AgentDependencyResolver.memory(explicitMemory: nil, environmentMemory: nil, defaultMemory: nil) == nil)
+    }
+
+    @Test("runtime environment merges the provider token counter when present")
+    func runtimeEnvironmentTokenCounterMerge() {
+        func identity(_ counter: any PromptTokenCounter) -> ObjectIdentifier {
+            ObjectIdentifier(counter as AnyObject)
+        }
+
+        let countingProvider = MockInferenceProvider(responses: ["counted"])
+        let bare = BareInferenceProvider()
+        let originalCounter = EstimatedPromptTokenCounter.shared
+        let environment = AgentEnvironment(promptTokenCounter: originalCounter)
+
+        let merged = AgentDependencyResolver.runtimeEnvironment(environment, addingTokenCounterFrom: countingProvider)
+        #expect(identity(merged.promptTokenCounter) == identity(countingProvider))
+
+        let preserved = AgentDependencyResolver.runtimeEnvironment(environment, addingTokenCounterFrom: bare)
+        #expect(identity(preserved.promptTokenCounter) == identity(originalCounter))
+    }
+
+    // MARK: Tool registry
+
+    @Test("tool registry preserves the agent's registered tools")
+    func toolRegistryRoundTripsBaseTools() async throws {
+        let registry = try ToolRegistry(tools: [MockTool(name: "marker")])
+        let resolved = try await AgentDependencyResolver.toolRegistry(
+            baseTools: await registry.allTools,
+            taskLocalWebSearch: nil,
+            runEnvironment: AgentRunEnvironment(webConfiguration: { nil })
+        )
+
+        let names = await resolved.toolNames
+        #expect(names == ["marker"])
+    }
+
+    // MARK: Inference options assembly
+
+    @Test("previous response id is stripped without continuation capability")
+    func optionsStripWithoutContinuationSupport() async {
+        var configuration = AgentConfiguration.default
+        configuration.autoPreviousResponseId = true
+
+        let options = await AgentDependencyResolver.inferenceOptions(
+            configuration: configuration,
+            capabilities: [],
+            sessionID: "any",
+            responseTracker: ResponseTracker()
+        )
+        #expect(options.previousResponseId == nil)
+    }
+
+    @Test("configured previous response id trims whitespace and beats auto tracking")
+    func optionsExplicitIDWins() async throws {
+        var configuration = AgentConfiguration.default
+        configuration.autoPreviousResponseId = true
+        configuration.previousResponseId = "  explicit-id  "
+
+        let options = await AgentDependencyResolver.inferenceOptions(
+            configuration: configuration,
+            capabilities: [.responseContinuation],
+            sessionID: "session-a",
+            responseTracker: ResponseTracker()
+        )
+        #expect(options.previousResponseId == "explicit-id")
+    }
+
+    @Test("auto tracking reads the latest response id from the shared tracker")
+    func optionsAutoTracksLatestResponse() async throws {
+        var configuration = AgentConfiguration.default
+        configuration.autoPreviousResponseId = true
+
+        let tracker = ResponseTracker()
+        let response = AgentResponse(responseId: "tracked-1", output: "out", agentName: "A")
+        await tracker.recordResponse(response, sessionId: "session-b")
+
+        let options = await AgentDependencyResolver.inferenceOptions(
+            configuration: configuration,
+            capabilities: [.responseContinuation],
+            sessionID: "session-b",
+            responseTracker: tracker
+        )
+        #expect(options.previousResponseId == "tracked-1")
+
+        let unknownSession = await AgentDependencyResolver.inferenceOptions(
+            configuration: configuration,
+            capabilities: [.responseContinuation],
+            sessionID: "unknown-session",
+            responseTracker: tracker
+        )
+        #expect(unknownSession.previousResponseId == nil)
+    }
+
+    @Test("auto tracking requires a session and stays inert when disabled")
+    func optionsAutoRequiresSessionAndFlag() async throws {
+        var disabled = AgentConfiguration.default
+        disabled.previousResponseId = nil
+
+        let tracker = ResponseTracker()
+        let response = AgentResponse(responseId: "tracked-2", output: "out", agentName: "A")
+        await tracker.recordResponse(response, sessionId: "session-c")
+
+        let noSession = await AgentDependencyResolver.inferenceOptions(
+            configuration: disabled,
+            capabilities: [.responseContinuation],
+            sessionID: nil,
+            responseTracker: tracker
+        )
+        #expect(noSession.previousResponseId == nil)
+
+        var flagOff = disabled
+        flagOff.autoPreviousResponseId = false
+        let flagOffResult = await AgentDependencyResolver.inferenceOptions(
+            configuration: flagOff,
+            capabilities: [.responseContinuation],
+            sessionID: "session-c",
+            responseTracker: tracker
+        )
+        #expect(flagOffResult.previousResponseId == nil)
+    }
+}

--- a/docs/reference/api-catalog.md
+++ b/docs/reference/api-catalog.md
@@ -3,7 +3,7 @@
 Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for high-risk public rows on 2026-07-28 (Conduit hard-removed in 0.6). MCP client rows refreshed 2026-08-14. OpenAI-compatible provider rows added 2026-08-14.
 
 - Scope: all `.swift` files under `Sources/Swarm/`, excluding `Internal/GraphRuntime/`
-- Source files scanned: 180
+- Source files scanned: 182
 - Public/open symbols cataloged: 2510
 
 ## 1. Swarm (entry point)


### PR DESCRIPTION
Spec \`spec-architecture-resilience-clock-runenv\` ticket T6 (stacked on T5, PR #173). Candidate 02 (Explicit Run Environment).

- NEW \`AgentRunEnvironment\` (Sendable value: response tracker, default-memory session tracker, injectable provider/web lookups; \`.live\` reproduces today's global sharing exactly)
- NEW \`AgentDependencyResolver\`: pure static extraction of tracer composition, provider chain + privacy filter, membrane adapter, memory resolution, tool registry, options assembly from Agent.swift (−239/+86)
- Statics delegate to shared default instance; all five public Agent inits byte-identical signatures
- Default-sharing proven by identity + functional continuation tests; custom environments fully isolated (AC-005)

Full lean lane 1999 green. Reviews: swift-adversarial-pr-review round-1 (approve, zero fixes) + final pass (approve).