### PR TITLE
arch(W3-T3): converge resilience behind one canonical retry seam

### DIFF
--- a/Sources/Swarm/Agents/Agent+Resilience.swift
+++ b/Sources/Swarm/Agents/Agent+Resilience.swift
@@ -74,6 +74,13 @@ extension Agent {
         return try await invoke()
     }
 
+    /// Retries provider inference under the canonical internal seam
+    /// ``ResilienceRetry`` (W3-T3), which pins the historical semantics:
+    /// hard gate (`InferenceRetryability`) conjoined with `shouldRetry`,
+    /// initial attempt + `maxAttempts` retries, immediate cancellation
+    /// rethrow, and `ResilienceError.retriesExhausted` on budget exhaustion.
+    /// This wrapper only layers agent-path side effects onto each retry:
+    /// warning log, observer callback, trace metric.
     private static func invokeWithRetry<T: Sendable>(
         policy: RetryPolicy,
         agent: any AgentRuntime,
@@ -81,31 +88,17 @@ extension Agent {
         tracing: TracingHelper?,
         operation: @escaping @Sendable () async throws -> T
     ) async throws -> T {
-        guard policy.maxAttempts > 0 else {
-            return try await operation()
-        }
-
-        let retryPolicy = RetryPolicy(
-            maxAttempts: policy.maxAttempts,
-            backoff: policy.backoff,
-            shouldRetry: { error in
-                InferenceRetryability.isRetryable(error) && policy.shouldRetry(error)
-            },
-            onRetry: { attempt, error in
-                await policy.onRetry?(attempt, error)
-                Log.agents.warning(
-                    "Inference retry attempt \(attempt): \(error.localizedDescription)"
-                )
-                await observer?.onInferenceRetry(
-                    context: nil,
-                    agent: agent,
-                    attempt: attempt,
-                    error: error
-                )
-                await tracing?.traceInferenceRetry(attempt: attempt, error: error)
-            }
-        )
-
-        return try await retryPolicy.execute(operation)
+        try await ResilienceRetry.run(policy: policy, onRetryAttempt: { attempt, error in
+            Log.agents.warning(
+                "Inference retry attempt \(attempt): \(error.localizedDescription)"
+            )
+            await observer?.onInferenceRetry(
+                context: nil,
+                agent: agent,
+                attempt: attempt,
+                error: error
+            )
+            await tracing?.traceInferenceRetry(attempt: attempt, error: error)
+        }, operation: operation)
     }
 }

--- a/Sources/Swarm/Internal/GraphRuntime/ChatGraph.swift
+++ b/Sources/Swarm/Internal/GraphRuntime/ChatGraph.swift
@@ -946,16 +946,16 @@ extension ChatGraph {
     ///   W3-T3 REQ-010 / AC-301 documented-divergence clause). A classifier
     ///   closure alone cannot reconcile these, so this local loop is kept:
     ///   1. Attempt accounting — here `maxAttempts` counts **total** attempts
-    ///      (`for attempt in 0 ..< maxAttempts`, line ~959); the agent path
+    ///      (`for attempt in 0 ..< maxAttempts`, line ~983); the agent path
     ///      treats `maxAttempts` as retries *after* the initial attempt
     ///      (`retryCount < maxAttempts` guard).
     ///   2. Exhaustion surface — the last operation error is rethrown verbatim
-    ///      (lines ~973–974) so graph-runtime errors (e.g.
+    ///      (lines ~997–998) so graph-runtime errors (e.g.
     ///      `SwarmRuntimeError.modelStreamInvalid`) reach `HiveRunResult`
     ///      unchanged; the agent path wraps exhaustion in
     ///      `ResilienceError.retriesExhausted(attempts:lastError:)`.
     ///   3. Retry gating — every caught error is retried unconditionally,
-    ///      including `CancellationError` (catch at lines ~962–971 has no
+    ///      including `CancellationError` (catch at lines ~986–995 has no
     ///      cancellation short-circuit); the agent path hard-gates on
     ///      `InferenceRetryability.isRetryable` + user `shouldRetry` and never
     ///      retries cancellation.

--- a/Sources/Swarm/Internal/GraphRuntime/ChatGraph.swift
+++ b/Sources/Swarm/Internal/GraphRuntime/ChatGraph.swift
@@ -940,6 +940,30 @@ extension ChatGraph {
     /// Uses the Hive clock for deterministic backoff sleep — no jitter is applied.
     /// Returns immediately on the first success, or rethrows the last error
     /// after all attempts are exhausted.
+    ///
+    /// - Note: Deliberate divergence from the canonical agent-inference retry
+    ///   seam (`Sources/Swarm/Internal/TurnEngine/ResilienceRetry.swift`,
+    ///   W3-T3 REQ-010 / AC-301 documented-divergence clause). A classifier
+    ///   closure alone cannot reconcile these, so this local loop is kept:
+    ///   1. Attempt accounting — here `maxAttempts` counts **total** attempts
+    ///      (`for attempt in 0 ..< maxAttempts`, line ~959); the agent path
+    ///      treats `maxAttempts` as retries *after* the initial attempt
+    ///      (`retryCount < maxAttempts` guard).
+    ///   2. Exhaustion surface — the last operation error is rethrown verbatim
+    ///      (lines ~973–974) so graph-runtime errors (e.g.
+    ///      `SwarmRuntimeError.modelStreamInvalid`) reach `HiveRunResult`
+    ///      unchanged; the agent path wraps exhaustion in
+    ///      `ResilienceError.retriesExhausted(attempts:lastError:)`.
+    ///   3. Retry gating — every caught error is retried unconditionally,
+    ///      including `CancellationError` (catch at lines ~962–971 has no
+    ///      cancellation short-circuit); the agent path hard-gates on
+    ///      `InferenceRetryability.isRetryable` + user `shouldRetry` and never
+    ///      retries cancellation.
+    ///   4. Backoff math — saturating `delay * factor` growth where the cap is
+    ///      applied per-sleep (`min(delay, maxNs)`) and growth happens after
+    ///      each sleep; the agent path evaluates
+    ///      `BackoffStrategy.delay(forAttempt:)` (including jitter strategies)
+    ///      sanitized to a fixed one-hour ceiling before sleeping.
     private static func withRetry<T>(
         policy: HiveRetryPolicy?,
         clock: any HiveClock,

--- a/Sources/Swarm/Internal/TurnEngine/ResilienceRetry.swift
+++ b/Sources/Swarm/Internal/TurnEngine/ResilienceRetry.swift
@@ -1,0 +1,123 @@
+// ResilienceRetry.swift
+// Swarm Framework
+//
+// Canonical retry/backoff loop for agent provider inference (W3-T3).
+//
+// Single source of truth for the inference retry path previously inlined in
+// `Agent+Resilience.invokeWithRetry` as a derived `RetryPolicy` fed to the
+// public `RetryPolicy.execute`. Semantics are identical to the pre-W3-T3
+// agent path:
+//
+// - Attempt budget: one initial attempt plus `policy.maxAttempts` retries;
+//   `maxAttempts == 0` short-circuits to a single bare attempt whose error is
+//   rethrown verbatim (never wrapped).
+// - Hard retryability gate: retries require BOTH
+//   ``InferenceRetryability/isRetryable(_:)`` and the user-supplied
+//   `RetryPolicy.shouldRetry` predicate.
+// - Cancellation: a `CancellationError` or an already-cancelled task rethrows
+//   immediately without consuming budget or sleeping.
+// - Exhaustion throws `ResilienceError.retriesExhausted(attempts:lastError:)`
+//   with `attempts == maxAttempts + 1`.
+// - Backoff: `BackoffStrategy.delay(forAttempt:)` sanitized into
+//   `[0, 1h]` nanoseconds before each sleep.
+//
+// Delays suspend through the injected `SwarmClock` seam (wave-1 convention),
+// so suites drive exact backoff progression deterministically with a virtual
+// clock instead of real sleeps.
+//
+// Divergence note: `ChatGraph.withRetry`
+// (`Sources/Swarm/Internal/GraphRuntime/ChatGraph.swift`) deliberately keeps
+// its own local loop for the Hive graph path; its doc comment cites the
+// concrete semantic differences (total-attempt counting, verbatim last-error
+// rethrow in the graph runtime error domain, unconditional retry gating).
+
+import Foundation
+
+/// Namespace for the canonical agent-inference retry executor.
+///
+/// See the file header for the pinned semantics and the deliberate
+/// `ChatGraph.withRetry` divergence.
+enum ResilienceRetry {
+    /// Backoff ceiling shared with ``RetryPolicy``: one hour in nanoseconds.
+    private static let maxBackoffNanoseconds: UInt64 = 3_600_000_000_000
+
+    /// Runs `operation` under the canonical inference retry policy.
+    ///
+    /// - Parameters:
+    ///   - policy: User retry configuration; `maxAttempts` counts retries
+    ///     **after** the initial attempt.
+    ///   - clock: Suspension seam for backoff delays; inject a virtual clock
+    ///     in tests for deterministic progression.
+    ///   - onRetryAttempt: Extra per-retry side effects (logging, observer,
+    ///     tracing), invoked after `policy.onRetry` and before the backoff
+    ///     sleep, preserving the historical agent-path ordering.
+    ///   - operation: The inference call to protect.
+    static func run<T: Sendable>(
+        policy: RetryPolicy,
+        clock: any SwarmClock = LiveSwarmClock.live,
+        onRetryAttempt: (@Sendable (Int, Error) async -> Void)? = nil,
+        operation: @escaping @Sendable () async throws -> T
+    ) async throws -> T {
+        guard policy.maxAttempts > 0 else {
+            return try await operation()
+        }
+
+        var retryCount = 0
+        var lastError: (any Error)?
+
+        while true {
+            do {
+                return try await operation()
+            } catch {
+                if error is CancellationError || Task.isCancelled {
+                    throw error
+                }
+
+                lastError = error
+
+                guard retryCount < policy.maxAttempts else {
+                    break
+                }
+
+                // Hard retryability gate conjoined with the user predicate;
+                // identical composition to the pre-convergence
+                // `invokeWithRetry` wrapper.
+                guard InferenceRetryability.isRetryable(error) && policy.shouldRetry(error) else {
+                    throw error
+                }
+
+                retryCount += 1
+
+                await policy.onRetry?(retryCount, error)
+                await onRetryAttempt?(retryCount, error)
+
+                let delay = sanitizedBackoffNanoseconds(policy.backoff.delay(forAttempt: retryCount))
+                if delay > 0 {
+                    try await clock.sleep(nanoseconds: delay)
+                }
+            }
+        }
+
+        throw ResilienceError.retriesExhausted(
+            attempts: retryCount + 1,
+            lastError: lastError?.localizedDescription ?? "Unknown error"
+        )
+    }
+
+    private static func sanitizedBackoffNanoseconds(_ delaySeconds: TimeInterval) -> UInt64 {
+        guard delaySeconds.isFinite, delaySeconds > 0 else {
+            return 0
+        }
+
+        let nanoseconds = delaySeconds * 1_000_000_000
+        guard nanoseconds.isFinite, nanoseconds > 0 else {
+            return 0
+        }
+
+        if nanoseconds >= Double(maxBackoffNanoseconds) {
+            return maxBackoffNanoseconds
+        }
+
+        return UInt64(nanoseconds)
+    }
+}

--- a/Tests/SwarmTests/Resilience/TurnEngineResilienceRetryTests.swift
+++ b/Tests/SwarmTests/Resilience/TurnEngineResilienceRetryTests.swift
@@ -1,0 +1,407 @@
+// TurnEngineResilienceRetryTests.swift
+// Swarm Framework
+//
+// Deterministic tests for the canonical inference retry seam
+// (`ResilienceRetry`, W3-T3). All backoff progression runs against a
+// `VirtualClock` — no real sleeps. Also pins the documented divergence of the
+// Hive graph path's local retry loop (`ChatGraph.withRetry`) at both sites.
+
+import Foundation
+@_spi(ColonyInternal) @testable import Swarm
+import Testing
+
+// MARK: - Fixtures
+
+/// Unclassified error type: `InferenceRetryability` fails closed on it.
+private struct UnclassifiedError: Error, Equatable {}
+
+private actor CallCounter {
+    private(set) var count = 0
+
+    func increment() -> Int {
+        count += 1
+        return count
+    }
+}
+
+private final class RetryEventLog: @unchecked Sendable {
+    private let lock = NSLock()
+    private var items: [String] = []
+
+    func record(_ item: String) {
+        lock.withLock { items.append(item) }
+    }
+
+    var entries: [String] {
+        lock.withLock { items }
+    }
+}
+
+// MARK: - Canonical Retry Seam Tests
+
+@Suite("TurnEngine Canonical ResilienceRetry Tests")
+struct TurnEngineResilienceRetryTests {
+
+    // MARK: Failing-then-succeeding progression
+
+    @Test("Failing-then-succeeding retries exactly per exponential backoff curve")
+    func failingThenSucceedingExactProgression() async throws {
+        let clock = VirtualClock()
+        let counter = CallCounter()
+        let policy = RetryPolicy(
+            maxAttempts: 3,
+            backoff: .exponential(base: 1.0, multiplier: 2.0, maxDelay: 60.0)
+        )
+
+        let result = try await ResilienceRetry.run(policy: policy, clock: clock) {
+            let attempt = await counter.increment()
+            if attempt < 3 {
+                throw AgentError.generationFailed(reason: "transient-\(attempt)")
+            }
+            return "recovered"
+        }
+
+        #expect(result == "recovered")
+        let calls = await counter.count
+        // Initial attempt + two retries; third call succeeds.
+        #expect(calls == 3)
+        // Exact curve: 1s, then 1s * 2.
+        #expect(clock.recordedSleeps == [1_000_000_000, 2_000_000_000])
+        #expect(clock.now == 3_000_000_000)
+    }
+
+    // MARK: Exhaustion
+
+    @Test("Exhaustion throws retriesExhausted with exact attempt count")
+    func exhaustionWrapsInRetriesExhausted() async throws {
+        let clock = VirtualClock()
+        let counter = CallCounter()
+        let policy = RetryPolicy(maxAttempts: 2, backoff: .fixed(delay: 0.25))
+
+        var caught: Error?
+        do {
+            _ = try await ResilienceRetry.run(policy: policy, clock: clock) { () -> String in
+                _ = await counter.increment()
+                throw AgentError.rateLimitExceeded(retryAfter: nil)
+            }
+        } catch {
+            caught = error
+        }
+
+        let calls = await counter.count
+        // Initial attempt + maxAttempts(2) retries, all failing.
+        #expect(calls == 3)
+        #expect(clock.recordedSleeps == [250_000_000, 250_000_000])
+
+        guard case let .retriesExhausted(attempts, lastError) = caught as? ResilienceError else {
+            Issue.record("Expected ResilienceError.retriesExhausted, got \(String(describing: caught))")
+            return
+        }
+        #expect(attempts == 3)
+        #expect(!lastError.isEmpty)
+    }
+
+    // MARK: Hard retryability gate
+
+    @Test("Unclassified errors fail closed without consuming budget")
+    func unclassifiedErrorsFailClosed() async throws {
+        let clock = VirtualClock()
+        let counter = CallCounter()
+        let policy = RetryPolicy(maxAttempts: 3, backoff: .immediate)
+
+        var caught: Error?
+        do {
+            _ = try await ResilienceRetry.run(policy: policy, clock: clock) { () -> String in
+                _ = await counter.increment()
+                throw UnclassifiedError()
+            }
+        } catch {
+            caught = error
+        }
+
+        let calls = await counter.count
+        // shouldRetry defaults to true, yet the hard gate fails closed:
+        // single attempt, original error rethrown verbatim, no sleeps.
+        #expect(calls == 1)
+        #expect(clock.sleepCount == 0)
+        #expect(caught as? UnclassifiedError == UnclassifiedError())
+    }
+
+    @Test("userShouldRetry false short-circuits even a retryable error")
+    func userGateFalseShortCircuits() async throws {
+        let clock = VirtualClock()
+        let counter = CallCounter()
+        let policy = RetryPolicy(
+            maxAttempts: 3,
+            backoff: .immediate,
+            shouldRetry: { _ in false }
+        )
+
+        var caught: Error?
+        do {
+            _ = try await ResilienceRetry.run(policy: policy, clock: clock) { () -> String in
+                _ = await counter.increment()
+                throw AgentError.generationFailed(reason: "hard-gate passes, user gate blocks")
+            }
+        } catch {
+            caught = error
+        }
+
+        let calls = await counter.count
+        #expect(calls == 1)
+        #expect(clock.sleepCount == 0)
+
+        guard case let .generationFailed(reason) = caught as? AgentError else {
+            Issue.record("Expected original AgentError.generationFailed, got \(String(describing: caught))")
+            return
+        }
+        #expect(reason == "hard-gate passes, user gate blocks")
+    }
+
+    // MARK: Cancellation
+
+    @Test("CancellationError is never retried")
+    func cancellationErrorNeverRetried() async throws {
+        let clock = VirtualClock()
+        let counter = CallCounter()
+
+        var caught: Error?
+        do {
+            _ = try await ResilienceRetry.run(
+                policy: RetryPolicy.standard,
+                clock: clock
+            ) { () -> String in
+                _ = await counter.increment()
+                throw CancellationError()
+            }
+        } catch {
+            caught = error
+        }
+
+        let calls = await counter.count
+        #expect(calls == 1)
+        #expect(clock.sleepCount == 0)
+        #expect(caught is CancellationError)
+    }
+
+    @Test("Pre-cancelled task rethrows without retrying a retryable error")
+    func preCancelledTaskSkipsRetry() async throws {
+        let clock = VirtualClock()
+        let counter = CallCounter()
+
+        // URLError.timedOut IS hard-gate retryable, so this isolates the
+        // Task.isCancelled branch. Whichever wins the benign race (cancel
+        // landing before or after the body starts), the first catch must
+        // rethrow verbatim without sleeping: either checkCancellation fires,
+        // or Task.isCancelled is observed in the catch block.
+        let task = Task {
+            try await ResilienceRetry.run(policy: RetryPolicy.standard, clock: clock) { () -> String in
+                _ = await counter.increment()
+                try Task.checkCancellation()
+                throw URLError(.timedOut)
+            }
+        }
+        task.cancel()
+
+        var caught: Error?
+        do {
+            _ = try await task.value
+            Issue.record("Expected cancelled run to throw")
+        } catch {
+            caught = error
+        }
+
+        let calls = await counter.count
+        #expect(calls == 1)
+        #expect(clock.sleepCount == 0)
+        #expect(!(caught is ResilienceError))
+        #expect(caught is CancellationError || caught is URLError)
+    }
+
+    // MARK: No-retry fast path
+
+    @Test("maxAttempts == 0 runs the operation exactly once on success")
+    func zeroBudgetSuccessFastPath() async throws {
+        let clock = VirtualClock()
+        let counter = CallCounter()
+
+        let result = try await ResilienceRetry.run(
+            policy: .noRetry,
+            clock: clock
+        ) {
+            _ = await counter.increment()
+            return "done"
+        }
+
+        #expect(result == "done")
+        let calls = await counter.count
+        #expect(calls == 1)
+        #expect(clock.sleepCount == 0)
+    }
+
+    @Test("maxAttempts == 0 rethrows the bare error instead of wrapping it")
+    func zeroBudgetFailureRethrowsOriginal() async throws {
+        let clock = VirtualClock()
+        let counter = CallCounter()
+
+        var caught: Error?
+        do {
+            _ = try await ResilienceRetry.run(policy: .noRetry, clock: clock) { () -> String in
+                _ = await counter.increment()
+                throw AgentError.embeddingFailed(reason: "no budget")
+            }
+        } catch {
+            caught = error
+        }
+
+        let calls = await counter.count
+        #expect(calls == 1)
+        #expect(!(caught is ResilienceError))
+        guard case let .embeddingFailed(reason) = caught as? AgentError else {
+            Issue.record("Expected original AgentError.embeddingFailed, got \(String(describing: caught))")
+            return
+        }
+        #expect(reason == "no budget")
+    }
+
+    // MARK: Backoff sanitization
+
+    @Test("Backoff above the one-hour ceiling sanitizes to exactly one hour")
+    func backoffSanitizesToOneHourCeiling() async throws {
+        let clock = VirtualClock()
+        let counter = CallCounter()
+        let policy = RetryPolicy(maxAttempts: 2, backoff: .fixed(delay: 7200))
+
+        _ = try await ResilienceRetry.run(policy: policy, clock: clock) { () -> String in
+            let attempt = await counter.increment()
+            if attempt == 1 {
+                throw AgentError.inferenceProviderUnavailable(reason: "blip")
+            }
+            return "ok"
+        }
+
+        let calls = await counter.count
+        #expect(calls == 2)
+        #expect(clock.recordedSleeps == [3_600_000_000_000])
+    }
+
+    @Test("Non-finite backoff delays are dropped, not slept")
+    func nonFiniteDelayIsDropped() async throws {
+        let clock = VirtualClock()
+        let counter = CallCounter()
+        let policy = RetryPolicy(maxAttempts: 2, backoff: .custom { _ in .nan })
+
+        _ = try await ResilienceRetry.run(policy: policy, clock: clock) { () -> String in
+            let attempt = await counter.increment()
+            if attempt == 1 {
+                throw AgentError.generationFailed(reason: "retry me")
+            }
+            return "ok"
+        }
+
+        let calls = await counter.count
+        #expect(calls == 2)
+        #expect(clock.recordedSleeps.isEmpty)
+    }
+
+    // MARK: Side-effect ordering
+
+    @Test("onRetry ordering: operation, user callback, injected hook, sleep")
+    func retrySideEffectOrderingPreserved() async throws {
+        let clock = VirtualClock()
+        let counter = CallCounter()
+        let log = RetryEventLog()
+        let policy = RetryPolicy(
+            maxAttempts: 2,
+            backoff: .fixed(delay: 0.5),
+            onRetry: { attempt, _ in log.record("user:\(attempt)") }
+        )
+
+        let result = try await ResilienceRetry.run(policy: policy, clock: clock, onRetryAttempt: { attempt, _ in
+            log.record("hook:\(attempt)")
+        }) { () -> String in
+            let attempt = await counter.increment()
+            log.record("op:\(attempt)")
+            if attempt == 1 {
+                throw AgentError.rateLimitExceeded(retryAfter: nil)
+            }
+            return "ok"
+        }
+
+        #expect(result == "ok")
+        // Historical agent-path order: the composed callback ran the user
+        // policy first, then logging/observer/tracing, before the backoff
+        // sleep. Attempt numbering starts at 1 on the first RETRY.
+        #expect(log.entries == ["op:1", "user:1", "hook:1", "op:2"])
+        #expect(clock.recordedSleeps == [500_000_000])
+    }
+
+    @Test("Jittered backoff stays beneath the uncapped exponential curve")
+    func jitterStaysBeneathCurve() async throws {
+        let clock = VirtualClock()
+        let counter = CallCounter()
+        let policy = RetryPolicy(
+            maxAttempts: 3,
+            backoff: .exponentialWithJitter(base: 0.5, multiplier: 2.0, maxDelay: 30.0)
+        )
+
+        _ = try await ResilienceRetry.run(policy: policy, clock: clock) { () -> String in
+            let attempt = await counter.increment()
+            if attempt < 3 {
+                throw AgentError.inferenceProviderUnavailable(reason: "flaky")
+            }
+            return "ok"
+        }
+
+        let calls = await counter.count
+        let sleeps = clock.recordedSleeps
+        #expect(calls == 3)
+        #expect(sleeps.count == 2)
+        // Jitter draws from [0, capped delay]: attempt 1 caps at 0.5s,
+        // attempt 2 at 1.0s.
+        #expect(sleeps[0] <= 500_000_000)
+        #expect(sleeps[1] <= 1_000_000_000)
+    }
+}
+
+// MARK: - Graph Path Divergence Contract
+
+@Suite("TurnEngine Graph Retry Divergence Contract")
+struct TurnEngineGraphRetryDivergenceTests {
+
+    private var repoRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent() // Tests/SwarmTests/Resilience/
+            .deletingLastPathComponent() // Tests/SwarmTests/
+            .deletingLastPathComponent() // Tests/
+            .deletingLastPathComponent() // repo root
+    }
+
+    /// The Hive graph path keeps its own loop because its semantics diverge
+    /// beyond an injectable classifier (total-attempt counting, verbatim
+    /// last-error rethrow, unconditional gating, different backoff math).
+    /// This pins that BOTH sites carry the written rationale so the
+    /// divergence stays deliberate rather than accidental drift.
+    @Test("Documented divergence rationale exists at both retry sites")
+    func divergenceRationalePresentAtBothSites() throws {
+        let chatGraphSource = try String(
+            contentsOf: repoRoot.appendingPathComponent("Sources/Swarm/Internal/GraphRuntime/ChatGraph.swift"),
+            encoding: .utf8
+        )
+        let canonicalSource = try String(
+            contentsOf: repoRoot.appendingPathComponent("Sources/Swarm/Internal/TurnEngine/ResilienceRetry.swift"),
+            encoding: .utf8
+        )
+
+        // Graph site: rationale cites total-attempt counting and verbatim
+        // last-error rethrow.
+        #expect(chatGraphSource.contains("Deliberate divergence from the canonical agent-inference retry"))
+        #expect(chatGraphSource.contains("for attempt in 0 ..< maxAttempts"))
+        #expect(chatGraphSource.contains("ResilienceError.retriesExhausted(attempts:lastError:)"))
+
+        // Canonical site: header cross-references the graph loop.
+        #expect(canonicalSource.contains("ChatGraph.withRetry"))
+        // And still expresses the agent-path hard gate conjunction.
+        #expect(canonicalSource.contains("InferenceRetryability.isRetryable(error) && policy.shouldRetry(error)"))
+    }
+}

--- a/Tests/SwarmTests/Resilience/TurnEngineResilienceRetryTests.swift
+++ b/Tests/SwarmTests/Resilience/TurnEngineResilienceRetryTests.swift
@@ -319,14 +319,14 @@ struct TurnEngineResilienceRetryTests {
 
         let result = try await ResilienceRetry.run(policy: policy, clock: clock, onRetryAttempt: { attempt, _ in
             log.record("hook:\(attempt)")
-        }) { () -> String in
+        }, operation: { () -> String in
             let attempt = await counter.increment()
             log.record("op:\(attempt)")
             if attempt == 1 {
                 throw AgentError.rateLimitExceeded(retryAfter: nil)
             }
             return "ok"
-        }
+        })
 
         #expect(result == "ok")
         // Historical agent-path order: the composed callback ran the user

--- a/docs/reference/api-catalog.md
+++ b/docs/reference/api-catalog.md
@@ -3,7 +3,7 @@
 Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for high-risk public rows on 2026-07-28 (Conduit hard-removed in 0.6). MCP client rows refreshed 2026-08-14. OpenAI-compatible provider rows added 2026-08-14.
 
 - Scope: all `.swift` files under `Sources/Swarm/`, excluding `Internal/GraphRuntime/`
-- Source files scanned: 186
+- Source files scanned: 187
 - Public/open symbols cataloged: 2350
 
 ## 1. Swarm (entry point)


### PR DESCRIPTION
## Ticket
W3-T3 of spec `swift-arch-3ad8899e` — stacked on #180 (W3-T2) ← #179 (W3-T1). Discovery report: swift-architecture-review-Swarm-20260825-1715 (candidate 01, resilience axis).

## What
- `Sources/Swarm/Internal/TurnEngine/ResilienceRetry.swift` (new, internal): ONE canonical retry/backoff seam built on existing `RetryPolicy` + `InferenceRetryability`; hard gate, immediate cancellation rethrow, exhaustion wraps `ResilienceError.retriesExhausted`, backoff via injected `SwarmClock`.
- `Agent+Resilience.invokeWithRetry` now delegates; warning-log → observer → tracing side-effect ordering preserved exactly.
- `ChatGraph.withRetry`: kept local with a **documented divergence** — 4 verified semantic differences make unification behavior-changing (total-attempts counting vs retries-after-initial; verbatim error rethrow vs ResilienceError wrap; retries CancellationError vs hard gate; per-sleep cap vs BackoffStrategy sanitize). A source-contract test pins the rationale at both sites so the divergence can't silently rot.
- 14 new fake-clock tests (`VirtualClock`, zero real sleeps): exact backoff progression `[1s, 2s]`, exact exhaustion accounting, fail-closed gate, jitter bounds, NaN/∞ delay handling, ordering pins.
- api-catalog header count 186→187 (mechanical; public rows unchanged at 2350).

## Review
Fresh swift-pr-review pass (stale line-ref fix + lint fix applied) then independent final pass: exhaustion math, side-effect ordering, sanitizer edges, divergence claims all re-audited → **READY**, no open findings.

## Merge order
#179 → #180 → this PR (stacked).