### PR TITLE
arch(W3): port settlement + keyed cancellation onto split Agent

### DIFF
--- a/Sources/Swarm/Agents/Agent+Cancellation.swift
+++ b/Sources/Swarm/Agents/Agent+Cancellation.swift
@@ -7,140 +7,28 @@
 import Foundation
 
 extension Agent {
-    actor ActiveRunCancellationState {
-        private var activeRunID: UUID?
-        private var activeTask: Task<InternalRunResult, Error>?
-
-        func begin(runID: UUID, task: Task<InternalRunResult, Error>) {
-            activeRunID = runID
-            activeTask = task
-        }
-
-        func finish(runID: UUID) {
-            guard activeRunID == runID else { return }
-            activeRunID = nil
-            activeTask = nil
-        }
-
-        func cancelCurrent() {
-            activeTask?.cancel()
-        }
-    }
-
-    final class TimedOperationCoordinator<T: Sendable>: @unchecked Sendable {
-        private let lock = NSLock()
-        private var continuation: CheckedContinuation<T, Error>?
-        private var operationTask: Task<Void, Never>?
-        private var timeoutTask: Task<Void, Never>?
-        private var ownedLoopGate: ProviderOwnedLoopGate?
-        private var completed = false
-
-        func setOwnedLoopGate(_ gate: ProviderOwnedLoopGate?) {
-            lock.lock()
-            defer { lock.unlock() }
-            ownedLoopGate = gate
-        }
-
-        func install(continuation: CheckedContinuation<T, Error>) {
-            lock.lock()
-            defer { lock.unlock() }
-            self.continuation = continuation
-        }
-
-        func setOperationTask(_ task: Task<Void, Never>) {
-            lock.lock()
-            defer { lock.unlock() }
-            operationTask = task
-        }
-
-        func setTimeoutTask(_ task: Task<Void, Never>) {
-            lock.lock()
-            defer { lock.unlock() }
-            timeoutTask = task
-        }
-
-        func finish(returning value: T) {
-            complete(deactivateOwnedLoop: false) { continuation in
-                continuation.resume(returning: value)
-            }
-        }
-
-        func finish(throwing error: Error) {
-            complete(deactivateOwnedLoop: Self.shouldDeactivateOwnedLoop(for: error)) { continuation in
-                continuation.resume(throwing: error)
-            }
-        }
-
-        func cancelPending(with error: Error) {
-            let pendingState = takePendingState()
-            if Self.shouldDeactivateOwnedLoop(for: error) {
-                pendingState.ownedLoopGate?.deactivate()
-            }
-            pendingState.operationTask?.cancel()
-            pendingState.timeoutTask?.cancel()
-            pendingState.continuation?.resume(throwing: error)
-        }
-
-        private func complete(
-            deactivateOwnedLoop: Bool,
-            _ resume: (CheckedContinuation<T, Error>) -> Void
-        ) {
-            let pendingState = takePendingState()
-            if deactivateOwnedLoop {
-                pendingState.ownedLoopGate?.deactivate()
-            }
-            pendingState.operationTask?.cancel()
-            pendingState.timeoutTask?.cancel()
-            guard let continuation = pendingState.continuation else { return }
-            resume(continuation)
-        }
-
-        private static func shouldDeactivateOwnedLoop(for error: Error) -> Bool {
-            if error is CancellationError {
-                return true
-            }
-            if case .timeout = error as? AgentError {
-                return true
-            }
-            return false
-        }
-
-        private func takePendingState() -> (
-            continuation: CheckedContinuation<T, Error>?,
-            operationTask: Task<Void, Never>?,
-            timeoutTask: Task<Void, Never>?,
-            ownedLoopGate: ProviderOwnedLoopGate?
-        ) {
-            lock.lock()
-            defer { lock.unlock() }
-
-            guard completed == false else {
-                return (nil, nil, nil, nil)
-            }
-
-            completed = true
-            let pendingContinuation = continuation
-            let pendingOperationTask = operationTask
-            let pendingTimeoutTask = timeoutTask
-            let pendingGate = ownedLoopGate
-            continuation = nil
-            operationTask = nil
-            timeoutTask = nil
-            ownedLoopGate = nil
-            return (pendingContinuation, pendingOperationTask, pendingTimeoutTask, pendingGate)
-        }
-    }
-
-    /// Cancels any ongoing execution.
+    /// Registry of in-flight runs keyed by run ID.
     ///
+    /// Unlike the single-slot state it replaces, this supports multiple
+    /// concurrent runs on one agent value: `cancelAll()` reaches every
+    /// in-flight run, while `finish(_:)` removes exactly the run that
+    /// completed so finished runs never shadow live ones.
+    typealias ActiveRunRegistry = KeyedRunRegistry<UUID>
+
+    /// Cancels every in-flight execution on this agent.
+    ///
+    /// All runs started through ``run(_:session:observer:)`` or
+    /// ``runStructured(_:request:session:observer:)`` that have not finished
+    /// yet are cancelled, including runs started concurrently on copies of
+    /// this agent value. Earlier releases cancelled only the most recently
+    /// registered run; the run registry now tracks every concurrent run by
+    /// ID, so cancellation reaches all of them.
     public func cancel() async {
-        await cancellationState.cancelCurrent()
+        await activeRuns.cancelAll()
     }
 
     /// Checks for cancellation and timeout conditions.
     func checkCancellationAndTimeout(startTime: ContinuousClock.Instant) throws {
-        // Use Task.checkCancellation() for reliable cancellation detection
-        // This is the standard Swift concurrency pattern
         try Task.checkCancellation()
 
         let elapsed = ContinuousClock.now - startTime
@@ -149,53 +37,66 @@ extension Agent {
         }
     }
 
+    /// Runs `operation` bounded by the remaining run timeout.
+    ///
+    /// Delegates to the shared ``withTimeoutRace`` settlement primitive, so
+    /// outcomes recorded before the continuation installs are replayed and
+    /// worker tasks registered after settlement are cancelled. Owned-loop-gate
+    /// deactivation rides on the race's `onSettle` hook: the gate is
+    /// deactivated exactly when settlement fails with `CancellationError` or
+    /// `AgentError.timeout` (see `shouldDeactivateOwnedLoop`), never on
+    /// success or unrelated failures.
+    ///
+    /// The remaining budget is computed from `startTime` and consumed through
+    /// the injected `SwarmClock`, keeping the sleep on the same fake-clock
+    /// seam used by resilience code.
     func executeWithinRemainingTimeout<T: Sendable>(
         startTime: ContinuousClock.Instant,
         executionGate: ProviderOwnedLoopGate? = nil,
+        clock: any SwarmClock = LiveSwarmClock.live,
         operation: @escaping @Sendable () async throws -> T
     ) async throws -> T {
-        try Task.checkCancellation()
+        let deactivateIfNeeded: @Sendable (Error) -> Void = { error in
+            guard Self.shouldDeactivateOwnedLoop(for: error) else { return }
+            executionGate?.deactivate()
+        }
+
+        do {
+            try Task.checkCancellation()
+        } catch {
+            deactivateIfNeeded(error)
+            throw error
+        }
 
         let remaining = configuration.timeout - (ContinuousClock.now - startTime)
         if remaining <= .zero {
-            throw AgentError.timeout(duration: configuration.timeout)
+            let timeout = AgentError.timeout(duration: configuration.timeout)
+            deactivateIfNeeded(timeout)
+            throw timeout
         }
 
-        let coordinator = TimedOperationCoordinator<T>()
-        coordinator.setOwnedLoopGate(executionGate)
-
-        return try await withTaskCancellationHandler(
-            operation: {
-                try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<T, Error>) in
-                    coordinator.install(continuation: continuation)
-
-                    let operationTask = Task {
-                        do {
-                            coordinator.finish(returning: try await operation())
-                        } catch {
-                            coordinator.finish(throwing: error)
-                        }
-                    }
-                    coordinator.setOperationTask(operationTask)
-
-                    let timeoutTask = Task { [timeout = configuration.timeout, remaining] in
-                        do {
-                            try await Task.sleep(for: remaining)
-                            operationTask.cancel()
-                            coordinator.finish(throwing: AgentError.timeout(duration: timeout))
-                        } catch is CancellationError {
-                            return
-                        } catch {
-                            coordinator.finish(throwing: error)
-                        }
-                    }
-                    coordinator.setTimeoutTask(timeoutTask)
-                }
+        return try await withTimeoutRace(
+            timeout: remaining,
+            clock: clock,
+            timeoutError: AgentError.timeout(duration: configuration.timeout),
+            onSettle: { error in
+                guard let error else { return }
+                deactivateIfNeeded(error)
             },
-            onCancel: {
-                coordinator.cancelPending(with: CancellationError())
-            }
+            operation: operation
         )
+    }
+
+    /// Owned-loop gates deactivate only when a run dies by cancellation or
+    /// timeout; ordinary inference/tool failures must leave the gate armed.
+    static func shouldDeactivateOwnedLoop(for error: Error) -> Bool {
+        if error is CancellationError {
+            return true
+        }
+        if case .timeout = error as? AgentError {
+            return true
+        }
+        return false
     }
 
     func normalizeCancellation(_ error: Error) -> Error {

--- a/Sources/Swarm/Agents/Agent+OwnedLoopTypes.swift
+++ b/Sources/Swarm/Agents/Agent+OwnedLoopTypes.swift
@@ -17,9 +17,13 @@ final class OwnedLoopPendingHandoff: @unchecked Sendable {
     private let lock = NSLock()
     private var pending: (name: String, arguments: [String: SendableValue])?
 
+    /// First-winner: a later concurrent provider callback cannot overwrite
+    /// an already-captured handoff.
     func store(name: String, arguments: [String: SendableValue]) {
         lock.lock()
-        pending = (name, arguments)
+        if pending == nil {
+            pending = (name, arguments)
+        }
         lock.unlock()
     }
 

--- a/Sources/Swarm/Agents/Agent+RunLoop.swift
+++ b/Sources/Swarm/Agents/Agent+RunLoop.swift
@@ -16,10 +16,13 @@ extension Agent {
     /// - Throws: `AgentError` if execution fails, or `GuardrailError` if guardrails trigger.
     public func run(_ input: String, session: (any Session)? = nil, observer: (any AgentObserver)? = nil) async throws -> AgentResult {
         let runID = UUID()
+        await activeRuns.reserve(runID)
         let task = Task { [self] in
             try await runInternal(input, session: session, observer: observer, structuredOutputRequest: nil)
         }
-        await cancellationState.begin(runID: runID, task: task)
+        await activeRuns.attach(runID) { [task] in
+            task.cancel()
+        }
 
         do {
             let result = try await withTaskCancellationHandler(
@@ -30,11 +33,11 @@ extension Agent {
                     task.cancel()
                 }
             )
-            await cancellationState.finish(runID: runID)
+            await activeRuns.finish(runID)
             return result
         } catch {
             task.cancel()
-            await cancellationState.finish(runID: runID)
+            await activeRuns.finish(runID)
             throw normalizeCancellation(error)
         }
     }
@@ -47,10 +50,13 @@ extension Agent {
         observer: (any AgentObserver)? = nil
     ) async throws -> StructuredAgentResult {
         let runID = UUID()
+        await activeRuns.reserve(runID)
         let task = Task { [self] in
             try await runInternal(input, session: session, observer: observer, structuredOutputRequest: request)
         }
-        await cancellationState.begin(runID: runID, task: task)
+        await activeRuns.attach(runID) { [task] in
+            task.cancel()
+        }
 
         do {
             let result = try await withTaskCancellationHandler(
@@ -61,7 +67,7 @@ extension Agent {
                     task.cancel()
                 }
             )
-            await cancellationState.finish(runID: runID)
+            await activeRuns.finish(runID)
 
             guard let structuredOutput = result.structuredOutput else {
                 throw AgentError.generationFailed(reason: "Structured output request completed without a structured result")
@@ -70,7 +76,7 @@ extension Agent {
             return StructuredAgentResult(agentResult: result.agentResult, structuredOutput: structuredOutput)
         } catch {
             task.cancel()
-            await cancellationState.finish(runID: runID)
+            await activeRuns.finish(runID)
             throw normalizeCancellation(error)
         }
     }

--- a/Sources/Swarm/Agents/Agent.swift
+++ b/Sources/Swarm/Agents/Agent.swift
@@ -510,7 +510,9 @@ public struct Agent: AgentRuntime, Sendable {
     // MARK: - Internal State
 
     private var toolRegistry: ToolRegistry
-    let cancellationState = ActiveRunCancellationState()
+    /// Registry of in-flight runs; copies of this value share the actor, so
+    /// every run started through any copy is reachable from ``cancel()``.
+    let activeRuns = ActiveRunRegistry()
     /// Created from ``AgentConfiguration/resilience`` at init. Copies of this value share the actor.
     let inferenceCircuitBreaker: CircuitBreaker?
     /// Created from ``AgentConfiguration/resilience`` at init. Copies of this value share the actor.

--- a/Sources/Swarm/Core/TimeoutRace.swift
+++ b/Sources/Swarm/Core/TimeoutRace.swift
@@ -3,11 +3,11 @@
 //
 // Shared completion machinery for async operations raced against a timeout,
 // consolidating the per-site coordinator/race classes that previously lived
-// in GuardrailRunner and Workflow+Timeout. Two timeout sites deliberately
-// keep their own machinery: Agent.executeWithinRemainingTimeout ties race
-// settlement to its ProviderOwnedLoopGate execution-gate state, and
-// StreamOperations.timeout(after:) is a stream-lifetime operator rather than
-// a one-shot race.
+// in GuardrailRunner and Workflow+Timeout and in Agent's
+// TimedOperationCoordinator (whose owned-loop-gate deactivation now rides on
+// the `onSettle` hook). One timeout site deliberately keeps its own
+// machinery: StreamOperations.timeout(after:) is a stream-lifetime operator
+// rather than a one-shot race.
 
 import Foundation
 
@@ -20,6 +20,11 @@ import Foundation
 /// recorded before `install(continuation:)` runs (e.g. a cancellation handler
 /// firing in that window) is applied as soon as the continuation arrives, so
 /// no registration order can leak or strand it.
+///
+/// `onSettle` fires exactly once per race — at settlement time, before the
+/// worker tasks are cancelled and the continuation is resumed — with `nil`
+/// for success or the settled error. It runs even when settlement precedes
+/// continuation installation.
 final class TimeoutRace<T: Sendable>: @unchecked Sendable {
     private enum Outcome {
         case success(T)
@@ -27,10 +32,15 @@ final class TimeoutRace<T: Sendable>: @unchecked Sendable {
     }
 
     private let lock = NSLock()
+    private let onSettle: (@Sendable (Error?) -> Void)?
     private var continuation: CheckedContinuation<T, Error>?
     private var operationTask: Task<Void, Never>?
     private var timeoutTask: Task<Void, Never>?
     private var outcome: Outcome?
+
+    init(onSettle: (@Sendable (Error?) -> Void)? = nil) {
+        self.onSettle = onSettle
+    }
 
     func install(continuation: CheckedContinuation<T, Error>) {
         lock.lock()
@@ -88,6 +98,12 @@ final class TimeoutRace<T: Sendable>: @unchecked Sendable {
         timeoutTask = nil
         lock.unlock()
 
+        switch newOutcome {
+        case .success:
+            onSettle?(nil)
+        case let .failure(error):
+            onSettle?(error)
+        }
         pendingOperationTask?.cancel()
         pendingTimeoutTask?.cancel()
         if let pendingContinuation {
@@ -132,15 +148,20 @@ final class TimeoutRace<T: Sendable>: @unchecked Sendable {
 ///
 /// Sleep failures other than cancellation surface through the continuation;
 /// `LiveSwarmClock` suspension only ever throws `CancellationError`.
+///
+/// `onSettle`, when provided, fires exactly once with the settled outcome —
+/// `nil` for success or the winning error — before the losing task is
+/// cancelled and the continuation resumes.
 func withTimeoutRace<T: Sendable>(
     timeout: Duration,
     clock: any SwarmClock = LiveSwarmClock.live,
     cancelsOnParentCancellation: Bool = true,
     priority: TaskPriority? = nil,
     timeoutError: @autoclosure @escaping @Sendable () -> Error,
+    onSettle: (@Sendable (_ error: Error?) -> Void)? = nil,
     operation: @escaping @Sendable () async throws -> T
 ) async throws -> T {
-    let race = TimeoutRace<T>()
+    let race = TimeoutRace<T>(onSettle: onSettle)
 
     func run() async throws -> T {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<T, Error>) in
@@ -171,7 +192,9 @@ func withTimeoutRace<T: Sendable>(
                     race.finish(throwing: error)
                     return
                 }
-                operationTask.cancel()
+                // Claim the timeout outcome first so a concurrently unwinding
+                // operation cannot win with CancellationError and skip gate
+                // deactivation. record() cancels the losing operation task.
                 race.finish(throwing: timeoutError())
             }
             race.setTimeoutTask(timeoutTask)

--- a/Sources/Swarm/Internal/GraphRuntime/ChatGraph.swift
+++ b/Sources/Swarm/Internal/GraphRuntime/ChatGraph.swift
@@ -940,6 +940,26 @@ extension ChatGraph {
     /// Uses the Hive clock for deterministic backoff sleep — no jitter is applied.
     /// Returns immediately on the first success, or rethrows the last error
     /// after all attempts are exhausted.
+    ///
+    /// - Note: Deliberate divergence from the canonical agent-inference retry
+    ///   seam (`RetryPolicy.execute` in `Sources/Swarm/Resilience/RetryPolicy.swift`).
+    ///   A classifier closure alone cannot reconcile these, so this local loop is kept:
+    ///   1. Attempt accounting — here `maxAttempts` counts **total** attempts
+    ///      (`for attempt in 0 ..< maxAttempts`); the agent path treats
+    ///      `maxAttempts` as retries *after* the initial attempt
+    ///      (`retryCount < maxAttempts` guard).
+    ///   2. Exhaustion surface — the last operation error is rethrown verbatim
+    ///      so graph-runtime errors reach `HiveRunResult` unchanged; the agent
+    ///      path wraps exhaustion in
+    ///      `ResilienceError.retriesExhausted(attempts:lastError:)`.
+    ///   3. Retry gating — every caught error is retried unconditionally,
+    ///      including `CancellationError`; the agent path hard-gates on
+    ///      `InferenceRetryability.isRetryable` + user `shouldRetry` and never
+    ///      retries cancellation.
+    ///   4. Backoff math — saturating `delay * factor` growth where the cap is
+    ///      applied per-sleep (`min(delay, maxNs)`); the agent path evaluates
+    ///      `BackoffStrategy.delay(forAttempt:)` (including jitter strategies)
+    ///      sanitized to a fixed one-hour ceiling before sleeping.
     private static func withRetry<T>(
         policy: HiveRetryPolicy?,
         clock: any HiveClock,

--- a/Sources/Swarm/Internal/GraphRuntime/GraphAgent.swift
+++ b/Sources/Swarm/Internal/GraphRuntime/GraphAgent.swift
@@ -120,7 +120,14 @@ struct GraphAgent: AgentRuntime, Sendable {
             )
             await cancellation.track(handle)
 
-            let outcome = try await handle.outcome.value
+            let outcome: HiveRunOutcome<ChatGraph.Schema>
+            do {
+                outcome = try await handle.outcome.value
+            } catch {
+                await cancellation.untrack(handle.attemptID)
+                throw error
+            }
+            await cancellation.untrack(handle.attemptID)
             let result = try buildResult(from: outcome, builder: resultBuilder)
 
             await observer?.onAgentEnd(context: nil, agent: self, result: result)
@@ -228,8 +235,10 @@ struct GraphAgent: AgentRuntime, Sendable {
                     outcome = try await handle.outcome.value
                 } catch {
                     eventsTask.cancel()
+                    await cancellation.untrack(handle.attemptID)
                     throw error
                 }
+                await cancellation.untrack(handle.attemptID)
 
                 // Wait for all events to be consumed before building the result.
                 await eventsTask.value
@@ -263,7 +272,7 @@ struct GraphAgent: AgentRuntime, Sendable {
         }
     }
 
-    /// Cancels any ongoing Hive run.
+    /// Cancels every Hive run currently tracked on this agent.
     func cancel() async {
         await cancellation.cancelCurrent()
     }
@@ -666,26 +675,38 @@ extension GraphAgent: ConversationBranchingRuntime {
 
 // MARK: - CancellationController
 
-/// Actor that safely tracks and cancels the current Hive run handle.
+/// Actor that safely tracks and cancels in-flight Hive run handles.
 ///
-/// Stores the actual `HiveRunHandle` so cancellation propagates to the Hive runtime,
-/// not just to an awaiting wrapper task.
+/// Runs are keyed by `HiveRunAttemptID` (not reusable `HiveRunID`) so two
+/// concurrent attempts on the same thread cannot overwrite each other, and
+/// a finishing attempt cannot untrack a newer one. Stores the actual
+/// `HiveRunHandle` outcome tasks so cancellation propagates to the Hive
+/// runtime, not just to an awaiting wrapper task.
 private actor CancellationController {
-    private var currentHandle: HiveRunHandle<ChatGraph.Schema>?
+    private let registry = TrackedRunRegistry<HiveRunAttemptID>()
 
-    /// Records a new run handle for potential cancellation.
-    func track(_ handle: HiveRunHandle<ChatGraph.Schema>) {
-        // Cancel any previously tracked run.
-        currentHandle?.outcome.cancel()
-        currentHandle = handle
+    /// Records a new run handle without cancelling any previously tracked run.
+    func track(_ handle: HiveRunHandle<ChatGraph.Schema>) async {
+        await registry.begin(handle.attemptID) { [outcome = handle.outcome] in
+            outcome.cancel()
+        }
     }
 
-    /// Cancels the currently tracked run.
-    func cancelCurrent() {
-        currentHandle?.outcome.cancel()
-        currentHandle = nil
+    /// Removes a finished run from tracking without cancelling it.
+    func untrack(_ attemptID: HiveRunAttemptID) async {
+        await registry.finish(attemptID)
+    }
+
+    /// Cancels every currently tracked run and clears the registry.
+    func cancelCurrent() async {
+        await registry.cancelAll()
     }
 }
+
+/// Graph-side alias of the shared keyed registry. Lean builds exclude
+/// `Internal/GraphRuntime`, so the implementation lives in always-compiled
+/// `Sources/Swarm/Internal/KeyedRunRegistry.swift`.
+typealias TrackedRunRegistry = KeyedRunRegistry
 
 // HiveChatRole typed constants are defined in ChatGraph.swift (internal)
 // and shared across the HiveSwarm module.

--- a/Sources/Swarm/Internal/KeyedRunRegistry.swift
+++ b/Sources/Swarm/Internal/KeyedRunRegistry.swift
@@ -1,0 +1,96 @@
+// KeyedRunRegistry.swift
+// Swarm Framework
+//
+// Shared keyed registry of in-flight runs. One always-compiled
+// implementation so Agent and GraphAgent cannot drift on
+// begin/finish/cancel semantics.
+
+import Foundation
+
+/// Keyed registry of in-flight runs supporting concurrent registrations.
+///
+/// Ownership rules:
+/// - ``reserve(_:)`` then ``attach(_:onCancel:)`` records a run without
+///   touching other entries. A concurrent ``cancelAll()`` between those
+///   calls cannot miss the reserved key: attach fires immediately.
+/// - ``begin(_:onCancel:)`` is reserve+attach for callers that already
+///   hold the canceller.
+/// - ``finish(_:)`` removes exactly one settled run, so finished runs never
+///   shadow live ones.
+/// - ``cancel(_:)`` fires exactly the named run's canceller.
+/// - ``cancelAll()`` cancels every tracked run once and clears the registry.
+///
+/// Generic over the key: the agent facade keys by `UUID` run IDs while the
+/// Hive bridge keys by `HiveRunAttemptID`. Internal only — no public API.
+actor KeyedRunRegistry<Key: Hashable & Sendable> {
+    private enum Slot {
+        case reserved
+        case attached(@Sendable () -> Void)
+    }
+
+    private var slots: [Key: Slot] = [:]
+    /// Keys cancelled while reserved (or cancelled before attach), so a later
+    /// attach fires immediately instead of registering a live run.
+    private var pendingCancel: Set<Key> = []
+
+    /// Occupies `key` so ``cancelAll()`` cannot race past an in-flight start.
+    func reserve(_ key: Key) {
+        guard !pendingCancel.contains(key) else { return }
+        slots[key] = .reserved
+    }
+
+    /// Attaches the canceller, or fires it immediately if the key was
+    /// cancelled while reserved.
+    func attach(_ key: Key, onCancel: @escaping @Sendable () -> Void) {
+        if pendingCancel.remove(key) != nil {
+            slots[key] = nil
+            onCancel()
+            return
+        }
+        slots[key] = .attached(onCancel)
+    }
+
+    /// Records a run's cancellation action under `key` without disturbing
+    /// other entries. Re-registering an existing key replaces its canceller
+    /// without firing it.
+    func begin(_ key: Key, onCancel: @escaping @Sendable () -> Void) {
+        reserve(key)
+        attach(key, onCancel: onCancel)
+    }
+
+    /// Forgets one settled run without cancelling it.
+    func finish(_ key: Key) {
+        slots[key] = nil
+        pendingCancel.remove(key)
+    }
+
+    /// Fires exactly the named run's canceller, leaving an attached entry
+    /// registered until ``finish(_:)``.
+    func cancel(_ key: Key) {
+        switch slots[key] {
+        case let .attached(onCancel):
+            onCancel()
+        case .reserved, nil:
+            pendingCancel.insert(key)
+        }
+    }
+
+    /// Cancels every tracked run once and clears the registry.
+    func cancelAll() {
+        let snapshot = slots
+        slots.removeAll()
+        for (key, slot) in snapshot {
+            switch slot {
+            case let .attached(onCancel):
+                onCancel()
+            case .reserved:
+                pendingCancel.insert(key)
+            }
+        }
+    }
+
+    /// Number of runs currently tracked.
+    var trackedCount: Int {
+        slots.count
+    }
+}

--- a/Sources/Swarm/Resilience/RetryPolicy.swift
+++ b/Sources/Swarm/Resilience/RetryPolicy.swift
@@ -258,6 +258,13 @@ public struct RetryPolicy: Sendable {
     // MARK: - Execution
 
     /// Executes an operation with retry logic.
+    ///
+    /// Canonical agent-inference retry seam: `maxAttempts` counts retries after
+    /// the initial attempt, `CancellationError` rethrows immediately, exhaustion
+    /// wraps `ResilienceError.retriesExhausted`, and backoff sleeps on the
+    /// injected `SwarmClock`. `ChatGraph.withRetry` keeps a local loop with
+    /// documented semantic divergence (total-attempt counting, verbatim rethrow,
+    /// unconditional gating, different backoff math).
     /// - Parameter operation: The async operation to execute.
     /// - Returns: The result of the operation.
     /// - Throws: `ResilienceError.retriesExhausted` if all attempts fail, or the original error if retries are
@@ -269,6 +276,7 @@ public struct RetryPolicy: Sendable {
         var lastError: Error?
 
         while true {
+            try Task.checkCancellation()
             do {
                 return try await operation()
             } catch {
@@ -291,6 +299,7 @@ public struct RetryPolicy: Sendable {
 
                 // Invoke retry callback
                 await onRetry?(retryCount, error)
+                try Task.checkCancellation()
 
                 // Calculate and apply backoff delay
                 let delay = sanitizeBackoffDelay(
@@ -298,6 +307,7 @@ public struct RetryPolicy: Sendable {
                 )
                 if delay > 0 {
                     try await clock.sleep(nanoseconds: delay)
+                    try Task.checkCancellation()
                 }
             }
         }
@@ -315,7 +325,11 @@ public struct RetryPolicy: Sendable {
         }
 
         let nanoseconds = delaySeconds * 1_000_000_000
-        guard nanoseconds.isFinite, nanoseconds > 0 else {
+        // Overflow of a positive finite delay saturates to the ceiling, not 0.
+        guard nanoseconds.isFinite else {
+            return Self.maxBackoffNanoseconds
+        }
+        guard nanoseconds > 0 else {
             return 0
         }
 

--- a/Tests/SwarmTests/Agents/AgentRunCancellationRegistryTests.swift
+++ b/Tests/SwarmTests/Agents/AgentRunCancellationRegistryTests.swift
@@ -1,0 +1,354 @@
+// AgentRunCancellationRegistryTests.swift
+// Swarm Framework
+//
+// Deterministic tests for per-run cancellation ownership: the keyed
+// ``Agent/ActiveRunRegistry`` replaces the single-slot state so concurrent
+// runs are individually tracked, `cancel()` reaches all of them, and a
+// reserve-before-spawn gap cannot miss cancelAll.
+
+import Foundation
+import Testing
+@_spi(ColonyInternal) @testable import Swarm
+
+private final class CancelProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var fires = 0
+
+    var count: Int {
+        lock.withLock { fires }
+    }
+
+    func fire() {
+        lock.withLock { fires += 1 }
+    }
+}
+
+private actor SignalingHangingProvider: InferenceProvider, MessagesFromPromptInference {
+    let delay: Duration
+    let entered: AsyncStream<Void>.Continuation
+
+    init(delay: Duration, entered: AsyncStream<Void>.Continuation) {
+        self.delay = delay
+        self.entered = entered
+    }
+
+    func generate(prompt _: String, options _: InferenceOptions) async throws -> String {
+        entered.yield()
+        try await Task.sleep(for: delay)
+        return "Final Answer: delayed"
+    }
+
+    nonisolated func stream(prompt: String, options: InferenceOptions) -> AsyncThrowingStream<String, Error> {
+        StreamHelper.makeTrackedStream { continuation in
+            let token = try await self.generate(prompt: prompt, options: options)
+            continuation.yield(token)
+            continuation.finish()
+        }
+    }
+
+    func generateWithToolCalls(
+        prompt: String,
+        tools _: [ToolSchema],
+        options: InferenceOptions
+    ) async throws -> InferenceResponse {
+        let content = try await generate(prompt: prompt, options: options)
+        return InferenceResponse(content: content, finishReason: .completed)
+    }
+}
+
+private final class ParkableGateOperation: @unchecked Sendable {
+    private let entered: AsyncStream<Void>.Continuation?
+    private let lock = NSLock()
+    private var parked: CheckedContinuation<String, Error>?
+    private var pendingRelease: Result<String, Error>?
+
+    init(entered: AsyncStream<Void>.Continuation? = nil) {
+        self.entered = entered
+    }
+
+    func release(_ result: Result<String, Error>) {
+        lock.lock()
+        if let continuation = parked {
+            parked = nil
+            lock.unlock()
+            continuation.resume(with: result)
+            return
+        }
+        pendingRelease = result
+        lock.unlock()
+    }
+
+    func run() async throws -> String {
+        try Task.checkCancellation()
+        return try await withCheckedThrowingContinuation { continuation in
+            lock.lock()
+            if let armed = pendingRelease {
+                pendingRelease = nil
+                lock.unlock()
+                continuation.resume(with: armed)
+                return
+            }
+            parked = continuation
+            let signal = entered
+            lock.unlock()
+            signal?.yield()
+        }
+    }
+}
+
+private final class SettableClockForGateTests: SwarmClock, @unchecked Sendable {
+    private let lock = NSLock()
+    private var sleepers: [CheckedContinuation<Void, Error>] = []
+
+    func nowNanoseconds() -> UInt64 {
+        DispatchTime.now().uptimeNanoseconds
+    }
+
+    func sleep(nanoseconds _: UInt64) async throws {
+        try Task.checkCancellation()
+        try await withCheckedThrowingContinuation { continuation in
+            lock.lock()
+            sleepers.append(continuation)
+            lock.unlock()
+        }
+    }
+
+    func releaseAll() {
+        lock.lock()
+        let parked = sleepers
+        sleepers.removeAll()
+        lock.unlock()
+        for continuation in parked {
+            continuation.resume()
+        }
+    }
+}
+
+@Suite("ActiveRunRegistry Tests")
+private struct ActiveRunRegistryTests {
+    @Test("cancel(runID) fires only that run's canceller")
+    func cancelTargetsSingleRun() async {
+        let registry = Agent.ActiveRunRegistry()
+        let first = CancelProbe()
+        let second = CancelProbe()
+        let firstID = UUID()
+        let secondID = UUID()
+
+        await registry.begin(firstID, onCancel: { first.fire() })
+        await registry.begin(secondID, onCancel: { second.fire() })
+
+        await registry.cancel(firstID)
+
+        #expect(first.count == 1)
+        #expect(second.count == 0)
+    }
+
+    @Test("finish removes exactly its own run; finished runs never shadow live ones")
+    func finishRemovesOnlyItsOwnRun() async {
+        let registry = Agent.ActiveRunRegistry()
+        let first = CancelProbe()
+        let second = CancelProbe()
+        let firstID = UUID()
+        let secondID = UUID()
+
+        await registry.begin(firstID, onCancel: { first.fire() })
+        await registry.begin(secondID, onCancel: { second.fire() })
+        await registry.finish(firstID)
+
+        #expect(await registry.trackedCount == 1)
+
+        await registry.cancelAll()
+
+        #expect(first.count == 0)
+        #expect(second.count == 1)
+    }
+
+    @Test("cancelAll cancels every concurrently in-flight run")
+    func cancelAllReachesEveryRun() async {
+        let registry = Agent.ActiveRunRegistry()
+        let probes = (CancelProbe(), CancelProbe(), CancelProbe())
+
+        await registry.begin(UUID(), onCancel: { probes.0.fire() })
+        await registry.begin(UUID(), onCancel: { probes.1.fire() })
+        await registry.begin(UUID(), onCancel: { probes.2.fire() })
+
+        await registry.cancelAll()
+
+        #expect(probes.0.count == 1)
+        #expect(probes.1.count == 1)
+        #expect(probes.2.count == 1)
+    }
+
+    @Test("reserve then cancelAll fires attach immediately")
+    func reserveThenCancelAllFiresAttach() async {
+        let registry = Agent.ActiveRunRegistry()
+        let probe = CancelProbe()
+        let id = UUID()
+
+        await registry.reserve(id)
+        await registry.cancelAll()
+        await registry.attach(id, onCancel: { probe.fire() })
+
+        #expect(probe.count == 1)
+        #expect(await registry.trackedCount == 0)
+    }
+
+    @Test("trackedCount reflects begin and finish transitions")
+    func trackedCountTransitions() async {
+        let registry = Agent.ActiveRunRegistry()
+
+        let a = UUID()
+        let b = UUID()
+        await registry.begin(a, onCancel: {})
+        await registry.begin(b, onCancel: {})
+        #expect(await registry.trackedCount == 2)
+
+        await registry.finish(a)
+        #expect(await registry.trackedCount == 1)
+
+        await registry.finish(b)
+        #expect(await registry.trackedCount == 0)
+    }
+}
+
+@Suite("Agent Cancel All Runs")
+private struct AgentCancelAllRunsTests {
+    @Test("agent.cancel() cancels two concurrently in-flight runs")
+    func cancelReachesAllConcurrentRuns() async throws {
+        let (enteredStream, entered) = AsyncStream<Void>.makeStream(bufferingPolicy: .unbounded)
+        let provider = SignalingHangingProvider(delay: .seconds(60), entered: entered)
+        let agent = try Agent(
+            tools: [],
+            instructions: "Cancel-all test agent",
+            inferenceProvider: provider
+        )
+
+        let first = Task {
+            try await agent.run("first")
+        }
+        let second = Task {
+            try await agent.run("second")
+        }
+
+        var entries = 0
+        for await _ in enteredStream {
+            entries += 1
+            if entries == 2 { break }
+        }
+        #expect(entries == 2)
+
+        await agent.cancel()
+
+        let firstOutcome = await first.result
+        let secondOutcome = await second.result
+
+        for (label, outcome) in [("first", firstOutcome), ("second", secondOutcome)] {
+            guard case let .failure(error as AgentError) = outcome else {
+                Issue.record("\(label) run should fail after cancel(), got \(outcome)")
+                continue
+            }
+            #expect(error == .cancelled, "\(label) run expected .cancelled, got \(error)")
+        }
+    }
+}
+
+@Suite("Owned Loop Gate Deactivation Parity")
+private struct OwnedLoopGateDeactivationTests {
+    @Test("gate deactivates when the timeout wins")
+    func gateDeactivatesOnTimeout() async throws {
+        let agent = try Agent(instructions: "Gate timeout agent", inferenceProvider: nil)
+        let gate = ProviderOwnedLoopGate()
+        let clock = VirtualClock(startingAtNanoseconds: 0)
+        let operation = ParkableGateOperation()
+
+        do {
+            _ = try await agent.executeWithinRemainingTimeout(
+                startTime: ContinuousClock.now,
+                executionGate: gate,
+                clock: clock
+            ) {
+                try await operation.run()
+            }
+            Issue.record("Timeout did not settle the race")
+        } catch let error as AgentError {
+            guard case .timeout = error else {
+                Issue.record("Expected AgentError.timeout, got \(error)")
+                return
+            }
+        }
+
+        #expect(!gate.isActive)
+        #expect(clock.sleepCount == 1)
+        operation.release(.success("drain"))
+    }
+
+    @Test("gate stays armed when the operation succeeds")
+    func gateStaysArmedOnSuccess() async throws {
+        let agent = try Agent(instructions: "Gate success agent", inferenceProvider: nil)
+        let gate = ProviderOwnedLoopGate()
+        let clock = SettableClockForGateTests()
+        defer { clock.releaseAll() }
+
+        let value = try await agent.executeWithinRemainingTimeout(
+            startTime: ContinuousClock.now,
+            executionGate: gate,
+            clock: clock
+        ) {
+            "done"
+        }
+
+        #expect(value == "done")
+        #expect(gate.isActive)
+    }
+
+    @Test("gate stays armed on ordinary operation failure")
+    func gateStaysArmedOnOperationFailure() async throws {
+        let agent = try Agent(instructions: "Gate failure agent", inferenceProvider: nil)
+        let gate = ProviderOwnedLoopGate()
+        let clock = SettableClockForGateTests()
+        defer { clock.releaseAll() }
+
+        struct ToolExplosion: Error {}
+        do {
+            _ = try await agent.executeWithinRemainingTimeout(
+                startTime: ContinuousClock.now,
+                executionGate: gate,
+                clock: clock
+            ) {
+                throw ToolExplosion()
+            }
+            Issue.record("Expected ToolExplosion to propagate")
+        } catch is ToolExplosion {
+        }
+
+        #expect(gate.isActive)
+    }
+
+    @Test("already-expired remaining budget deactivates the gate")
+    func expiredBudgetDeactivatesGate() async throws {
+        let agent = try Agent(
+            instructions: "Gate expired agent",
+            configuration: AgentConfiguration.default.timeout(.milliseconds(1)),
+            inferenceProvider: nil
+        )
+        let gate = ProviderOwnedLoopGate()
+        let start = ContinuousClock.now - .seconds(1)
+
+        do {
+            _ = try await agent.executeWithinRemainingTimeout(
+                startTime: start,
+                executionGate: gate
+            ) {
+                "never"
+            }
+            Issue.record("Expected timeout")
+        } catch let error as AgentError {
+            guard case .timeout = error else {
+                Issue.record("Expected timeout, got \(error)")
+                return
+            }
+        }
+
+        #expect(!gate.isActive)
+    }
+}

--- a/Tests/SwarmTests/Agents/GraphRunTrackingTests.swift
+++ b/Tests/SwarmTests/Agents/GraphRunTrackingTests.swift
@@ -1,0 +1,110 @@
+// GraphRunTrackingTests.swift
+// Swarm Framework
+//
+// Deterministic tests for graph-run cancellation ownership: the keyed
+// ``TrackedRunRegistry`` registers concurrent Hive runs without disturbing
+// earlier ones. Keys are `HiveRunAttemptID` at the GraphAgent seam; tests
+// use plain identifiers for the shared registry.
+
+#if SWARM_INTEGRATIONS
+import Foundation
+import Testing
+@testable import Swarm
+
+private final class CancelProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var fires = 0
+
+    var count: Int {
+        lock.withLock { fires }
+    }
+
+    func fire() {
+        lock.withLock { fires += 1 }
+    }
+}
+
+@Suite("TrackedRunRegistry Tests")
+private struct TrackedRunRegistryTests {
+    @Test("registering a new run leaves previously tracked runs untouched")
+    func beginDoesNotCancelPreviousRun() async {
+        let registry = TrackedRunRegistry<String>()
+        let first = CancelProbe()
+        let second = CancelProbe()
+
+        await registry.begin("run-1", onCancel: { first.fire() })
+        #expect(first.count == 0)
+
+        await registry.begin("run-2", onCancel: { second.fire() })
+
+        #expect(first.count == 0)
+        #expect(second.count == 0)
+        #expect(await registry.trackedCount == 2)
+
+        await registry.cancelAll()
+        #expect(first.count == 1)
+        #expect(second.count == 1)
+    }
+
+    @Test("finish removes one settled run without cancelling anything")
+    func finishRemovesWithoutCancelling() async {
+        let registry = TrackedRunRegistry<String>()
+        let first = CancelProbe()
+        let second = CancelProbe()
+
+        await registry.begin("run-1", onCancel: { first.fire() })
+        await registry.begin("run-2", onCancel: { second.fire() })
+
+        await registry.finish("run-1")
+
+        #expect(first.count == 0)
+        #expect(second.count == 0)
+        #expect(await registry.trackedCount == 1)
+
+        await registry.cancelAll()
+        #expect(first.count == 0)
+        #expect(second.count == 1)
+    }
+
+    @Test("cancelAll cancels every tracked run exactly once")
+    func cancelAllFiresEveryCancellerOnce() async {
+        let registry = TrackedRunRegistry<String>()
+        let first = CancelProbe()
+        let second = CancelProbe()
+        let third = CancelProbe()
+
+        await registry.begin("run-1", onCancel: { first.fire() })
+        await registry.begin("run-2", onCancel: { second.fire() })
+        await registry.begin("run-3", onCancel: { third.fire() })
+
+        await registry.cancelAll()
+
+        #expect(first.count == 1)
+        #expect(second.count == 1)
+        #expect(third.count == 1)
+        #expect(await registry.trackedCount == 0)
+
+        await registry.cancelAll()
+        #expect(first.count == 1)
+        #expect(second.count == 1)
+        #expect(third.count == 1)
+    }
+
+    @Test("re-registering a finished run ID tracks the new canceller")
+    func reBeginAfterFinishTracksReplacement() async {
+        let registry = TrackedRunRegistry<String>()
+        let original = CancelProbe()
+        let replacement = CancelProbe()
+
+        await registry.begin("run-1", onCancel: { original.fire() })
+        await registry.finish("run-1")
+        await registry.begin("run-1", onCancel: { replacement.fire() })
+
+        await registry.cancelAll()
+
+        #expect(original.count == 0)
+        #expect(replacement.count == 1)
+    }
+}
+
+#endif

--- a/Tests/SwarmTests/Core/TimeoutRaceSettlementHookTests.swift
+++ b/Tests/SwarmTests/Core/TimeoutRaceSettlementHookTests.swift
@@ -1,0 +1,231 @@
+// TimeoutRaceSettlementHookTests.swift
+// Swarm Framework
+//
+// Deterministic tests for the `onSettle` hook: replayed pre-install outcomes
+// run the hook, the hook observes the exact winning outcome exactly once, and
+// the timeout path claims the timeout before cancelling the operation.
+
+import Foundation
+import Testing
+@_spi(ColonyInternal) @testable import Swarm
+
+private final class HookRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var outcomes: [Error?] = []
+
+    var calls: [Error?] {
+        lock.withLock { outcomes }
+    }
+
+    func record(_ error: Error?) {
+        lock.withLock { outcomes.append(error) }
+    }
+}
+
+private final class SettableTestClock: SwarmClock, @unchecked Sendable {
+    private let lock = NSLock()
+    private var sleepers: [CheckedContinuation<Void, Error>] = []
+
+    func nowNanoseconds() -> UInt64 {
+        DispatchTime.now().uptimeNanoseconds
+    }
+
+    func sleep(nanoseconds _: UInt64) async throws {
+        try Task.checkCancellation()
+        try await withCheckedThrowingContinuation { continuation in
+            lock.lock()
+            sleepers.append(continuation)
+            lock.unlock()
+        }
+    }
+
+    func releaseAll() {
+        lock.lock()
+        let parked = sleepers
+        sleepers.removeAll()
+        lock.unlock()
+        for continuation in parked {
+            continuation.resume()
+        }
+    }
+}
+
+private final class ParkableOperation: @unchecked Sendable {
+    private let lock = NSLock()
+    private var parked: CheckedContinuation<String, Error>?
+    private var pendingRelease: Result<String, Error>?
+
+    func release(_ result: Result<String, Error>) {
+        lock.lock()
+        if let continuation = parked {
+            parked = nil
+            lock.unlock()
+            continuation.resume(with: result)
+            return
+        }
+        pendingRelease = result
+        lock.unlock()
+    }
+
+    func run() async throws -> String {
+        try Task.checkCancellation()
+        return try await withCheckedThrowingContinuation { continuation in
+            lock.lock()
+            if let release = pendingRelease {
+                pendingRelease = nil
+                lock.unlock()
+                continuation.resume(with: release)
+                return
+            }
+            parked = continuation
+            lock.unlock()
+        }
+    }
+}
+
+private struct BoomError: Error {}
+private struct MappedCancelled: Error {}
+
+@Suite("TimeoutRace Settlement Hook")
+private struct TimeoutRaceSettlementHookTests {
+    @Test("onSettle fires once with nil when the operation succeeds")
+    func hookFiresOnceWithNilOnSuccess() async throws {
+        let recorder = HookRecorder()
+        let clock = SettableTestClock()
+        defer { clock.releaseAll() }
+
+        let value = try await withTimeoutRace(
+            timeout: .seconds(30),
+            clock: clock,
+            timeoutError: AgentError.timeout(duration: .seconds(30)),
+            onSettle: recorder.record
+        ) {
+            42
+        }
+
+        #expect(value == 42)
+        #expect(recorder.calls.count == 1)
+        #expect(recorder.calls[0] == nil)
+    }
+
+    @Test("onSettle receives the exact operation failure")
+    func hookReceivesOperationFailure() async throws {
+        let recorder = HookRecorder()
+        let clock = SettableTestClock()
+        defer { clock.releaseAll() }
+
+        do {
+            _ = try await withTimeoutRace(
+                timeout: .seconds(30),
+                clock: clock,
+                timeoutError: AgentError.timeout(duration: .seconds(30)),
+                onSettle: recorder.record
+            ) {
+                throw BoomError()
+            }
+            Issue.record("Expected BoomError to propagate")
+        } catch is BoomError {
+        }
+
+        #expect(recorder.calls.count == 1)
+        #expect(recorder.calls.first is BoomError)
+    }
+
+    @Test("outcome recorded before install replays and still runs onSettle")
+    func hookRunsForPreInstallSettlement() async throws {
+        let recorder = HookRecorder()
+        let race = TimeoutRace<Int>(onSettle: recorder.record)
+        race.finish(returning: 7)
+
+        let value = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Int, Error>) in
+            race.install(continuation: continuation)
+        }
+
+        #expect(value == 7)
+        #expect(recorder.calls.count == 1)
+        #expect(recorder.calls[0] == nil)
+    }
+
+    @Test("timeout wins on an instant-return fake clock with the timeout payload")
+    func timeoutWinsOnInstantFakeClock() async throws {
+        let recorder = HookRecorder()
+        let clock = VirtualClock(startingAtNanoseconds: 0)
+        let parkable = ParkableOperation()
+
+        do {
+            _ = try await withTimeoutRace(
+                timeout: .milliseconds(5),
+                clock: clock,
+                timeoutError: AgentError.timeout(duration: .milliseconds(5)),
+                onSettle: recorder.record
+            ) {
+                try await parkable.run()
+            }
+            Issue.record("Expected timeout")
+        } catch let error as AgentError {
+            guard case .timeout = error else {
+                Issue.record("Expected AgentError.timeout, got \(error)")
+                return
+            }
+        }
+
+        #expect(recorder.calls.count == 1)
+        #expect(recorder.calls.first is AgentError)
+        if case .timeout = recorder.calls.first as? AgentError {
+        } else {
+            Issue.record("Expected timeout payload, got \(String(describing: recorder.calls.first))")
+        }
+        #expect(clock.sleepCount == 1)
+        parkable.release(.success("drain"))
+    }
+
+    @Test("timeout claim beats a cancellation-mapped operation unwind")
+    func timeoutClaimBeatsMappedCancellation() async throws {
+        let recorder = HookRecorder()
+        let clock = VirtualClock(startingAtNanoseconds: 0)
+
+        do {
+            _ = try await withTimeoutRace(
+                timeout: .milliseconds(5),
+                clock: clock,
+                timeoutError: AgentError.timeout(duration: .milliseconds(5)),
+                onSettle: recorder.record
+            ) {
+                try await Task.sleep(nanoseconds: .max)
+                return "never"
+            }
+            Issue.record("Expected timeout")
+        } catch let error as AgentError {
+            guard case .timeout = error else {
+                Issue.record("Expected AgentError.timeout, got \(error)")
+                return
+            }
+        } catch {
+            Issue.record("Expected AgentError.timeout, got \(error)")
+        }
+
+        #expect(recorder.calls.count == 1)
+        if case .timeout = recorder.calls.first as? AgentError {
+        } else {
+            Issue.record("Timeout must win the settle payload, got \(String(describing: recorder.calls.first))")
+        }
+    }
+
+    @Test("tasks registered against a settled coordinator are cancelled synchronously")
+    func lateRegistrationCancelledAfterSettlement() {
+        let race = TimeoutRace<Int>(onSettle: nil)
+        race.finish(returning: 1)
+
+        let lateOperation = Task<Void, Never> {
+            _ = try? await Task.sleep(nanoseconds: 1_000_000_000)
+        }
+        race.setOperationTask(lateOperation)
+        let lateTimer = Task<Void, Never> {
+            _ = try? await Task.sleep(nanoseconds: 1_000_000_000)
+        }
+        race.setTimeoutTask(lateTimer)
+
+        #expect(lateOperation.isCancelled)
+        #expect(lateTimer.isCancelled)
+    }
+}

--- a/Tests/SwarmTests/Resilience/ResilienceTests+Retry.swift
+++ b/Tests/SwarmTests/Resilience/ResilienceTests+Retry.swift
@@ -619,4 +619,43 @@ private struct RetryPolicyDeterminismTests {
         #expect(await retryRecorder.getAll().isEmpty)
         #expect(clock.recordedSleeps.isEmpty)
     }
+
+    @Test("Cancellation during onRetry does not start another attempt")
+    func cancellationDuringOnRetryDoesNotRetryAgain() async throws {
+        let clock = VirtualClock()
+        let counter = TestCounter()
+        let (startedRetry, startedRetryContinuation) = AsyncStream<Void>.makeStream()
+
+        let work = Task<String, Error> {
+            let policy = RetryPolicy(
+                maxAttempts: 5,
+                backoff: .immediate,
+                onRetry: { _, _ in
+                    startedRetryContinuation.yield()
+                    while !Task.isCancelled {
+                        await Task.yield()
+                    }
+                },
+                clock: clock
+            )
+            return try await policy.execute {
+                _ = await counter.increment()
+                throw TestError.transient
+            }
+        }
+
+        _ = await startedRetry.first { _ in true }
+        work.cancel()
+
+        do {
+            _ = try await work.value
+            Issue.record("Expected CancellationError after cancel during onRetry")
+        } catch is CancellationError {
+        } catch {
+            Issue.record("Expected CancellationError, got \(error)")
+        }
+
+        #expect(await counter.get() == 1)
+        #expect(clock.recordedSleeps.isEmpty)
+    }
 }

--- a/docs/reference/api-catalog.md
+++ b/docs/reference/api-catalog.md
@@ -3,7 +3,7 @@
 Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for high-risk public rows on 2026-07-28 (Conduit hard-removed in 0.6). MCP client rows refreshed 2026-08-14. OpenAI-compatible provider rows added 2026-08-14.
 
 - Scope: all `.swift` files under `Sources/Swarm/`, excluding `Internal/GraphRuntime/`
-- Source files scanned: 193
+- Source files scanned: 194
 - Public/open symbols cataloged: 2325
 
 ## 1. Swarm (entry point)


### PR DESCRIPTION
## Why not merge #179/#180/#181 as-is

Three stacked PRs (`#179` → `#180` → `#181`) targeted a pre-split `Agent.swift`. Current `main` already split Agent beside `AgentTurnKernel` / `Agent+ToolLoop` / `Agent+Cancellation`. Merging the stack would resurrect the god-file and conflict in `Agent.swift`.

Nine adversarial reviews (3 per PR) **BLOCKED** a direct merge. This PR ports the surviving behavior onto current main.

## What landed

- Shared `KeyedRunRegistry` (always compiled). `Agent.ActiveRunRegistry` and graph `TrackedRunRegistry` are typealiases.
- `cancel()` reaches every concurrent run. `reserve` then `attach` so `cancelAll` cannot miss a run that has not attached yet.
- GraphAgent keys by `HiveRunAttemptID` (not reusable `HiveRunID`).
- `TimedOperationCoordinator` deleted. `executeWithinRemainingTimeout` uses `withTimeoutRace` + `onSettle`. Timeout claims the outcome **before** cancelling the operation.
- Pre-expired / pre-cancelled paths deactivate the owned-loop gate.
- Owned-loop pending handoff is first-winner.
- `RetryPolicy.execute` checks cancellation at loop entry, after `onRetry`, and after sleep. Overflow delays saturate to the one-hour ceiling.
- `ChatGraph.withRetry` kept local; documented divergence vs `RetryPolicy.execute`. No second `ResilienceRetry` type (`RetryPolicy.execute` already is that seam). `#180` TurnEngine dump **not** ported — main already has `Agent+ToolLoop` + `AgentTurnKernel`.

## Proof

- Lean Swarm build: exit 0
- Integrations Swarm build: exit 0
- 69 lean tests across RetryPolicy / TimeoutRace / ActiveRunRegistry / Agent cancel-all / gate parity / DocumentationFreshness: pass
- `cancellationDuringOnRetryDoesNotRetryAgain`: pass
- Integrations `GraphRunTrackingTests` (4): pass

## Closes

Supersedes #179 #180 #181.