### PR TITLE
fix(mcp): compile StdioMCPServer on iOS without Foundation.Process

### DIFF
--- a/Sources/Swarm/MCP/StdioMCPServer.swift
+++ b/Sources/Swarm/MCP/StdioMCPServer.swift
@@ -36,6 +36,11 @@ import Foundation
 /// ## Thread Safety
 ///
 /// `StdioMCPServer` is an actor. All process and pipe state is isolated.
+///
+/// Stdio transport needs `Foundation.Process`, which exists on macOS and Linux
+/// only. On iOS, tvOS, watchOS, and visionOS, ``initialize()`` throws
+/// ``MCPError/internalError(_:)`` and tells the caller to use an HTTP MCP
+/// server instead.
 public actor StdioMCPServer: MCPServerConnection {
     // MARK: Public
 
@@ -186,7 +191,11 @@ public actor StdioMCPServer: MCPServerConnection {
     private let encoder: JSONEncoder
     private let decoder: JSONDecoder
 
-    private var process: Process?
+    #if os(macOS) || os(Linux)
+        private var process: Process?
+    #else
+        private var process: StdioUnavailableProcess?
+    #endif
     private var stdinHandle: FileHandle?
     private var stdoutHandle: FileHandle?
     private var stderrHandle: FileHandle?
@@ -199,6 +208,7 @@ public actor StdioMCPServer: MCPServerConnection {
     private var cachedProtocolVersion: String?
 
     private func startProcessIfNeeded() throws {
+        #if os(macOS) || os(Linux)
         if let process, process.isRunning {
             return
         }
@@ -260,6 +270,11 @@ public actor StdioMCPServer: MCPServerConnection {
                 await self?.consumeStderr(chunk)
             }
         }
+        #else
+        throw MCPError.internalError(
+            "Stdio MCP servers are unavailable on this platform. Use an HTTP MCP server instead."
+        )
+        #endif
     }
 
     private func makeDataStream(from handle: FileHandle) -> AsyncStream<Data> {
@@ -439,9 +454,24 @@ public actor StdioMCPServer: MCPServerConnection {
         return result
     }
 
-    private func killProcess(_ process: Process) {
-        let pid = process.processIdentifier
-        guard pid > 0 else { return }
-        _ = kill(pid, SIGKILL)
-    }
+    #if os(macOS) || os(Linux)
+        private func killProcess(_ process: Process) {
+            let pid = process.processIdentifier
+            guard pid > 0 else { return }
+            _ = kill(pid, SIGKILL)
+        }
+    #else
+        private func killProcess(_ process: StdioUnavailableProcess) {
+            _ = process
+        }
+    #endif
 }
+
+#if !os(macOS) && !os(Linux)
+    /// `Foundation.Process` is unavailable on iOS, tvOS, watchOS, and visionOS.
+    private struct StdioUnavailableProcess: Sendable {
+        var isRunning: Bool { false }
+        var processIdentifier: Int32 { 0 }
+        func terminate() {}
+    }
+#endif

--- a/Tests/SwarmTests/MCP/StdioMCPServerPlatformTests.swift
+++ b/Tests/SwarmTests/MCP/StdioMCPServerPlatformTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+@testable import Swarm
+import Testing
+
+struct StdioMCPServerPlatformTests {
+    @Test func initializeMissingExecutableDoesNotClaimMobileUnavailability() async {
+        let server = StdioMCPServer(
+            command: "/this/path/does/not/exist/swarm-mcp-fixture",
+            name: "missing-stdio"
+        )
+        do {
+            _ = try await server.initialize()
+            Issue.record("Expected initialize() to throw for a missing executable.")
+        } catch let error as MCPError {
+            #expect(
+                error.message.contains("unavailable on this platform") == false,
+                "macOS/Linux should still use Process, not the mobile stdio stub"
+            )
+        } catch {
+            Issue.record("Expected MCPError, got \(error)")
+        }
+        try? await server.close()
+    }
+
+    #if os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
+        @Test func initializeThrowsOnAppleMobilePlatforms() async throws {
+            let server = StdioMCPServer(command: "/usr/bin/true", name: "ios-stdio")
+            do {
+                _ = try await server.initialize()
+                Issue.record("Expected initialize() to throw on this platform.")
+            } catch let error as MCPError {
+                #expect(error.message.contains("unavailable on this platform"))
+                #expect(error.message.contains("HTTP"))
+            } catch {
+                Issue.record("Expected MCPError, got \(error)")
+            }
+            try? await server.close()
+        }
+    #endif
+}

--- a/Tests/SwarmTests/MCP/StdioMCPServerPlatformTests.swift
+++ b/Tests/SwarmTests/MCP/StdioMCPServerPlatformTests.swift
@@ -3,6 +3,7 @@ import Foundation
 import Testing
 
 struct StdioMCPServerPlatformTests {
+    #if os(macOS) || os(Linux)
     @Test func initializeMissingExecutableDoesNotClaimMobileUnavailability() async {
         let server = StdioMCPServer(
             command: "/this/path/does/not/exist/swarm-mcp-fixture",
@@ -21,6 +22,7 @@ struct StdioMCPServerPlatformTests {
         }
         try? await server.close()
     }
+    #endif
 
     #if os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
         @Test func initializeThrowsOnAppleMobilePlatforms() async throws {


### PR DESCRIPTION
## Why

Swarm lists iOS 26+, but `StdioMCPServer` stored `Foundation.Process`. That type exists only on macOS and Linux, so an Xcode iOS app linking Swarm 0.6.2 failed to compile before any app code ran.

This blocked the Swarmy research-agent demo.

## Change

- Gate the child-process path behind `#if os(macOS) || os(Linux)`
- On iOS/tvOS/watchOS/visionOS, `initialize()` throws `MCPError.internalError` telling the caller to use HTTP MCP instead
- Add `StdioMCPServerPlatformTests` so macOS/Linux still uses `Process` and does not take the mobile stub path

## Test

```
SWARM_OMIT_INTEGRATION_TARGETS=1 swift test --filter StdioMCPServerPlatformTests
```

Passed on macOS. The iOS `#if` path is compile-time; it was also proven by building an iOS simulator app against a patched checkout.

No public API added. Unrelated `tr2` work is not in this PR.