### PR TITLE
arch(T1): restore resilience FSM, token-bucket math, and retry clock/RNG

### DIFF
--- a/Sources/Swarm/Resilience/CircuitBreaker.swift
+++ b/Sources/Swarm/Resilience/CircuitBreaker.swift
@@ -77,11 +77,47 @@ public actor CircuitBreaker {
         resetTimeout: TimeInterval = 60.0,
         halfOpenMaxRequests: Int = 1
     ) {
+        self.init(
+            name: name,
+            failureThreshold: failureThreshold,
+            successThreshold: successThreshold,
+            resetTimeout: resetTimeout,
+            halfOpenMaxRequests: halfOpenMaxRequests,
+            clock: LiveSwarmClock.live
+        )
+    }
+
+    /// Creates a new circuit breaker driven by an injected time source.
+    ///
+    /// Injecting a virtual clock makes open-window deadlines deterministic for
+    /// tests; production callers use the default initializer backed by the
+    /// live clock. Declared under `ColonyInternal` because `SwarmClock` is an
+    /// SPI protocol and cannot appear in an unannotated public signature.
+    /// - Parameters:
+    ///   - name: Unique name for this breaker.
+    ///   - failureThreshold: Number of consecutive failures before opening.
+    ///   - successThreshold: Number of consecutive successes to close from half-open.
+    ///   - resetTimeout: Time in seconds before attempting recovery.
+    ///   - halfOpenMaxRequests: Maximum concurrent requests in half-open state.
+    ///   - clock: Time source driving open-window deadlines and timestamps;
+    ///     pass `nil` to use the live clock.
+    @_spi(ColonyInternal)
+    public init(
+        name: String,
+        failureThreshold: Int,
+        successThreshold: Int,
+        resetTimeout: TimeInterval,
+        halfOpenMaxRequests: Int,
+        clock: (any SwarmClock)?
+    ) {
         self.name = name
         self.failureThreshold = max(1, failureThreshold)
         self.successThreshold = max(1, successThreshold)
         self.resetTimeout = max(0, resetTimeout)
         self.halfOpenMaxRequests = max(1, halfOpenMaxRequests)
+        let resolvedClock = clock ?? LiveSwarmClock.live
+        self.clock = resolvedClock
+        self.clockBridge = CircuitBreakerClockBridge(clock: resolvedClock)
     }
 
     // MARK: - Public API
@@ -132,9 +168,11 @@ public actor CircuitBreaker {
 
     /// Manually opens the circuit breaker.
     public func trip() async {
-        let openUntil = Date().addingTimeInterval(resetTimeout)
-        state = .open(until: openUntil)
-        consecutiveSuccesses = 0
+        fsmSnapshot = CircuitBreakerTransitions.tripped(
+            fsmSnapshot,
+            resetTimeout: resetTimeout,
+            now: currentDate()
+        )
     }
 
     /// Returns statistics about this circuit breaker.
@@ -149,6 +187,13 @@ public actor CircuitBreaker {
     }
 
     // MARK: Private
+
+    /// Injected time source; every deadline and timestamp reads through it.
+    private let clock: any SwarmClock
+
+    /// Maps injected-clock readings onto the `Date` timeline of the public state.
+    /// Internal (not private) so tests can assert exact instants against the anchor.
+    let clockBridge: CircuitBreakerClockBridge
 
     /// Current state of the circuit breaker.
     private var state: State = .closed
@@ -171,6 +216,30 @@ public actor CircuitBreaker {
     /// Timestamp of last failure.
     private var lastFailureTime: Date?
 
+    /// Transition-relevant state as a pure-FSM snapshot, bridged to the stored fields.
+    private var fsmSnapshot: CircuitBreakerTransitions.Snapshot {
+        get {
+            .init(
+                state: state,
+                consecutiveFailures: consecutiveFailures,
+                consecutiveSuccesses: consecutiveSuccesses
+            )
+        }
+        set {
+            state = newValue.state
+            consecutiveFailures = newValue.consecutiveFailures
+            consecutiveSuccesses = newValue.consecutiveSuccesses
+        }
+    }
+
+    /// Current instant on the breaker's `Date` timeline, read through the injected clock.
+    ///
+    /// This conversion is part of the clock↔`Date` adapter (AC-007): all breaker
+    /// time math flows through here instead of raw wall-clock reads.
+    private func currentDate() -> Date {
+        clockBridge.date(atNanoseconds: clock.nowNanoseconds())
+    }
+
     // MARK: - Private Helpers
 
     /// Executes the operation and handles state transitions based on success/failure.
@@ -190,58 +259,193 @@ public actor CircuitBreaker {
     /// Records a successful operation and handles state transitions.
     private func recordSuccess() async {
         totalSuccesses += 1
-        consecutiveFailures = 0
-
-        switch state {
-        case .halfOpen:
-            consecutiveSuccesses += 1
-            if consecutiveSuccesses >= successThreshold {
-                // Transition to closed
-                state = .closed
-                consecutiveSuccesses = 0
-            }
-        case .closed,
-             .open:
-            consecutiveSuccesses = 0
-        }
+        fsmSnapshot = CircuitBreakerTransitions.success(fsmSnapshot, successThreshold: successThreshold)
     }
 
     /// Records a failed operation and handles state transitions.
     private func recordFailure() async {
         totalFailures += 1
-        consecutiveFailures += 1
-        consecutiveSuccesses = 0
-        lastFailureTime = Date()
-
-        switch state {
-        case .closed:
-            if consecutiveFailures >= failureThreshold {
-                // Transition to open
-                let openUntil = Date().addingTimeInterval(resetTimeout)
-                state = .open(until: openUntil)
-            }
-        case .halfOpen:
-            // Any failure in half-open transitions back to open
-            let openUntil = Date().addingTimeInterval(resetTimeout)
-            state = .open(until: openUntil)
-        case .open:
-            // Already open, no state change needed
-            break
-        }
+        let now = currentDate()
+        lastFailureTime = now
+        fsmSnapshot = CircuitBreakerTransitions.failure(
+            fsmSnapshot,
+            failureThreshold: failureThreshold,
+            resetTimeout: resetTimeout,
+            now: now
+        )
     }
 
     /// Checks if the circuit should transition from open to half-open based on timeout.
     private func checkAndTransitionState() async throws {
-        guard case let .open(until) = state else {
-            return
-        }
-
-        if Date() >= until {
-            // Transition to half-open
-            state = .halfOpen
-            consecutiveSuccesses = 0
+        if let transitioned = CircuitBreakerTransitions.timeoutCheck(fsmSnapshot, now: currentDate()) {
+            fsmSnapshot = transitioned
             halfOpenRequestsInFlight = 0
         }
+    }
+}
+
+// MARK: - Clock Bridge
+
+/// Maps monotonic `SwarmClock` nanoseconds onto the `Date` timeline used by
+/// the breaker's public state (`State.open(until:)`, `Statistics.lastFailureTime`).
+///
+/// This is the clock↔`Date` adapter (AC-007): construction captures a single
+/// wall-clock anchor paired with the injected clock's reading; every later
+/// conversion derives purely from injected-clock readings via
+/// `date(atNanoseconds:)`.
+struct CircuitBreakerClockBridge: Sendable {
+    /// Injected-clock reading captured at construction.
+    let anchorNanoseconds: UInt64
+
+    /// Wall-clock instant corresponding to `anchorNanoseconds`.
+    let anchorDate: Date
+
+    /// Creates a bridge from an explicit anchor pair (test-friendly).
+    init(anchorNanoseconds: UInt64, anchorDate: Date) {
+        self.anchorNanoseconds = anchorNanoseconds
+        self.anchorDate = anchorDate
+    }
+
+    /// Anchors one raw wall-clock read to the injected clock's current reading.
+    init(clock: any SwarmClock) {
+        self.init(anchorNanoseconds: clock.nowNanoseconds(), anchorDate: Date())
+    }
+
+    /// Converts an injected-clock reading into its `Date` timeline instant.
+    func date(atNanoseconds nanoseconds: UInt64) -> Date {
+        let delta = Int64(bitPattern: nanoseconds &- anchorNanoseconds)
+        return anchorDate.addingTimeInterval(Double(delta) / 1_000_000_000)
+    }
+}
+
+// MARK: - Pure FSM Transitions
+
+/// Pure transition math for the circuit-breaker state machine.
+///
+/// Functions are static and side-effect free: each takes the full pre-event
+/// snapshot plus configuration and event instant, returning the post-event
+/// snapshot or `nil` when nothing changes. Keeping them off the actor makes
+/// every transition rule unit-testable without executing actor code or reading
+/// a clock. Behavior mirrors the original inline logic exactly:
+/// - Failure in closed state trips once consecutive failures reach the threshold.
+/// - Any failure in half-open reopens the window from that instant.
+/// - Tripping while open extends the window from the new event's instant.
+/// - Success in half-open closes only after the success threshold is met.
+enum CircuitBreakerTransitions {
+    /// Complete transition-relevant state of a breaker.
+    struct Snapshot: Equatable, Sendable {
+        /// Current breaker state.
+        var state: CircuitBreaker.State
+
+        /// Consecutive failure count driving trip thresholds.
+        var consecutiveFailures = 0
+
+        /// Consecutive success count driving half-open recovery.
+        var consecutiveSuccesses = 0
+
+        /// Creates a snapshot.
+        init(
+            state: CircuitBreaker.State,
+            consecutiveFailures: Int = 0,
+            consecutiveSuccesses: Int = 0
+        ) {
+            self.state = state
+            self.consecutiveFailures = consecutiveFailures
+            self.consecutiveSuccesses = consecutiveSuccesses
+        }
+    }
+
+    /// Applies one failed operation outcome.
+    ///
+    /// - Parameters:
+    ///   - before: Pre-failure snapshot.
+    ///   - failureThreshold: Consecutive failures required to trip from closed.
+    ///   - resetTimeout: Open-window length applied when tripping/reopening.
+    ///   - now: Failure instant; anchors any new `.open(until:)` deadline.
+    static func failure(
+        _ before: Snapshot,
+        failureThreshold: Int,
+        resetTimeout: TimeInterval,
+        now: Date
+    ) -> Snapshot {
+        var after = before
+        after.consecutiveFailures += 1
+        after.consecutiveSuccesses = 0
+
+        switch before.state {
+        case .closed:
+            if after.consecutiveFailures >= failureThreshold {
+                // Transition to open
+                after.state = .open(until: now.addingTimeInterval(resetTimeout))
+            }
+        case .halfOpen:
+            // Any failure in half-open transitions back to open
+            after.state = .open(until: now.addingTimeInterval(resetTimeout))
+        case .open:
+            // Already open, no state change needed
+            break
+        }
+        return after
+    }
+
+    /// Applies one successful operation outcome.
+    ///
+    /// - Parameters:
+    ///   - before: Pre-success snapshot.
+    ///   - successThreshold: Consecutive half-open successes required to close.
+    static func success(_ before: Snapshot, successThreshold: Int) -> Snapshot {
+        var after = before
+        after.consecutiveFailures = 0
+
+        switch before.state {
+        case .halfOpen:
+            after.consecutiveSuccesses += 1
+            if after.consecutiveSuccesses >= successThreshold {
+                // Transition to closed
+                after.state = .closed
+                after.consecutiveSuccesses = 0
+            }
+        case .closed,
+             .open:
+            after.consecutiveSuccesses = 0
+        }
+        return after
+    }
+
+    /// Applies a manual trip.
+    ///
+    /// Opens the window from `now`, extending it even if already open;
+    /// resets the half-open success streak without touching failures.
+    ///
+    /// - Parameters:
+    ///   - before: Pre-trip snapshot.
+    ///   - resetTimeout: Open-window length.
+    ///   - now: Trip instant; anchors the new `.open(until:)` deadline.
+    static func tripped(
+        _ before: Snapshot,
+        resetTimeout: TimeInterval,
+        now: Date
+    ) -> Snapshot {
+        var after = before
+        after.state = .open(until: now.addingTimeInterval(resetTimeout))
+        after.consecutiveSuccesses = 0
+        return after
+    }
+
+    /// Applies the open-timeout check performed before each execution.
+    ///
+    /// Returns the post-transition snapshot when the open window has elapsed by
+    /// `now` (`now >= until`), moving to half-open and resetting the success
+    /// streak; returns `nil` when no transition occurs.
+    static func timeoutCheck(_ before: Snapshot, now: Date) -> Snapshot? {
+        guard case let .open(until) = before.state, now >= until else {
+            return nil
+        }
+
+        var after = before
+        after.state = .halfOpen
+        after.consecutiveSuccesses = 0
+        return after
     }
 }
 

--- a/Sources/Swarm/Resilience/RateLimiter.swift
+++ b/Sources/Swarm/Resilience/RateLimiter.swift
@@ -38,15 +38,62 @@ public actor RateLimiter {
 
     /// Create rate limiter with requests per minute
     public init(maxRequestsPerMinute: Int) {
-        let normalizedMaxRequests = max(1, maxRequestsPerMinute)
-        maxTokens = normalizedMaxRequests
-        refillRate = max(1.0 / 60.0, Double(normalizedMaxRequests) / 60.0)
-        availableTokens = Double(normalizedMaxRequests)
-        lastRefillTime = .now
+        self.init(
+            maxRequestsPerMinute: maxRequestsPerMinute,
+            clock: LiveSwarmClock.live
+        )
     }
 
     /// Create rate limiter with custom token bucket parameters
     public init(maxTokens: Int, refillRatePerSecond: Double) {
+        self.init(
+            maxTokens: maxTokens,
+            refillRatePerSecond: refillRatePerSecond,
+            clock: LiveSwarmClock.live
+        )
+    }
+
+    // MARK: - Initialization
+
+    /// Creates a new rate limiter driven by an injected time source.
+    ///
+    /// Injecting a virtual clock makes refill timing deterministic for tests;
+    /// production callers use the default initializers backed by the live
+    /// clock. Declared under `ColonyInternal` because `SwarmClock` is an SPI
+    /// protocol and cannot appear in an unannotated public signature.
+    /// - Parameters:
+    ///   - maxRequestsPerMinute: Bucket capacity in requests per minute.
+    ///   - clock: Time source driving refill timestamps and waits;
+    ///     pass `nil` to use the live clock.
+    @_spi(ColonyInternal)
+    public init(maxRequestsPerMinute: Int, clock: (any SwarmClock)?) {
+        let normalizedMaxRequests = max(1, maxRequestsPerMinute)
+        maxTokens = normalizedMaxRequests
+        refillRate = max(1.0 / 60.0, Double(normalizedMaxRequests) / 60.0)
+        availableTokens = Double(normalizedMaxRequests)
+
+        let resolvedClock = clock ?? LiveSwarmClock.live
+        self.clock = resolvedClock
+        lastRefillTime = resolvedClock.nowNanoseconds()
+    }
+
+    /// Creates a new rate limiter with custom bucket parameters and an
+    /// injected time source.
+    ///
+    /// Declared under `ColonyInternal` because `SwarmClock` is an SPI protocol
+    /// and cannot appear in an unannotated public signature.
+    /// - Parameters:
+    ///   - maxTokens: Bucket capacity; values below 1 normalize to 1.
+    ///   - refillRatePerSecond: Tokens per second; non-finite or non-positive
+    ///     rates normalize to 1.
+    ///   - clock: Time source driving refill timestamps and waits;
+    ///     pass `nil` to use the live clock.
+    @_spi(ColonyInternal)
+    public init(
+        maxTokens: Int,
+        refillRatePerSecond: Double,
+        clock: (any SwarmClock)?
+    ) {
         let normalizedMaxTokens = max(1, maxTokens)
         let normalizedRefillRate = refillRatePerSecond.isFinite && refillRatePerSecond > 0
             ? refillRatePerSecond
@@ -55,7 +102,10 @@ public actor RateLimiter {
         self.maxTokens = normalizedMaxTokens
         refillRate = normalizedRefillRate
         availableTokens = Double(normalizedMaxTokens)
-        lastRefillTime = .now
+
+        let resolvedClock = clock ?? LiveSwarmClock.live
+        self.clock = resolvedClock
+        lastRefillTime = resolvedClock.nowNanoseconds()
     }
 
     /// Acquire a token, waiting if necessary
@@ -64,9 +114,11 @@ public actor RateLimiter {
         refill()
 
         while availableTokens < 1 {
-            let rawWaitTime = (1 - availableTokens) / refillRate
-            let waitTime = rawWaitTime.isFinite && rawWaitTime > 0 ? rawWaitTime : 0
-            try await Task.sleep(for: .seconds(waitTime))
+            let waitTime = TokenBucketMath.waitSeconds(
+                forDeficit: 1 - availableTokens,
+                refillRate: refillRate
+            )
+            try await clock.sleep(nanoseconds: Duration.seconds(waitTime).swarmNanoseconds)
             try Task.checkCancellation()
             refill()
         }
@@ -87,28 +139,65 @@ public actor RateLimiter {
     /// Reset the limiter to full capacity
     public func reset() {
         availableTokens = Double(maxTokens)
-        lastRefillTime = .now
+        lastRefillTime = clock.nowNanoseconds()
     }
 
     // MARK: Private
 
+    /// Injected time source; every refill timestamp and wait reads through it.
+    private let clock: any SwarmClock
+
     private let maxTokens: Int
     private let refillRate: Double // tokens per second
     private var availableTokens: Double
-    private var lastRefillTime: ContinuousClock.Instant
+    private var lastRefillTime: UInt64
 
     private func refill() {
-        let now = ContinuousClock.now
-        let elapsed = now - lastRefillTime
-        let tokensToAdd = elapsed.seconds * refillRate
-        availableTokens = min(Double(maxTokens), availableTokens + tokensToAdd)
+        let now = clock.nowNanoseconds()
+        availableTokens = TokenBucketMath.refilled(
+            tokens: availableTokens,
+            elapsedSeconds: TokenBucketMath.elapsedSeconds(from: lastRefillTime, to: now),
+            refillRate: refillRate,
+            maxTokens: maxTokens
+        )
         lastRefillTime = now
     }
 }
 
-private extension Duration {
-    var seconds: Double {
-        let (seconds, attoseconds) = components
-        return Double(seconds) + Double(attoseconds) / 1_000_000_000_000_000_000
+// MARK: - TokenBucketMath
+
+/// Pure refill and wait-time math for the token bucket.
+///
+/// Functions are static and side-effect free so every rule is unit-testable
+/// without actor code or a live clock. Behavior mirrors the original inline
+/// logic exactly, including clamping at capacity and the finite/positive
+/// guards on computed wait times.
+enum TokenBucketMath {
+    /// Post-refill token count after adding `elapsedSeconds * refillRate`
+    /// tokens, capped at bucket capacity.
+    ///
+    /// A negative elapsed interval (clock moved backwards) removes tokens at
+    /// the same rate, matching the original signed-duration arithmetic.
+    static func refilled(
+        tokens: Double,
+        elapsedSeconds: Double,
+        refillRate: Double,
+        maxTokens: Int
+    ) -> Double {
+        min(Double(maxTokens), tokens + elapsedSeconds * refillRate)
+    }
+
+    /// Seconds to wait until `deficit` additional tokens have accumulated,
+    /// or `0` when the raw quotient is non-finite or non-positive — preserving
+    /// the original guard so pathological inputs never produce invalid sleeps.
+    static func waitSeconds(forDeficit deficit: Double, refillRate: Double) -> Double {
+        let rawWaitTime = deficit / refillRate
+        return rawWaitTime.isFinite && rawWaitTime > 0 ? rawWaitTime : 0
+    }
+
+    /// Signed elapsed seconds between two nanosecond readings on one clock's
+    /// timeline (`endNanoseconds - startNanoseconds`).
+    static func elapsedSeconds(from startNanoseconds: UInt64, to endNanoseconds: UInt64) -> Double {
+        Double(Int64(bitPattern: endNanoseconds &- startNanoseconds)) / 1_000_000_000
     }
 }

--- a/Sources/Swarm/Resilience/RetryPolicy.swift
+++ b/Sources/Swarm/Resilience/RetryPolicy.swift
@@ -59,6 +59,21 @@ public enum BackoffStrategy: Sendable {
     /// - Parameter attempt: The attempt number (1-indexed).
     /// - Returns: The delay in seconds before the next retry.
     public func delay(forAttempt attempt: Int) -> TimeInterval {
+        delay(forAttempt: attempt, random: { Double.random(in: $0) })
+    }
+
+    /// Calculates the delay using an explicit randomness source so that
+    /// jittered strategies produce reproducible sequences (e.g. seeded
+    /// generators under test).
+    /// - Parameters:
+    ///   - attempt: The attempt number (1-indexed).
+    ///   - random: Replacement for `Double.random(in:)`; receives the legal
+    ///     range for the drawn value.
+    /// - Returns: The delay in seconds before the next retry.
+    func delay(
+        forAttempt attempt: Int,
+        random: @Sendable (ClosedRange<Double>) -> Double
+    ) -> TimeInterval {
         switch self {
         case let .fixed(delay):
             return delay
@@ -75,14 +90,14 @@ public enum BackoffStrategy: Sendable {
             let exponentialDelay = base * pow(multiplier, Double(attempt - 1))
             let cappedDelay = min(exponentialDelay, maxDelay)
             // Add random jitter between 0 and the calculated delay
-            let jitter = Double.random(in: 0...cappedDelay)
+            let jitter = random(0...cappedDelay)
             return jitter
 
         case let .decorrelatedJitter(base, maxDelay):
             // Decorrelated jitter: sleep = min(cap, random_between(base, sleep * 3))
             // For the first attempt, use base as the previous sleep
             let previousSleep = attempt == 1 ? base : base * pow(3.0, Double(attempt - 2))
-            let delay = Double.random(in: base...(previousSleep * 3.0))
+            let delay = random(base...(previousSleep * 3.0))
             return min(delay, maxDelay)
 
         case .immediate:
@@ -183,6 +198,16 @@ public struct RetryPolicy: Sendable {
     /// Optional callback invoked before each retry attempt.
     public let onRetry: (@Sendable (Int, Error) async -> Void)?
 
+    // MARK: Private
+
+    /// Clock used to suspend between retries. Defaults to `LiveSwarmClock`
+    /// (plain `Task.sleep`) so existing behavior is unchanged when nil.
+    let clock: any SwarmClock
+
+    /// Randomness source consulted by jittered backoff strategies. Defaults
+    /// to `Double.random(in:)` so existing behavior is unchanged when nil.
+    let randomSource: @Sendable (ClosedRange<Double>) -> Double
+
     // MARK: - Initialization
 
     /// Creates a new retry policy.
@@ -197,10 +222,37 @@ public struct RetryPolicy: Sendable {
         shouldRetry: @escaping @Sendable (Error) -> Bool = { _ in true },
         onRetry: (@Sendable (Int, Error) async -> Void)? = nil
     ) {
+        self.init(
+            maxAttempts: maxAttempts,
+            backoff: backoff,
+            shouldRetry: shouldRetry,
+            onRetry: onRetry,
+            clock: nil,
+            random: nil
+        )
+    }
+
+    /// Package-internal injection point for deterministic tests.
+    ///
+    /// `clock` replaces the default `Task.sleep(nanoseconds:)` suspension path;
+    /// `random` replaces `Double.random(in:)` for jittered backoff strategies.
+    /// Both default to the live behaviors when `nil`. Kept internal because
+    /// `SwarmClock` is `@_spi(ColonyInternal)` and cannot appear in a public
+    /// signature.
+    init(
+        maxAttempts: Int = 3,
+        backoff: BackoffStrategy = .exponential(base: 1.0, multiplier: 2.0, maxDelay: 60.0),
+        shouldRetry: @escaping @Sendable (Error) -> Bool = { _ in true },
+        onRetry: (@Sendable (Int, Error) async -> Void)? = nil,
+        clock: (any SwarmClock)? = nil,
+        random: (@Sendable (ClosedRange<Double>) -> Double)? = nil
+    ) {
         self.maxAttempts = max(0, maxAttempts)
         self.backoff = backoff
         self.shouldRetry = shouldRetry
         self.onRetry = onRetry
+        self.clock = clock ?? LiveSwarmClock.live
+        self.randomSource = random ?? { Double.random(in: $0) }
     }
 
     // MARK: - Execution
@@ -241,9 +293,11 @@ public struct RetryPolicy: Sendable {
                 await onRetry?(retryCount, error)
 
                 // Calculate and apply backoff delay
-                let delay = sanitizeBackoffDelay(backoff.delay(forAttempt: retryCount))
+                let delay = sanitizeBackoffDelay(
+                    backoff.delay(forAttempt: retryCount, random: randomSource)
+                )
                 if delay > 0 {
-                    try await Task.sleep(nanoseconds: delay)
+                    try await clock.sleep(nanoseconds: delay)
                 }
             }
         }

--- a/Sources/Swarm/Resilience/RetryPolicy.swift
+++ b/Sources/Swarm/Resilience/RetryPolicy.swift
@@ -202,11 +202,11 @@ public struct RetryPolicy: Sendable {
 
     /// Clock used to suspend between retries. Defaults to `LiveSwarmClock`
     /// (plain `Task.sleep`) so existing behavior is unchanged when nil.
-    let clock: any SwarmClock
+    private let clock: any SwarmClock
 
     /// Randomness source consulted by jittered backoff strategies. Defaults
     /// to `Double.random(in:)` so existing behavior is unchanged when nil.
-    let randomSource: @Sendable (ClosedRange<Double>) -> Double
+    private let randomSource: @Sendable (ClosedRange<Double>) -> Double
 
     // MARK: - Initialization
 

--- a/Tests/SwarmTests/Resilience/ResilienceTests+CircuitBreaker.swift
+++ b/Tests/SwarmTests/Resilience/ResilienceTests+CircuitBreaker.swift
@@ -2,15 +2,46 @@
 // Swarm Framework
 //
 // Tests for CircuitBreaker resilience component using Swift Testing framework.
+// Transition timing is driven entirely by VirtualClock (no real sleeping).
 
 import Foundation
-@testable import Swarm
+@_spi(ColonyInternal) @testable import Swarm
 import Testing
 
 // MARK: - CircuitBreakerTests
 
 @Suite("CircuitBreaker Tests")
 struct CircuitBreakerTests {
+    /// Creates a breaker driven by a fresh virtual clock starting at nanosecond 0.
+    ///
+    /// Construction anchors the breaker's Date timeline at the current wall
+    /// clock paired with nanosecond 0, so every injected instant converts via
+    /// `anchorDate.addingTimeInterval(nanoseconds / 1e9)`.
+    private func makeVirtualBreaker(
+        name: String = "test",
+        failureThreshold: Int,
+        successThreshold: Int = 2,
+        resetTimeout: TimeInterval,
+        halfOpenMaxRequests: Int = 1
+    ) -> (breaker: CircuitBreaker, clock: VirtualClock) {
+        let clock = VirtualClock()
+        let breaker = CircuitBreaker(
+            name: name,
+            failureThreshold: failureThreshold,
+            successThreshold: successThreshold,
+            resetTimeout: resetTimeout,
+            halfOpenMaxRequests: halfOpenMaxRequests,
+            clock: clock
+        )
+        return (breaker, clock)
+    }
+
+    /// The `Date` the breaker assigns to the given virtual-clock reading.
+    private func date(_ breaker: CircuitBreaker, atNanoseconds nanoseconds: UInt64) async -> Date {
+        let bridge = await breaker.clockBridge
+        return bridge.date(atNanoseconds: nanoseconds)
+    }
+
     // MARK: - Initial State Tests
 
     @Test("Initial state is closed")
@@ -55,6 +86,32 @@ struct CircuitBreakerTests {
         } else {
             Issue.record("Expected circuit to be open, got \(state)")
         }
+    }
+
+    @Test("Circuit opens at the exact injected instant")
+    func circuitOpensAtExactInjectedInstant() async throws {
+        let (breaker, clock) = makeVirtualBreaker(
+            name: "test",
+            failureThreshold: 3,
+            resetTimeout: 60.0
+        )
+
+        // All three failures stamp at virtual time 10 s.
+        clock.advance(by: 10_000_000_000)
+
+        for _ in 1...3 {
+            do {
+                _ = try await breaker.execute {
+                    throw TestError.network
+                }
+            } catch {
+                // Expected
+            }
+        }
+
+        let expectedUntil = await date(breaker, atNanoseconds: 10_000_000_000).addingTimeInterval(60.0)
+        let state = await breaker.currentState()
+        #expect(state == .open(until: expectedUntil))
     }
 
     @Test("Circuit remains closed below failureThreshold")
@@ -116,15 +173,15 @@ struct CircuitBreakerTests {
 
     // MARK: - Half-Open Transition Tests
 
-    @Test("Circuit transitions to halfOpen after timeout")
+    @Test("Circuit transitions to halfOpen at the exact injected instant")
     func circuitTransitionsToHalfOpen() async throws {
-        let breaker = CircuitBreaker(
+        let (breaker, clock) = makeVirtualBreaker(
             name: "test",
             failureThreshold: 2,
-            resetTimeout: 0.1 // Short timeout for testing
+            resetTimeout: 60.0
         )
 
-        // Open the circuit
+        // Open the circuit at virtual time 0
         for _ in 1...2 {
             do {
                 _ = try await breaker.execute {
@@ -135,41 +192,52 @@ struct CircuitBreakerTests {
             }
         }
 
-        // Verify circuit is open
+        let expectedUntil = await date(breaker, atNanoseconds: 0).addingTimeInterval(60.0)
+
+        // Verify circuit is open with the exact window
         var state = await breaker.currentState()
-        if case .open = state {
-            // Good
-        } else {
-            Issue.record("Expected circuit to be open")
-        }
+        #expect(state == .open(until: expectedUntil))
 
-        // Wait for timeout
-        try await Task.sleep(nanoseconds: 150_000_000) // 0.15 seconds
-
-        // Trigger state check by attempting execution
+        // Just before the window elapses: still open, requests blocked.
+        // Margin is 1 ms because Date's Double storage resolves ~100 ns at
+        // present-day epochs; finer probes round onto the boundary itself.
+        clock.advance(to: 60_000_000_000 - 1_000_000)
         do {
             _ = try await breaker.execute {
-                // This will check state and transition to half-open
-                "test"
+                "too early"
             }
-        } catch {
-            // May fail depending on timing
+            Issue.record("Request before the deadline should have been blocked")
+        } catch let error as ResilienceError {
+            guard case .circuitBreakerOpen = error else {
+                Issue.record("Expected circuitBreakerOpen, got \(error)")
+                return
+            }
         }
 
         state = await breaker.currentState()
-        // Should be halfOpen or closed (if the test operation succeeded)
-        #expect(state == .halfOpen || state == .closed)
+        #expect(state == .open(until: expectedUntil))
+
+        // Advance to exactly the injected deadline: transition fires
+        clock.advance(to: 60_000_000_000)
+        let result = try await breaker.execute {
+            "recovered"
+        }
+        #expect(result == "recovered")
+
+        state = await breaker.currentState()
+        // Success streak (1 of 2) keeps the circuit half-open
+        #expect(state == .halfOpen)
     }
 
     // MARK: - Circuit Closing Tests
 
     @Test("Circuit closes after successThreshold successes in halfOpen")
     func circuitClosesAfterSuccesses() async throws {
-        let breaker = CircuitBreaker(
+        let (breaker, clock) = makeVirtualBreaker(
             name: "test",
             failureThreshold: 2,
             successThreshold: 2,
-            resetTimeout: 0.1,
+            resetTimeout: 60.0,
             halfOpenMaxRequests: 5
         )
 
@@ -184,8 +252,8 @@ struct CircuitBreakerTests {
             }
         }
 
-        // Wait for timeout to transition to half-open
-        try await Task.sleep(nanoseconds: 150_000_000)
+        // Jump instantly to the exact half-open transition instant
+        clock.advance(to: 60_000_000_000)
 
         // Execute successful operations to close circuit
         for _ in 1...2 {
@@ -200,11 +268,11 @@ struct CircuitBreakerTests {
 
     @Test("Single success in halfOpen keeps circuit halfOpen")
     func singleSuccessInHalfOpen() async throws {
-        let breaker = CircuitBreaker(
+        let (breaker, clock) = makeVirtualBreaker(
             name: "test",
             failureThreshold: 2,
             successThreshold: 3,
-            resetTimeout: 0.1
+            resetTimeout: 60.0
         )
 
         // Open circuit
@@ -214,8 +282,8 @@ struct CircuitBreakerTests {
             } catch {}
         }
 
-        // Wait and transition to half-open
-        try await Task.sleep(nanoseconds: 150_000_000)
+        // Jump instantly past the open window into half-open
+        clock.advance(to: 60_000_000_000)
 
         // One success
         _ = try await breaker.execute { "success" }
@@ -271,6 +339,23 @@ struct CircuitBreakerTests {
         }
     }
 
+    @Test("Second trip extends the window from the second call's instant")
+    func secondTripExtendsWindowFromLatestInstant() async throws {
+        let (breaker, clock) = makeVirtualBreaker(name: "test", failureThreshold: 2, resetTimeout: 60.0)
+
+        // First trip at virtual time 10 s
+        clock.advance(to: 10_000_000_000)
+        await breaker.trip()
+        var state = await breaker.currentState()
+        #expect(state == .open(until: await date(breaker, atNanoseconds: 10_000_000_000).addingTimeInterval(60.0)))
+
+        // Second trip at virtual time 20 s must re-anchor the window there
+        clock.advance(to: 20_000_000_000)
+        await breaker.trip()
+        state = await breaker.currentState()
+        #expect(state == .open(until: await date(breaker, atNanoseconds: 20_000_000_000).addingTimeInterval(60.0)))
+    }
+
     // MARK: - Statistics Tests
 
     @Test("Statistics track success and failure counts")
@@ -302,6 +387,29 @@ struct CircuitBreakerTests {
         #expect(stats.lastFailureTime != nil)
     }
 
+    @Test("Statistics lastFailureTime stamps from the injected clock")
+    func statisticsLastFailureTimeUsesInjectedClock() async throws {
+        let (breaker, clock) = makeVirtualBreaker(
+            name: "test",
+            failureThreshold: 5,
+            resetTimeout: 60.0
+        )
+
+        // Failure stamped at virtual time 42 s
+        clock.advance(to: 42_000_000_000)
+        do {
+            _ = try await breaker.execute {
+                throw TestError.network
+            }
+        } catch {
+            // Expected
+        }
+
+        let stats = await breaker.statistics()
+        let expectedFailureInstant = await date(breaker, atNanoseconds: 42_000_000_000)
+        #expect(stats.lastFailureTime == expectedFailureInstant)
+    }
+
     @Test("Statistics calculate success rate correctly")
     func testSuccessRate() async throws {
         let breaker = CircuitBreaker(name: "test")
@@ -323,10 +431,10 @@ struct CircuitBreakerTests {
 
     @Test("HalfOpen state limits concurrent requests")
     func halfOpenRequestLimit() async throws {
-        let breaker = CircuitBreaker(
+        let (breaker, clock) = makeVirtualBreaker(
             name: "test",
             failureThreshold: 2,
-            resetTimeout: 0.1,
+            resetTimeout: 60.0,
             halfOpenMaxRequests: 1
         )
 
@@ -337,19 +445,24 @@ struct CircuitBreakerTests {
             } catch {}
         }
 
-        // Wait for half-open transition
-        try await Task.sleep(nanoseconds: 150_000_000)
+        // Jump to the exact half-open transition instant
+        clock.advance(to: 60_000_000_000)
 
-        // First request should be allowed
-        let task = Task { @Sendable in
+        // Deterministic in-flight coordination: the first half-open operation
+        // signals entry, then suspends until released by this test.
+        let started = AsyncLatch()
+        let release = AsyncLatch()
+
+        let task = Task {
             try await breaker.execute {
-                try await Task.sleep(nanoseconds: 100_000_000) // Slow operation
+                started.open()
+                await release.wait()
                 return "success"
             }
         }
 
-        // Give it time to start
-        try await Task.sleep(nanoseconds: 10_000_000)
+        // Proceed only once the first request holds the half-open slot.
+        await started.wait()
 
         // Second concurrent request should be blocked
         do {
@@ -366,11 +479,189 @@ struct CircuitBreakerTests {
         }
 
         // Clean up
+        release.open()
         _ = try await task.value
     }
 }
 
-// MARK: - CircuitBreakerRegistryTests
+// MARK: - Pure Transition Math Tests
+
+@Suite("CircuitBreaker Transition Math Tests")
+struct CircuitBreakerTransitionMathTests {
+    /// Fixed reference instant for deterministic expectations.
+    private let reference = Date(timeIntervalSince1970: 1_000_000)
+
+    private func snapshot(
+        state: CircuitBreaker.State = .closed,
+        consecutiveFailures: Int = 0,
+        consecutiveSuccesses: Int = 0
+    ) -> CircuitBreakerTransitions.Snapshot {
+        .init(
+            state: state,
+            consecutiveFailures: consecutiveFailures,
+            consecutiveSuccesses: consecutiveSuccesses
+        )
+    }
+
+    @Test("Failure below threshold keeps the circuit closed")
+    func failureBelowThresholdKeepsClosed() {
+        let after = CircuitBreakerTransitions.failure(
+            snapshot(consecutiveFailures: 1),
+            failureThreshold: 3,
+            resetTimeout: 60.0,
+            now: reference
+        )
+
+        #expect(after.state == .closed)
+        #expect(after.consecutiveFailures == 2)
+        #expect(after.consecutiveSuccesses == 0)
+    }
+
+    @Test("Failure at threshold opens with the exact deadline")
+    func failureAtThresholdOpensWithExactDeadline() {
+        let after = CircuitBreakerTransitions.failure(
+            snapshot(consecutiveFailures: 2),
+            failureThreshold: 3,
+            resetTimeout: 90.0,
+            now: reference
+        )
+
+        #expect(after.state == .open(until: reference.addingTimeInterval(90.0)))
+        #expect(after.consecutiveFailures == 3)
+    }
+
+    @Test("Failure while open leaves the window untouched")
+    func failureWhileOpenLeavesWindowUntouched() {
+        let originalUntil = reference.addingTimeInterval(30.0)
+        let after = CircuitBreakerTransitions.failure(
+            snapshot(state: .open(until: originalUntil), consecutiveFailures: 4),
+            failureThreshold: 3,
+            resetTimeout: 90.0,
+            now: reference.addingTimeInterval(40.0)
+        )
+
+        #expect(after.state == .open(until: originalUntil))
+        #expect(after.consecutiveFailures == 5)
+    }
+
+    @Test("Any failure in halfOpen reopens from that failure's instant")
+    func failureInHalfOpenReopensFromFailureInstant() {
+        let failureInstant = reference.addingTimeInterval(75.0)
+        let after = CircuitBreakerTransitions.failure(
+            snapshot(state: .halfOpen),
+            failureThreshold: 3,
+            resetTimeout: 90.0,
+            now: failureInstant
+        )
+
+        #expect(after.state == .open(until: failureInstant.addingTimeInterval(90.0)))
+    }
+
+    @Test("Success in halfOpen accumulates and closes at the threshold")
+    func successInHalfOpenAccumulatesAndCloses() {
+        let afterFirst = CircuitBreakerTransitions.success(snapshot(state: .halfOpen), successThreshold: 2)
+        #expect(afterFirst.state == .halfOpen)
+        #expect(afterFirst.consecutiveSuccesses == 1)
+
+        let afterSecond = CircuitBreakerTransitions.success(afterFirst, successThreshold: 2)
+        #expect(afterSecond.state == .closed)
+        #expect(afterSecond.consecutiveSuccesses == 0)
+        #expect(afterSecond.consecutiveFailures == 0)
+    }
+
+    @Test("Success outside halfOpen resets the success streak")
+    func successOutsideHalfOpenResetsStreak() {
+        let after = CircuitBreakerTransitions.success(
+            snapshot(state: .open(until: reference), consecutiveSuccesses: 1),
+            successThreshold: 2
+        )
+        #expect(after.state == .open(until: reference))
+        #expect(after.consecutiveSuccesses == 0)
+    }
+
+    @Test("Manual trip opens the window from the given instant")
+    func trippedOpensFromGivenInstant() {
+        let after = CircuitBreakerTransitions.tripped(
+            snapshot(consecutiveFailures: 7, consecutiveSuccesses: 1),
+            resetTimeout: 45.0,
+            now: reference
+        )
+
+        #expect(after.state == .open(until: reference.addingTimeInterval(45.0)))
+        #expect(after.consecutiveSuccesses == 0)
+        // Tripping does not erase the failure streak, matching legacy behavior.
+        #expect(after.consecutiveFailures == 7)
+    }
+
+    @Test("Manual trip while open extends the window from the new instant")
+    func trippedWhileOpenExtendsWindow() {
+        let firstWindow = CircuitBreakerTransitions.tripped(
+            snapshot(),
+            resetTimeout: 60.0,
+            now: reference
+        )
+
+        let secondInstant = reference.addingTimeInterval(25.0)
+        let extended = CircuitBreakerTransitions.tripped(
+            firstWindow,
+            resetTimeout: 60.0,
+            now: secondInstant
+        )
+
+        // Window extends from the second call's now, not stacked onto the old one.
+        #expect(firstWindow.state == .open(until: reference.addingTimeInterval(60.0)))
+        #expect(extended.state == .open(until: secondInstant.addingTimeInterval(60.0)))
+    }
+
+    @Test("Timeout check returns nil before the deadline")
+    func timeoutCheckBeforeDeadlineReturnsNil() {
+        let open = snapshot(state: .open(until: reference.addingTimeInterval(60.0)))
+        let early = CircuitBreakerTransitions.timeoutCheck(open, now: reference.addingTimeInterval(59.999))
+
+        #expect(early == nil)
+
+        let closed = snapshot(state: .closed)
+        #expect(CircuitBreakerTransitions.timeoutCheck(closed, now: reference.addingTimeInterval(999)) == nil)
+
+        let halfOpen = snapshot(state: .halfOpen)
+        #expect(CircuitBreakerTransitions.timeoutCheck(halfOpen, now: reference) == nil)
+    }
+
+    @Test("Timeout check at the deadline moves to halfOpen and resets the streak")
+    func timeoutCheckAtDeadlineTransitionsToHalfOpen() {
+        let open = snapshot(
+            state: .open(until: reference.addingTimeInterval(60.0)),
+            consecutiveFailures: 3,
+            consecutiveSuccesses: 1
+        )
+
+        let transitioned = CircuitBreakerTransitions.timeoutCheck(open, now: reference.addingTimeInterval(60.0))
+
+        #expect(transitioned != nil)
+        #expect(transitioned?.state == .halfOpen)
+        #expect(transitioned?.consecutiveSuccesses == 0)
+        // Failure streak survives the half-open probe window.
+        #expect(transitioned?.consecutiveFailures == 3)
+    }
+}
+
+// MARK: - Clock Bridge Tests
+
+@Suite("CircuitBreaker Clock Bridge Tests")
+struct CircuitBreakerClockBridgeTests {
+    @Test("Anchor instant maps to itself; deltas convert to seconds")
+    func anchorAndDeltaMapping() {
+        let anchorDate = Date(timeIntervalSince1970: 777_777)
+        let bridge = CircuitBreakerClockBridge(anchorNanoseconds: 500, anchorDate: anchorDate)
+
+        #expect(bridge.anchorNanoseconds == 500)
+        #expect(bridge.date(atNanoseconds: 500) == anchorDate)
+        #expect(bridge.date(atNanoseconds: 1_000_000_500) == anchorDate.addingTimeInterval(1.0))
+        #expect(bridge.date(atNanoseconds: 0) == anchorDate.addingTimeInterval(-0.000_000_5))
+    }
+}
+
+// MARK: - CircuitBreakerRegistry Tests
 
 @Suite("CircuitBreakerRegistry Tests")
 struct CircuitBreakerRegistryTests {
@@ -440,5 +731,41 @@ struct CircuitBreakerRegistryTests {
 
         #expect(state1 == .closed)
         #expect(state2 == .closed)
+    }
+}
+
+// MARK: - AsyncLatch
+
+/// One-shot async gate for deterministic coordination of in-flight operations.
+///
+/// `wait()` suspends until `open()` is called (or resumes immediately when
+/// already open), letting tests pin ordering without real sleeping.
+private final class AsyncLatch: @unchecked Sendable {
+    private let lock = NSLock()
+    private var opened = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    /// Opens the gate and resumes all suspended waiters.
+    func open() {
+        lock.lock()
+        opened = true
+        let pending = waiters
+        waiters.removeAll()
+        lock.unlock()
+        pending.forEach { $0.resume() }
+    }
+
+    /// Suspends until the gate is open.
+    func wait() async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            lock.lock()
+            if opened {
+                lock.unlock()
+                continuation.resume()
+                return
+            }
+            waiters.append(continuation)
+            lock.unlock()
+        }
     }
 }

--- a/Tests/SwarmTests/Resilience/ResilienceTests+RateLimiter.swift
+++ b/Tests/SwarmTests/Resilience/ResilienceTests+RateLimiter.swift
@@ -2,13 +2,33 @@
 // Swarm Framework
 //
 // Tests for RateLimiter edge cases and safety constraints.
+// Refill timing is driven entirely by VirtualClock (no real sleeping).
 
 import Foundation
-@testable import Swarm
+@_spi(ColonyInternal) @testable import Swarm
 import Testing
+
+// MARK: - RateLimiterTests
 
 @Suite("RateLimiter Tests")
 struct RateLimiterTests {
+    /// Creates a limiter driven by a fresh virtual clock starting at nanosecond 0,
+    /// so refill math can be asserted against exact injected instants.
+    private func makeVirtualLimiter(
+        maxTokens: Int,
+        refillRatePerSecond: Double
+    ) -> (limiter: RateLimiter, clock: VirtualClock) {
+        let clock = VirtualClock()
+        let limiter = RateLimiter(
+            maxTokens: maxTokens,
+            refillRatePerSecond: refillRatePerSecond,
+            clock: clock
+        )
+        return (limiter, clock)
+    }
+
+    // MARK: - Sanitization Tests
+
     @Test("Invalid maxRequestsPerMinute is sanitized")
     func invalidMaxRequestsPerMinuteIsSanitized() async {
         let limiter = RateLimiter(maxRequestsPerMinute: 0)
@@ -26,5 +46,240 @@ struct RateLimiterTests {
 
         // Refill path should remain safe and not produce invalid sleep math.
         try await limiter.acquire()
+    }
+
+    @Test("Nil clock falls back to the live clock")
+    func nilClockFallsBackToLiveClock() async {
+        let limiter = RateLimiter(maxTokens: 2, refillRatePerSecond: 1.0, clock: nil)
+        #expect(await limiter.available == 2)
+        #expect(await limiter.tryAcquire() == true)
+    }
+
+    // MARK: - Virtual Clock Refill Tests
+
+    @Test("Bucket starts full and stays capped regardless of elapsed time")
+    func bucketStartsFullAndStaysCapped() async {
+        let (limiter, clock) = makeVirtualLimiter(maxTokens: 3, refillRatePerSecond: 1.0)
+
+        clock.advance(by: 60_000_000_000)
+        #expect(await limiter.available == 3)
+        #expect(await limiter.tryAcquire() == true)
+        #expect(await limiter.available == 2)
+    }
+
+    @Test("Refill grants tokens at exactly the configured virtual instants")
+    func refillGrantsAtExactInstants() async {
+        let (limiter, clock) = makeVirtualLimiter(maxTokens: 2, refillRatePerSecond: 1.0)
+
+        // Drain the bucket completely.
+        #expect(await limiter.tryAcquire() == true)
+        #expect(await limiter.tryAcquire() == true)
+        #expect(await limiter.available == 0)
+
+        // Half a second at 1 token/s yields half a token: still blocked.
+        clock.advance(by: 500_000_000)
+        #expect(await limiter.available == 0)
+        #expect(await limiter.tryAcquire() == false)
+
+        // At exactly 1 s one full token has accumulated.
+        clock.advance(to: 1_000_000_000)
+        #expect(await limiter.tryAcquire() == true)
+
+        // Immediately after, the remainder (0.5 s worth) is insufficient.
+        #expect(await limiter.tryAcquire() == false)
+
+        // At exactly 2 s total, the second token has accumulated.
+        clock.advance(to: 2_000_000_000)
+        #expect(await limiter.tryAcquire() == true)
+        #expect(await limiter.available == 0)
+    }
+
+    @Test("Refill caps at maxTokens after long idle periods")
+    func refillCapsAtMaxTokens() async {
+        let (limiter, clock) = makeVirtualLimiter(maxTokens: 4, refillRatePerSecond: 2.0)
+
+        #expect(await limiter.tryAcquire() == true)
+        #expect(await limiter.tryAcquire() == true)
+        #expect(await limiter.available == 2)
+
+        // 100 s at 2 tokens/s far exceeds capacity; refill must clamp at 4.
+        clock.advance(by: 100_000_000_000)
+        #expect(await limiter.available == 4)
+
+        // All four tokens are spendable after the capped refill.
+        for _ in 1...4 {
+            #expect(await limiter.tryAcquire() == true)
+        }
+        #expect(await limiter.tryAcquire() == false)
+    }
+
+    @Test("acquire() waits through the injected clock with zero real sleeping")
+    func acquireWaitsThroughInjectedClock() async throws {
+        let (limiter, clock) = makeVirtualLimiter(maxTokens: 1, refillRatePerSecond: 2.0)
+
+        #expect(await limiter.tryAcquire() == true)
+
+        let wallStart = ContinuousClock.now
+        try await limiter.acquire()
+
+        // Deficit 1.0 at 2 tokens/s requires exactly 0.5 s of virtual sleep;
+        // VirtualClock completes it instantly and advances itself.
+        #expect(clock.recordedSleeps == [500_000_000])
+        let elapsed = ContinuousClock.now - wallStart
+        // A real 0.5 s sleep would exceed this bound even on a loaded runner.
+        #expect(elapsed < .milliseconds(250))
+
+        // Bucket is empty again after consumption.
+        #expect(await limiter.available == 0)
+    }
+
+    @Test("Consecutive acquires each record their exact virtual wait")
+    func consecutiveAcquiresRecordExactWaits() async throws {
+        let (limiter, clock) = makeVirtualLimiter(maxTokens: 1, refillRatePerSecond: 1.0)
+
+        #expect(await limiter.tryAcquire() == true)
+        try await limiter.acquire()
+        try await limiter.acquire()
+
+        // Each refill needs a full second at 1 token/s.
+        #expect(clock.recordedSleeps == [1_000_000_000, 1_000_000_000])
+        #expect(clock.now == 2_000_000_000)
+    }
+
+    @Test("reset() restores full capacity on the injected timeline")
+    func resetRestoresFullCapacityOnInjectedTimeline() async {
+        let (limiter, clock) = makeVirtualLimiter(maxTokens: 3, refillRatePerSecond: 1.0)
+
+        clock.advance(by: 30_000_000_000)
+        #expect(await limiter.tryAcquire() == true)
+        #expect(await limiter.available == 2)
+
+        await limiter.reset()
+        #expect(await limiter.available == 3)
+        #expect(await limiter.tryAcquire() == true)
+        #expect(await limiter.available == 2)
+    }
+
+    @Test("acquire() stays cancellation-aware between injected waits")
+    func acquireRemainsCancellationAwareBetweenWaits() async throws {
+        // A clock whose sleeps never advance time keeps acquire() looping in
+        // its wait branch, so cancellation must come from the loop itself.
+        final class FrozenClock: SwarmClock, @unchecked Sendable {
+            private let lock = NSLock()
+            private var sleeps: [UInt64] = []
+
+            var recordedSleeps: [UInt64] {
+                lock.withLock { sleeps }
+            }
+
+            func nowNanoseconds() -> UInt64 { 0 }
+
+            func sleep(nanoseconds duration: UInt64) async throws {
+                lock.withLock { sleeps.append(duration) }
+                try Task.checkCancellation()
+            }
+        }
+
+        let frozen = FrozenClock()
+        let limiter = RateLimiter(maxTokens: 1, refillRatePerSecond: 1.0, clock: frozen)
+
+        #expect(await limiter.tryAcquire() == true)
+
+        let task = Task {
+            try await limiter.acquire()
+        }
+        // Yield until the waiter has entered (and slept inside) the loop.
+        while await frozen.recordedSleeps.isEmpty {
+            await Task.yield()
+        }
+        task.cancel()
+
+        do {
+            try await task.value
+            Issue.record("Expected cancelled acquire to throw CancellationError")
+        } catch is CancellationError {
+            // Expected: propagated between injected waits.
+        }
+    }
+}
+
+// MARK: - TokenBucketMath Tests
+
+@Suite("TokenBucketMath Tests")
+private struct TokenBucketMathTests {
+    // MARK: refilled
+
+    @Test("Zero elapsed time leaves tokens unchanged")
+    func zeroElapsedLeavesTokensUnchanged() {
+        #expect(
+            TokenBucketMath.refilled(tokens: 2.5, elapsedSeconds: 0, refillRate: 3.0, maxTokens: 10)
+                == 2.5
+        )
+    }
+
+    @Test("Elapsed time adds elapsed times rate tokens")
+    func elapsedAddsRateScaledTokens() {
+        #expect(
+            TokenBucketMath.refilled(tokens: 1.0, elapsedSeconds: 2.5, refillRate: 4.0, maxTokens: 20)
+                == 11.0
+        )
+    }
+
+    @Test("Refill clamps at maxTokens")
+    func refillClampsAtMaxTokens() {
+        #expect(
+            TokenBucketMath.refilled(tokens: 8.0, elapsedSeconds: 10, refillRate: 5.0, maxTokens: 9)
+                == 9.0
+        )
+        #expect(
+            TokenBucketMath.refilled(tokens: 9.0, elapsedSeconds: 60, refillRate: 1.0, maxTokens: 9)
+                == 9.0
+        )
+    }
+
+    @Test("Negative elapsed removes tokens at the refill rate")
+    func negativeElapsedRemovesTokens() {
+        #expect(
+            TokenBucketMath.refilled(tokens: 5.0, elapsedSeconds: -2.0, refillRate: 1.5, maxTokens: 10)
+                == 2.0
+        )
+    }
+
+    // MARK: waitSeconds
+
+    @Test("Wait time is deficit divided by rate")
+    func waitTimeIsDeficitOverRate() {
+        #expect(TokenBucketMath.waitSeconds(forDeficit: 0.5, refillRate: 2.0) == 0.25)
+        #expect(TokenBucketMath.waitSeconds(forDeficit: 1.0, refillRate: 4.0) == 0.25)
+    }
+
+    @Test("Non-positive deficits yield zero wait")
+    func nonPositiveDeficitsYieldZeroWait() {
+        #expect(TokenBucketMath.waitSeconds(forDeficit: 0, refillRate: 2.0) == 0)
+        #expect(TokenBucketMath.waitSeconds(forDeficit: -1.5, refillRate: 2.0) == 0)
+    }
+
+    @Test("Non-finite raw quotients yield zero wait")
+    func nonFiniteQuotientsYieldZeroWait() {
+        // Division by a non-finite deficit or rate must never produce an
+        // invalid sleep duration.
+        #expect(TokenBucketMath.waitSeconds(forDeficit: .infinity, refillRate: 2.0) == 0)
+        #expect(TokenBucketMath.waitSeconds(forDeficit: .nan, refillRate: 2.0) == 0)
+        #expect(TokenBucketMath.waitSeconds(forDeficit: 1.0, refillRate: .infinity) == 0)
+        #expect(TokenBucketMath.waitSeconds(forDeficit: 1.0, refillRate: 0) == 0)
+        #expect(TokenBucketMath.waitSeconds(forDeficit: 1.0, refillRate: .nan) == 0)
+    }
+
+    // MARK: elapsedSeconds
+
+    @Test("Elapsed seconds converts nanosecond deltas forward and backward")
+    func elapsedConvertsNanosecondDeltas() {
+        #expect(
+            TokenBucketMath.elapsedSeconds(from: 1_000_000_000, to: 2_500_000_000) == 1.5
+        )
+        #expect(TokenBucketMath.elapsedSeconds(from: 500, to: 500) == 0)
+        #expect(
+            TokenBucketMath.elapsedSeconds(from: 2_000_000_000, to: 1_500_000_000) == -0.5
+        )
     }
 }

--- a/Tests/SwarmTests/Resilience/ResilienceTests+RateLimiter.swift
+++ b/Tests/SwarmTests/Resilience/ResilienceTests+RateLimiter.swift
@@ -44,8 +44,12 @@ struct RateLimiterTests {
         // First token should always be available after sanitization.
         #expect(await limiter.tryAcquire() == true)
 
-        // Refill path should remain safe and not produce invalid sleep math.
-        try await limiter.acquire()
+        // Acquire wait uses the sanitized 1 token/s rate; drive it through the
+        // virtual clock so the refill path is proven without a wall-clock sleep.
+        let (virtualLimiter, clock) = makeVirtualLimiter(maxTokens: -10, refillRatePerSecond: 0)
+        #expect(await virtualLimiter.tryAcquire() == true)
+        try await virtualLimiter.acquire()
+        #expect(clock.recordedSleeps == [1_000_000_000])
     }
 
     @Test("Nil clock falls back to the live clock")

--- a/Tests/SwarmTests/Resilience/ResilienceTests+Retry.swift
+++ b/Tests/SwarmTests/Resilience/ResilienceTests+Retry.swift
@@ -4,7 +4,7 @@
 // Tests for RetryPolicy resilience component using Swift Testing framework.
 
 import Foundation
-@testable import Swarm
+@_spi(ColonyInternal) @testable import Swarm
 import Testing
 
 // MARK: - RetryPolicy Tests
@@ -437,5 +437,186 @@ struct RetryPolicyTests {
         }
 
         #expect(await counter.get() == 2)
+    }
+}
+
+// MARK: - Deterministic Randomness & Sleep Seam Support
+
+/// Lock-guarded wrapper exposing `SeededRandomGenerator` through the
+/// `@Sendable` closure shape accepted by RetryPolicy and BackoffStrategy.
+/// (The generator is a value type; `@Sendable` closures need shared state.)
+private final class SharedSeededRandom: @unchecked Sendable {
+    // MARK: Private
+
+    private let lock = NSLock()
+    private var generator: SeededRandomGenerator
+
+    // MARK: Init
+
+    init(seed: UInt64) {
+        generator = SeededRandomGenerator(seed: seed)
+    }
+
+    // MARK: Internal
+
+    func random(in range: ClosedRange<Double>) -> Double {
+        lock.withLock { generator.random(in: range) }
+    }
+}
+
+// MARK: - Jitter Determinism Tests
+
+@Suite("RetryPolicy Determinism Tests")
+private struct RetryPolicyDeterminismTests {
+    @Test("Seeded randomness reproduces exponentialWithJitter sequences")
+    func seededExponentialJitterReplaysExactly() {
+        let strategy = BackoffStrategy.exponentialWithJitter(base: 1.0, multiplier: 2.0, maxDelay: 10.0)
+
+        let firstRun = SharedSeededRandom(seed: 99)
+        let firstSequence = (1...6).map { strategy.delay(forAttempt: $0, random: firstRun.random(in:)) }
+
+        let replayRun = SharedSeededRandom(seed: 99)
+        let replaySequence = (1...6).map { strategy.delay(forAttempt: $0, random: replayRun.random(in:)) }
+
+        #expect(firstSequence == replaySequence)
+
+        for (index, delay) in firstSequence.enumerated() {
+            let capped = min(1.0 * pow(2.0, Double(index)), 10.0)
+            #expect(delay >= 0)
+            #expect(delay <= capped)
+        }
+        #expect(Set(firstSequence).count > 1) // jitter actually varies
+    }
+
+    @Test("Seeded randomness reproduces decorrelatedJitter sequences")
+    func seededDecorrelatedJitterReplaysExactly() {
+        let strategy = BackoffStrategy.decorrelatedJitter(base: 0.5, maxDelay: 20.0)
+
+        let firstRun = SharedSeededRandom(seed: 7)
+        let firstSequence = (1...5).map { strategy.delay(forAttempt: $0, random: firstRun.random(in:)) }
+
+        let replayRun = SharedSeededRandom(seed: 7)
+        let replaySequence = (1...5).map { strategy.delay(forAttempt: $0, random: replayRun.random(in:)) }
+
+        #expect(firstSequence == replaySequence)
+
+        for (index, delay) in firstSequence.enumerated() {
+            // previousSleep formula preserved byte-identically:
+            // attempt == 1 uses base; else base * pow(3, attempt - 2).
+            let previousSleep = index == 0 ? 0.5 : 0.5 * pow(3.0, Double(index - 1))
+            #expect(delay >= 0.5)
+            #expect(delay <= min(previousSleep * 3.0, 20.0))
+        }
+    }
+
+    @Test("Public delay(forAttempt:) keeps live randomness and unchanged math")
+    func publicDelayKeepsLiveRandomness() {
+        let strategy = BackoffStrategy.exponentialWithJitter(base: 1.0, multiplier: 2.0, maxDelay: 1_000_000.0)
+
+        let delays = (0..<16).map { _ in strategy.delay(forAttempt: 1) }
+
+        #expect(delays.allSatisfy { $0 >= 0 && $0 <= 1.0 })
+        #expect(Set(delays).count > 1)
+
+        // Non-jitter strategies are unaffected by the seam.
+        #expect(BackoffStrategy.fixed(delay: 1.5).delay(forAttempt: 3) == 1.5)
+        #expect(BackoffStrategy.immediate.delay(forAttempt: 9) == 0)
+    }
+
+    // MARK: Injected Sleep Seam Tests
+
+    @Test("Injected clock records exact per-attempt delays without real sleeping")
+    func executeRecordsExactDelaysViaVirtualClock() async throws {
+        let clock = VirtualClock()
+        let counter = TestCounter()
+        let policy = RetryPolicy(
+            maxAttempts: 3,
+            backoff: .fixed(delay: 0.25),
+            clock: clock
+        )
+
+        let wallStart = ContinuousClock.now
+
+        let result = try await policy.execute {
+            let count = await counter.increment()
+            if count < 3 {
+                throw TestError.transient
+            }
+            return "recovered"
+        }
+
+        #expect(result == "recovered")
+        #expect(await counter.get() == 3)
+        #expect(clock.recordedSleeps == [250_000_000, 250_000_000]) // attempts 1 and 2 only
+        #expect(clock.now == 500_000_000) // virtual time advanced by the two sleeps
+
+        let elapsed = ContinuousClock.now - wallStart
+        // Two real 250 ms sleeps would take at least 0.5 s.
+        #expect(elapsed < .milliseconds(250))
+    }
+
+    @Test("Seeded jitter retries replay identical sleep sequences end to end")
+    func seededJitterEndToEndReplaysIdenticalSleeps() async throws {
+        let strategy = BackoffStrategy.exponentialWithJitter(base: 1.0, multiplier: 2.0, maxDelay: 60.0)
+
+        func runOnce() async throws -> [UInt64] {
+            let clock = VirtualClock()
+            let random = SharedSeededRandom(seed: 2_026)
+            let counter = TestCounter()
+            let policy = RetryPolicy(maxAttempts: 3, backoff: strategy, clock: clock, random: random.random(in:))
+
+            _ = try await policy.execute {
+                let count = await counter.increment()
+                if count < 4 {
+                    throw TestError.network
+                }
+                return true
+            }
+
+            #expect(await counter.get() == 4) // initial + 3 retries
+            return clock.recordedSleeps
+        }
+
+        let firstRun = try await runOnce()
+        let secondRun = try await runOnce()
+
+        #expect(firstRun.count == 3)
+        #expect(firstRun == secondRun)
+
+        for (index, nanoseconds) in firstRun.enumerated() {
+            let capped = min(1.0 * pow(2.0, Double(index)), 60.0)
+            #expect(Double(nanoseconds) / 1_000_000_000 <= capped)
+        }
+    }
+
+    @Test("Injected clock preserves immediate cancellation semantics")
+    func injectedClockPreservesCancellationSemantics() async throws {
+        let clock = VirtualClock()
+        let counter = TestCounter()
+        let retryRecorder = TestRecorder<Int>()
+        let policy = RetryPolicy(
+            maxAttempts: 3,
+            backoff: .fixed(delay: 1.0),
+            onRetry: { attempt, _ in
+                await retryRecorder.append(attempt)
+            },
+            clock: clock
+        )
+
+        do {
+            _ = try await policy.execute {
+                _ = await counter.increment()
+                throw CancellationError()
+            }
+            Issue.record("Expected CancellationError")
+        } catch is CancellationError {
+            // Expected: cancellation rethrown immediately, no retry, no sleep.
+        } catch {
+            Issue.record("Expected CancellationError, got \(error)")
+        }
+
+        #expect(await counter.get() == 1)
+        #expect(await retryRecorder.getAll().isEmpty)
+        #expect(clock.recordedSleeps.isEmpty)
     }
 }


### PR DESCRIPTION
## Summary

Restores the functional cores T8 (`b2e4c1c6`) deleted from CircuitBreaker, RateLimiter, and RetryPolicy:

- `CircuitBreakerTransitions` + `CircuitBreakerClockBridge` (pure FSM; `Date()` no longer in `recordFailure` / timeout check)
- `TokenBucketMath` (refill / wait / elapsed)
- Injectable RNG + `SwarmClock.sleep` on `RetryPolicy.execute`

Public initializer labels are unchanged. Clock injection is `@_spi(ColonyInternal)` (breaker/limiter) or internal (retry).

## Spec / ticket

- Spec: `spec/spec-architecture-functional-core.md` (local to architecture-pipeline run `aabfa70c`; not in this PR)
- Ticket **T1** — Restore CircuitBreaker FSM, TokenBucketMath, RetryPolicy clock/RNG
- Design source: T2 `5ec052c6`, T3 `6c4c849f`, T4 `db13dd81`

## Reviews

- Step 6: `swift-pr-review` (code-reviewer) — APPROVE after F1/F2 fixes (`8f18e562`)
- Step 7: `swift-pr-review` (fresh) — APPROVE, no further diffs

Largest changed Swift file: `CircuitBreaker.swift` (616 LOC) → `swift-pr-review` bucket.

## Proof

```
SWARM_OMIT_INTEGRATION_TARGETS=1 swift test --filter ResilienceTests --no-parallel
# 95 tests, 10 suites, passed (0.016s after rebase onto main)
```

Rebased onto current `main` (`4cc96538`, including #145 / #156).

## Sister ticket

T2 (kernel `next()` owns host loop) was implemented on `181c8119` then **superseded** by #156 (`TurnMode` / `TurnState` / `TurnTransition`) and #145 (Agent.swift split). Not opened.

Discovery report: functional-evolution HTML (local).
