### PR TITLE
arch(W3-T1): consolidate settlement primitive + per-run cancellation ownership

### DIFF
--- a/Sources/Swarm/Agents/Agent.swift
+++ b/Sources/Swarm/Agents/Agent.swift
@@ -517,7 +517,9 @@ public struct Agent: AgentRuntime, Sendable {
         let task = Task { [self] in
             try await runInternal(input, session: session, observer: observer, structuredOutputRequest: nil)
         }
-        await cancellationState.begin(runID: runID, task: task)
+        await activeRuns.begin(runID) { [task] in
+            task.cancel()
+        }
 
         do {
             let result = try await withTaskCancellationHandler(
@@ -528,11 +530,11 @@ public struct Agent: AgentRuntime, Sendable {
                     task.cancel()
                 }
             )
-            await cancellationState.finish(runID: runID)
+            await activeRuns.finish(runID)
             return result
         } catch {
             task.cancel()
-            await cancellationState.finish(runID: runID)
+            await activeRuns.finish(runID)
             throw normalizeCancellation(error)
         }
     }
@@ -548,7 +550,9 @@ public struct Agent: AgentRuntime, Sendable {
         let task = Task { [self] in
             try await runInternal(input, session: session, observer: observer, structuredOutputRequest: request)
         }
-        await cancellationState.begin(runID: runID, task: task)
+        await activeRuns.begin(runID) { [task] in
+            task.cancel()
+        }
 
         do {
             let result = try await withTaskCancellationHandler(
@@ -559,7 +563,7 @@ public struct Agent: AgentRuntime, Sendable {
                     task.cancel()
                 }
             )
-            await cancellationState.finish(runID: runID)
+            await activeRuns.finish(runID)
 
             guard let structuredOutput = result.structuredOutput else {
                 throw AgentError.generationFailed(reason: "Structured output request completed without a structured result")
@@ -568,15 +572,21 @@ public struct Agent: AgentRuntime, Sendable {
             return StructuredAgentResult(agentResult: result.agentResult, structuredOutput: structuredOutput)
         } catch {
             task.cancel()
-            await cancellationState.finish(runID: runID)
+            await activeRuns.finish(runID)
             throw normalizeCancellation(error)
         }
     }
 
-    /// Cancels any ongoing execution.
+    /// Cancels every in-flight execution on this agent.
     ///
+    /// All runs started through ``run(_:session:observer:)`` or
+    /// ``runStructured(_:request:session:observer:)`` that have not finished
+    /// yet are cancelled, including runs started concurrently on copies of
+    /// this agent value. Earlier releases cancelled only the most recently
+    /// registered run; the run registry now tracks every concurrent run by
+    /// ID, so cancellation reaches all of them.
     public func cancel() async {
-        await cancellationState.cancelCurrent()
+        await activeRuns.cancelAll()
     }
 
     /// Streams the agent's execution, yielding events as they occur.
@@ -669,7 +679,9 @@ public struct Agent: AgentRuntime, Sendable {
     // MARK: - Internal State
 
     private var toolRegistry: ToolRegistry
-    private let cancellationState = ActiveRunCancellationState()
+    /// Registry of in-flight runs; copies of this value share the actor, so
+    /// every run started through any copy is reachable from ``cancel()``.
+    private let activeRuns = ActiveRunRegistry()
     /// Created from ``AgentConfiguration/resilience`` at init. Copies of this value share the actor.
     let inferenceCircuitBreaker: CircuitBreaker?
     /// Created from ``AgentConfiguration/resilience`` at init. Copies of this value share the actor.
@@ -713,127 +725,40 @@ public struct Agent: AgentRuntime, Sendable {
         let structuredOutput: StructuredOutputResult?
     }
 
-    private actor ActiveRunCancellationState {
-        private var activeRunID: UUID?
-        private var activeTask: Task<InternalRunResult, Error>?
+    /// Registry of in-flight runs keyed by run ID.
+    ///
+    /// Unlike the single-slot state it replaces, this supports multiple
+    /// concurrent runs on one agent value: `cancelAll()` reaches every
+    /// in-flight run, while `finish(_:)` removes exactly the run that
+    /// completed so finished runs never shadow live ones. Each entry stores
+    /// its run task's cancellation action, mirroring ``TrackedRunRegistry``.
+    ///
+    /// Internal (not private) so deterministic tests can drive the registry
+    /// directly; adds no public API surface.
+    actor ActiveRunRegistry {
+        private var cancellers: [UUID: @Sendable () -> Void] = [:]
 
-        func begin(runID: UUID, task: Task<InternalRunResult, Error>) {
-            activeRunID = runID
-            activeTask = task
+        func begin(_ id: UUID, onCancel: @escaping @Sendable () -> Void) {
+            cancellers[id] = onCancel
         }
 
-        func finish(runID: UUID) {
-            guard activeRunID == runID else { return }
-            activeRunID = nil
-            activeTask = nil
+        func finish(_ id: UUID) {
+            cancellers[id] = nil
         }
 
-        func cancelCurrent() {
-            activeTask?.cancel()
-        }
-    }
-
-    private final class TimedOperationCoordinator<T: Sendable>: @unchecked Sendable {
-        private let lock = NSLock()
-        private var continuation: CheckedContinuation<T, Error>?
-        private var operationTask: Task<Void, Never>?
-        private var timeoutTask: Task<Void, Never>?
-        private var ownedLoopGate: ProviderOwnedLoopGate?
-        private var completed = false
-
-        func setOwnedLoopGate(_ gate: ProviderOwnedLoopGate?) {
-            lock.lock()
-            defer { lock.unlock() }
-            ownedLoopGate = gate
+        func cancel(_ id: UUID) {
+            cancellers[id]?()
         }
 
-        func install(continuation: CheckedContinuation<T, Error>) {
-            lock.lock()
-            defer { lock.unlock() }
-            self.continuation = continuation
-        }
-
-        func setOperationTask(_ task: Task<Void, Never>) {
-            lock.lock()
-            defer { lock.unlock() }
-            operationTask = task
-        }
-
-        func setTimeoutTask(_ task: Task<Void, Never>) {
-            lock.lock()
-            defer { lock.unlock() }
-            timeoutTask = task
-        }
-
-        func finish(returning value: T) {
-            complete(deactivateOwnedLoop: false) { continuation in
-                continuation.resume(returning: value)
+        func cancelAll() {
+            for cancel in cancellers.values {
+                cancel()
             }
         }
 
-        func finish(throwing error: Error) {
-            complete(deactivateOwnedLoop: Self.shouldDeactivateOwnedLoop(for: error)) { continuation in
-                continuation.resume(throwing: error)
-            }
-        }
-
-        func cancelPending(with error: Error) {
-            let pendingState = takePendingState()
-            if Self.shouldDeactivateOwnedLoop(for: error) {
-                pendingState.ownedLoopGate?.deactivate()
-            }
-            pendingState.operationTask?.cancel()
-            pendingState.timeoutTask?.cancel()
-            pendingState.continuation?.resume(throwing: error)
-        }
-
-        private func complete(
-            deactivateOwnedLoop: Bool,
-            _ resume: (CheckedContinuation<T, Error>) -> Void
-        ) {
-            let pendingState = takePendingState()
-            if deactivateOwnedLoop {
-                pendingState.ownedLoopGate?.deactivate()
-            }
-            pendingState.operationTask?.cancel()
-            pendingState.timeoutTask?.cancel()
-            guard let continuation = pendingState.continuation else { return }
-            resume(continuation)
-        }
-
-        private static func shouldDeactivateOwnedLoop(for error: Error) -> Bool {
-            if error is CancellationError {
-                return true
-            }
-            if case .timeout = error as? AgentError {
-                return true
-            }
-            return false
-        }
-
-        private func takePendingState() -> (
-            continuation: CheckedContinuation<T, Error>?,
-            operationTask: Task<Void, Never>?,
-            timeoutTask: Task<Void, Never>?,
-            ownedLoopGate: ProviderOwnedLoopGate?
-        ) {
-            lock.lock()
-            defer { lock.unlock() }
-
-            guard completed == false else {
-                return (nil, nil, nil, nil)
-            }
-
-            completed = true
-            let pendingContinuation = continuation
-            let pendingOperationTask = operationTask
-            let pendingTimeoutTask = timeoutTask
-            let pendingGate = ownedLoopGate
-            continuation = nil
-            operationTask = nil
-            timeoutTask = nil
-            ownedLoopGate = nil
-            return (pendingContinuation, pendingOperationTask, pendingTimeoutTask, pendingGate)
+        /// Number of runs currently tracked.
+        var trackedCount: Int {
+            cancellers.count
         }
     }
 
@@ -1560,9 +1485,29 @@ public struct Agent: AgentRuntime, Sendable {
         }
     }
 
+    /// Runs `operation` bounded by the remaining run timeout.
+    ///
+    /// Delegates to the shared ``withTimeoutRace`` settlement primitive, so
+    /// outcomes recorded before the continuation installs are replayed and
+    /// worker tasks registered after settlement are cancelled. Owned-loop-gate
+    /// deactivation rides on the race's `onSettle` hook: the gate is
+    /// deactivated exactly when settlement fails with `CancellationError` or
+    /// `AgentError.timeout` (see `shouldDeactivateOwnedLoop`), never on
+    /// success or unrelated failures.
+    ///
+    /// The remaining budget is computed from `startTime` and consumed through
+    /// the injected `SwarmClock`, keeping the sleep on the same fake-clock
+    /// seam used by resilience code.
+    ///
+    /// - Parameters:
+    ///   - startTime: Run start instant used to compute the remaining budget.
+    ///   - executionGate: Optional owned-loop gate deactivated on cancellation/timeout.
+    ///   - clock: Clock driving the timeout suspension; inject a fake clock in tests.
+    ///   - operation: The work to bound.
     func executeWithinRemainingTimeout<T: Sendable>(
         startTime: ContinuousClock.Instant,
         executionGate: ProviderOwnedLoopGate? = nil,
+        clock: any SwarmClock = LiveSwarmClock.live,
         operation: @escaping @Sendable () async throws -> T
     ) async throws -> T {
         try Task.checkCancellation()
@@ -1572,41 +1517,28 @@ public struct Agent: AgentRuntime, Sendable {
             throw AgentError.timeout(duration: configuration.timeout)
         }
 
-        let coordinator = TimedOperationCoordinator<T>()
-        coordinator.setOwnedLoopGate(executionGate)
-
-        return try await withTaskCancellationHandler(
-            operation: {
-                try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<T, Error>) in
-                    coordinator.install(continuation: continuation)
-
-                    let operationTask = Task {
-                        do {
-                            coordinator.finish(returning: try await operation())
-                        } catch {
-                            coordinator.finish(throwing: error)
-                        }
-                    }
-                    coordinator.setOperationTask(operationTask)
-
-                    let timeoutTask = Task { [timeout = configuration.timeout, remaining] in
-                        do {
-                            try await Task.sleep(for: remaining)
-                            operationTask.cancel()
-                            coordinator.finish(throwing: AgentError.timeout(duration: timeout))
-                        } catch is CancellationError {
-                            return
-                        } catch {
-                            coordinator.finish(throwing: error)
-                        }
-                    }
-                    coordinator.setTimeoutTask(timeoutTask)
-                }
+        return try await withTimeoutRace(
+            timeout: remaining,
+            clock: clock,
+            timeoutError: AgentError.timeout(duration: configuration.timeout),
+            onSettle: { error in
+                guard let error, Self.shouldDeactivateOwnedLoop(for: error) else { return }
+                executionGate?.deactivate()
             },
-            onCancel: {
-                coordinator.cancelPending(with: CancellationError())
-            }
+            operation: operation
         )
+    }
+
+    /// Owned-loop gates deactivate only when a run dies by cancellation or
+    /// timeout; ordinary inference/tool failures must leave the gate armed.
+    private static func shouldDeactivateOwnedLoop(for error: Error) -> Bool {
+        if error is CancellationError {
+            return true
+        }
+        if case .timeout = error as? AgentError {
+            return true
+        }
+        return false
     }
 
     private func normalizeCancellation(_ error: Error) -> Error {

--- a/Sources/Swarm/Agents/Agent.swift
+++ b/Sources/Swarm/Agents/Agent.swift
@@ -729,9 +729,16 @@ public struct Agent: AgentRuntime, Sendable {
     ///
     /// Unlike the single-slot state it replaces, this supports multiple
     /// concurrent runs on one agent value: `cancelAll()` reaches every
-    /// in-flight run, while `finish(_:)` removes exactly the run that
-    /// completed so finished runs never shadow live ones. Each entry stores
-    /// its run task's cancellation action, mirroring ``TrackedRunRegistry``.
+    /// in-flight run and empties the registry, while `finish(_:)` removes
+    /// exactly the run that completed so finished runs never shadow live
+    /// ones. Each entry stores its run task's cancellation action.
+    ///
+    /// Deliberately mirrors ``TrackedRunRegistry`` in GraphAgent.swift: the
+    /// graph runtime copy cannot be shared from here because Package.swift
+    /// excludes `Internal/GraphRuntime` from lean (`SWARM_OMIT_
+    /// INTEGRATION_TARGETS=1`) builds, where this type must still compile.
+    /// Keep begin/finish/cancel semantics identical in both copies until a
+    /// follow-up consolidates them into one always-compiled registry.
     ///
     /// Internal (not private) so deterministic tests can drive the registry
     /// directly; adds no public API surface.
@@ -754,6 +761,7 @@ public struct Agent: AgentRuntime, Sendable {
             for cancel in cancellers.values {
                 cancel()
             }
+            cancellers.removeAll()
         }
 
         /// Number of runs currently tracked.

--- a/Sources/Swarm/Core/TimeoutRace.swift
+++ b/Sources/Swarm/Core/TimeoutRace.swift
@@ -3,11 +3,11 @@
 //
 // Shared completion machinery for async operations raced against a timeout,
 // consolidating the per-site coordinator/race classes that previously lived
-// in GuardrailRunner and Workflow+Timeout. Two timeout sites deliberately
-// keep their own machinery: Agent.executeWithinRemainingTimeout ties race
-// settlement to its ProviderOwnedLoopGate execution-gate state, and
-// StreamOperations.timeout(after:) is a stream-lifetime operator rather than
-// a one-shot race.
+// in GuardrailRunner and Workflow+Timeout and in Agent's
+// TimedOperationCoordinator (whose owned-loop-gate deactivation now rides on
+// the `onSettle` hook). One timeout site deliberately keeps its own
+// machinery: StreamOperations.timeout(after:) is a stream-lifetime operator
+// rather than a one-shot race.
 
 import Foundation
 
@@ -20,6 +20,13 @@ import Foundation
 /// recorded before `install(continuation:)` runs (e.g. a cancellation handler
 /// firing in that window) is applied as soon as the continuation arrives, so
 /// no registration order can leak or strand it.
+///
+/// `onSettle` fires exactly once per race — at settlement time, before the
+/// worker tasks are cancelled and the continuation is resumed — with `nil`
+/// for success or the settled error. It runs even when settlement precedes
+/// continuation installation, mirroring how callers release outcome-specific
+/// resources (e.g. owned-loop gate deactivation) regardless of whether a
+/// continuation was installed yet.
 final class TimeoutRace<T: Sendable>: @unchecked Sendable {
     private enum Outcome {
         case success(T)
@@ -27,10 +34,15 @@ final class TimeoutRace<T: Sendable>: @unchecked Sendable {
     }
 
     private let lock = NSLock()
+    private let onSettle: (@Sendable (Error?) -> Void)?
     private var continuation: CheckedContinuation<T, Error>?
     private var operationTask: Task<Void, Never>?
     private var timeoutTask: Task<Void, Never>?
     private var outcome: Outcome?
+
+    init(onSettle: (@Sendable (Error?) -> Void)? = nil) {
+        self.onSettle = onSettle
+    }
 
     func install(continuation: CheckedContinuation<T, Error>) {
         lock.lock()
@@ -88,6 +100,12 @@ final class TimeoutRace<T: Sendable>: @unchecked Sendable {
         timeoutTask = nil
         lock.unlock()
 
+        switch newOutcome {
+        case .success:
+            onSettle?(nil)
+        case let .failure(error):
+            onSettle?(error)
+        }
         pendingOperationTask?.cancel()
         pendingTimeoutTask?.cancel()
         if let pendingContinuation {
@@ -132,15 +150,23 @@ final class TimeoutRace<T: Sendable>: @unchecked Sendable {
 ///
 /// Sleep failures other than cancellation surface through the continuation;
 /// `LiveSwarmClock` suspension only ever throws `CancellationError`.
+///
+/// `onSettle`, when provided, fires exactly once with the settled outcome —
+/// `nil` for success or the winning error — before the losing task is
+/// cancelled and the continuation resumes. Callers use it to release state
+/// tied to specific outcomes (e.g. deactivating a `ProviderOwnedLoopGate`
+/// only on `CancellationError`/timeout) without re-introducing per-site
+/// settlement coordinators.
 func withTimeoutRace<T: Sendable>(
     timeout: Duration,
     clock: any SwarmClock = LiveSwarmClock.live,
     cancelsOnParentCancellation: Bool = true,
     priority: TaskPriority? = nil,
     timeoutError: @autoclosure @escaping @Sendable () -> Error,
+    onSettle: (@Sendable (_ error: Error?) -> Void)? = nil,
     operation: @escaping @Sendable () async throws -> T
 ) async throws -> T {
-    let race = TimeoutRace<T>()
+    let race = TimeoutRace<T>(onSettle: onSettle)
 
     func run() async throws -> T {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<T, Error>) in

--- a/Sources/Swarm/Internal/GraphRuntime/GraphAgent.swift
+++ b/Sources/Swarm/Internal/GraphRuntime/GraphAgent.swift
@@ -120,7 +120,14 @@ struct GraphAgent: AgentRuntime, Sendable {
             )
             await cancellation.track(handle)
 
-            let outcome = try await handle.outcome.value
+            let outcome: HiveRunOutcome<ChatGraph.Schema>
+            do {
+                outcome = try await handle.outcome.value
+            } catch {
+                await cancellation.untrack(handle.runID)
+                throw error
+            }
+            await cancellation.untrack(handle.runID)
             let result = try buildResult(from: outcome, builder: resultBuilder)
 
             await observer?.onAgentEnd(context: nil, agent: self, result: result)
@@ -228,8 +235,10 @@ struct GraphAgent: AgentRuntime, Sendable {
                     outcome = try await handle.outcome.value
                 } catch {
                     eventsTask.cancel()
+                    await cancellation.untrack(handle.runID)
                     throw error
                 }
+                await cancellation.untrack(handle.runID)
 
                 // Wait for all events to be consumed before building the result.
                 await eventsTask.value
@@ -263,7 +272,7 @@ struct GraphAgent: AgentRuntime, Sendable {
         }
     }
 
-    /// Cancels any ongoing Hive run.
+    /// Cancels every Hive run currently tracked on this agent.
     func cancel() async {
         await cancellation.cancelCurrent()
     }
@@ -666,27 +675,77 @@ extension GraphAgent: ConversationBranchingRuntime {
 
 // MARK: - CancellationController
 
-/// Actor that safely tracks and cancels the current Hive run handle.
+/// Actor that safely tracks and cancels in-flight Hive run handles.
 ///
-/// Stores the actual `HiveRunHandle` so cancellation propagates to the Hive runtime,
-/// not just to an awaiting wrapper task.
+/// Runs are keyed by `HiveRunID`, so registering a new run never disturbs
+/// previously tracked ones and cancellation targets explicit runs instead of
+/// whatever happened to register last. Stores the actual
+/// `HiveRunHandle` outcome tasks so cancellation propagates to the Hive
+/// runtime, not just to an awaiting wrapper task.
 private actor CancellationController {
-    private var currentHandle: HiveRunHandle<ChatGraph.Schema>?
+    private let registry = TrackedRunRegistry<HiveRunID>()
 
-    /// Records a new run handle for potential cancellation.
-    func track(_ handle: HiveRunHandle<ChatGraph.Schema>) {
-        // Cancel any previously tracked run.
-        currentHandle?.outcome.cancel()
-        currentHandle = handle
+    /// Records a new run handle without cancelling any previously tracked run.
+    func track(_ handle: HiveRunHandle<ChatGraph.Schema>) async {
+        await registry.begin(handle.runID) { [outcome = handle.outcome] in
+            outcome.cancel()
+        }
     }
 
-    /// Cancels the currently tracked run.
-    func cancelCurrent() {
-        currentHandle?.outcome.cancel()
-        currentHandle = nil
+    /// Removes a finished run from tracking without cancelling it.
+    func untrack(_ runID: HiveRunID) async {
+        await registry.finish(runID)
+    }
+
+    /// Cancels every currently tracked run and clears the registry.
+    func cancelCurrent() async {
+        await registry.cancelAll()
     }
 }
 
 // HiveChatRole typed constants are defined in ChatGraph.swift (internal)
 // and shared across the HiveSwarm module.
 #endif
+
+// MARK: - TrackedRunRegistry
+
+/// Keyed registry of in-flight runs supporting concurrent registrations.
+///
+/// Ownership rules:
+/// - ``begin(_:onCancel:)`` records a run without touching other entries;
+///   registering a newer run must never cancel an older one.
+/// - ``finish(_:)`` removes exactly one settled run.
+/// - ``cancelAll()`` cancels every tracked run once and clears the registry.
+///
+/// Each entry stores the cancellation action for its run (typically the
+/// outcome task's `cancel()`), so cancellation always targets explicit
+/// handles rather than "the last registered" slot.
+///
+/// Generic over the key so the Hive bridge keys by `HiveRunID` while unit
+/// tests exercise identical semantics with plain identifiers.
+actor TrackedRunRegistry<Key: Hashable & Sendable> {
+    private var cancellers: [Key: @Sendable () -> Void] = [:]
+
+    /// Records a run's cancellation action under `key`.
+    func begin(_ key: Key, onCancel: @escaping @Sendable () -> Void) {
+        cancellers[key] = onCancel
+    }
+
+    /// Forgets one settled run without cancelling it.
+    func finish(_ key: Key) {
+        cancellers[key] = nil
+    }
+
+    /// Cancels every tracked run and clears the registry.
+    func cancelAll() {
+        for cancel in cancellers.values {
+            cancel()
+        }
+        cancellers.removeAll()
+    }
+
+    /// Number of runs currently tracked.
+    var trackedCount: Int {
+        cancellers.count
+    }
+}

--- a/Tests/SwarmTests/Agents/AgentRunCancellationRegistryTests.swift
+++ b/Tests/SwarmTests/Agents/AgentRunCancellationRegistryTests.swift
@@ -1,0 +1,449 @@
+// AgentRunCancellationRegistryTests.swift
+// Swarm Framework
+//
+// Deterministic tests for W3-T1 cancellation ownership: the per-run
+// ``Agent/ActiveRunRegistry`` replaces the single-slot state so concurrent
+// runs are individually tracked, `cancel()` reaches all of them (AC-103),
+// finishing one run never shadows another, and owned-loop gates deactivate
+// on exactly the same outcomes as before the settlement-primitive
+// consolidation (REQ-003).
+
+import Foundation
+import Testing
+@_spi(ColonyInternal) @testable import Swarm
+
+// MARK: - Test Helpers
+
+/// Counts cancellation firings behind a lock.
+private final class CancelProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var fires = 0
+
+    var count: Int {
+        lock.withLock { fires }
+    }
+
+    func fire() {
+        lock.withLock { fires += 1 }
+    }
+}
+
+/// Inference provider that signals each `generate` entry into an async
+/// stream and then hangs for `delay`, so tests synchronize on actual run
+/// progress instead of sleeping.
+private actor SignalingHangingProvider: InferenceProvider, MessagesFromPromptInference {
+    let delay: Duration
+    let entered: AsyncStream<Void>.Continuation
+
+    init(delay: Duration, entered: AsyncStream<Void>.Continuation) {
+        self.delay = delay
+        self.entered = entered
+    }
+
+    func generate(prompt _: String, options _: InferenceOptions) async throws -> String {
+        entered.yield()
+        try await Task.sleep(for: delay)
+        return "Final Answer: delayed"
+    }
+
+    nonisolated func stream(prompt: String, options: InferenceOptions) -> AsyncThrowingStream<String, Error> {
+        StreamHelper.makeTrackedStream { continuation in
+            let token = try await self.generate(prompt: prompt, options: options)
+            continuation.yield(token)
+            continuation.finish()
+        }
+    }
+
+    func generateWithToolCalls(
+        prompt: String,
+        tools _: [ToolSchema],
+        options: InferenceOptions
+    ) async throws -> InferenceResponse {
+        let content = try await generate(prompt: prompt, options: options)
+        return InferenceResponse(content: content, finishReason: .completed)
+    }
+}
+
+/// Operation body that parks on a manually released continuation. A body
+/// whose task was already cancelled refuses to park, so draining a losing
+/// operation after settlement can never strand a late-arriving parker; if
+/// ``release(_:)`` runs before the body parks, the release is armed instead.
+private final class ParkableGateOperation: @unchecked Sendable {
+    private let entered: AsyncStream<Void>.Continuation?
+    private let lock = NSLock()
+    private var parked: CheckedContinuation<String, Error>?
+    private var pendingRelease: Result<String, Error>?
+
+    init(entered: AsyncStream<Void>.Continuation? = nil) {
+        self.entered = entered
+    }
+
+    /// Resumes the parked body (or arms the release if not yet parked).
+    func release(_ result: Result<String, Error>) {
+        lock.lock()
+        if let continuation = parked {
+            parked = nil
+            lock.unlock()
+            continuation.resume(with: result)
+            return
+        }
+        pendingRelease = result
+        lock.unlock()
+    }
+
+    func run() async throws -> String {
+        try Task.checkCancellation()
+        return try await withCheckedThrowingContinuation { continuation in
+            lock.lock()
+            if let armed = pendingRelease {
+                pendingRelease = nil
+                lock.unlock()
+                continuation.resume(with: armed)
+                return
+            }
+            parked = continuation
+            let signal = entered
+            lock.unlock()
+            // Yield only after the continuation is installed so an observer of
+            // the event can rely on the body being parked.
+            signal?.yield()
+        }
+    }
+}
+
+/// Clock whose sleep parks until explicitly released. A worker already
+/// cancelled before sleeping refuses to park (it throws), so cleanup cannot
+/// strand a late-arriving sleeper.
+private final class SettableClockForGateTests: SwarmClock, @unchecked Sendable {
+    private let lock = NSLock()
+    private var sleepers: [CheckedContinuation<Void, Error>] = []
+
+    func nowNanoseconds() -> UInt64 {
+        DispatchTime.now().uptimeNanoseconds
+    }
+
+    func sleep(nanoseconds _: UInt64) async throws {
+        try Task.checkCancellation()
+        try await withCheckedThrowingContinuation { continuation in
+            lock.lock()
+            sleepers.append(continuation)
+            lock.unlock()
+        }
+    }
+
+    /// Wakes every parked sleep, returning normally from each.
+    func releaseAll() {
+        lock.lock()
+        let parked = sleepers
+        sleepers.removeAll()
+        lock.unlock()
+        for continuation in parked {
+            continuation.resume()
+        }
+    }
+}
+
+/// Awaits a task result with a watchdog bound so regressions surface as fast
+/// failures instead of hangs; the bound never decides a passing outcome.
+private func boundedResult<T: Sendable>(
+    of task: Task<T, Error>,
+    timeout: Duration
+) async -> Result<T, Error>? {
+    await withTaskGroup(of: Result<T, Error>?.self) { group in
+        group.addTask {
+            do {
+                return .success(try await task.value)
+            } catch {
+                return .failure(error)
+            }
+        }
+        group.addTask {
+            try? await Task.sleep(for: timeout)
+            return nil
+        }
+        let first = await group.next() ?? nil
+        group.cancelAll()
+        return first
+    }
+}
+
+// MARK: - Registry Unit Tests
+
+@Suite("ActiveRunRegistry Tests")
+private struct ActiveRunRegistryTests {
+    @Test("cancel(runID) fires only that run's canceller")
+    func cancelTargetsSingleRun() async {
+        let registry = Agent.ActiveRunRegistry()
+        let first = CancelProbe()
+        let second = CancelProbe()
+        let firstID = UUID()
+        let secondID = UUID()
+
+        await registry.begin(firstID, onCancel: { first.fire() })
+        await registry.begin(secondID, onCancel: { second.fire() })
+
+        await registry.cancel(firstID)
+
+        #expect(first.count == 1)
+        #expect(second.count == 0)
+    }
+
+    @Test("finish removes exactly its own run; finished runs never shadow live ones")
+    func finishRemovesOnlyItsOwnRun() async {
+        let registry = Agent.ActiveRunRegistry()
+        let first = CancelProbe()
+        let second = CancelProbe()
+        let firstID = UUID()
+        let secondID = UUID()
+
+        await registry.begin(firstID, onCancel: { first.fire() })
+        await registry.begin(secondID, onCancel: { second.fire() })
+        await registry.finish(firstID)
+
+        #expect(await registry.trackedCount == 1)
+
+        await registry.cancelAll()
+
+        // The finished run's canceller must never fire again...
+        #expect(first.count == 0)
+        // ...while the live run is still reachable.
+        #expect(second.count == 1)
+    }
+
+    @Test("cancelAll cancels every concurrently in-flight run")
+    func cancelAllReachesEveryRun() async {
+        let registry = Agent.ActiveRunRegistry()
+        let probes = (CancelProbe(), CancelProbe(), CancelProbe())
+
+        await registry.begin(UUID(), onCancel: { probes.0.fire() })
+        await registry.begin(UUID(), onCancel: { probes.1.fire() })
+        await registry.begin(UUID(), onCancel: { probes.2.fire() })
+
+        await registry.cancelAll()
+
+        #expect(probes.0.count == 1)
+        #expect(probes.1.count == 1)
+        #expect(probes.2.count == 1)
+    }
+
+    @Test("re-registering an ID replaces its canceller without firing it")
+    func reBeginReplacesSilently() async {
+        let registry = Agent.ActiveRunRegistry()
+        let original = CancelProbe()
+        let replacement = CancelProbe()
+        let id = UUID()
+
+        await registry.begin(id, onCancel: { original.fire() })
+        await registry.begin(id, onCancel: { replacement.fire() })
+
+        await registry.cancelAll()
+
+        #expect(original.count == 0)
+        #expect(replacement.count == 1)
+    }
+
+    @Test("trackedCount reflects begin and finish transitions")
+    func trackedCountTransitions() async {
+        let registry = Agent.ActiveRunRegistry()
+
+        let a = UUID()
+        let b = UUID()
+        await registry.begin(a, onCancel: {})
+        await registry.begin(b, onCancel: {})
+        #expect(await registry.trackedCount == 2)
+
+        await registry.finish(a)
+        #expect(await registry.trackedCount == 1)
+
+        await registry.finish(b)
+        #expect(await registry.trackedCount == 0)
+    }
+}
+
+// MARK: - Agent-Level Cancel All (AC-103)
+
+@Suite("Agent Cancel All Runs")
+private struct AgentCancelAllRunsTests {
+    @Test("agent.cancel() cancels two concurrently in-flight runs (AC-103)")
+    func cancelReachesAllConcurrentRuns() async throws {
+        let (enteredStream, entered) = AsyncStream<Void>.makeStream(bufferingPolicy: .unbounded)
+        let provider = SignalingHangingProvider(delay: .seconds(60), entered: entered)
+        let agent = try Agent(
+            tools: [],
+            instructions: "Cancel-all test agent",
+            inferenceProvider: provider
+        )
+
+        let first = Task {
+            try await agent.run("first")
+        }
+        let second = Task {
+            try await agent.run("second")
+        }
+
+        // Event-driven readiness: once both runs entered inference they are
+        // both registered in the per-run registry.
+        var entries = 0
+        for await _ in enteredStream {
+            entries += 1
+            if entries == 2 { break }
+        }
+        #expect(entries == 2)
+
+        await agent.cancel()
+
+        guard let firstOutcome = await boundedResult(of: first, timeout: .seconds(2)) else {
+            first.cancel()
+            second.cancel()
+            Issue.record("First run did not settle promptly after agent.cancel()")
+            return
+        }
+        guard let secondOutcome = await boundedResult(of: second, timeout: .seconds(2)) else {
+            second.cancel()
+            Issue.record("Second run did not settle promptly after agent.cancel()")
+            return
+        }
+
+        for (label, outcome) in [("first", firstOutcome), ("second", secondOutcome)] {
+            guard case let .failure(error as AgentError) = outcome else {
+                Issue.record("\(label) run should fail after cancel(), got \(outcome)")
+                continue
+            }
+            #expect(error == .cancelled, "\(label) run expected .cancelled, got \(error)")
+        }
+    }
+}
+
+// MARK: - Owned Loop Gate Deactivation Parity (REQ-003)
+
+@Suite("Owned Loop Gate Deactivation Parity")
+private struct OwnedLoopGateDeactivationTests {
+    @Test("gate deactivates when the timeout wins")
+    func gateDeactivatesOnTimeout() async throws {
+        let agent = try Agent(instructions: "Gate timeout agent", inferenceProvider: nil)
+        let gate = ProviderOwnedLoopGate()
+        // Instant-return fake clock: only the timer side can settle this
+        // race because the operation parks on an unreleased continuation.
+        let clock = VirtualClock(startingAtNanoseconds: 0)
+        let operation = ParkableGateOperation()
+
+        let work = Task<String, Error> {
+            try await agent.executeWithinRemainingTimeout(
+                startTime: ContinuousClock.now,
+                executionGate: gate,
+                clock: clock
+            ) {
+                try await operation.run()
+            }
+        }
+
+        guard case let .failure(error)? = await boundedResult(of: work, timeout: .seconds(2)) else {
+            work.cancel()
+            operation.release(.success("drain"))
+            Issue.record("Timeout did not settle the race promptly")
+            return
+        }
+        guard case .timeout = error as? AgentError else {
+            operation.release(.success("drain"))
+            work.cancel()
+            Issue.record("Expected AgentError.timeout, got \(error)")
+            return
+        }
+        #expect(!gate.isActive)
+        // REQ-006 pin at the agent seam: the timer suspension went through
+        // the injected SwarmClock, not a raw Task.sleep.
+        #expect(clock.sleepCount == 1)
+
+        operation.release(.success("drain"))
+        work.cancel()
+    }
+
+    @Test("gate stays armed when the operation succeeds")
+    func gateStaysArmedOnSuccess() async throws {
+        let agent = try Agent(instructions: "Gate success agent", inferenceProvider: nil)
+        let gate = ProviderOwnedLoopGate()
+        let clock = SettableClockForGateTests()
+        // Timer stays parked until cleanup: the operation wins the race.
+        defer { clock.releaseAll() }
+
+        let value = try await agent.executeWithinRemainingTimeout(
+            startTime: ContinuousClock.now,
+            executionGate: gate,
+            clock: clock
+        ) {
+            "done"
+        }
+
+        #expect(value == "done")
+        #expect(gate.isActive)
+    }
+
+    @Test("gate stays armed on ordinary operation failure")
+    func gateStaysArmedOnOperationFailure() async throws {
+        let agent = try Agent(instructions: "Gate failure agent", inferenceProvider: nil)
+        let gate = ProviderOwnedLoopGate()
+        let clock = SettableClockForGateTests()
+        defer { clock.releaseAll() }
+
+        struct ToolExplosion: Error {}
+        do {
+            _ = try await agent.executeWithinRemainingTimeout(
+                startTime: ContinuousClock.now,
+                executionGate: gate,
+                clock: clock
+            ) {
+                throw ToolExplosion()
+            }
+            Issue.record("Expected ToolExplosion to propagate")
+        } catch is ToolExplosion {
+            // Expected winner.
+        }
+
+        #expect(gate.isActive)
+    }
+
+    @Test("gate deactivates when the parent task is cancelled")
+    func gateDeactivatesOnParentCancellation() async throws {
+        let agent = try Agent(instructions: "Gate cancel agent", inferenceProvider: nil)
+        let gate = ProviderOwnedLoopGate()
+        let clock = SettableClockForGateTests()
+        let (enteredStream, entered) = AsyncStream<Void>.makeStream(bufferingPolicy: .unbounded)
+        let operation = ParkableGateOperation(entered: entered)
+
+        let work = Task<String, Error> {
+            try await agent.executeWithinRemainingTimeout(
+                startTime: ContinuousClock.now,
+                executionGate: gate,
+                clock: clock
+            ) {
+                try await operation.run()
+            }
+        }
+
+        // Wait until the race is fully installed and the operation parked, so
+        // cancellation settles through the race's cancellation handler exactly
+        // like an in-flight run (pre-install cancellation exits at
+        // Task.checkCancellation before any gate exists — same as before the
+        // consolidation).
+        _ = await enteredStream.first(where: { _ in true })
+        work.cancel()
+
+        guard case let .failure(error)? = await boundedResult(of: work, timeout: .seconds(2)) else {
+            work.cancel()
+            operation.release(.success("drain"))
+            clock.releaseAll()
+            Issue.record("Parent cancellation did not settle the race promptly")
+            return
+        }
+        guard error is CancellationError else {
+            operation.release(.success("drain"))
+            clock.releaseAll()
+            Issue.record("Expected raw CancellationError, got \(error)")
+            return
+        }
+        #expect(!gate.isActive)
+
+        operation.release(.success("drain"))
+        clock.releaseAll()
+    }
+}

--- a/Tests/SwarmTests/Agents/GraphRunTrackingTests.swift
+++ b/Tests/SwarmTests/Agents/GraphRunTrackingTests.swift
@@ -1,0 +1,119 @@
+// GraphRunTrackingTests.swift
+// Swarm Framework
+//
+// Deterministic tests for W3-T1 graph-run cancellation ownership: the keyed
+// ``TrackedRunRegistry`` behind GraphAgent.CancellationController registers
+// concurrent Hive runs without disturbing earlier ones and cancellation
+// targets explicit runs instead of the most recent registration (AC-104).
+// The registry is generic over its key precisely so unit tests can exercise
+// the exact semantics used by the Hive bridge with plain identifiers.
+
+// The registry lives in GraphAgent.swift, which only compiles when
+// integration targets are enabled; gate identically so lean builds skip it.
+#if SWARM_INTEGRATIONS
+import Foundation
+import Testing
+@testable import Swarm
+
+/// Counts cancellation firings behind a lock.
+private final class CancelProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var fires = 0
+
+    var count: Int {
+        lock.withLock { fires }
+    }
+
+    func fire() {
+        lock.withLock { fires += 1 }
+    }
+}
+
+@Suite("TrackedRunRegistry Tests")
+private struct TrackedRunRegistryTests {
+    @Test("registering a new run leaves previously tracked runs untouched (AC-104)")
+    func beginDoesNotCancelPreviousRun() async {
+        let registry = TrackedRunRegistry<String>()
+        let first = CancelProbe()
+        let second = CancelProbe()
+
+        await registry.begin("run-1", onCancel: { first.fire() })
+        #expect(first.count == 0)
+
+        // Regression guard: the single-slot controller this registry replaces
+        // cancelled the previous handle right here.
+        await registry.begin("run-2", onCancel: { second.fire() })
+
+        #expect(first.count == 0)
+        #expect(second.count == 0)
+        #expect(await registry.trackedCount == 2)
+
+        // Both runs remain individually cancellable.
+        await registry.cancelAll()
+        #expect(first.count == 1)
+        #expect(second.count == 1)
+    }
+
+    @Test("finish removes one settled run without cancelling anything")
+    func finishRemovesWithoutCancelling() async {
+        let registry = TrackedRunRegistry<String>()
+        let first = CancelProbe()
+        let second = CancelProbe()
+
+        await registry.begin("run-1", onCancel: { first.fire() })
+        await registry.begin("run-2", onCancel: { second.fire() })
+
+        await registry.finish("run-1")
+
+        #expect(first.count == 0)
+        #expect(second.count == 0)
+        #expect(await registry.trackedCount == 1)
+
+        await registry.cancelAll()
+        #expect(first.count == 0)
+        #expect(second.count == 1)
+    }
+
+    @Test("cancelAll cancels every tracked run exactly once")
+    func cancelAllFiresEveryCancellerOnce() async {
+        let registry = TrackedRunRegistry<String>()
+        let first = CancelProbe()
+        let second = CancelProbe()
+        let third = CancelProbe()
+
+        await registry.begin("run-1", onCancel: { first.fire() })
+        await registry.begin("run-2", onCancel: { second.fire() })
+        await registry.begin("run-3", onCancel: { third.fire() })
+
+        await registry.cancelAll()
+
+        #expect(first.count == 1)
+        #expect(second.count == 1)
+        #expect(third.count == 1)
+        #expect(await registry.trackedCount == 0)
+
+        // A second cancel is idempotent: entries were cleared.
+        await registry.cancelAll()
+        #expect(first.count == 1)
+        #expect(second.count == 1)
+        #expect(third.count == 1)
+    }
+
+    @Test("re-registering a finished run ID tracks the new canceller")
+    func reBeginAfterFinishTracksReplacement() async {
+        let registry = TrackedRunRegistry<String>()
+        let original = CancelProbe()
+        let replacement = CancelProbe()
+
+        await registry.begin("run-1", onCancel: { original.fire() })
+        await registry.finish("run-1")
+        await registry.begin("run-1", onCancel: { replacement.fire() })
+
+        await registry.cancelAll()
+
+        #expect(original.count == 0)
+        #expect(replacement.count == 1)
+    }
+}
+
+#endif

--- a/Tests/SwarmTests/Core/TimeoutRaceSettlementHookTests.swift
+++ b/Tests/SwarmTests/Core/TimeoutRaceSettlementHookTests.swift
@@ -1,0 +1,286 @@
+// TimeoutRaceSettlementHookTests.swift
+// Swarm Framework
+//
+// Deterministic tests for the `onSettle` hook added to the shared settlement
+// primitive (W3-T1): replayed pre-install outcomes run the hook, the hook
+// observes the exact winning outcome exactly once, and the timeout path runs
+// through the SwarmClock seam. All timing is driven by fake clocks or
+// explicit settlement — no assertion depends on real-sleep timing.
+
+import Foundation
+import Testing
+@_spi(ColonyInternal) @testable import Swarm
+
+// MARK: - Test Helpers
+
+/// Records every `onSettle` invocation behind a lock.
+private final class HookRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var outcomes: [Error?] = []
+
+    var calls: [Error?] {
+        lock.withLock { outcomes }
+    }
+
+    func record(_ error: Error?) {
+        lock.withLock {
+            outcomes.append(error)
+        }
+    }
+}
+
+/// Clock whose sleep parks until explicitly released, so tests decide which
+/// race side settles. Resuming normally lets the timer branch proceed. A
+/// worker already cancelled before sleeping refuses to park (it throws),
+/// so cleanup cannot strand a late-arriving sleeper; workers parked first are
+/// not woken by task cancellation and must be released via ``releaseAll()``.
+private final class SettableTestClock: SwarmClock, @unchecked Sendable {
+    private let lock = NSLock()
+    private var sleepers: [CheckedContinuation<Void, Error>] = []
+
+    func nowNanoseconds() -> UInt64 {
+        DispatchTime.now().uptimeNanoseconds
+    }
+
+    func sleep(nanoseconds _: UInt64) async throws {
+        try Task.checkCancellation()
+        try await withCheckedThrowingContinuation { continuation in
+            lock.lock()
+            sleepers.append(continuation)
+            lock.unlock()
+        }
+    }
+
+    /// Wakes every parked sleep, returning normally from each.
+    func releaseAll() {
+        lock.lock()
+        let parked = sleepers
+        sleepers.removeAll()
+        lock.unlock()
+        for continuation in parked {
+            continuation.resume()
+        }
+    }
+}
+
+/// Operation body that parks on a manually released continuation, giving
+/// tests explicit control over whether the raced operation can settle. A
+/// body whose task was already cancelled refuses to park, so draining a
+/// losing operation after settlement can never strand a late-arriving parker.
+private final class ParkableOperation: @unchecked Sendable {
+    private let lock = NSLock()
+    private var parked: CheckedContinuation<String, Error>?
+    private var pendingRelease: Result<String, Error>?
+
+    /// Resumes the parked body (or arms the release if not yet parked).
+    func release(_ result: Result<String, Error>) {
+        lock.lock()
+        if let continuation = parked {
+            parked = nil
+            lock.unlock()
+            continuation.resume(with: result)
+            return
+        }
+        pendingRelease = result
+        lock.unlock()
+    }
+
+    func run() async throws -> String {
+        try Task.checkCancellation()
+        return try await withCheckedThrowingContinuation { continuation in
+            lock.lock()
+            if let release = pendingRelease {
+                pendingRelease = nil
+                lock.unlock()
+                continuation.resume(with: release)
+                return
+            }
+            parked = continuation
+            lock.unlock()
+        }
+    }
+}
+
+private struct BoomError: Error {}
+
+// MARK: - Settlement Hook Tests
+
+@Suite("TimeoutRace Settlement Hook")
+private struct TimeoutRaceSettlementHookTests {
+    @Test("onSettle fires once with nil when the operation succeeds")
+    func hookFiresOnceWithNilOnSuccess() async throws {
+        let recorder = HookRecorder()
+        let clock = SettableTestClock()
+        // The timer stays parked until cleanup releases it, so the operation
+        // deterministically wins the race.
+        defer { clock.releaseAll() }
+
+        let value = try await withTimeoutRace(
+            timeout: .seconds(30),
+            clock: clock,
+            timeoutError: AgentError.timeout(duration: .seconds(30)),
+            onSettle: recorder.record
+        ) {
+            42
+        }
+
+        #expect(value == 42)
+        #expect(recorder.calls.count == 1)
+        #expect(recorder.calls[0] == nil)
+    }
+
+    @Test("onSettle receives the exact operation failure")
+    func hookReceivesOperationFailure() async throws {
+        let recorder = HookRecorder()
+        let clock = SettableTestClock()
+        defer { clock.releaseAll() }
+
+        do {
+            _ = try await withTimeoutRace(
+                timeout: .seconds(30),
+                clock: clock,
+                timeoutError: AgentError.timeout(duration: .seconds(30)),
+                onSettle: recorder.record
+            ) {
+                throw BoomError()
+            }
+            Issue.record("Expected BoomError to propagate")
+        } catch is BoomError {
+            // Expected winner.
+        }
+
+        #expect(recorder.calls.count == 1)
+        #expect(recorder.calls.first is BoomError)
+    }
+
+    @Test("onSettle receives CancellationError when the parent task is cancelled")
+    func hookReceivesParentCancellation() async throws {
+        let recorder = HookRecorder()
+        let clock = SettableTestClock()
+        let parkable = ParkableOperation()
+
+        // The operation parks, so settlement can only come from the parent's
+        // cancellation handler.
+        let work = Task<String, Error> {
+            try await withTimeoutRace(
+                timeout: .seconds(30),
+                clock: clock,
+                timeoutError: AgentError.timeout(duration: .seconds(30)),
+                onSettle: recorder.record
+            ) {
+                try await parkable.run()
+            }
+        }
+        work.cancel()
+
+        guard case let .failure(error)? = await boundedOutcome(of: work, timeout: .seconds(2)) else {
+            work.cancel()
+            parkable.release(.success("drain"))
+            clock.releaseAll()
+            Issue.record("Race did not settle promptly after parent cancellation")
+            return
+        }
+        #expect(error is CancellationError)
+
+        #expect(recorder.calls.count == 1)
+        #expect(recorder.calls.first is CancellationError)
+
+        parkable.release(.success("drain"))
+        clock.releaseAll()
+    }
+
+    @Test("outcome recorded before install replays and still runs onSettle")
+    func hookRunsForPreInstallSettlement() async throws {
+        let recorder = HookRecorder()
+        let race = TimeoutRace<Int>(onSettle: recorder.record)
+        race.finish(returning: 7)
+
+        let value = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Int, Error>) in
+            race.install(continuation: continuation)
+        }
+
+        // AC-101 companion: the replay path applies the hook exactly like a
+        // live settlement, with no hang between record and install.
+        #expect(value == 7)
+        #expect(recorder.calls.count == 1)
+        #expect(recorder.calls[0] == nil)
+    }
+
+    @Test("timeout wins deterministically on an instant-return fake clock")
+    func timeoutWinsOnInstantFakeClock() async throws {
+        let recorder = HookRecorder()
+        let clock = VirtualClock(startingAtNanoseconds: 0)
+
+        let work = Task<String, Error> {
+            try await withTimeoutRace(
+                timeout: .milliseconds(5),
+                clock: clock,
+                timeoutError: AgentError.timeout(duration: .milliseconds(5)),
+                onSettle: recorder.record
+            ) {
+                try await Task.sleep(nanoseconds: 60_000_000_000)
+                return "never"
+            }
+        }
+
+        guard case let .failure(error)? = await boundedOutcome(of: work, timeout: .seconds(2)) else {
+            work.cancel()
+            Issue.record("Instant-clock timeout did not settle the race promptly")
+            return
+        }
+
+        guard case .timeout = error as? AgentError else {
+            Issue.record("Expected AgentError.timeout, got \(error)")
+            return
+        }
+        #expect(recorder.calls.count == 1)
+        #expect(recorder.calls.first is AgentError)
+        // REQ-006 pin: the timer suspension went through the SwarmClock seam,
+        // not a raw Task.sleep.
+        #expect(clock.sleepCount == 1)
+
+        work.cancel()
+    }
+
+    @Test("tasks registered against a settled coordinator are cancelled synchronously")
+    func lateRegistrationCancelledAfterSettlement() {
+        // AC-102 through the class seam, where registration order is fully
+        // controlled: both worker slots registered after settlement must be
+        // cancelled immediately instead of being stored for a replay that can
+        // never happen.
+        let race = TimeoutRace<Int>(onSettle: nil)
+        race.finish(returning: 1)
+
+        let lateOperation = Task { _ = try? await Task.sleep(nanoseconds: 5_000_000_000) }
+        race.setOperationTask(lateOperation)
+        let lateTimer = Task { _ = try? await Task.sleep(nanoseconds: 5_000_000_000) }
+        race.setTimeoutTask(lateTimer)
+
+        #expect(lateOperation.isCancelled)
+        #expect(lateTimer.isCancelled)
+    }
+}
+
+/// Awaits a task result with a watchdog bound so regressions surface as fast
+/// failures instead of hangs; the bound never decides a passing outcome.
+private func boundedOutcome<T: Sendable>(
+    of task: Task<T, Error>,
+    timeout: Duration
+) async -> Result<T, Error>? {
+    await withTaskGroup(of: Result<T, Error>?.self) { group in
+        group.addTask {
+            do {
+                return .success(try await task.value)
+            } catch {
+                return .failure(error)
+            }
+        }
+        group.addTask {
+            try? await Task.sleep(for: timeout)
+            return nil
+        }
+        let first = await group.next() ?? nil
+        group.cancelAll()
+        return first
+    }
+}


### PR DESCRIPTION
## Ticket
W3-T1 of spec `swift-arch-3ad8899e` (wave-3 architecture: settlement primitive + cancellation ownership). Discovery report: swift-architecture-review-Swarm-20260825-1715.

## What
- Deletes `TimedOperationCoordinator` — a drifted duplicate of `TimeoutRace` whose `install` lacked replay safety (verified continuation-stranding hang window) and whose post-settlement task registration was never cancelled.
- `executeWithinRemainingTimeout` now routes through `withTimeoutRace`, extended with a one-shot `onSettle(Error?)` hook that moves owned-loop-gate deactivation behind the primitive (exact parity: fires only on `CancellationError` / `AgentError.timeout`).
- Timeout suspension routes through the injected `SwarmClock` seam (raw `Task.sleep(for:)` eliminated).
- Replaces single-slot `ActiveRunCancellationState` (concurrent runs overwrote each other's cancel target) with an internal registry keyed by runID. Public `cancel()` signature unchanged; behavior is a documented superset (cancels all in-flight runs instead of newest-only).
- `GraphAgent.CancellationController`: tracking a new run no longer cancels the previous one (`TrackedRunRegistry`); untrack paired on run + stream completion paths.

## Tests
Deterministic Swift Testing suites: settlement-hook replay/late-registration semantics, gate-deactivation parity, multi-run cancellation end-to-end, graph-run tracking regression guard (integration-gated where the subject type is).

42 tests / 8 lean suites green · 4/4 integration-profile green · lean build clean.

## Review
Fresh-context adversarial review (swift-adversarial-pr-review) ×2 rounds: 1 major fixed (registry `cancelAll` parity), rest verified/dismissed-with-reason. Final pass: READY.

Known deferral: single-implementation consolidation of the two keyed registries lands in W3-T2 (lean builds exclude Internal/GraphRuntime, so unification is impossible in this ticket).