### PR TITLE
feat(core): type AgentContext orchestration slots through ContextKey

### DIFF
--- a/Sources/Swarm/Core/Execution/AgentContext.swift
+++ b/Sources/Swarm/Core/Execution/AgentContext.swift
@@ -9,16 +9,18 @@ import Foundation
 
 /// Predefined keys for common agent context values.
 ///
-/// Use these standardized keys when storing and retrieving common
-/// orchestration data from `AgentContext`.
+/// Use typed ``ContextKey`` orchestration statics such as
+/// ``ContextKey/originalInput``. These string keys remain for source
+/// compatibility.
 ///
 /// Example:
 /// ```swift
-/// await context.set(.originalInput, value: .string("User query"))
-/// if let input = await context.get(.originalInput)?.stringValue {
+/// await context.set(.originalInput, "User query")
+/// if let input = await context.get(.originalInput) {
 ///     print("Original: \(input)")
 /// }
 /// ```
+@available(*, deprecated, message: "Use typed ContextKey orchestration statics such as ContextKey.originalInput.")
 public enum AgentContextKey: String, Sendable {
     /// The original input that started orchestration.
     case originalInput = "original_input"
@@ -181,9 +183,18 @@ public actor AgentContext {
         messages = []
         executionPath = []
 
-        // Store original input in values
-        values[AgentContextKey.originalInput.rawValue] = .string(input)
-        values[AgentContextKey.startTime.rawValue] = .double(createdAt.timeIntervalSince1970)
+        // Isolated ContextKey setters cannot run from init. Seed the same
+        // raw names and typed slots the orchestration setters use.
+        values[ContextKey<String>.originalInput.name] = .string(input)
+        values[ContextKey<Date>.startTime.name] = .double(createdAt.timeIntervalSince1970)
+        self.slots.setValuePayload(
+            ContextKey<String>.originalInput,
+            payload: ContextValueCodec.encode(input)
+        )
+        self.slots.setValuePayload(
+            ContextKey<Date>.startTime,
+            payload: ContextValueCodec.encode(createdAt)
+        )
     }
 
     // MARK: - Key-Value Storage
@@ -200,8 +211,10 @@ public actor AgentContext {
     ///
     /// - Parameter key: The context key to look up.
     /// - Returns: The stored value, or nil if not found.
+    @available(*, deprecated, message: "Use typed ContextKey accessors such as get(.originalInput).")
+    @_disfavoredOverload
     public func get(_ key: AgentContextKey) -> SendableValue? {
-        values[key.rawValue]
+        snapshot[key.rawValue]
     }
 
     /// Stores a value by string key.
@@ -218,6 +231,8 @@ public actor AgentContext {
     /// - Parameters:
     ///   - key: The context key to store under.
     ///   - value: The value to store.
+    @available(*, deprecated, message: "Use typed ContextKey accessors such as set(.originalInput, _).")
+    @_disfavoredOverload
     public func set(_ key: AgentContextKey, value: SendableValue) {
         values[key.rawValue] = value
     }
@@ -265,10 +280,8 @@ public actor AgentContext {
     /// - Parameter agentName: The name of the agent that executed.
     public func recordExecution(agentName: String) {
         executionPath.append(agentName)
-        values[AgentContextKey.executionPath.rawValue] = .array(
-            executionPath.map { .string($0) }
-        )
-        values[AgentContextKey.currentAgentName.rawValue] = .string(agentName)
+        set(.executionPath, executionPath)
+        set(.currentAgentName, agentName)
     }
 
     /// Gets the execution path.
@@ -287,14 +300,14 @@ public actor AgentContext {
     ///
     /// - Parameter result: The result from the previous agent.
     public func setPreviousOutput(_ result: AgentResult) {
-        values[AgentContextKey.previousOutput.rawValue] = .string(result.output)
+        set(.previousOutput, result.output)
     }
 
     /// Gets the previous agent's output.
     ///
     /// - Returns: The previous output, or nil if not set.
     public func getPreviousOutput() -> String? {
-        values[AgentContextKey.previousOutput.rawValue]?.stringValue
+        get(.previousOutput)
     }
 
     // MARK: - Merging

--- a/Sources/Swarm/Core/Execution/AgentContext.swift
+++ b/Sources/Swarm/Core/Execution/AgentContext.swift
@@ -224,6 +224,10 @@ public actor AgentContext {
     ///   - value: The value to store.
     public func set(_ key: String, value: SendableValue) {
         values[key] = value
+        // Orchestration names are also typed slots. A raw write must drop the
+        // matching slot so `get(.originalInput)` cannot keep serving init's
+        // seed after this name has been overwritten.
+        clearTypedOrchestrationSlot(named: key)
     }
 
     /// Stores a value by predefined context key.
@@ -234,7 +238,41 @@ public actor AgentContext {
     @available(*, deprecated, message: "Use typed ContextKey accessors such as set(.originalInput, _).")
     @_disfavoredOverload
     public func set(_ key: AgentContextKey, value: SendableValue) {
+        switch key {
+        case .originalInput:
+            if let string = value.stringValue {
+                set(ContextKey<String>.originalInput, string)
+                return
+            }
+        case .previousOutput:
+            if let string = value.stringValue {
+                set(ContextKey<String>.previousOutput, string)
+                return
+            }
+        case .currentAgentName:
+            if let string = value.stringValue {
+                set(ContextKey<String>.currentAgentName, string)
+                return
+            }
+        case .executionPath:
+            if let elements = value.arrayValue {
+                let path = elements.compactMap(\.stringValue)
+                if path.count == elements.count {
+                    set(ContextKey<[String]>.executionPath, path)
+                    return
+                }
+            }
+        case .startTime:
+            if let timestamp = value.doubleValue {
+                set(ContextKey<Date>.startTime, Date(timeIntervalSince1970: timestamp))
+                return
+            }
+        case .metadata:
+            break
+        }
+
         values[key.rawValue] = value
+        clearTypedOrchestrationSlot(named: key.rawValue)
     }
 
     /// Removes a value by string key.
@@ -487,6 +525,25 @@ public actor AgentContext {
     /// the two namespaces.
     func rawValuesAndValueSlots() -> (raw: [String: SendableValue], slots: ContextSlotStore) {
         (values, slots)
+    }
+
+    /// Drops the typed orchestration slot for `name`, if this name is one of
+    /// the five slots that also live behind `ContextKey` statics.
+    private func clearTypedOrchestrationSlot(named name: String) {
+        switch name {
+        case ContextKey<String>.originalInput.name:
+            removeTyped(ContextKey<String>.originalInput)
+        case ContextKey<String>.previousOutput.name:
+            removeTyped(ContextKey<String>.previousOutput)
+        case ContextKey<String>.currentAgentName.name:
+            removeTyped(ContextKey<String>.currentAgentName)
+        case ContextKey<[String]>.executionPath.name:
+            removeTyped(ContextKey<[String]>.executionPath)
+        case ContextKey<Date>.startTime.name:
+            removeTyped(ContextKey<Date>.startTime)
+        default:
+            break
+        }
     }
 
     // MARK: Private

--- a/Sources/Swarm/Core/Execution/ContextKey.swift
+++ b/Sources/Swarm/Core/Execution/ContextKey.swift
@@ -30,8 +30,10 @@ import Foundation
 /// }
 ///
 /// // Use with type safety
+/// await context.set(.originalInput, "User query")
+/// let input: String? = await context.get(.originalInput)
 /// await context.setTyped(.userID, value: "user-123")
-/// let id: String? = await context.getTyped(.userID)  // Type-safe!
+/// let id: String? = await context.getTyped(.userID)
 /// ```
 public struct ContextKey<Value: Sendable>: Hashable, Sendable {
     /// The string name of the key.
@@ -74,6 +76,15 @@ public extension ContextKey where Value == String {
 
     /// API version being used.
     static let apiVersion = ContextKey("api_version")
+
+    /// The original input that started orchestration (`original_input`).
+    static let originalInput = ContextKey("original_input")
+
+    /// The output from the previous agent in the chain (`previous_output`).
+    static let previousOutput = ContextKey("previous_output")
+
+    /// The name of the current executing agent (`current_agent_name`).
+    static let currentAgentName = ContextKey("current_agent_name")
 }
 
 // MARK: - Standard Int Keys
@@ -119,6 +130,9 @@ public extension ContextKey where Value == [String] {
 
     /// Feature flags enabled.
     static let featureFlags = ContextKey("feature_flags")
+
+    /// The execution path as a list of agent names (`execution_path`).
+    static let executionPath = ContextKey("execution_path")
 }
 
 // MARK: - Standard Date Keys
@@ -129,6 +143,9 @@ public extension ContextKey where Value == Date {
 
     /// Expiration time.
     static let expiresAt = ContextKey("expires_at")
+
+    /// The start time of orchestration (`start_time`).
+    static let startTime = ContextKey("start_time")
 }
 
 // MARK: - AgentContext Typed Extensions
@@ -142,6 +159,85 @@ public extension ContextKey where Value == Date {
 /// write and decoded once on read by `ContextValueCodec`; no runtime casting
 /// participates in typed reads.
 public extension AgentContext {
+    /// Stores a string under a typed context key.
+    ///
+    /// Writes the slot store and clears any raw entry of the same name so
+    /// ``snapshot`` projects this value.
+    func set(_ key: ContextKey<String>, _ value: String) {
+        setTyped(key, value: value)
+        _ = remove(key.name)
+    }
+
+    /// Reads a string stored under a typed context key, falling back to the
+    /// raw namespace when the slot is empty.
+    func get(_ key: ContextKey<String>) -> String? {
+        getTyped(key) ?? get(key.name)?.stringValue
+    }
+
+    /// Stores an integer under a typed context key.
+    func set(_ key: ContextKey<Int>, _ value: Int) {
+        setTyped(key, value: value)
+        _ = remove(key.name)
+    }
+
+    /// Reads an integer stored under a typed context key.
+    func get(_ key: ContextKey<Int>) -> Int? {
+        getTyped(key) ?? get(key.name)?.intValue
+    }
+
+    /// Stores a Boolean under a typed context key.
+    func set(_ key: ContextKey<Bool>, _ value: Bool) {
+        setTyped(key, value: value)
+        _ = remove(key.name)
+    }
+
+    /// Reads a Boolean stored under a typed context key.
+    func get(_ key: ContextKey<Bool>) -> Bool? {
+        getTyped(key) ?? get(key.name)?.boolValue
+    }
+
+    /// Stores a double under a typed context key.
+    func set(_ key: ContextKey<Double>, _ value: Double) {
+        setTyped(key, value: value)
+        _ = remove(key.name)
+    }
+
+    /// Reads a double stored under a typed context key.
+    func get(_ key: ContextKey<Double>) -> Double? {
+        getTyped(key) ?? get(key.name)?.doubleValue
+    }
+
+    /// Stores a string array under a typed context key.
+    func set(_ key: ContextKey<[String]>, _ value: [String]) {
+        setTyped(key, value: value)
+        _ = remove(key.name)
+    }
+
+    /// Reads a string array stored under a typed context key.
+    func get(_ key: ContextKey<[String]>) -> [String]? {
+        if let typed = getTyped(key) {
+            return typed
+        }
+        return get(key.name)?.arrayValue?.compactMap(\.stringValue)
+    }
+
+    /// Stores a date under a typed context key.
+    func set(_ key: ContextKey<Date>, _ value: Date) {
+        setTyped(key, value: value)
+        _ = remove(key.name)
+    }
+
+    /// Reads a date stored under a typed context key.
+    func get(_ key: ContextKey<Date>) -> Date? {
+        if let typed = getTyped(key) {
+            return typed
+        }
+        guard let timestamp = get(key.name)?.doubleValue else {
+            return nil
+        }
+        return Date(timeIntervalSince1970: timestamp)
+    }
+
     /// Sets a typed value in the context.
     ///
     /// The value is encoded into the unified slot store under this key's

--- a/Tests/SwarmTests/Agents/AgentHandoffRuntimeTests.swift
+++ b/Tests/SwarmTests/Agents/AgentHandoffRuntimeTests.swift
@@ -63,7 +63,7 @@ struct AgentHandoffRuntimeTests {
             onTransfer: { context, data in
                 await callbackRecorder.recordTransfer(data)
                 await context.set("transfer_seen", value: .string(data.input))
-                await context.set(.originalInput, value: .string("callback-updated-original-input"))
+                await context.set(.originalInput, "callback-updated-original-input")
             },
             transform: { data in
                 HandoffInputData(

--- a/Tests/SwarmTests/Core/AgentContextKeySurfaceTests.swift
+++ b/Tests/SwarmTests/Core/AgentContextKeySurfaceTests.swift
@@ -130,6 +130,18 @@ struct AgentContextKeySurfaceTests {
         await context.set(AgentContextKey.previousOutput, value: .string("legacy"))
         #expect(await context.get(AgentContextKey.previousOutput)?.stringValue == "legacy")
         #expect(await context.get(.previousOutput) == "legacy")
+
+        await context.set(AgentContextKey.originalInput, value: .string("legacy-original"))
+        #expect(await context.get(.originalInput) == "legacy-original")
+        #expect(await context.get(AgentContextKey.originalInput)?.stringValue == "legacy-original")
+
+        let start = Date(timeIntervalSince1970: 1_700_000_000)
+        await context.set(AgentContextKey.startTime, value: .double(start.timeIntervalSince1970))
+        #expect(await context.get(.startTime)?.timeIntervalSince1970 == 1_700_000_000)
+
+        await context.set("original_input", value: .string("raw-original"))
+        #expect(await context.get(.originalInput) == "raw-original")
+        #expect(await context.snapshot["original_input"] == .string("raw-original"))
     }
 
     // MARK: - Type-Indexed Typed Contexts (REQ-006, AC-003)

--- a/Tests/SwarmTests/Core/AgentContextKeySurfaceTests.swift
+++ b/Tests/SwarmTests/Core/AgentContextKeySurfaceTests.swift
@@ -1,0 +1,149 @@
+// AgentContextKeySurfaceTests.swift
+// SwarmTests
+//
+// Typed ContextKey orchestration slots on the unified AgentContext store.
+
+import Foundation
+@testable import Swarm
+import Testing
+
+// MARK: - Collision Contexts
+
+private struct ContextTypeA: AgentContextProviding {
+    static let contextKey = "same"
+    let n: Int
+}
+
+private struct ContextTypeB: AgentContextProviding {
+    static let contextKey = "same"
+    let n: Int
+}
+
+// MARK: - AgentContextKeySurfaceTests
+
+@Suite("AgentContext key surfaces")
+struct AgentContextKeySurfaceTests {
+
+    // MARK: - Orchestration Key Names (REQ-001)
+
+    @Test("orchestration ContextKey names match AgentContextKey raw values")
+    func orchestrationKeyNamesMatchLegacyRawValues() {
+        #expect(ContextKey<String>.originalInput.name == AgentContextKey.originalInput.rawValue)
+        #expect(ContextKey<String>.previousOutput.name == AgentContextKey.previousOutput.rawValue)
+        #expect(ContextKey<String>.currentAgentName.name == AgentContextKey.currentAgentName.rawValue)
+        #expect(ContextKey<[String]>.executionPath.name == AgentContextKey.executionPath.rawValue)
+        #expect(ContextKey<Date>.startTime.name == AgentContextKey.startTime.rawValue)
+
+        #expect(ContextKey<String>.originalInput.name == "original_input")
+        #expect(ContextKey<String>.previousOutput.name == "previous_output")
+        #expect(ContextKey<String>.currentAgentName.name == "current_agent_name")
+        #expect(ContextKey<[String]>.executionPath.name == "execution_path")
+        #expect(ContextKey<Date>.startTime.name == "start_time")
+    }
+
+    // MARK: - Snapshot Wire (AC-001, REQ-003)
+
+    @Test("init recordExecution and previous output keep today's snapshot shapes")
+    func snapshotWireFormatUnchanged() async {
+        let context = AgentContext(input: "User query")
+        await context.recordExecution(agentName: "Fetcher")
+        await context.setPreviousOutput(AgentResult(output: "fetched"))
+
+        let snapshot = await context.snapshot
+        #expect(snapshot["original_input"] == .string("User query"))
+        #expect(snapshot["previous_output"] == .string("fetched"))
+        #expect(snapshot["current_agent_name"] == .string("Fetcher"))
+        #expect(snapshot["execution_path"] == .array([.string("Fetcher")]))
+        #expect(snapshot["start_time"] == .double(context.createdAt.timeIntervalSince1970))
+
+        #expect(snapshot[AgentContextKey.originalInput.rawValue] == .string("User query"))
+        #expect(snapshot[AgentContextKey.executionPath.rawValue] == .array([.string("Fetcher")]))
+    }
+
+    @Test("typed ContextKey set updates the same snapshot slots")
+    func typedSetUpdatesSnapshotSlots() async {
+        let context = AgentContext(input: "initial")
+        await context.set(.originalInput, "hello")
+        await context.set(.previousOutput, "done")
+        await context.set(.currentAgentName, "Writer")
+        await context.set(.executionPath, ["Writer"])
+
+        let snapshot = await context.snapshot
+        #expect(snapshot["original_input"] == .string("hello"))
+        #expect(snapshot["previous_output"] == .string("done"))
+        #expect(snapshot["current_agent_name"] == .string("Writer"))
+        #expect(snapshot["execution_path"] == .array([.string("Writer")]))
+
+        #expect(await context.get(.originalInput) == "hello")
+        #expect(await context.get(.previousOutput) == "done")
+        #expect(await context.get(.currentAgentName) == "Writer")
+        #expect(await context.get(.executionPath) == ["Writer"])
+    }
+
+    // MARK: - Primitive ContextKey Accessors (REQ-004)
+
+    @Test("primitive String Int Bool Double and array keys round-trip")
+    func primitiveKeysRoundTrip() async {
+        let context = AgentContext(input: "seed")
+
+        await context.set(.userID, "user-123")
+        await context.set(.retryCount, 3)
+        await context.set(.isAuthenticated, true)
+        await context.set(ContextKey<Double>("score"), 2.5)
+        await context.set(.tags, ["alpha", "beta"])
+
+        #expect(await context.get(.userID) == "user-123")
+        #expect(await context.get(.retryCount) == 3)
+        #expect(await context.get(.isAuthenticated) == true)
+        #expect(await context.get(ContextKey<Double>("score")) == 2.5)
+        #expect(await context.get(.tags) == ["alpha", "beta"])
+
+        #expect(await context.getTyped(.userID) == "user-123")
+        #expect(await context.getTyped(.retryCount) == 3)
+    }
+
+    @Test("Date ContextKey set and setTyped store epoch seconds")
+    func dateKeysStoreEpochSeconds() async {
+        let context = AgentContext(input: "seed")
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+
+        await context.set(.startTime, date)
+        #expect(await context.get(.startTime)?.timeIntervalSince1970 == 1_700_000_000)
+        #expect(await context.getTyped(.startTime)?.timeIntervalSince1970 == 1_700_000_000)
+
+        let later = Date(timeIntervalSince1970: 1_800_000_000)
+        await context.setTyped(.timestamp, value: later)
+        #expect(await context.getTyped(.timestamp)?.timeIntervalSince1970 == 1_800_000_000)
+        #expect(await context.get(.timestamp)?.timeIntervalSince1970 == 1_800_000_000)
+    }
+
+    // MARK: - Deprecated AgentContextKey (REQ-005)
+
+    @Test("deprecated AgentContextKey get and set still function")
+    func deprecatedAgentContextKeyAccessorsStillWork() async {
+        let context = AgentContext(input: "seed")
+
+        await context.set(AgentContextKey.metadata, value: .string("meta"))
+        #expect(await context.get(AgentContextKey.metadata) == .string("meta"))
+        #expect(await context.get("metadata") == .string("meta"))
+
+        await context.set(AgentContextKey.previousOutput, value: .string("legacy"))
+        #expect(await context.get(AgentContextKey.previousOutput)?.stringValue == "legacy")
+        #expect(await context.get(.previousOutput) == "legacy")
+    }
+
+    // MARK: - Type-Indexed Typed Contexts (REQ-006, AC-003)
+
+    @Test("two AgentContextProviding types that share contextKey both persist")
+    func sharedContextKeyTypesBothPersist() async {
+        let context = AgentContext(input: "seed")
+        await context.setTyped(ContextTypeA(n: 1))
+        await context.setTyped(ContextTypeB(n: 2))
+
+        #expect(ContextTypeA.contextKey == ContextTypeB.contextKey)
+        #expect(await context.typed(ContextTypeA.self)?.n == 1)
+        #expect(await context.typed(ContextTypeB.self)?.n == 2)
+        #expect(await context.hasTyped(ContextTypeA.self))
+        #expect(await context.hasTyped(ContextTypeB.self))
+    }
+}

--- a/Tests/SwarmTests/Guardrails/InputGuardrailTests.swift
+++ b/Tests/SwarmTests/Guardrails/InputGuardrailTests.swift
@@ -391,8 +391,8 @@ struct InputGuardrailTests {
                 return .tripwire(message: "No context provided")
             }
 
-            let originalInput = await ctx.get(.originalInput)
-            if originalInput?.stringValue == "test input" {
+            let originalInput: String? = await ctx.get(.originalInput)
+            if originalInput == "test input" {
                 return .passed(message: "Context verified")
             }
 

--- a/docs/reference/api-catalog.md
+++ b/docs/reference/api-catalog.md
@@ -567,23 +567,23 @@ Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for
 | 206 | func | public | AgentContext.get(_:) | `public func get(_ key: String) -> SendableValue?` |
 | 216 | func | public | AgentContext.get(_:) | `public func get(_ key: AgentContextKey) -> SendableValue?` _(Availability: * (deprecated); Use typed ContextKey accessors such as get(.originalInput).)_ |
 | 225 | func | public | AgentContext.set(_:value:) | `public func set(_ key: String, value: SendableValue)` |
-| 236 | func | public | AgentContext.set(_:value:) | `public func set(_ key: AgentContextKey, value: SendableValue)` _(Availability: * (deprecated); Use typed ContextKey accessors such as set(.originalInput, _).)_ |
-| 245 | func | public | AgentContext.remove(_:) | `public @discardableResult func remove(_ key: String) -> SendableValue?` |
-| 254 | func | public | AgentContext.addMessage(_:) | `public func addMessage(_ message: MemoryMessage)` |
-| 264 | func | public | AgentContext.getMessages() | `public func getMessages() -> [MemoryMessage]` |
-| 269 | func | public | AgentContext.clearMessages() | `public func clearMessages()` |
-| 281 | func | public | AgentContext.recordExecution(agentName:) | `public func recordExecution(agentName: String)` |
-| 290 | func | public | AgentContext.getExecutionPath() | `public func getExecutionPath() -> [String]` |
-| 302 | func | public | AgentContext.setPreviousOutput(_:) | `public func setPreviousOutput(_ result: AgentResult)` |
-| 309 | func | public | AgentContext.getPreviousOutput() | `public func getPreviousOutput() -> String?` |
-| 329 | func | public | AgentContext.merge(from:overwrite:) | `public func merge(from other: AgentContext, overwrite: Bool = false) async` |
-| 383 | func | public | AgentContext.copy(additionalValues:) | `public func copy(additionalValues: [String : SendableValue] = [:]) -> AgentContext` |
-| 415 | func | public | AgentContext.setTyped(_:) | `public func setTyped<T>(_ context: T) where T : AgentContextProviding` |
-| 423 | func | public | AgentContext.typed(_:) | `public func typed<T>(_: T.Type) -> T? where T : AgentContextProviding` |
-| 432 | func | public | AgentContext.removeTyped(_:) | `public @discardableResult func removeTyped<T>(_: T.Type) -> T? where T : AgentContextProviding` |
-| 440 | func | public | AgentContext.hasTyped(_:) | `public func hasTyped<T>(_: T.Type) -> Bool where T : AgentContextProviding` |
-| 517 | var | public | AgentContext.description | `public nonisolated var description: String { get }` |
-| 531 | var | public | AgentContext.debugDescription | `public nonisolated var debugDescription: String { get }` |
+| 240 | func | public | AgentContext.set(_:value:) | `public func set(_ key: AgentContextKey, value: SendableValue)` _(Availability: * (deprecated); Use typed ContextKey accessors such as set(.originalInput, _).)_ |
+| 283 | func | public | AgentContext.remove(_:) | `public @discardableResult func remove(_ key: String) -> SendableValue?` |
+| 292 | func | public | AgentContext.addMessage(_:) | `public func addMessage(_ message: MemoryMessage)` |
+| 302 | func | public | AgentContext.getMessages() | `public func getMessages() -> [MemoryMessage]` |
+| 307 | func | public | AgentContext.clearMessages() | `public func clearMessages()` |
+| 319 | func | public | AgentContext.recordExecution(agentName:) | `public func recordExecution(agentName: String)` |
+| 328 | func | public | AgentContext.getExecutionPath() | `public func getExecutionPath() -> [String]` |
+| 340 | func | public | AgentContext.setPreviousOutput(_:) | `public func setPreviousOutput(_ result: AgentResult)` |
+| 347 | func | public | AgentContext.getPreviousOutput() | `public func getPreviousOutput() -> String?` |
+| 367 | func | public | AgentContext.merge(from:overwrite:) | `public func merge(from other: AgentContext, overwrite: Bool = false) async` |
+| 421 | func | public | AgentContext.copy(additionalValues:) | `public func copy(additionalValues: [String : SendableValue] = [:]) -> AgentContext` |
+| 453 | func | public | AgentContext.setTyped(_:) | `public func setTyped<T>(_ context: T) where T : AgentContextProviding` |
+| 461 | func | public | AgentContext.typed(_:) | `public func typed<T>(_: T.Type) -> T? where T : AgentContextProviding` |
+| 470 | func | public | AgentContext.removeTyped(_:) | `public @discardableResult func removeTyped<T>(_: T.Type) -> T? where T : AgentContextProviding` |
+| 478 | func | public | AgentContext.hasTyped(_:) | `public func hasTyped<T>(_: T.Type) -> Bool where T : AgentContextProviding` |
+| 574 | var | public | AgentContext.description | `public nonisolated var description: String { get }` |
+| 588 | var | public | AgentContext.debugDescription | `public nonisolated var debugDescription: String { get }` |
 
 ### Core/Execution/ContextKey.swift
 

--- a/docs/reference/api-catalog.md
+++ b/docs/reference/api-catalog.md
@@ -548,75 +548,92 @@ Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for
 
 | Line | Kind | Access | Name | Signature |
 |------|------|--------|------|-----------|
-| 22 | enum | public | AgentContextKey | `public enum AgentContextKey` |
-| 24 | case | public | AgentContextKey.originalInput | `public case originalInput` |
-| 27 | case | public | AgentContextKey.previousOutput | `public case previousOutput` |
-| 30 | case | public | AgentContextKey.currentAgentName | `public case currentAgentName` |
-| 33 | case | public | AgentContextKey.executionPath | `public case executionPath` |
-| 36 | case | public | AgentContextKey.startTime | `public case startTime` |
-| 39 | case | public | AgentContextKey.metadata | `public case metadata` |
-| 66 | protocol | public | AgentContextProviding | `public protocol AgentContextProviding : Sendable` |
-| 68 | var | public | AgentContextProviding.contextKey | `public static var contextKey: String { get }` |
-| 98 | class | public | AgentContext | `public actor AgentContext` |
-| 102 | var | public | AgentContext.originalInput | `public nonisolated let originalInput: String` |
-| 105 | var | public | AgentContext.executionId | `public nonisolated let executionId: UUID` |
-| 108 | var | public | AgentContext.createdAt | `public nonisolated let createdAt: Date` |
-| 111 | var | public | AgentContext.allKeys | `public var allKeys: [String] { get }` |
-| 119 | var | public | AgentContext.snapshot | `public var snapshot: [String : SendableValue] { get }` |
-| 130 | func | public | AgentContext.init(input:initialValues:) | `public init(input: String, initialValues: [String : SendableValue] = [:])` |
-| 149 | func | public | AgentContext.get(_:) | `public func get(_ key: String) -> SendableValue?` |
-| 157 | func | public | AgentContext.get(_:) | `public func get(_ key: AgentContextKey) -> SendableValue?` |
-| 166 | func | public | AgentContext.set(_:value:) | `public func set(_ key: String, value: SendableValue)` |
-| 175 | func | public | AgentContext.set(_:value:) | `public func set(_ key: AgentContextKey, value: SendableValue)` |
-| 184 | func | public | AgentContext.remove(_:) | `public @discardableResult func remove(_ key: String) -> SendableValue?` |
-| 193 | func | public | AgentContext.addMessage(_:) | `public func addMessage(_ message: MemoryMessage)` |
-| 203 | func | public | AgentContext.getMessages() | `public func getMessages() -> [MemoryMessage]` |
-| 208 | func | public | AgentContext.clearMessages() | `public func clearMessages()` |
-| 220 | func | public | AgentContext.recordExecution(agentName:) | `public func recordExecution(agentName: String)` |
-| 231 | func | public | AgentContext.getExecutionPath() | `public func getExecutionPath() -> [String]` |
-| 243 | func | public | AgentContext.setPreviousOutput(_:) | `public func setPreviousOutput(_ result: AgentResult)` |
-| 250 | func | public | AgentContext.getPreviousOutput() | `public func getPreviousOutput() -> String?` |
-| 270 | func | public | AgentContext.merge(from:overwrite:) | `public func merge(from other: AgentContext, overwrite: Bool = false) async` |
-| 309 | func | public | AgentContext.copy(additionalValues:) | `public func copy(additionalValues: [String : SendableValue] = [:]) -> AgentContext` |
-| 334 | func | public | AgentContext.setTyped(_:) | `public func setTyped<T>(_ context: T) where T : AgentContextProviding` |
-| 342 | func | public | AgentContext.typed(_:) | `public func typed<T>(_: T.Type) -> T? where T : AgentContextProviding` |
-| 351 | func | public | AgentContext.removeTyped(_:) | `public @discardableResult func removeTyped<T>(_: T.Type) -> T? where T : AgentContextProviding` |
-| 359 | func | public | AgentContext.hasTyped(_:) | `public func hasTyped<T>(_: T.Type) -> Bool where T : AgentContextProviding` |
-| 383 | var | public | AgentContext.description | `public nonisolated var description: String { get }` |
-| 397 | var | public | AgentContext.debugDescription | `public nonisolated var debugDescription: String { get }` |
+| 24 | enum | public | AgentContextKey | `public enum AgentContextKey` _(Availability: * (deprecated); Use typed ContextKey orchestration statics such as ContextKey.originalInput.)_ |
+| 26 | case | public | AgentContextKey.originalInput | `public case originalInput` |
+| 29 | case | public | AgentContextKey.previousOutput | `public case previousOutput` |
+| 32 | case | public | AgentContextKey.currentAgentName | `public case currentAgentName` |
+| 35 | case | public | AgentContextKey.executionPath | `public case executionPath` |
+| 38 | case | public | AgentContextKey.startTime | `public case startTime` |
+| 41 | case | public | AgentContextKey.metadata | `public case metadata` |
+| 86 | protocol | public | AgentContextProviding | `public protocol AgentContextProviding : Sendable` _(Availability: * (deprecated); Use ContextKey<Value> with setTyped(_:value:)/getTyped(_:) instead)_ |
+| 88 | var | public | AgentContextProviding.contextKey | `public static var contextKey: String { get }` |
+| 118 | class | public | AgentContext | `public actor AgentContext` |
+| 122 | var | public | AgentContext.originalInput | `public nonisolated let originalInput: String` |
+| 125 | var | public | AgentContext.executionId | `public nonisolated let executionId: UUID` |
+| 128 | var | public | AgentContext.createdAt | `public nonisolated let createdAt: Date` |
+| 134 | var | public | AgentContext.allKeys | `public var allKeys: [String] { get }` |
+| 149 | var | public | AgentContext.snapshot | `public var snapshot: [String : SendableValue] { get }` |
+| 164 | func | public | AgentContext.init(input:initialValues:) | `public init(input: String, initialValues: [String : SendableValue] = [:])` |
+| 206 | func | public | AgentContext.get(_:) | `public func get(_ key: String) -> SendableValue?` |
+| 216 | func | public | AgentContext.get(_:) | `public func get(_ key: AgentContextKey) -> SendableValue?` _(Availability: * (deprecated); Use typed ContextKey accessors such as get(.originalInput).)_ |
+| 225 | func | public | AgentContext.set(_:value:) | `public func set(_ key: String, value: SendableValue)` |
+| 236 | func | public | AgentContext.set(_:value:) | `public func set(_ key: AgentContextKey, value: SendableValue)` _(Availability: * (deprecated); Use typed ContextKey accessors such as set(.originalInput, _).)_ |
+| 245 | func | public | AgentContext.remove(_:) | `public @discardableResult func remove(_ key: String) -> SendableValue?` |
+| 254 | func | public | AgentContext.addMessage(_:) | `public func addMessage(_ message: MemoryMessage)` |
+| 264 | func | public | AgentContext.getMessages() | `public func getMessages() -> [MemoryMessage]` |
+| 269 | func | public | AgentContext.clearMessages() | `public func clearMessages()` |
+| 281 | func | public | AgentContext.recordExecution(agentName:) | `public func recordExecution(agentName: String)` |
+| 290 | func | public | AgentContext.getExecutionPath() | `public func getExecutionPath() -> [String]` |
+| 302 | func | public | AgentContext.setPreviousOutput(_:) | `public func setPreviousOutput(_ result: AgentResult)` |
+| 309 | func | public | AgentContext.getPreviousOutput() | `public func getPreviousOutput() -> String?` |
+| 329 | func | public | AgentContext.merge(from:overwrite:) | `public func merge(from other: AgentContext, overwrite: Bool = false) async` |
+| 383 | func | public | AgentContext.copy(additionalValues:) | `public func copy(additionalValues: [String : SendableValue] = [:]) -> AgentContext` |
+| 415 | func | public | AgentContext.setTyped(_:) | `public func setTyped<T>(_ context: T) where T : AgentContextProviding` |
+| 423 | func | public | AgentContext.typed(_:) | `public func typed<T>(_: T.Type) -> T? where T : AgentContextProviding` |
+| 432 | func | public | AgentContext.removeTyped(_:) | `public @discardableResult func removeTyped<T>(_: T.Type) -> T? where T : AgentContextProviding` |
+| 440 | func | public | AgentContext.hasTyped(_:) | `public func hasTyped<T>(_: T.Type) -> Bool where T : AgentContextProviding` |
+| 517 | var | public | AgentContext.description | `public nonisolated var description: String { get }` |
+| 531 | var | public | AgentContext.debugDescription | `public nonisolated var debugDescription: String { get }` |
 
 ### Core/Execution/ContextKey.swift
 
 | Line | Kind | Access | Name | Signature |
 |------|------|--------|------|-----------|
-| 30 | struct | public | ContextKey | `public struct ContextKey<Value> where Value : Sendable` |
-| 32 | var | public | ContextKey.name | `public let name: String` |
-| 37 | func | public | ContextKey.init(_:) | `public init(_ name: String)` |
-| 43 | func | public | ContextKey.==(_:_:) | `public static func == (lhs: ContextKey<Value>, rhs: ContextKey<Value>) -> Bool` |
-| 49 | func | public | ContextKey.hash(into:) | `public func hash(into hasher: inout Hasher)` |
-| 58 | var | public | ContextKey.userID | `public static let userID: ContextKey<String>` |
-| 61 | var | public | ContextKey.sessionID | `public static let sessionID: ContextKey<String>` |
-| 64 | var | public | ContextKey.correlationID | `public static let correlationID: ContextKey<String>` |
-| 67 | var | public | ContextKey.language | `public static let language: ContextKey<String>` |
-| 70 | var | public | ContextKey.apiVersion | `public static let apiVersion: ContextKey<String>` |
-| 77 | var | public | ContextKey.requestCount | `public static let requestCount: ContextKey<Int>` |
-| 80 | var | public | ContextKey.retryCount | `public static let retryCount: ContextKey<Int>` |
-| 83 | var | public | ContextKey.iterationCount | `public static let iterationCount: ContextKey<Int>` |
-| 86 | var | public | ContextKey.depth | `public static let depth: ContextKey<Int>` |
-| 93 | var | public | ContextKey.isAuthenticated | `public static let isAuthenticated: ContextKey<Bool>` |
-| 96 | var | public | ContextKey.isDebugMode | `public static let isDebugMode: ContextKey<Bool>` |
-| 99 | var | public | ContextKey.verboseLogging | `public static let verboseLogging: ContextKey<Bool>` |
-| 102 | var | public | ContextKey.isDryRun | `public static let isDryRun: ContextKey<Bool>` |
-| 109 | var | public | ContextKey.permissions | `public static let permissions: ContextKey<[String]>` |
-| 112 | var | public | ContextKey.tags | `public static let tags: ContextKey<[String]>` |
-| 115 | var | public | ContextKey.featureFlags | `public static let featureFlags: ContextKey<[String]>` |
-| 122 | var | public | ContextKey.timestamp | `public static let timestamp: ContextKey<Date>` |
-| 125 | var | public | ContextKey.expiresAt | `public static let expiresAt: ContextKey<Date>` |
-| 142 | func | public | AgentContext.setTyped(_:value:) | `public func setTyped<T>(_ key: ContextKey<T>, value: T) where T : Encodable, T : Sendable` |
-| 162 | func | public | AgentContext.getTyped(_:) | `public func getTyped<T>(_ key: ContextKey<T>) -> T? where T : Decodable, T : Sendable` |
-| 215 | func | public | AgentContext.getTyped(_:default:) | `public func getTyped<T>(_ key: ContextKey<T>, default defaultValue: T) -> T where T : Decodable, T : Sendable` |
-| 227 | func | public | AgentContext.removeTyped(_:) | `public func removeTyped(_ key: ContextKey<some Sendable>)` |
-| 242 | func | public | AgentContext.hasTyped(_:) | `public func hasTyped(_ key: ContextKey<some Sendable>) -> Bool` |
+| 38 | struct | public | ContextKey | `public struct ContextKey<Value> where Value : Sendable` |
+| 40 | var | public | ContextKey.name | `public let name: String` |
+| 45 | func | public | ContextKey.init(_:) | `public init(_ name: String)` |
+| 51 | func | public | ContextKey.==(_:_:) | `public static func == (lhs: ContextKey<Value>, rhs: ContextKey<Value>) -> Bool` |
+| 57 | func | public | ContextKey.hash(into:) | `public func hash(into hasher: inout Hasher)` |
+| 66 | var | public | ContextKey.userID | `public static let userID: ContextKey<String>` |
+| 69 | var | public | ContextKey.sessionID | `public static let sessionID: ContextKey<String>` |
+| 72 | var | public | ContextKey.correlationID | `public static let correlationID: ContextKey<String>` |
+| 75 | var | public | ContextKey.language | `public static let language: ContextKey<String>` |
+| 78 | var | public | ContextKey.apiVersion | `public static let apiVersion: ContextKey<String>` |
+| 81 | var | public | ContextKey.originalInput | `public static let originalInput: ContextKey<String>` |
+| 84 | var | public | ContextKey.previousOutput | `public static let previousOutput: ContextKey<String>` |
+| 87 | var | public | ContextKey.currentAgentName | `public static let currentAgentName: ContextKey<String>` |
+| 94 | var | public | ContextKey.requestCount | `public static let requestCount: ContextKey<Int>` |
+| 97 | var | public | ContextKey.retryCount | `public static let retryCount: ContextKey<Int>` |
+| 100 | var | public | ContextKey.iterationCount | `public static let iterationCount: ContextKey<Int>` |
+| 103 | var | public | ContextKey.depth | `public static let depth: ContextKey<Int>` |
+| 110 | var | public | ContextKey.isAuthenticated | `public static let isAuthenticated: ContextKey<Bool>` |
+| 113 | var | public | ContextKey.isDebugMode | `public static let isDebugMode: ContextKey<Bool>` |
+| 116 | var | public | ContextKey.verboseLogging | `public static let verboseLogging: ContextKey<Bool>` |
+| 119 | var | public | ContextKey.isDryRun | `public static let isDryRun: ContextKey<Bool>` |
+| 126 | var | public | ContextKey.permissions | `public static let permissions: ContextKey<[String]>` |
+| 129 | var | public | ContextKey.tags | `public static let tags: ContextKey<[String]>` |
+| 132 | var | public | ContextKey.featureFlags | `public static let featureFlags: ContextKey<[String]>` |
+| 135 | var | public | ContextKey.executionPath | `public static let executionPath: ContextKey<[String]>` |
+| 142 | var | public | ContextKey.timestamp | `public static let timestamp: ContextKey<Date>` |
+| 145 | var | public | ContextKey.expiresAt | `public static let expiresAt: ContextKey<Date>` |
+| 148 | var | public | ContextKey.startTime | `public static let startTime: ContextKey<Date>` |
+| 166 | func | public | AgentContext.set(_:_:) | `public func set(_ key: ContextKey<String>, _ value: String)` |
+| 173 | func | public | AgentContext.get(_:) | `public func get(_ key: ContextKey<String>) -> String?` |
+| 178 | func | public | AgentContext.set(_:_:) | `public func set(_ key: ContextKey<Int>, _ value: Int)` |
+| 184 | func | public | AgentContext.get(_:) | `public func get(_ key: ContextKey<Int>) -> Int?` |
+| 189 | func | public | AgentContext.set(_:_:) | `public func set(_ key: ContextKey<Bool>, _ value: Bool)` |
+| 195 | func | public | AgentContext.get(_:) | `public func get(_ key: ContextKey<Bool>) -> Bool?` |
+| 200 | func | public | AgentContext.set(_:_:) | `public func set(_ key: ContextKey<Double>, _ value: Double)` |
+| 206 | func | public | AgentContext.get(_:) | `public func get(_ key: ContextKey<Double>) -> Double?` |
+| 211 | func | public | AgentContext.set(_:_:) | `public func set(_ key: ContextKey<[String]>, _ value: [String])` |
+| 217 | func | public | AgentContext.get(_:) | `public func get(_ key: ContextKey<[String]>) -> [String]?` |
+| 225 | func | public | AgentContext.set(_:_:) | `public func set(_ key: ContextKey<Date>, _ value: Date)` |
+| 231 | func | public | AgentContext.get(_:) | `public func get(_ key: ContextKey<Date>) -> Date?` |
+| 256 | func | public | AgentContext.setTyped(_:value:) | `public func setTyped<T>(_ key: ContextKey<T>, value: T) where T : Encodable, T : Sendable` |
+| 273 | func | public | AgentContext.getTyped(_:) | `public func getTyped<T>(_ key: ContextKey<T>) -> T? where T : Decodable, T : Sendable` |
+| 289 | func | public | AgentContext.getTyped(_:default:) | `public func getTyped<T>(_ key: ContextKey<T>, default defaultValue: T) -> T where T : Decodable, T : Sendable` |
+| 304 | func | public | AgentContext.removeTyped(_:) | `public func removeTyped(_ key: ContextKey<some Sendable>)` |
+| 319 | func | public | AgentContext.hasTyped(_:) | `public func hasTyped(_ key: ContextKey<some Sendable>) -> Bool` |
 
 ### Core/Handoff/Handoff.swift
 

--- a/docs/reference/front-facing-api.md
+++ b/docs/reference/front-facing-api.md
@@ -444,6 +444,14 @@ public protocol OutputGuardrail: Sendable {
 }
 ```
 
+`AgentContext` orchestration slots (`originalInput`, `previousOutput`,
+`currentAgentName`, `executionPath`, `startTime`) are typed `ContextKey`
+statics. Prefer `set(.originalInput, "…")` / `get(.originalInput)` over the
+deprecated `AgentContextKey` get/set. Typed `ContextKey` writes stay in the
+slot store introduced with the unified context; `snapshot` still projects
+those names. `AgentContextProviding` remains a deprecated shim keyed by
+concrete type plus `contextKey`.
+
 ## 9) Memory factories
 
 Dot-syntax memory factories are contextual. Use them where Swift can infer a


### PR DESCRIPTION
## Summary
- Close AgentContext's three key doors onto one typed surface: orchestration slots (`originalInput`, `previousOutput`, `currentAgentName`, `executionPath`, `startTime`) are now `ContextKey` statics, so `set(.originalInput, "…")` / `get(.originalInput)` pair the key with its value at compile time.
- Runtime writes go through those typed setters on top of the unified slot store from #164. Snapshot wire format is unchanged; `AgentContextKey` get/set remain as a deprecated compatibility path.
- Call sites that treated `get(.originalInput)` as `SendableValue` now read `String?`. Two `AgentContextProviding` types that share `contextKey` continue to coexist.

## Test plan
- [x] `SWARM_OMIT_INTEGRATION_TARGETS=1 swift test --filter 'AgentContextKeySurfaceTests|ContextStoreUnificationTests|InputGuardrailTests|AgentHandoffRuntimeTests|DocumentationFreshnessTests|APIAuditTests'`
- [ ] Confirm `set(.originalInput, 1)` does not compile
- [ ] Confirm handoff snapshot still exposes `original_input` / `execution_path` as today's `SendableValue` shapes


Made with [Cursor](https://cursor.com)