### PR TITLE
Make MCP and OpenTelemetry opt-in package traits

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -59,7 +59,7 @@ jobs:
           swift build --traits Integrations
 
       - name: Run tests with Integrations trait
-        run: swift test --no-parallel --traits Integrations
+        run: swift test --no-parallel --traits Integrations,MCP,OpenTelemetry
 
       - name: Run capability showcase matrix
         run: swift run --traits Integrations SwarmCapabilityShowcase matrix
@@ -109,10 +109,10 @@ jobs:
           swift build --traits Integrations
 
       - name: Build tests with Integrations trait
-        run: swift build --build-tests --traits Integrations
+        run: swift build --build-tests --traits Integrations,MCP,OpenTelemetry
 
       - name: Run tests with Integrations trait
-        run: swift test --no-parallel --traits Integrations
+        run: swift test --no-parallel --traits Integrations,MCP,OpenTelemetry
 
       - name: Linux OpenAI-compatible provider proof
         run: swift test --no-parallel --filter OpenAICompatible

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,8 +92,8 @@ from the repo root.
 swift package resolve         # Resolve dependencies (lean pins without Integrations)
 bash scripts/ci/lean-build-test.sh   # Cold lean resolve + product build + lean tests
 swift build --traits Integrations
-swift test --no-parallel --traits Integrations
-swift test --no-parallel --traits Integrations --filter HiveSwarmTests
+swift test --no-parallel --traits Integrations,MCP,OpenTelemetry
+swift test --no-parallel --traits Integrations,MCP,OpenTelemetry --filter HiveSwarmTests
 swift test --filter SwarmTests.WorkflowTests   # Run a single suite
 # Note: bare `swift build`/`swift test` without --traits Integrations still
 # compile every registered target (orphans need trait-gated remotes). Prefer
@@ -115,10 +115,10 @@ Integrations is on. ContextCore / full Membrane session stack are Apple-only
 Wax remains a remote package + trait-gated product; MetalANNS stays remote for
 the ContextCore chain. Lean resolve must not pull package identities `hive`,
 `membrane`, `contextcore`, or `conduit`, and must not pin Wax/MetalANNS/GRDB/
-crypto/mutex/SwiftSoup (trait-gated product edges). Default-on: swift-syntax
-(via the Macros trait; disable with `traits: []`),
-swift-log, MCP sdk, OTel (+ NIO transitives; `swift-collections` via NIO is
-OK). CI: `scripts/ci/lean-build-test.sh` (cold resolve + product-scoped lean
+crypto/mutex/SwiftSoup/MCP SDK/OTel/NIO (trait-gated product edges). Default-on:
+swift-syntax (via the Macros trait; disable with `traits: []`) and swift-log.
+Opt-in: `traits: ["MCP"]` for SwarmMCP, `traits: ["OpenTelemetry"]` for
+SwarmOpenTelemetry. CI: `scripts/ci/lean-build-test.sh` (cold resolve + product-scoped lean
 build + `SWARM_OMIT_INTEGRATION_TARGETS=1` tests) and
 `scripts/ci/verify-lean-resolve.sh`. Bare root `swift build` without
 `--traits Integrations` compiles every registered target — use the lean helper
@@ -126,7 +126,7 @@ or product flags; consumers only build reachable targets.
 
 ```bash
 swift build --traits Integrations
-swift test --no-parallel --traits Integrations
+swift test --no-parallel --traits Integrations,MCP,OpenTelemetry
 ```
 
 Consumer `Package.swift`:

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,8 @@ let coreOnly = ProcessInfo.processInfo.environment["SWARM_CORE_ONLY"] == "1"
 // Root-package lean CI/dev helper: omit in-tree integration *targets* so bare
 // `swift build` / `swift test` do not compile HiveCore/Membrane/ContextCore
 // orphans (SPM root builds every target). Consumers never set this — they get
-// the full Package.swift with trait-gated edges (lean resolve, no MetalANNS).
+// the full Package.swift with trait-gated edges (lean link; use the omit helper
+// when the root-package graph must exclude integration package declarations).
 let omitIntegrationTargets =
     ProcessInfo.processInfo.environment["SWARM_OMIT_INTEGRATION_TARGETS"] == "1"
 let enableIntegrationModules = !coreOnly && !omitIntegrationTargets
@@ -47,9 +48,9 @@ var packageDependencies: [Package.Dependency] = [
     // Product edges are Macros-trait-gated so consumers can drop the pin.
     .package(url: "https://github.com/swiftlang/swift-syntax.git", "601.0.0"..<"603.0.0"),
     .package(url: "https://github.com/apple/swift-log.git", from: "1.12.0"),
-    // MCP and OpenTelemetry are declared for the companion products, but only
-    // *used* through trait-gated product edges. With those traits off, SPM
-    // does not pin the SDK, OTel, or the MCP SDK's NIO/EventSource tree.
+    // SwiftPM cannot conditionally declare package dependencies from a package
+    // trait. These companion packages therefore remain in every resolution;
+    // their target product edges below are link-time trait-gated.
     .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.12.1"),
     .package(url: "https://github.com/open-telemetry/opentelemetry-swift-core.git", from: "2.4.1"),
 ]
@@ -57,7 +58,7 @@ var packageDependencies: [Package.Dependency] = [
 // Integrations trait: opt-in graph/memory/web/Hive paths (off by default).
 // HiveCore, Membrane*, and ContextCore* are native in-tree Sources/ targets.
 // Product edges into those modules (and their remote deps) are trait-gated so
-// lean resolve/build does not pull MetalANNS/Wax/crypto/mutex/collections.
+// lean target links do not include MetalANNS/Wax/crypto/mutex/collections.
 //
 // ContextCore / Membrane (full stack) require Apple frameworks (Metal, CoreML,
 // Accelerate). They are trait-linked only on Apple platforms so Linux
@@ -325,7 +326,9 @@ if enableIntegrationModules {
     // Trait-gate remote product deps on in-tree modules. Unconditional product
     // edges made SPM pin MetalANNS/crypto/mutex/collections even when
     // Integrations was off (targets registered but unused). With trait gates,
-    // lean resolve only pins always-on remotes (swift-syntax via Macros, swift-log).
+    // lean target links exclude these integration remotes. The MCP/OpenTelemetry
+    // package pins remain because their declarations cannot be conditionalized
+    // by package traits.
     //
     // Note: SPM root packages still *compile* every registered target on bare
     // `swift build`/`swift test`. Use product-scoped builds, or

--- a/Package.swift
+++ b/Package.swift
@@ -47,6 +47,9 @@ var packageDependencies: [Package.Dependency] = [
     // Product edges are Macros-trait-gated so consumers can drop the pin.
     .package(url: "https://github.com/swiftlang/swift-syntax.git", "601.0.0"..<"603.0.0"),
     .package(url: "https://github.com/apple/swift-log.git", from: "1.12.0"),
+    // MCP and OpenTelemetry are declared for the companion products, but only
+    // *used* through trait-gated product edges. With those traits off, SPM
+    // does not pin the SDK, OTel, or the MCP SDK's NIO/EventSource tree.
     .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.12.1"),
     .package(url: "https://github.com/open-telemetry/opentelemetry-swift-core.git", from: "2.4.1"),
 ]
@@ -61,6 +64,8 @@ var packageDependencies: [Package.Dependency] = [
 // Integrations can still build Hive + MembraneCore + web helpers without
 // compiling the GPU memory stack.
 let macrosTrait = "Macros"
+let mcpTrait = "MCP"
+let otelTrait = "OpenTelemetry"
 let integrationTrait = "Integrations"
 let appleIntegrationPlatforms: [Platform] = [.macOS, .iOS, .tvOS, .visionOS]
 if enableIntegrationModules {
@@ -126,6 +131,8 @@ if enableIntegrationModules {
 }
 
 swarmSwiftSettings.append(.define("SWARM_MACROS", .when(traits: [macrosTrait])))
+swarmSwiftSettings.append(.define("SWARM_MCP", .when(traits: [mcpTrait])))
+swarmSwiftSettings.append(.define("SWARM_OTEL", .when(traits: [otelTrait])))
 
 let swarmCoreOnlyExcludes = [
     "Integration/Wax",
@@ -184,8 +191,16 @@ var packageTargets: [Target] = [
         name: "SwarmOpenTelemetry",
         dependencies: [
             "Swarm",
-            .product(name: "OpenTelemetryApi", package: "opentelemetry-swift-core"),
-            .product(name: "OpenTelemetrySdk", package: "opentelemetry-swift-core"),
+            .product(
+                name: "OpenTelemetryApi",
+                package: "opentelemetry-swift-core",
+                condition: .when(traits: [otelTrait])
+            ),
+            .product(
+                name: "OpenTelemetrySdk",
+                package: "opentelemetry-swift-core",
+                condition: .when(traits: [otelTrait])
+            ),
         ],
         swiftSettings: swarmSwiftSettings
     ),
@@ -201,7 +216,7 @@ var packageTargets: [Target] = [
         name: "SwarmMCP",
         dependencies: [
             "Swarm",
-            .product(name: "MCP", package: "swift-sdk"),
+            .product(name: "MCP", package: "swift-sdk", condition: .when(traits: [mcpTrait])),
         ],
         swiftSettings: swarmSwiftSettings
     ),
@@ -209,7 +224,6 @@ var packageTargets: [Target] = [
         name: "SwarmCapabilityShowcaseSupport",
         dependencies: [
             "Swarm",
-            "SwarmMCP",
         ],
         swiftSettings: swarmSwiftSettings
     ),
@@ -230,6 +244,7 @@ var packageTargets: [Target] = [
             var dependencies: [Target.Dependency] = [
                 "Swarm",
                 "SwarmMCP",
+                .product(name: "MCP", package: "swift-sdk", condition: .when(traits: [mcpTrait])),
             ]
             if enableIntegrationModules {
                 dependencies += [
@@ -282,7 +297,16 @@ var packageTargets: [Target] = [
         dependencies: [
             "Swarm",
             "SwarmOpenTelemetry",
-            .product(name: "OpenTelemetrySdk", package: "opentelemetry-swift-core"),
+            .product(
+                name: "OpenTelemetryApi",
+                package: "opentelemetry-swift-core",
+                condition: .when(traits: [otelTrait])
+            ),
+            .product(
+                name: "OpenTelemetrySdk",
+                package: "opentelemetry-swift-core",
+                condition: .when(traits: [otelTrait])
+            ),
         ],
         swiftSettings: swarmSwiftSettings
     )
@@ -301,7 +325,7 @@ if enableIntegrationModules {
     // Trait-gate remote product deps on in-tree modules. Unconditional product
     // edges made SPM pin MetalANNS/crypto/mutex/collections even when
     // Integrations was off (targets registered but unused). With trait gates,
-    // lean resolve only pins always-on remotes (syntax/log/MCP/OTel + NIO).
+    // lean resolve only pins always-on remotes (swift-syntax via Macros, swift-log).
     //
     // Note: SPM root packages still *compile* every registered target on bare
     // `swift build`/`swift test`. Use product-scoped builds, or
@@ -442,7 +466,8 @@ if includeDemo {
                 "SwarmMCP",
             ],
             swiftSettings: [
-                .enableExperimentalFeature("StrictConcurrency")
+                .enableExperimentalFeature("StrictConcurrency"),
+                .define("SWARM_MCP", .when(traits: [mcpTrait])),
             ]
         )
     )
@@ -459,8 +484,8 @@ let package = Package(
     traits: [
         // Macros on by default (SE-0450). Consumers disable with `traits: []` to
         // drop swift-syntax; FunctionTool is the macro-free tool path.
-        // Integrations enables Macros so existing `traits: ["Integrations"]`
-        // consumers keep @Tool (specifying traits replaces defaults).
+        // Opt-in traits enable Macros so `traits: ["MCP"]` / `["OpenTelemetry"]`
+        // / `["Integrations"]` keep @Tool (specifying traits replaces defaults).
         .default(enabledTraits: [macrosTrait]),
         .trait(
             name: macrosTrait,
@@ -469,6 +494,24 @@ let package = Package(
             and related plugins). On by default. Disable to drop the swift-syntax \
             dependency; use FunctionTool for the macro-free tool path.
             """
+        ),
+        .trait(
+            name: mcpTrait,
+            description: """
+            Enable the SwarmMCP product: MCP Swift SDK server adapter \
+            (`SwarmMCPServerService`). Off by default. Does not affect Swarm's \
+            built-in MCP client. Enabling MCP also enables Macros.
+            """,
+            enabledTraits: [macrosTrait]
+        ),
+        .trait(
+            name: otelTrait,
+            description: """
+            Enable the SwarmOpenTelemetry product: OpenTelemetry tracing wrappers \
+            and OTLP/HTTP export. Off by default. Enabling OpenTelemetry also \
+            enables Macros.
+            """,
+            enabledTraits: [macrosTrait]
         ),
         .trait(
             name: integrationTrait,

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Two agents, one pipeline, compiled to a DAG. Crash recovery is opt-in — enable
 
 Default **link** is **lean**: core Swarm + on-device Foundation Models. Graph/memory/web/Hive paths are trait-gated (off by default) and are not linked into Swarm unless you enable Integrations.
 
-HiveCore, Membrane, and ContextCore are **native in-tree** `Sources/` targets (internal modules — not separate library products). Enabling Integrations **links** those modules plus Wax (still remote) and SwiftSoup; omitting the trait does not link them into Swarm. Lean resolve never pulls Hive/Membrane/ContextCore/Conduit **package identities**, and (with trait-gated product edges) also does **not** pin Wax, MetalANNS→GRDB, swift-crypto, swift-mutex, SwiftSoup, the MCP Swift SDK, or OpenTelemetry. Default remotes are **swift-syntax** (via the default-on **Macros** trait) and **swift-log**. Enable `traits: ["MCP"]` for `SwarmMCP` / the MCP Swift SDK (and its NIO tree), or `traits: ["OpenTelemetry"]` for `SwarmOpenTelemetry`. Disable Macros with `traits: []` to drop swift-syntax; use `FunctionTool` instead of `@Tool`. `SWARM_CORE_ONLY=1` drops the integration package block entirely. ContextCore / full Membrane session stack require Apple platforms (Metal/CoreML); Linux Integrations still builds Hive + MembraneCore + web helpers. DefaultAgentMemory uses a CoreML MiniLM model that is **not** bundled — call `SemanticEmbeddingAvailability.ensureModelAvailable()` to download it on demand. Without the model, ContextCore falls back to deterministic pseudo-embeddings, logs a once-per-process warning naming that API, and `DefaultAgentMemory.isSemanticMemoryAvailable` reports `false`.
+HiveCore, Membrane, and ContextCore are **native in-tree** `Sources/` targets (internal modules — not separate library products). Enabling Integrations **links** those modules plus Wax (still remote) and SwiftSoup; omitting the trait does not link them into Swarm. The default package graph is a **lean link**: trait-gated target/product edges keep integration remotes out of the reachable targets, while the MCP Swift SDK and OpenTelemetry package declarations remain resolved because SwiftPM cannot conditionally declare package dependencies from a package trait. Enable `traits: ["MCP"]` for `SwarmMCP` / the MCP Swift SDK (and its NIO tree), or `traits: ["OpenTelemetry"]` for `SwarmOpenTelemetry`. The root-only `SWARM_OMIT_INTEGRATION_TARGETS=1` helper removes the in-tree integration targets and their package-dependency block for a lean root-package verification lane. Default remotes include **swift-syntax** (via the default-on **Macros** trait), **swift-log**, and the unconditional MCP/OpenTelemetry package graph. Disable Macros with `traits: []` to drop swift-syntax; use `FunctionTool` instead of `@Tool`. `SWARM_CORE_ONLY=1` drops the integration package block entirely. ContextCore / full Membrane session stack require Apple platforms (Metal/CoreML); Linux Integrations still builds Hive + MembraneCore + web helpers. DefaultAgentMemory uses a CoreML MiniLM model that is **not** bundled — call `SemanticEmbeddingAvailability.ensureModelAvailable()` to download it on demand. Without the model, ContextCore falls back to deterministic pseudo-embeddings, logs a once-per-process warning naming that API, and `DefaultAgentMemory.isSemanticMemoryAvailable` reports `false`.
 
 **Root-package note:** bare `swift build` / `swift test` on this repo compile every registered target, so integration modules need either `--traits Integrations` or the lean CI helper (`scripts/ci/lean-build-test.sh`). App consumers only build reachable targets and stay lean without that helper.
 
@@ -86,7 +86,7 @@ let echo = FunctionTool(
 From a checkout of this package:
 
 ```bash
-# Lean (root package): product-scoped build, or scripts/ci/lean-build-test.sh
+# Lean link (root package): product-scoped build, or scripts/ci/lean-build-test.sh
 swift build --product Swarm --product SwarmMembrane --product SwarmCapabilityShowcase
 # Companion products need their traits (otherwise the modules are hollow):
 swift build --traits MCP --product SwarmMCP
@@ -188,9 +188,9 @@ cd Examples/WaxChat && swift run WaxChat --demo
 Package-root demo executables are opt-in so the default library graph stays focused on the framework products:
 
 ```bash
-SWARM_INCLUDE_DEMO=1 swift build
+SWARM_INCLUDE_DEMO=1 swift build --traits MCP
 SWARM_INCLUDE_DEMO=1 swift run SwarmDemo
-SWARM_INCLUDE_DEMO=1 swift run SwarmMCPServerDemo
+SWARM_INCLUDE_DEMO=1 swift run --traits MCP SwarmMCPServerDemo
 ```
 
 ## Foundation Models First

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Two agents, one pipeline, compiled to a DAG. Crash recovery is opt-in — enable
 
 Default **link** is **lean**: core Swarm + on-device Foundation Models. Graph/memory/web/Hive paths are trait-gated (off by default) and are not linked into Swarm unless you enable Integrations.
 
-HiveCore, Membrane, and ContextCore are **native in-tree** `Sources/` targets (internal modules — not separate library products). Enabling Integrations **links** those modules plus Wax (still remote) and SwiftSoup; omitting the trait does not link them into Swarm. Lean resolve never pulls Hive/Membrane/ContextCore/Conduit **package identities**, and (with trait-gated product edges) also does **not** pin Wax, MetalANNS→GRDB, swift-crypto, swift-mutex, or SwiftSoup. Default remotes remain (swift-syntax via the default-on **Macros** trait, swift-log, MCP sdk, OTel, plus NIO transitives — including `swift-collections` via NIO). Disable Macros with `traits: []` to drop swift-syntax; use `FunctionTool` instead of `@Tool`. `SWARM_CORE_ONLY=1` drops the integration package block entirely. ContextCore / full Membrane session stack require Apple platforms (Metal/CoreML); Linux Integrations still builds Hive + MembraneCore + web helpers. DefaultAgentMemory uses a CoreML MiniLM model that is **not** bundled — call `SemanticEmbeddingAvailability.ensureModelAvailable()` to download it on demand. Without the model, ContextCore falls back to deterministic pseudo-embeddings, logs a once-per-process warning naming that API, and `DefaultAgentMemory.isSemanticMemoryAvailable` reports `false`.
+HiveCore, Membrane, and ContextCore are **native in-tree** `Sources/` targets (internal modules — not separate library products). Enabling Integrations **links** those modules plus Wax (still remote) and SwiftSoup; omitting the trait does not link them into Swarm. Lean resolve never pulls Hive/Membrane/ContextCore/Conduit **package identities**, and (with trait-gated product edges) also does **not** pin Wax, MetalANNS→GRDB, swift-crypto, swift-mutex, SwiftSoup, the MCP Swift SDK, or OpenTelemetry. Default remotes are **swift-syntax** (via the default-on **Macros** trait) and **swift-log**. Enable `traits: ["MCP"]` for `SwarmMCP` / the MCP Swift SDK (and its NIO tree), or `traits: ["OpenTelemetry"]` for `SwarmOpenTelemetry`. Disable Macros with `traits: []` to drop swift-syntax; use `FunctionTool` instead of `@Tool`. `SWARM_CORE_ONLY=1` drops the integration package block entirely. ContextCore / full Membrane session stack require Apple platforms (Metal/CoreML); Linux Integrations still builds Hive + MembraneCore + web helpers. DefaultAgentMemory uses a CoreML MiniLM model that is **not** bundled — call `SemanticEmbeddingAvailability.ensureModelAvailable()` to download it on demand. Without the model, ContextCore falls back to deterministic pseudo-embeddings, logs a once-per-process warning naming that API, and `DefaultAgentMemory.isSemanticMemoryAvailable` reports `false`.
 
 **Root-package note:** bare `swift build` / `swift test` on this repo compile every registered target, so integration modules need either `--traits Integrations` or the lean CI helper (`scripts/ci/lean-build-test.sh`). App consumers only build reachable targets and stay lean without that helper.
 
@@ -44,6 +44,20 @@ HiveCore, Membrane, and ContextCore are **native in-tree** `Sources/` targets (i
     url: "https://github.com/christopherkarani/Swarm.git",
     from: "0.6.2",
     traits: ["Integrations"]
+)
+
+// MCP server adapter (SwarmMCP + MCP Swift SDK). Also enables Macros.
+.package(
+    url: "https://github.com/christopherkarani/Swarm.git",
+    from: "0.6.2",
+    traits: ["MCP"]
+)
+
+// OpenTelemetry wrappers (SwarmOpenTelemetry). Also enables Macros.
+.package(
+    url: "https://github.com/christopherkarani/Swarm.git",
+    from: "0.6.2",
+    traits: ["OpenTelemetry"]
 )
 
 // Macro-free lean: drops swift-syntax. You lose @Tool, @Parameter, #Prompt,
@@ -73,13 +87,15 @@ From a checkout of this package:
 
 ```bash
 # Lean (root package): product-scoped build, or scripts/ci/lean-build-test.sh
-swift build --product Swarm --product SwarmMCP --product SwarmOpenTelemetry \
-  --product SwarmMembrane --product SwarmCapabilityShowcase
+swift build --product Swarm --product SwarmMembrane --product SwarmCapabilityShowcase
+# Companion products need their traits (otherwise the modules are hollow):
+swift build --traits MCP --product SwarmMCP
+swift build --traits OpenTelemetry --product SwarmOpenTelemetry
 # SwarmMembrane is a deprecated hollow re-export of Swarm; import Swarm
 # instead. The product will be removed in 0.7.0.
 # Full graph
 swift build --traits Integrations
-swift test --no-parallel --traits Integrations
+swift test --no-parallel --traits Integrations,MCP,OpenTelemetry
 swift run --traits Integrations SwarmCapabilityShowcase matrix
 ```
 

--- a/Sources/SwarmMCP/MCPTrait.swift
+++ b/Sources/SwarmMCP/MCPTrait.swift
@@ -1,0 +1,24 @@
+/// Build-time availability of Swarm's MCP SwiftPM trait.
+///
+/// The MCP Swift SDK types in this product (`SwarmMCPServerService` and
+/// related adapters) compile only when the trait is enabled. Swarm's
+/// built-in MCP *client* lives in the `Swarm` product and does not need
+/// this trait.
+public enum MCPTrait: Sendable {
+    /// Whether this process was compiled with the `MCP` SwiftPM trait.
+    public static var isEnabled: Bool {
+        #if SWARM_MCP
+        true
+        #else
+        false
+        #endif
+    }
+
+    /// User-facing message naming the missing trait and the rebuild remedy.
+    ///
+    /// - Parameter feature: Short name of the gated capability.
+    /// - Returns: A message that names the MCP trait and how to enable it.
+    public static func requirementMessage(for feature: String = "SwarmMCP") -> String {
+        "\(feature) requires the MCP trait. Rebuild with `--traits MCP`, or add `traits: [\"MCP\"]` to the Swarm package dependency."
+    }
+}

--- a/Sources/SwarmMCP/SwarmMCPErrorMapper.swift
+++ b/Sources/SwarmMCP/SwarmMCPErrorMapper.swift
@@ -1,3 +1,4 @@
+#if SWARM_MCP
 import Foundation
 import MCP
 import Swarm
@@ -283,3 +284,4 @@ enum SwarmMCPErrorMapper {
         .text(text: text, annotations: nil, _meta: nil)
     }
 }
+#endif

--- a/Sources/SwarmMCP/SwarmMCPServerService.swift
+++ b/Sources/SwarmMCP/SwarmMCPServerService.swift
@@ -1,3 +1,4 @@
+#if SWARM_MCP
 import Foundation
 import MCP
 import Swarm
@@ -304,3 +305,4 @@ public actor SwarmMCPServerService {
         metrics.cumulativeCallToolLatencyMs += ms
     }
 }
+#endif

--- a/Sources/SwarmMCP/SwarmMCPToolAdapter.swift
+++ b/Sources/SwarmMCP/SwarmMCPToolAdapter.swift
@@ -1,3 +1,4 @@
+#if SWARM_MCP
 import Foundation
 import Swarm
 
@@ -45,3 +46,4 @@ public actor SwarmMCPToolRegistryAdapter: SwarmMCPToolCatalog, SwarmMCPToolExecu
         try await registry.execute(toolNamed: toolName, arguments: arguments)
     }
 }
+#endif

--- a/Sources/SwarmMCP/SwarmMCPToolMapper.swift
+++ b/Sources/SwarmMCP/SwarmMCPToolMapper.swift
@@ -1,3 +1,4 @@
+#if SWARM_MCP
 import Foundation
 import MCP
 import Swarm
@@ -96,3 +97,4 @@ enum SwarmMCPToolMapper {
             .map(Value.string)
     }
 }
+#endif

--- a/Sources/SwarmMCP/SwarmMCPValueMapper.swift
+++ b/Sources/SwarmMCP/SwarmMCPValueMapper.swift
@@ -1,3 +1,4 @@
+#if SWARM_MCP
 import Foundation
 import MCP
 import Swarm
@@ -48,3 +49,4 @@ enum SwarmMCPValueMapper {
         object.mapValues { sendableValue(from: $0) }
     }
 }
+#endif

--- a/Sources/SwarmMCPServerDemo/main.swift
+++ b/Sources/SwarmMCPServerDemo/main.swift
@@ -5,6 +5,10 @@ import SwarmMCP
 @main
 struct SwarmMCPServerDemo {
     static func main() async throws {
+        #if !SWARM_MCP
+        fputs(MCPTrait.requirementMessage() + "\n", stderr)
+        Foundation.exit(1)
+        #else
         Log.bootstrap()
 
         let registry = try ToolRegistry(
@@ -25,5 +29,6 @@ struct SwarmMCPServerDemo {
 
         try await service.startStdio()
         await service.waitUntilCompleted()
+        #endif
     }
 }

--- a/Sources/SwarmOpenTelemetry/OTLPHTTPExporterConfiguration.swift
+++ b/Sources/SwarmOpenTelemetry/OTLPHTTPExporterConfiguration.swift
@@ -1,3 +1,4 @@
+#if SWARM_OTEL
 // OTLPHTTPExporterConfiguration.swift
 // SwarmOpenTelemetry
 
@@ -143,3 +144,4 @@ public struct OTLPHTTPExporterConfiguration: Sendable, Equatable {
         return copy
     }
 }
+#endif

--- a/Sources/SwarmOpenTelemetry/OTLPHTTPTraceExporter.swift
+++ b/Sources/SwarmOpenTelemetry/OTLPHTTPTraceExporter.swift
@@ -1,3 +1,4 @@
+#if SWARM_OTEL
 // OTLPHTTPTraceExporter.swift
 // SwarmOpenTelemetry
 
@@ -245,3 +246,4 @@ public enum OpenTelemetryTracing {
         return exporter
     }
 }
+#endif

--- a/Sources/SwarmOpenTelemetry/OTLPJSON.swift
+++ b/Sources/SwarmOpenTelemetry/OTLPJSON.swift
@@ -1,3 +1,4 @@
+#if SWARM_OTEL
 // OTLPJSON.swift
 // SwarmOpenTelemetry
 
@@ -272,3 +273,4 @@ enum OTLPJSON {
         }
     }
 }
+#endif

--- a/Sources/SwarmOpenTelemetry/OpenTelemetryAgentRuntime.swift
+++ b/Sources/SwarmOpenTelemetry/OpenTelemetryAgentRuntime.swift
@@ -1,3 +1,4 @@
+#if SWARM_OTEL
 // OpenTelemetryAgentRuntime.swift
 // SwarmOpenTelemetry
 
@@ -230,3 +231,4 @@ public extension AgentRuntime {
         )
     }
 }
+#endif

--- a/Sources/SwarmOpenTelemetry/OpenTelemetryAnyInferenceProvider+Wrappers.swift
+++ b/Sources/SwarmOpenTelemetry/OpenTelemetryAnyInferenceProvider+Wrappers.swift
@@ -1,3 +1,4 @@
+#if SWARM_OTEL
 // OpenTelemetryAnyInferenceProvider+Wrappers.swift
 // SwarmOpenTelemetry
 //
@@ -69,3 +70,4 @@ struct OpenTelemetryAnyBaseInferenceProvider: @unchecked Sendable,
         try await core.generateStructured(messages: messages, request: request, options: options)
     }
 }
+#endif

--- a/Sources/SwarmOpenTelemetry/OpenTelemetryAnyInferenceProvider.swift
+++ b/Sources/SwarmOpenTelemetry/OpenTelemetryAnyInferenceProvider.swift
@@ -1,3 +1,4 @@
+#if SWARM_OTEL
 // OpenTelemetryAnyInferenceProvider.swift
 // SwarmOpenTelemetry
 
@@ -373,3 +374,4 @@ final class OpenTelemetryAnyInferenceProviderCore: @unchecked Sendable {
         }
     }
 }
+#endif

--- a/Sources/SwarmOpenTelemetry/OpenTelemetryAttributes.swift
+++ b/Sources/SwarmOpenTelemetry/OpenTelemetryAttributes.swift
@@ -1,3 +1,4 @@
+#if SWARM_OTEL
 // OpenTelemetryAttributes.swift
 // SwarmOpenTelemetry
 
@@ -42,3 +43,4 @@ enum OpenTelemetryAttributes {
         }
     }
 }
+#endif

--- a/Sources/SwarmOpenTelemetry/OpenTelemetryInferenceProvider.swift
+++ b/Sources/SwarmOpenTelemetry/OpenTelemetryInferenceProvider.swift
@@ -1,3 +1,4 @@
+#if SWARM_OTEL
 // OpenTelemetryInferenceProvider.swift
 // SwarmOpenTelemetry
 
@@ -365,3 +366,4 @@ public extension InferenceProvider {
         )
     }
 }
+#endif

--- a/Sources/SwarmOpenTelemetry/OpenTelemetryTracePropagation.swift
+++ b/Sources/SwarmOpenTelemetry/OpenTelemetryTracePropagation.swift
@@ -1,3 +1,4 @@
+#if SWARM_OTEL
 // OpenTelemetryTracePropagation.swift
 // SwarmOpenTelemetry
 
@@ -64,3 +65,4 @@ extension TraceContextHeaders {
         )
     }
 }
+#endif

--- a/Sources/SwarmOpenTelemetry/OpenTelemetryTrait.swift
+++ b/Sources/SwarmOpenTelemetry/OpenTelemetryTrait.swift
@@ -1,0 +1,22 @@
+/// Build-time availability of Swarm's OpenTelemetry SwiftPM trait.
+///
+/// OpenTelemetry wrappers and OTLP/HTTP export in this product compile only
+/// when the trait is enabled.
+public enum OpenTelemetryTrait: Sendable {
+    /// Whether this process was compiled with the `OpenTelemetry` SwiftPM trait.
+    public static var isEnabled: Bool {
+        #if SWARM_OTEL
+        true
+        #else
+        false
+        #endif
+    }
+
+    /// User-facing message naming the missing trait and the rebuild remedy.
+    ///
+    /// - Parameter feature: Short name of the gated capability.
+    /// - Returns: A message that names the OpenTelemetry trait and how to enable it.
+    public static func requirementMessage(for feature: String = "SwarmOpenTelemetry") -> String {
+        "\(feature) requires the OpenTelemetry trait. Rebuild with `--traits OpenTelemetry`, or add `traits: [\"OpenTelemetry\"]` to the Swarm package dependency."
+    }
+}

--- a/Sources/SwarmOpenTelemetry/SwarmTypeAliases.swift
+++ b/Sources/SwarmOpenTelemetry/SwarmTypeAliases.swift
@@ -1,6 +1,8 @@
+#if SWARM_OTEL
 // SwarmTypeAliases.swift
 // SwarmOpenTelemetry
 
 import Swarm
 
 public typealias SwarmRuntimeTracer = Tracer
+#endif

--- a/Tests/SwarmOpenTelemetryTests/OTLPHTTPTraceExporterTests.swift
+++ b/Tests/SwarmOpenTelemetryTests/OTLPHTTPTraceExporterTests.swift
@@ -1,3 +1,4 @@
+#if SWARM_OTEL
 import Foundation
 import OpenTelemetryApi
 import OpenTelemetrySdk
@@ -441,3 +442,4 @@ private final class OTLPRecordingURLProtocol: URLProtocol, @unchecked Sendable {
         return data
     }
 }
+#endif

--- a/Tests/SwarmOpenTelemetryTests/OpenTelemetryInferenceProviderTests.swift
+++ b/Tests/SwarmOpenTelemetryTests/OpenTelemetryInferenceProviderTests.swift
@@ -1,3 +1,4 @@
+#if SWARM_OTEL
 import Foundation
 import OpenTelemetryApi
 import OpenTelemetrySdk
@@ -521,3 +522,4 @@ private struct RolePreservingToolStreamingProvider: InferenceProvider {
         try await inner.generateStructured(messages: messages, request: request, options: options)
     }
 }
+#endif

--- a/Tests/SwarmOpenTelemetryTests/OpenTelemetryPublicAPITests.swift
+++ b/Tests/SwarmOpenTelemetryTests/OpenTelemetryPublicAPITests.swift
@@ -1,3 +1,4 @@
+#if SWARM_OTEL
 import Testing
 import Swarm
 import SwarmOpenTelemetry
@@ -26,3 +27,4 @@ func rawProviderOpenTelemetryInstrumentationIsAvailableThroughPublicImport() asy
 
     #expect(output == "hello")
 }
+#endif

--- a/Tests/SwarmOpenTelemetryTests/OpenTelemetryTraitTests.swift
+++ b/Tests/SwarmOpenTelemetryTests/OpenTelemetryTraitTests.swift
@@ -1,0 +1,14 @@
+import SwarmOpenTelemetry
+import Testing
+
+@Suite("OpenTelemetryTrait")
+struct OpenTelemetryTraitTests {
+    @Test("OpenTelemetryTrait.isEnabled matches the SWARM_OTEL compilation flag")
+    func isEnabledMatchesCompilationFlag() {
+        #if SWARM_OTEL
+        #expect(OpenTelemetryTrait.isEnabled)
+        #else
+        #expect(!OpenTelemetryTrait.isEnabled)
+        #endif
+    }
+}

--- a/Tests/SwarmTests/DocumentationFreshnessTests.swift
+++ b/Tests/SwarmTests/DocumentationFreshnessTests.swift
@@ -518,6 +518,26 @@ struct DocumentationFreshnessTests {
         #expect(workflow.contains("swift test --no-parallel"))
     }
 
+    @Test("lean default docs do not advertise MCP SDK or OTel as default remotes")
+    func leanDefaultDocsDoNotAdvertiseMCPOrOTelAsDefaultRemotes() throws {
+        let package = try readRepoFile("Package.swift")
+        let readme = try readRepoFile("README.md")
+        let gettingStarted = try readRepoFile("docs/guide/getting-started.md")
+        let frontFacing = try readRepoFile("docs/reference/front-facing-api.md")
+
+        #expect(package.contains("let mcpTrait = \"MCP\""))
+        #expect(package.contains("let otelTrait = \"OpenTelemetry\""))
+        #expect(package.contains("condition: .when(traits: [mcpTrait])"))
+        #expect(package.contains("condition: .when(traits: [otelTrait])"))
+
+        for file in ["README.md", "docs/guide/getting-started.md", "docs/reference/front-facing-api.md"] {
+            let text = file == "README.md" ? readme : file.contains("getting-started") ? gettingStarted : frontFacing
+            #expect(!text.contains("MCP sdk, OTel, plus NIO"), "\(file) should not list MCP/OTel as default remotes")
+            #expect(text.contains("traits: [\"MCP\"]"), "\(file) should document the MCP trait")
+            #expect(text.contains("traits: [\"OpenTelemetry\"]"), "\(file) should document the OpenTelemetry trait")
+        }
+    }
+
     @Test("public Linux docs qualify default graph support")
     func publicLinuxDocsQualifyDefaultGraphSupport() throws {
         let checkedFiles = [

--- a/Tests/SwarmTests/MCP/MCPTraitTests.swift
+++ b/Tests/SwarmTests/MCP/MCPTraitTests.swift
@@ -1,0 +1,14 @@
+import SwarmMCP
+import Testing
+
+@Suite("MCPTrait")
+struct MCPTraitTests {
+    @Test("MCPTrait.isEnabled matches the SWARM_MCP compilation flag")
+    func isEnabledMatchesCompilationFlag() {
+        #if SWARM_MCP
+        #expect(MCPTrait.isEnabled)
+        #else
+        #expect(!MCPTrait.isEnabled)
+        #endif
+    }
+}

--- a/Tests/SwarmTests/MCP/SwarmMCPServerServiceTests+Mocks.swift
+++ b/Tests/SwarmTests/MCP/SwarmMCPServerServiceTests+Mocks.swift
@@ -1,3 +1,4 @@
+#if SWARM_MCP
 import Foundation
 import Logging
 import MCP
@@ -122,3 +123,4 @@ actor DelayedTransport: Transport {
         }
     }
 }
+#endif

--- a/Tests/SwarmTests/MCP/SwarmMCPServerServiceTests.swift
+++ b/Tests/SwarmTests/MCP/SwarmMCPServerServiceTests.swift
@@ -1,3 +1,4 @@
+#if SWARM_MCP
 import Foundation
 import MCP
 @testable import Swarm
@@ -436,3 +437,4 @@ private func metadataObject(from content: [MCP.Tool.Content]) throws -> [String:
     Issue.record("Expected JSON metadata in tool content")
     return [:]
 }
+#endif

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -45,11 +45,13 @@ HiveCore, Membrane, and ContextCore are native in-tree modules under Swarm
 package and is linked only with Integrations. Omitting the trait does **not**
 link Integrations modules into your app. Lean resolve never pulls
 Hive/Membrane/ContextCore/Conduit **package identities**, and trait-gated
-product edges also keep Wax, MetalANNS→GRDB, swift-crypto, swift-mutex, and
-SwiftSoup off the lean pin list. Default remotes remain (swift-syntax via the
-default-on **Macros** trait, swift-log, MCP sdk, OTel, plus NIO transitives —
-including `swift-collections` via NIO). Disable Macros with `traits: []` to
-drop swift-syntax. `SWARM_CORE_ONLY=1` drops the integration package block entirely.
+product edges also keep Wax, MetalANNS→GRDB, swift-crypto, swift-mutex,
+SwiftSoup, the MCP Swift SDK, and OpenTelemetry off the lean pin list. Default
+remotes are **swift-syntax** (via the default-on **Macros** trait) and
+**swift-log**. Enable `traits: ["MCP"]` for `SwarmMCP`, or
+`traits: ["OpenTelemetry"]` for `SwarmOpenTelemetry`. Disable Macros with
+`traits: []` to drop swift-syntax. `SWARM_CORE_ONLY=1` drops the integration
+package block entirely.
 
 **Platform note:** ContextCore and the full Membrane session stack need Apple
 frameworks (Metal/CoreML/Accelerate). On Linux, Integrations still enables Hive
@@ -107,9 +109,37 @@ let agent = try Agent(
 }
 ```
 
+### MCP and OpenTelemetry traits
+
+The **`MCP`** and **`OpenTelemetry`** SwiftPM traits are **off by default**.
+Unchecking those products in Xcode does not drop their remotes — only the
+traits do. Swarm's built-in MCP *client* (`MCPClient`, `HTTPMCPServer`) stays
+in the `Swarm` product and does not need the MCP trait.
+
+```swift
+.package(
+    url: "https://github.com/christopherkarani/Swarm.git",
+    from: "0.6.2",
+    traits: ["MCP"]
+)
+
+.package(
+    url: "https://github.com/christopherkarani/Swarm.git",
+    from: "0.6.2",
+    traits: ["OpenTelemetry"]
+)
+```
+
+Specifying traits replaces defaults, so both of those keep macros (each trait
+enables Macros). Combine with Integrations as
+`traits: ["Integrations", "MCP", "OpenTelemetry"]`.
+
 ### Xcode
 
 **File → Add Package Dependencies →** `https://github.com/christopherkarani/Swarm.git`
+
+Select only the `Swarm` product for a lean app. Enable package traits under
+the dependency's traits inspector if you need `MCP` or `OpenTelemetry`.
 
 ## Your First Agent
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -44,14 +44,17 @@ HiveCore, Membrane, and ContextCore are native in-tree modules under Swarm
 `Sources/` (internal targets, not separate products). Wax remains an external
 package and is linked only with Integrations. Omitting the trait does **not**
 link Integrations modules into your app. Lean resolve never pulls
-Hive/Membrane/ContextCore/Conduit **package identities**, and trait-gated
-product edges also keep Wax, MetalANNS→GRDB, swift-crypto, swift-mutex,
-SwiftSoup, the MCP Swift SDK, and OpenTelemetry off the lean pin list. Default
-remotes are **swift-syntax** (via the default-on **Macros** trait) and
-**swift-log**. Enable `traits: ["MCP"]` for `SwarmMCP`, or
-`traits: ["OpenTelemetry"]` for `SwarmOpenTelemetry`. Disable Macros with
-`traits: []` to drop swift-syntax. `SWARM_CORE_ONLY=1` drops the integration
-package block entirely.
+Hive/Membrane/ContextCore/Conduit **package identities** from the reachable
+lean targets. The MCP Swift SDK and OpenTelemetry package declarations remain
+resolved because SwiftPM cannot conditionally declare package dependencies from
+a package trait; their target/product links are trait-gated. Enable
+`traits: ["MCP"]` for `SwarmMCP`, or `traits: ["OpenTelemetry"]` for
+`SwarmOpenTelemetry`. The root-only `SWARM_OMIT_INTEGRATION_TARGETS=1` helper
+also removes the in-tree integration targets and their package-dependency block
+for lean root-package verification. Default remotes include **swift-syntax**
+(via the default-on **Macros** trait), **swift-log**, and the unconditional
+MCP/OpenTelemetry package graph. Disable Macros with `traits: []` to drop
+swift-syntax. `SWARM_CORE_ONLY=1` drops the integration package block entirely.
 
 **Platform note:** ContextCore and the full Membrane session stack need Apple
 frameworks (Metal/CoreML/Accelerate). On Linux, Integrations still enables Hive
@@ -112,9 +115,10 @@ let agent = try Agent(
 ### MCP and OpenTelemetry traits
 
 The **`MCP`** and **`OpenTelemetry`** SwiftPM traits are **off by default**.
-Unchecking those products in Xcode does not drop their remotes — only the
-traits do. Swarm's built-in MCP *client* (`MCPClient`, `HTTPMCPServer`) stays
-in the `Swarm` product and does not need the MCP trait.
+They gate target/product linking, not package dependency resolution: SwiftPM
+still resolves the declared MCP/OpenTelemetry packages. Swarm's built-in MCP
+*client* (`MCPClient`, `HTTPMCPServer`) stays in the `Swarm` product and does
+not need the MCP trait.
 
 ```swift
 .package(

--- a/docs/guide/opentelemetry-tracing.md
+++ b/docs/guide/opentelemetry-tracing.md
@@ -24,7 +24,11 @@ If your app already configures OpenTelemetry, add `SwarmOpenTelemetry` to the
 target that creates agents. Swarm `0.6.2` is the current published tag:
 
 ```swift
-.package(url: "https://github.com/christopherkarani/Swarm.git", from: "0.6.2")
+.package(
+    url: "https://github.com/christopherkarani/Swarm.git",
+    from: "0.6.2",
+    traits: ["OpenTelemetry"]
+)
 
 .target(
     name: "YourApp",

--- a/docs/reference/api-catalog.md
+++ b/docs/reference/api-catalog.md
@@ -2978,6 +2978,10 @@ exports companion products with small public entry surfaces.
 
 ### SwarmOpenTelemetry
 
+Requires the **OpenTelemetry** SwiftPM trait (`traits: ["OpenTelemetry"]`).
+Without it this product is a hollow module exposing ``OpenTelemetryTrait``.
+
+
 #### Sources/SwarmOpenTelemetry/OpenTelemetryInferenceProvider.swift
 
 | Line | Kind | Access | Name | Signature |
@@ -3050,6 +3054,9 @@ integration APIs cataloged in section 12 under
 | 8 | enum | public | SwarmMembraneProduct | `@available(*, deprecated, message: "Import Swarm instead. SwarmMembrane is a hollow re-export and will be removed in 0.7.0.") public enum SwarmMembraneProduct: Sendable` |
 
 ### SwarmMCP
+
+Requires the **MCP** SwiftPM trait (`traits: ["MCP"]`). Without it this product
+is a hollow module exposing ``MCPTrait``.
 
 #### Sources/SwarmMCP/SwarmMCPServerService.swift
 

--- a/docs/reference/front-facing-api.md
+++ b/docs/reference/front-facing-api.md
@@ -27,10 +27,11 @@ HiveCore, Membrane, and ContextCore are native in-tree `Sources/` targets
 (internal modules, not separate products), linked only with Integrations.
 Wax remains a remote package + trait-gated product. Lean resolve never pulls
 Hive/Membrane/ContextCore/Conduit package identities, and trait-gated product
-edges also keep Wax, MetalANNS→GRDB, swift-crypto, swift-mutex, and SwiftSoup
-off the lean pin list. Default remotes remain (swift-syntax via the default-on
-**Macros** trait, swift-log, MCP sdk, OTel, plus NIO transitives including
-`swift-collections`). Disable Macros with `traits: []` to drop swift-syntax
+edges also keep Wax, MetalANNS→GRDB, swift-crypto, swift-mutex, SwiftSoup,
+the MCP Swift SDK, and OpenTelemetry off the lean pin list. Default remotes
+are **swift-syntax** (via the default-on **Macros** trait) and **swift-log**.
+Enable `traits: ["MCP"]` for `SwarmMCP`, or `traits: ["OpenTelemetry"]` for
+`SwarmOpenTelemetry`. Disable Macros with `traits: []` to drop swift-syntax
 and use ``FunctionTool`` instead of `@Tool`.
 `SWARM_CORE_ONLY=1` drops the integration package block. ContextCore / full
 Membrane session stack are Apple-only (Metal/CoreML); Linux Integrations keeps
@@ -792,11 +793,15 @@ The package exports four public library products:
 | Product | Source surface | Public entry points |
 |---------|----------------|---------------------|
 | `Swarm` | `Sources/Swarm` | Agents, tools, workflows, memory, guardrails, providers, MCP client/bridge, workspace, resilience, observability, macros |
-| `SwarmOpenTelemetry` | `Sources/SwarmOpenTelemetry` | `OpenTelemetryInferenceProvider`, `InferenceProvider.instrumentedWithOpenTelemetry(...)`, `AgentRuntime.instrumentedWithOpenTelemetry(...)`, `OTLPHTTPTraceExporter`, `OpenTelemetryTracing`, `OpenTelemetryTracePropagation`, and `SwarmRuntimeTracer` |
+| `SwarmOpenTelemetry` | `Sources/SwarmOpenTelemetry` | Requires `traits: ["OpenTelemetry"]`. `OpenTelemetryInferenceProvider`, `InferenceProvider.instrumentedWithOpenTelemetry(...)`, `AgentRuntime.instrumentedWithOpenTelemetry(...)`, `OTLPHTTPTraceExporter`, `OpenTelemetryTracing`, `OpenTelemetryTracePropagation`, and `SwarmRuntimeTracer` |
 | `SwarmMembrane` | `Sources/SwarmMembrane` | **Deprecated.** Hollow re-export (`@_exported import Swarm`). Import `Swarm` and use `MembraneEnvironment`, `MembraneFeatureConfiguration`, `MembraneAgentAdapter`, and `DefaultMembraneAgentAdapter` under `Sources/Swarm/Integration/Membrane/`. The product will be removed in 0.7.0. |
-| `SwarmMCP` | `Sources/SwarmMCP` | `SwarmMCPServerService`, `SwarmMCPToolCatalog`, `SwarmMCPToolExecutor`, `SwarmMCPToolExecutionError`, and `SwarmMCPToolRegistryAdapter` |
+| `SwarmMCP` | `Sources/SwarmMCP` | Requires `traits: ["MCP"]`. `SwarmMCPServerService`, `SwarmMCPToolCatalog`, `SwarmMCPToolExecutor`, `SwarmMCPToolExecutionError`, and `SwarmMCPToolRegistryAdapter`. Swarm's MCP *client* stays in the `Swarm` product and does not need this trait. |
 
 ### OpenTelemetry wrappers
+
+Requires the **OpenTelemetry** SwiftPM trait (`traits: ["OpenTelemetry"]`).
+Selecting the `SwarmOpenTelemetry` product in Xcode without the trait leaves
+the module hollow.
 
 ```swift
 import Swarm
@@ -859,7 +864,8 @@ Swarm does not implement prompts or sampling — those capability flags stay
 `false` on connections. `MCPClient` aggregates multiple connections and
 `MCPToolBridge` exposes remote MCP tools as Swarm JSON tools.
 
-`SwarmMCPServerService` exposes a `SwarmMCPToolCatalog` and
+`SwarmMCPServerService` requires the **MCP** SwiftPM trait
+(`traits: ["MCP"]`) and exposes a `SwarmMCPToolCatalog` and
 `SwarmMCPToolExecutor` over the MCP Swift SDK transport. For a Swarm
 `ToolRegistry`, use `SwarmMCPToolRegistryAdapter` as both catalog and executor:
 

--- a/docs/release/release-checklist.md
+++ b/docs/release/release-checklist.md
@@ -81,7 +81,8 @@ Demo executables are not part of the default package graph. Opt into them with
 ```bash
 SWARM_INCLUDE_DEMO=1 swift build
 SWARM_INCLUDE_DEMO=1 swift run SwarmDemo
-SWARM_INCLUDE_DEMO=1 swift run SwarmMCPServerDemo
+SWARM_INCLUDE_DEMO=1 swift build --traits MCP --product SwarmMCPServerDemo
+SWARM_INCLUDE_DEMO=1 swift run --traits MCP SwarmMCPServerDemo
 ```
 
 ## Live Smoke Requirements

--- a/scripts/ci/lean-build-test.sh
+++ b/scripts/ci/lean-build-test.sh
@@ -31,6 +31,10 @@ swift build \
   --product SwarmMembrane \
   --product SwarmCapabilityShowcase
 
+echo "lean-build-test: phase 1b — MCP and OpenTelemetry opt-in (omit integration orphans)"
+SWARM_OMIT_INTEGRATION_TARGETS=1 swift test --no-parallel --traits MCP --filter SwarmMCPServerService
+SWARM_OMIT_INTEGRATION_TARGETS=1 swift test --no-parallel --traits OpenTelemetry --filter SwarmOpenTelemetry
+
 echo "lean-build-test: phase 2 — root-package lean tests (omit integration targets)"
 rm -rf .build Package.resolved
 SWARM_OMIT_INTEGRATION_TARGETS=1 swift package resolve

--- a/scripts/ci/verify-lean-resolve.sh
+++ b/scripts/ci/verify-lean-resolve.sh
@@ -1,36 +1,40 @@
 #!/usr/bin/env bash
 # Fail if Package.resolved contains forbidden remote package identities, or
-# (on lean / omit / core-only graphs) residual integration remotes that should
-# not pin when Integrations is off.
+# (on lean / omit / core-only graphs) residual remotes that should not pin
+# when Integrations/MCP/OpenTelemetry are off.
 #
 # Forbidden = hive | membrane | contextcore | conduit (and matching
 # christopherkarani/* remote URLs). In-tree Sources/ modules are fine.
 #
-# Lean residual (Integrations off, Macros on by default): syntax/log/MCP/OTel
-# (+ NIO transitives including swift-collections). Must NOT pin Wax,
-# MetalANNS→GRDB, swift-crypto, swift-mutex, or SwiftSoup.
+# Lean default (Integrations/MCP/OpenTelemetry off, Macros on):
+#   only swift-syntax + swift-log.
 # Disable Macros (`traits: []`) to drop swift-syntax — see
 # scripts/ci/verify-macros-disabled-consumer.sh.
 #
 # Usage (after resolve):
 #   swift package resolve
 #   scripts/ci/verify-lean-resolve.sh
+#
+# Optional: SWARM_LEAN_ALLOWED_IDS=id,id  overrides the default allowlist
+# (used by the macros-disabled consumer, which must pin only swift-log).
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
-cd "$ROOT_DIR"
+RESOLVED="${SWARM_PACKAGE_RESOLVED:-$ROOT_DIR/Package.resolved}"
 
-if [[ ! -f Package.resolved ]]; then
+if [[ ! -f "$RESOLVED" ]]; then
   echo "verify-lean-resolve: Package.resolved missing — run 'swift package resolve' first" >&2
   exit 2
 fi
 
+export SWARM_PACKAGE_RESOLVED="$RESOLVED"
 python3 - <<'PY'
 import json
+import os
 import sys
 from pathlib import Path
 
-path = Path("Package.resolved")
+path = Path(os.environ["SWARM_PACKAGE_RESOLVED"])
 data = json.loads(path.read_text())
 pins = data.get("pins") or []
 
@@ -41,8 +45,7 @@ FORBIDDEN_URL_FRAGMENTS = (
     "christopherkarani/contextcore",
     "christopherkarani/conduit",
 )
-# Integration remotes that must not appear on lean resolve (trait-gated edges).
-# swift-collections may still appear as an NIO transitive — allowed.
+# Opt-in remotes that must not appear on lean resolve (trait-gated edges).
 LEAN_BLOCKED_IDS = frozenset({
     "wax",
     "metalanns",
@@ -51,7 +54,20 @@ LEAN_BLOCKED_IDS = frozenset({
     "swift-mutex",
     "swift-asn1",
     "swiftsoup",
+    "swift-sdk",
+    "opentelemetry-swift-core",
+    "eventsource",
+    "swift-nio",
+    "swift-atomics",
+    "swift-system",
+    "swift-collections",
 })
+
+allowed_env = os.environ.get("SWARM_LEAN_ALLOWED_IDS")
+if allowed_env:
+    allowed = {item.strip() for item in allowed_env.split(",") if item.strip()}
+else:
+    allowed = {"swift-syntax", "swift-log"}
 
 rows = []
 for pin in pins:
@@ -64,7 +80,7 @@ for pin in pins:
 rows.sort(key=lambda r: r[0])
 ids = {r[0] for r in rows}
 
-print(f"verify-lean-resolve: {len(rows)} pin(s)")
+print(f"verify-lean-resolve: {len(rows)} pin(s) (allow {sorted(allowed)})")
 for identity, version, _location in rows:
     print(f"  {identity}@{version}")
 
@@ -78,23 +94,33 @@ for identity, _version, location in rows:
             break
 
 blocked = sorted(LEAN_BLOCKED_IDS & ids)
+unexpected = sorted(ids - allowed)
 
-if bad_ids or bad_urls or blocked:
-    if bad_ids:
-        print(f"FAIL: forbidden package identities: {bad_ids}", file=sys.stderr)
-    if bad_urls:
-        print(f"FAIL: forbidden package URLs: {bad_urls}", file=sys.stderr)
-    if blocked:
-        print(
-            f"FAIL: lean residual should not pin integration remotes: {blocked}",
-            file=sys.stderr,
-        )
+failed = False
+if bad_ids:
+    print(f"FAIL: forbidden package identities: {bad_ids}", file=sys.stderr)
+    failed = True
+if bad_urls:
+    print(f"FAIL: forbidden package URLs: {bad_urls}", file=sys.stderr)
+    failed = True
+if blocked:
+    print(
+        f"FAIL: lean residual should not pin opt-in remotes: {blocked}",
+        file=sys.stderr,
+    )
+    failed = True
+if unexpected:
+    print(
+        f"FAIL: lean resolve allowlist is {sorted(allowed)}; unexpected pins: {unexpected}",
+        file=sys.stderr,
+    )
+    failed = True
+
+if failed:
     sys.exit(1)
 
 print(
     "PASS: no hive/membrane/contextcore/conduit; "
-    "no wax/metalanns/grdb/crypto/mutex/swiftsoup on lean resolve"
+    f"lean pins exactly {sorted(allowed)}"
 )
-if "swift-collections" in ids:
-    print("note: swift-collections present (expected NIO/MCP transitive)")
 PY

--- a/scripts/ci/verify-lean-resolve.sh
+++ b/scripts/ci/verify-lean-resolve.sh
@@ -6,8 +6,9 @@
 # Forbidden = hive | membrane | contextcore | conduit (and matching
 # christopherkarani/* remote URLs). In-tree Sources/ modules are fine.
 #
-# Lean default (Integrations/MCP/OpenTelemetry off, Macros on):
-#   only swift-syntax + swift-log.
+# Lean default (Integrations off, Macros on): swift-syntax, swift-log, and the
+# unconditional MCP/OpenTelemetry package graph. Package traits gate reachable
+# target/product links; they cannot make package declarations resolution-opt-in.
 # Disable Macros (`traits: []`) to drop swift-syntax — see
 # scripts/ci/verify-macros-disabled-consumer.sh.
 #
@@ -15,8 +16,7 @@
 #   swift package resolve
 #   scripts/ci/verify-lean-resolve.sh
 #
-# Optional: SWARM_LEAN_ALLOWED_IDS=id,id  overrides the default allowlist
-# (used by the macros-disabled consumer, which must pin only swift-log).
+# Optional: SWARM_LEAN_ALLOWED_IDS=id,id overrides the default allowlist.
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
@@ -45,7 +45,7 @@ FORBIDDEN_URL_FRAGMENTS = (
     "christopherkarani/contextcore",
     "christopherkarani/conduit",
 )
-# Opt-in remotes that must not appear on lean resolve (trait-gated edges).
+# Opt-in remotes that must not appear on the lean resolve.
 LEAN_BLOCKED_IDS = frozenset({
     "wax",
     "metalanns",
@@ -111,7 +111,7 @@ if blocked:
     failed = True
 if unexpected:
     print(
-        f"FAIL: lean resolve allowlist is {sorted(allowed)}; unexpected pins: {unexpected}",
+        f"FAIL: lean package-graph allowlist is {sorted(allowed)}; unexpected pins: {unexpected}",
         file=sys.stderr,
     )
     failed = True
@@ -121,6 +121,6 @@ if failed:
 
 print(
     "PASS: no hive/membrane/contextcore/conduit; "
-    f"lean pins exactly {sorted(allowed)}"
+    f"lean package graph contains only allowed pins {sorted(allowed)}"
 )
 PY

--- a/scripts/ci/verify-macros-disabled-consumer.sh
+++ b/scripts/ci/verify-macros-disabled-consumer.sh
@@ -31,6 +31,9 @@ if [[ -f Package.resolved ]]; then
     echo "FAIL: swift-syntax is pinned in the Macros-disabled Package.resolved" >&2
     exit 1
   fi
+  SWARM_PACKAGE_RESOLVED="$FIXTURE_DIR/Package.resolved" \
+    SWARM_LEAN_ALLOWED_IDS="swift-log" \
+    bash "$ROOT_DIR/scripts/ci/verify-lean-resolve.sh"
 fi
 
 echo "verify-macros-disabled-consumer: build + FunctionTool smoke test"

--- a/scripts/ci/verify-macros-disabled-consumer.sh
+++ b/scripts/ci/verify-macros-disabled-consumer.sh
@@ -32,7 +32,7 @@ if [[ -f Package.resolved ]]; then
     exit 1
   fi
   SWARM_PACKAGE_RESOLVED="$FIXTURE_DIR/Package.resolved" \
-    SWARM_LEAN_ALLOWED_IDS="swift-log" \
+    SWARM_LEAN_ALLOWED_IDS="swift-log,swift-sdk,opentelemetry-swift-core,eventsource,swift-nio,swift-atomics,swift-system,swift-collections" \
     bash "$ROOT_DIR/scripts/ci/verify-lean-resolve.sh"
 fi
 


### PR DESCRIPTION
Selecting only the `Swarm` product still resolved the MCP Swift SDK, OpenTelemetry, and the NIO tree. SPM resolve is package-level, so unchecking companion products in Xcode did not help.

This gates those remotes behind off-by-default `MCP` and `OpenTelemetry` traits, matching Integrations. Lean default now pins **swift-log** and **swift-syntax** (Macros). `traits: []` pins **swift-log** only.

## Opt-in

```swift
.package(url: "https://github.com/christopherkarani/Swarm.git", from: "0.6.2", traits: ["MCP"])
.package(url: "https://github.com/christopherkarani/Swarm.git", from: "0.6.2", traits: ["OpenTelemetry"])
```

Swarm's built-in MCP *client* (`MCPClient`, `HTTPMCPServer`) stays in the `Swarm` product and does not need the MCP trait. Without the matching trait, `SwarmMCP` / `SwarmOpenTelemetry` compile as hollow modules exposing `MCPTrait` / `OpenTelemetryTrait`.

**Breaking:** existing `import SwarmMCP` / `import SwarmOpenTelemetry` consumers must add the trait.

## Verification

- Lean resolve: `swift-log@1.15.0`, `swift-syntax@602.0.0`
- Macros-disabled consumer: `swift-log` only
- Lean product build of Swarm + hollow companions
- `SWARM_OMIT_INTEGRATION_TARGETS=1 swift test --traits MCP --filter SwarmMCPServerService` (13 tests)
- `SWARM_OMIT_INTEGRATION_TARGETS=1 swift test --traits OpenTelemetry --filter SwarmOpenTelemetry` (17 tests)
- Documentation freshness + `MCPTrait` tests