### PR TITLE
refactor(workflow): share direct and durable transitions

### DIFF
--- a/Sources/Swarm/Workflow/Workflow.swift
+++ b/Sources/Swarm/Workflow/Workflow.swift
@@ -542,44 +542,51 @@ public struct Workflow: Sendable {
     var observer: (any AgentObserver)?
     var advancedConfiguration = AdvancedConfiguration()
 
-    func executeDirect(input: String) async throws -> AgentResult {
-        guard !steps.isEmpty else {
-            throw WorkflowError.invalidWorkflow(reason: "Workflow has no steps")
-        }
-
-        if let repeatCondition {
-            var lastResult: AgentResult?
-
-            for _ in 0 ..< maxRepeatIterations {
-                let currentInput = lastResult?.output ?? input
-                let result = try await runSinglePass(input: currentInput)
-                lastResult = result
-                if repeatCondition(result) {
-                    return result
-                }
+    var workflowTransitionPolicy: WorkflowTransition.Policy {
+        WorkflowTransition.Policy(
+            stepCount: steps.count,
+            repetition: if repeatCondition == nil {
+                .singlePass
+            } else {
+                .until(maxIterations: maxRepeatIterations)
             }
-
-            guard let lastResult else {
-                throw WorkflowError.invalidWorkflow(
-                    reason: "Workflow repeatUntil completed without producing a result"
-                )
-            }
-            return lastResult
-        }
-
-        return try await runSinglePass(input: input)
+        )
     }
 
-    func runSinglePass(input: String) async throws -> AgentResult {
-        var currentInput = input
-        var lastResult = AgentResult(output: "")
+    func executeDirect(input: String) async throws -> AgentResult {
+        let policy = workflowTransitionPolicy
+        var decision = WorkflowTransition.start(input: input, policy: policy)
+        while true {
+            switch decision {
+            case .runStep(let progress):
+                let result = try await execute(
+                    step: steps[progress.stepCursor],
+                    withInput: progress.currentInput
+                )
+                decision = WorkflowTransition.afterStep(
+                    progress: progress,
+                    result: result,
+                    policy: policy
+                )
 
-        for step in steps {
-            lastResult = try await execute(step: step, withInput: currentInput)
-            currentInput = lastResult.output
+            case .evaluateRepeat(let progress, let result):
+                guard let repeatCondition else {
+                    throw WorkflowError.invalidWorkflow(reason: "workflow repeat predicate is missing")
+                }
+                decision = WorkflowTransition.afterRepeatBoundary(
+                    progress: progress,
+                    result: result,
+                    outcome: repeatCondition(result) ? .satisfied : .notSatisfied,
+                    policy: policy
+                )
+
+            case .complete(_, let result):
+                return result
+
+            case .fail(let error):
+                throw error
+            }
         }
-
-        return lastResult
     }
 
     func execute(step: Step, withInput input: String) async throws -> AgentResult {

--- a/Sources/Swarm/Workflow/Workflow.swift
+++ b/Sources/Swarm/Workflow/Workflow.swift
@@ -543,13 +543,15 @@ public struct Workflow: Sendable {
     var advancedConfiguration = AdvancedConfiguration()
 
     var workflowTransitionPolicy: WorkflowTransition.Policy {
-        WorkflowTransition.Policy(
+        let repetition: WorkflowTransition.Repetition
+        if repeatCondition == nil {
+            repetition = .singlePass
+        } else {
+            repetition = .until(maxIterations: maxRepeatIterations)
+        }
+        return WorkflowTransition.Policy(
             stepCount: steps.count,
-            repetition: if repeatCondition == nil {
-                .singlePass
-            } else {
-                .until(maxIterations: maxRepeatIterations)
-            }
+            repetition: repetition
         )
     }
 

--- a/Sources/Swarm/Workflow/WorkflowDurableEngine.swift
+++ b/Sources/Swarm/Workflow/WorkflowDurableEngine.swift
@@ -112,6 +112,9 @@ struct WorkflowDurableEngine: Sendable {
     let resume: Bool
 
     func run(startInput: String) async throws -> AgentResult {
+        if let error = WorkflowTransition.validationError(for: workflow.workflowTransitionPolicy) {
+            throw error
+        }
         if let controller = WorkflowDurableFaultInjection.controller {
             await controller.beginAttempt()
         }
@@ -289,74 +292,91 @@ private func workflowNode(_ input: HiveNodeInput<WorkflowDurableSchema>) async t
     guard case .running(let stepCursor, let iterationCursor, let lastResult) = phase else {
         return HiveNodeOutput(next: .end)
     }
-
-    // Cursors are untrusted persisted state: every engine-written cursor is
-    // non-negative by construction, so a negative value can only come from a
-    // tampered or truncated checkpoint. Fail the resume with a typed error
-    // instead of trapping on `steps[stepCursor]` below.
-    guard stepCursor >= 0, iterationCursor >= 0 else {
-        throw WorkflowError.invalidWorkflow(
-            reason: "durable checkpoint carries negative cursors "
-                + "(stepCursor: \(stepCursor), iterationCursor: \(iterationCursor))"
-        )
-    }
-
     let currentInput = try input.store.get(WorkflowDurableSchema.currentInputKey)
-    // The final result of a pass: the last committed step result, or the
-    // original input for workflows that complete before running any step.
-    let finalSnapshot = { lastResult ?? WorkflowResultSnapshot(AgentResult(output: currentInput)) }
+    let progress = WorkflowTransition.Progress(
+        stepCursor: stepCursor,
+        iterationCursor: iterationCursor,
+        currentInput: currentInput,
+        lastResult: lastResult?.agentResult
+    )
+    let policy = input.context.workflow.workflowTransitionPolicy
 
-    if stepCursor >= input.context.workflow.steps.count {
-        if let repeatCondition = input.context.workflow.repeatCondition {
-            let lastResultValue = lastResult?.agentResult ?? AgentResult(output: currentInput)
-            if repeatCondition(lastResultValue) {
-                return HiveNodeOutput(
-                    writes: [AnyHiveWrite(WorkflowDurableSchema.phaseKey, .completed(finalSnapshot()))],
-                    next: .end
-                )
-            }
-
-            let nextIteration = iterationCursor + 1
-            if nextIteration >= input.context.workflow.maxRepeatIterations {
-                return HiveNodeOutput(
-                    writes: [AnyHiveWrite(WorkflowDurableSchema.phaseKey, .completed(finalSnapshot()))],
-                    next: .end
-                )
-            }
-
-            return HiveNodeOutput(
-                writes: [
-                    AnyHiveWrite(
-                        WorkflowDurableSchema.phaseKey,
-                        .running(stepCursor: 0, iterationCursor: nextIteration, lastResult: lastResult)
-                    ),
-                    AnyHiveWrite(WorkflowDurableSchema.currentInputKey, lastResultValue.output),
-                ]
-            )
+    switch WorkflowTransition.decide(progress: progress, policy: policy) {
+    case .runStep(let progress):
+        let step = input.context.workflow.steps[progress.stepCursor]
+        if let controller = WorkflowDurableFaultInjection.controller {
+            await controller.markWorkflowStepStarted()
         }
-
-        return HiveNodeOutput(
-            writes: [AnyHiveWrite(WorkflowDurableSchema.phaseKey, .completed(finalSnapshot()))],
-            next: .end
+        let result = try await input.context.workflow.execute(step: step, withInput: progress.currentInput)
+        let nextDecision = WorkflowTransition.afterStep(
+            progress: progress,
+            result: result,
+            policy: policy
         )
-    }
+        let nextProgress = try progress(from: nextDecision)
+        return runningOutput(for: nextProgress)
 
-    let step = input.context.workflow.steps[stepCursor]
-    if let controller = WorkflowDurableFaultInjection.controller {
-        await controller.markWorkflowStepStarted()
-    }
-    let result = try await input.context.workflow.execute(step: step, withInput: currentInput)
-    let snapshot = WorkflowResultSnapshot(result)
+    case .evaluateRepeat(let progress, let result):
+        guard let repeatCondition = input.context.workflow.repeatCondition else {
+            throw WorkflowError.invalidWorkflow(reason: "workflow repeat predicate is missing")
+        }
+        let nextDecision = WorkflowTransition.afterRepeatBoundary(
+            progress: progress,
+            result: result,
+            outcome: repeatCondition(result) ? .satisfied : .notSatisfied,
+            policy: policy
+        )
+        return try output(for: nextDecision)
 
-    return HiveNodeOutput(
+    case .complete(_, let result):
+        return completedOutput(for: result)
+
+    case .fail(let error):
+        throw error
+    }
+}
+
+private func progress(from decision: WorkflowTransition.Decision) throws -> WorkflowTransition.Progress {
+    switch decision {
+    case .runStep(let progress), .evaluateRepeat(let progress, _), .complete(let progress, _):
+        return progress
+    case .fail(let error):
+        throw error
+    }
+}
+
+private func runningOutput(for progress: WorkflowTransition.Progress) -> HiveNodeOutput<WorkflowDurableSchema> {
+    HiveNodeOutput(
         writes: [
             AnyHiveWrite(
                 WorkflowDurableSchema.phaseKey,
-                .running(stepCursor: stepCursor + 1, iterationCursor: iterationCursor, lastResult: Optional(snapshot))
+                .running(
+                    stepCursor: progress.stepCursor,
+                    iterationCursor: progress.iterationCursor,
+                    lastResult: progress.lastResult.map { WorkflowResultSnapshot($0) }
+                )
             ),
-            AnyHiveWrite(WorkflowDurableSchema.currentInputKey, result.output),
+            AnyHiveWrite(WorkflowDurableSchema.currentInputKey, progress.currentInput),
         ]
     )
+}
+
+private func completedOutput(for result: AgentResult) -> HiveNodeOutput<WorkflowDurableSchema> {
+    HiveNodeOutput(
+        writes: [AnyHiveWrite(WorkflowDurableSchema.phaseKey, .completed(WorkflowResultSnapshot(result)))],
+        next: .end
+    )
+}
+
+private func output(for decision: WorkflowTransition.Decision) throws -> HiveNodeOutput<WorkflowDurableSchema> {
+    switch decision {
+    case .runStep(let progress), .evaluateRepeat(let progress, _):
+        return runningOutput(for: progress)
+    case .complete(_, let result):
+        return completedOutput(for: result)
+    case .fail(let error):
+        throw error
+    }
 }
 
 private struct WorkflowDurableClock: HiveClock {

--- a/Sources/Swarm/Workflow/WorkflowDurableEngine.swift
+++ b/Sources/Swarm/Workflow/WorkflowDurableEngine.swift
@@ -313,7 +313,7 @@ private func workflowNode(_ input: HiveNodeInput<WorkflowDurableSchema>) async t
             result: result,
             policy: policy
         )
-        let nextProgress = try progress(from: nextDecision)
+        let nextProgress = try progressValue(from: nextDecision)
         return runningOutput(for: nextProgress)
 
     case .evaluateRepeat(let progress, let result):
@@ -336,7 +336,7 @@ private func workflowNode(_ input: HiveNodeInput<WorkflowDurableSchema>) async t
     }
 }
 
-private func progress(from decision: WorkflowTransition.Decision) throws -> WorkflowTransition.Progress {
+private func progressValue(from decision: WorkflowTransition.Decision) throws -> WorkflowTransition.Progress {
     switch decision {
     case .runStep(let progress), .evaluateRepeat(let progress, _), .complete(let progress, _):
         return progress

--- a/Sources/Swarm/Workflow/WorkflowTransition.swift
+++ b/Sources/Swarm/Workflow/WorkflowTransition.swift
@@ -1,0 +1,162 @@
+import Foundation
+
+/// Pure state machine for the control flow shared by direct and durable workflows.
+///
+/// Agent execution, repeat predicates, and persistence remain in their respective
+/// shells. This type only validates progress and selects the next value-level
+/// action.
+enum WorkflowTransition {
+    enum Repetition: Sendable, Equatable {
+        case singlePass
+        case until(maxIterations: Int)
+    }
+
+    struct Policy: Sendable, Equatable {
+        let stepCount: Int
+        let repetition: Repetition
+
+        init(stepCount: Int, repetition: Repetition) {
+            self.stepCount = stepCount
+            self.repetition = repetition
+        }
+    }
+
+    struct Progress: Sendable, Equatable {
+        let stepCursor: Int
+        let iterationCursor: Int
+        let currentInput: String
+        let lastResult: AgentResult?
+
+        init(
+            stepCursor: Int,
+            iterationCursor: Int,
+            currentInput: String,
+            lastResult: AgentResult?
+        ) {
+            self.stepCursor = stepCursor
+            self.iterationCursor = iterationCursor
+            self.currentInput = currentInput
+            self.lastResult = lastResult
+        }
+    }
+
+    enum RepeatBoundaryOutcome: Sendable, Equatable {
+        case satisfied
+        case notSatisfied
+    }
+
+    enum Decision: Sendable, Equatable {
+        case runStep(Progress)
+        case evaluateRepeat(progress: Progress, result: AgentResult)
+        case complete(progress: Progress, result: AgentResult)
+        case fail(WorkflowError)
+    }
+
+    static func start(input: String, policy: Policy) -> Decision {
+        if let error = validationError(for: policy) {
+            return .fail(error)
+        }
+        return decide(
+            progress: Progress(
+                stepCursor: 0,
+                iterationCursor: 0,
+                currentInput: input,
+                lastResult: nil
+            ),
+            policy: policy
+        )
+    }
+
+    static func validationError(for policy: Policy) -> WorkflowError? {
+        guard policy.stepCount > 0 else {
+            return .invalidWorkflow(reason: "Workflow has no steps")
+        }
+        if case .until(let maxIterations) = policy.repetition, maxIterations <= 0 {
+            return .invalidWorkflow(reason: "Workflow repeatUntil requires maxIterations to be greater than zero")
+        }
+        return nil
+    }
+
+    static func decide(progress: Progress, policy: Policy) -> Decision {
+        if let error = validationError(for: policy) {
+            return .fail(error)
+        }
+        guard progress.stepCursor >= 0, progress.iterationCursor >= 0 else {
+            return .fail(.invalidWorkflow(
+                reason: "workflow transition received negative cursors "
+                    + "(stepCursor: \(progress.stepCursor), iterationCursor: \(progress.iterationCursor))"
+            ))
+        }
+
+        guard progress.stepCursor < policy.stepCount else {
+            let result = progress.lastResult ?? AgentResult(output: progress.currentInput)
+            switch policy.repetition {
+            case .singlePass:
+                return .complete(progress: progress, result: result)
+            case .until:
+                return .evaluateRepeat(progress: progress, result: result)
+            }
+        }
+
+        return .runStep(progress)
+    }
+
+    static func afterStep(
+        progress: Progress,
+        result: AgentResult,
+        policy: Policy
+    ) -> Decision {
+        guard progress.stepCursor >= 0, progress.stepCursor < policy.stepCount else {
+            return .fail(.invalidWorkflow(reason: "workflow transition completed an invalid step cursor"))
+        }
+        let (nextStepCursor, overflow) = progress.stepCursor.addingReportingOverflow(1)
+        guard !overflow else {
+            return .fail(.invalidWorkflow(reason: "workflow transition step cursor overflowed"))
+        }
+        return decide(
+            progress: Progress(
+                stepCursor: nextStepCursor,
+                iterationCursor: progress.iterationCursor,
+                currentInput: result.output,
+                lastResult: result
+            ),
+            policy: policy
+        )
+    }
+
+    static func afterRepeatBoundary(
+        progress: Progress,
+        result: AgentResult,
+        outcome: RepeatBoundaryOutcome,
+        policy: Policy
+    ) -> Decision {
+        guard case .until(let maxIterations) = policy.repetition else {
+            return .fail(.invalidWorkflow(reason: "workflow transition evaluated a non-repeating workflow"))
+        }
+        guard progress.stepCursor >= policy.stepCount else {
+            return .fail(.invalidWorkflow(reason: "workflow transition evaluated repeat before the final step"))
+        }
+
+        if outcome == .satisfied {
+            return .complete(progress: progress, result: result)
+        }
+
+        let (nextIteration, overflow) = progress.iterationCursor.addingReportingOverflow(1)
+        guard !overflow else {
+            return .fail(.invalidWorkflow(reason: "workflow transition iteration cursor overflowed"))
+        }
+        guard nextIteration < maxIterations else {
+            return .complete(progress: progress, result: result)
+        }
+
+        return decide(
+            progress: Progress(
+                stepCursor: 0,
+                iterationCursor: nextIteration,
+                currentInput: result.output,
+                lastResult: result
+            ),
+            policy: policy
+        )
+    }
+}

--- a/Tests/SwarmTests/Workflow/WorkflowDurableTests.swift
+++ b/Tests/SwarmTests/Workflow/WorkflowDurableTests.swift
@@ -5,6 +5,73 @@ import Testing
 
 @Suite("Workflow Advanced")
 struct WorkflowDurableTests {
+    @Test("direct and durable repeat execution share limits and result fidelity")
+    func directAndDurableRepeatParity() async throws {
+        for maxIterations in [1, 2] {
+            let directLog = WorkflowInvocationLog()
+            let direct = Workflow()
+                .step(WorkflowRecordingAgent(log: directLog))
+                .repeatUntil(maxIterations: maxIterations) { _ in false }
+
+            let checkpointing = WorkflowCheckpointing.inMemory()
+            let durableLog = WorkflowInvocationLog()
+            let durable = Workflow()
+                .step(WorkflowRecordingAgent(log: durableLog))
+                .repeatUntil(maxIterations: maxIterations) { _ in false }
+                .durable
+                .checkpoint(id: "wf-parity-\(maxIterations)", policy: .everyStep)
+                .durable
+                .checkpointing(checkpointing)
+
+            let directResult = try await direct.run("start")
+            let durableResult = try await durable.durable.execute("start")
+
+            #expect(directResult == durableResult)
+            #expect(await directLog.inputs == ["start"] + Array(repeating: "result", count: maxIterations - 1))
+            #expect(await durableLog.inputs == ["start"] + Array(repeating: "result", count: maxIterations - 1))
+        }
+    }
+
+    @Test("direct and durable execution reject invalid workflows before agent invocation")
+    func invalidWorkflowParity() async throws {
+        let directEmpty = Workflow()
+        await #expect(throws: WorkflowError.self) {
+            _ = try await directEmpty.run("ignored")
+        }
+
+        let directAgentLog = WorkflowInvocationLog()
+        let directRepeating = Workflow()
+            .step(WorkflowRecordingAgent(log: directAgentLog))
+            .repeatUntil(maxIterations: 0) { _ in false }
+        await #expect(throws: WorkflowError.self) {
+            _ = try await directRepeating.run("ignored")
+        }
+        #expect(await directAgentLog.inputs.isEmpty)
+
+        let checkpointing = WorkflowCheckpointing.inMemory()
+        let durableAgentLog = WorkflowInvocationLog()
+        let durableEmpty = Workflow()
+            .durable
+            .checkpoint(id: "wf-empty", policy: .everyStep)
+            .durable
+            .checkpointing(checkpointing)
+        await #expect(throws: WorkflowError.self) {
+            _ = try await durableEmpty.durable.execute("ignored")
+        }
+
+        let durableRepeating = Workflow()
+            .step(WorkflowRecordingAgent(log: durableAgentLog))
+            .repeatUntil(maxIterations: 0) { _ in false }
+            .durable
+            .checkpoint(id: "wf-zero-repeat", policy: .everyStep)
+            .durable
+            .checkpointing(checkpointing)
+        await #expect(throws: WorkflowError.self) {
+            _ = try await durableRepeating.durable.execute("ignored")
+        }
+        #expect(await durableAgentLog.inputs.isEmpty)
+    }
+
     @Test("durable checkpoint requires explicit checkpoint store")
     func checkpointRequiresStore() async throws {
         let workflow = Workflow()
@@ -226,6 +293,48 @@ struct WorkflowDurableTests {
         #expect(result.output == "backup")
         #expect(result.metadata["workflow.fallback.used"] == .bool(true))
     }
+}
+
+private actor WorkflowInvocationLog {
+    private(set) var inputs: [String] = []
+
+    func record(_ input: String) {
+        inputs.append(input)
+    }
+}
+
+private actor WorkflowRecordingAgent: AgentRuntime {
+    nonisolated let tools: [any AnyJSONTool] = []
+    nonisolated let instructions = "WorkflowRecordingAgent"
+    nonisolated let configuration = AgentConfiguration(name: "WorkflowRecordingAgent")
+    nonisolated let handoffs: [AnyHandoffConfiguration] = []
+
+    private let log: WorkflowInvocationLog
+
+    init(log: WorkflowInvocationLog) {
+        self.log = log
+    }
+
+    func run(_ input: String, session: (any Session)?, observer: (any AgentObserver)?) async throws -> AgentResult {
+        await log.record(input)
+        return AgentResult(
+            output: "result",
+            iterationCount: 2,
+            metadata: ["marker": .string("preserved")]
+        )
+    }
+
+    nonisolated func stream(
+        _ input: String,
+        session: (any Session)?,
+        observer: (any AgentObserver)?
+    ) -> AsyncThrowingStream<AgentEvent, Error> {
+        StreamHelper.makeTrackedStream { continuation in
+            continuation.finish(throwing: AgentError.internalError(reason: "recording agent does not stream"))
+        }
+    }
+
+    func cancel() async {}
 }
 
 private func repeatClosureIdentityWorkflow(

--- a/Tests/SwarmTests/Workflow/WorkflowTransitionTests.swift
+++ b/Tests/SwarmTests/Workflow/WorkflowTransitionTests.swift
@@ -1,0 +1,105 @@
+import Foundation
+import Testing
+@testable import Swarm
+
+@Suite("Workflow transition")
+struct WorkflowTransitionTests {
+    @Test("start rejects empty and non-positive repeating policies")
+    func invalidPoliciesFailBeforeRunning() {
+        let policies = [
+            WorkflowTransition.Policy(stepCount: 0, repetition: .singlePass),
+            WorkflowTransition.Policy(stepCount: 1, repetition: .until(maxIterations: 0)),
+            WorkflowTransition.Policy(stepCount: 1, repetition: .until(maxIterations: -1)),
+        ]
+
+        for policy in policies {
+            let decision = WorkflowTransition.start(input: "input", policy: policy)
+            guard case .fail(let error) = decision else {
+                Issue.record("expected invalid policy to fail: \(policy)")
+                continue
+            }
+            guard case .invalidWorkflow = error else {
+                Issue.record("expected WorkflowError.invalidWorkflow, got \(error)")
+                continue
+            }
+        }
+    }
+
+    @Test("repeat boundary honors one- and two-pass limits")
+    func repeatLimitsReturnTheLastFullResult() {
+        for maxIterations in [1, 2] {
+            let policy = WorkflowTransition.Policy(
+                stepCount: 1,
+                repetition: .until(maxIterations: maxIterations)
+            )
+            var decision = WorkflowTransition.start(input: "input", policy: policy)
+            var runCount = 0
+            var lastResult: AgentResult?
+
+            repeatLoop: while true {
+                switch decision {
+                case .runStep(let progress):
+                    runCount += 1
+                    let result = AgentResult(
+                        output: "pass-\(runCount)",
+                        iterationCount: runCount,
+                        metadata: ["marker": .string("full-result")]
+                    )
+                    lastResult = result
+                    decision = WorkflowTransition.afterStep(
+                        progress: progress,
+                        result: result,
+                        policy: policy
+                    )
+
+                case .evaluateRepeat(let progress, let result):
+                    #expect(result == lastResult)
+                    decision = WorkflowTransition.afterRepeatBoundary(
+                        progress: progress,
+                        result: result,
+                        outcome: .notSatisfied,
+                        policy: policy
+                    )
+
+                case .complete(_, let result):
+                    #expect(runCount == maxIterations)
+                    #expect(result == lastResult)
+                    break repeatLoop
+
+                case .fail(let error):
+                    Issue.record("unexpected transition failure: \(error)")
+                    break repeatLoop
+                }
+            }
+        }
+    }
+
+    @Test("a satisfied repeat boundary completes with the supplied result")
+    func satisfiedBoundaryPreservesResult() {
+        let policy = WorkflowTransition.Policy(stepCount: 1, repetition: .until(maxIterations: 3))
+        let result = AgentResult(
+            output: "done",
+            iterationCount: 7,
+            metadata: ["marker": .string("preserved")]
+        )
+        let progress = WorkflowTransition.Progress(
+            stepCursor: 1,
+            iterationCursor: 0,
+            currentInput: result.output,
+            lastResult: result
+        )
+
+        let decision = WorkflowTransition.afterRepeatBoundary(
+            progress: progress,
+            result: result,
+            outcome: .satisfied,
+            policy: policy
+        )
+
+        guard case .complete(_, let completed) = decision else {
+            Issue.record("expected satisfied repeat boundary to complete")
+            return
+        }
+        #expect(completed == result)
+    }
+}


### PR DESCRIPTION
## Summary

Implements architecture ticket T1 from the local functional-evolution spec:
`spec/spec-architecture-functional-evolution-2026-08-28.md`.

- Adds a pure shared Workflow transition model.
- Routes direct and durable execution through the same repeat/terminal semantics.
- Preserves Hive checkpoint state, result metadata, and effectful agent execution in the shells.
- Adds invalid-input, repeat-limit, parity, and persistence regression coverage.

## Validation

- Focused transition tests: pass (3 tests)
- Integrations Workflow durable tests: pass (13 tests)
- Broader lean Workflow selection: 37 tests, with one unrelated Documentation Freshness source-count failure
- `git diff --check`: pass

## Review

- Fresh first review: APPROVE; fixed Swift 6.2 expression/shadowing issues and added missing tests.
- Fresh final review: APPROVE; no actionable findings.
- Review route: `swift-pr-review`
