### PR TITLE
refactor(agent): canonicalize turn transcript projections

### DIFF
--- a/Sources/Swarm/Agents/Agent+ToolLoop.swift
+++ b/Sources/Swarm/Agents/Agent+ToolLoop.swift
@@ -7,47 +7,7 @@
 import Foundation
 
 extension Agent {
-    private enum ConversationMessage: Sendable {
-        case system(String)
-        case user(String)
-        case assistant(String, toolCalls: [InferenceResponse.ParsedToolCall] = [])
-        case toolResult(toolName: String, result: String, toolCallID: String? = nil)
-
-        var formatted: String {
-            switch self {
-            case let .system(content):
-                return "[System]: \(content)"
-            case let .user(content):
-                return "[User]: \(content)"
-            case let .assistant(content, toolCalls):
-                if toolCalls.isEmpty {
-                    return "[Assistant]: \(content)"
-                }
-
-                let summary = toolCalls.map { "Calling tool: \($0.name)" }.joined(separator: ", ")
-                if content.isEmpty {
-                    return "[Assistant]: \(summary)"
-                }
-
-                return "[Assistant]: \(content)\n[Assistant Tool Calls]: \(summary)"
-            case let .toolResult(toolName, result, _):
-                return "[Tool Result - \(toolName)]: \(result)"
-            }
-        }
-
-        var inferenceMessage: InferenceMessage {
-            switch self {
-            case let .system(content):
-                return .system(content)
-            case let .user(content):
-                return .user(content)
-            case let .assistant(content, toolCalls):
-                return .assistant(content, toolCalls: toolCalls.map(InferenceMessage.ToolCall.init))
-            case let .toolResult(toolName, result, toolCallID):
-                return .tool(name: toolName, content: result, toolCallID: toolCallID)
-            }
-        }
-    }
+    private typealias ConversationMessage = AgentTurnTranscript.Message
 
     // MARK: - Tool Calling Loop Implementation
 
@@ -99,13 +59,14 @@ extension Agent {
             }
         }
 
-        var conversationHistory = try buildInitialConversationHistory(
-            sessionHistory: sessionHistory,
-            input: input,
-            memory: activeMemory,
-            memoryContext: memoryContext
+        var turnTranscript = AgentTurnTranscript(
+            conversationMessages: try buildInitialConversationHistory(
+                sessionHistory: sessionHistory,
+                input: input,
+                memory: activeMemory,
+                memoryContext: memoryContext
+            )
         )
-        var transcriptMessages: [MemoryMessage] = []
         let systemMessage = buildSystemMessage(memory: activeMemory, memoryContext: memoryContext)
         await executionContext.recordExecution(agentName: name)
 
@@ -144,7 +105,7 @@ extension Agent {
                     context: executionContext
                 )
                 var plannedSchemas = MembraneInternalTools.sortedSchemas(unplannedSchemas)
-                let historyPrompt = buildPrompt(from: conversationHistory)
+                let historyPrompt = buildPrompt(from: turnTranscript.conversationMessages)
 
                 if let membraneAdapter {
                     do {
@@ -171,7 +132,7 @@ extension Agent {
                     return schemas
                 }()
                 let structuredMessages: [InferenceMessage] = await PromptEnvelope.enforce(
-                    messages: conversationHistory.map(\.inferenceMessage),
+                    messages: turnTranscript.inferenceMessages,
                     profile: configuration.effectiveContextProfile
                 )
                 // REQ-003: the turn mode is derived in exactly one place.
@@ -217,19 +178,15 @@ extension Agent {
                             observer: observer
                         )
                     }
-                    transcriptMessages.append(
-                        SwarmTranscriptCodec.encodeMessage(
-                            role: .assistant,
-                            content: response.content,
-                            toolCalls: [],
-                            structuredOutput: response.structuredOutput
-                        )
+                    turnTranscript.appendAssistant(
+                        content: response.content,
+                        structuredOutput: response.structuredOutput
                     )
                     await observer?.onIterationEnd(context: nil, agent: self, number: iteration)
                     return ToolLoopOutcome(
                         output: response.content,
                         structuredOutput: response.structuredOutput,
-                        transcriptMessages: transcriptMessages
+                        transcriptMessages: turnTranscript.memoryMessages
                     )
                 }
 
@@ -288,8 +245,7 @@ extension Agent {
                         toolRegistry: toolRegistry,
                         memory: activeMemory,
                         membraneAdapter: membraneAdapter,
-                        conversationHistory: conversationHistory,
-                        transcriptMessages: &transcriptMessages,
+                        turnTranscript: &turnTranscript,
                         resultBuilder: resultBuilder,
                         observer: observer,
                         tracing: tracing,
@@ -305,8 +261,7 @@ extension Agent {
                             toolRegistry: toolRegistry,
                             memory: activeMemory,
                             membraneAdapter: membraneAdapter,
-                            conversationHistory: conversationHistory,
-                            transcriptMessages: &transcriptMessages,
+                            turnTranscript: &turnTranscript,
                             resultBuilder: resultBuilder,
                             observer: observer,
                             tracing: tracing,
@@ -330,16 +285,18 @@ extension Agent {
                         request: structuredOutputRequest,
                         provider: provider
                     )
-                    appendOwnedLoopTranscript(
+                    turnTranscript.appendOwnedLoopTranscript(
                         response.transcriptMessages,
-                        finalized: finalResponse,
-                        to: &transcriptMessages
+                        finalizedResponse: AgentTurnTranscript.FinalizedResponse(
+                            content: finalResponse.content,
+                            structuredOutput: finalResponse.structuredOutput
+                        )
                     )
                     await observer?.onIterationEnd(context: nil, agent: self, number: iteration)
                     return ToolLoopOutcome(
                         output: finalResponse.content,
                         structuredOutput: finalResponse.structuredOutput,
-                        transcriptMessages: transcriptMessages
+                        transcriptMessages: turnTranscript.memoryMessages
                     )
 
                 case .executeTools(let toolsState):
@@ -348,8 +305,7 @@ extension Agent {
                         response: response,
                         toolRegistry: toolRegistry,
                         memory: activeMemory,
-                        conversationHistory: &conversationHistory,
-                        transcriptMessages: &transcriptMessages,
+                        turnTranscript: &turnTranscript,
                         resultBuilder: resultBuilder,
                         observer: observer,
                         tracing: tracing,
@@ -362,7 +318,7 @@ extension Agent {
                         return ToolLoopOutcome(
                             output: handoffOutput.content,
                             structuredOutput: handoffOutput.structuredOutput,
-                            transcriptMessages: transcriptMessages
+                            transcriptMessages: turnTranscript.memoryMessages
                         )
                     }
                     await observer?.onIterationEnd(context: nil, agent: self, number: iteration)
@@ -463,8 +419,7 @@ extension Agent {
         parsedCall: InferenceResponse.ParsedToolCall,
         toolRegistry: ToolRegistry,
         memory: (any Memory)?,
-        conversationHistory: inout [ConversationMessage],
-        transcriptMessages: inout [MemoryMessage],
+        turnTranscript: inout AgentTurnTranscript,
         resultBuilder: AgentResult.Builder,
         observer: (any AgentObserver)?,
         tracing: TracingHelper?,
@@ -501,18 +456,10 @@ extension Agent {
                 let duration = ContinuousClock.now - toolStartTime
                 let result = ToolResult.success(callId: call.id, output: .string(output), duration: duration)
                 _ = resultBuilder.addToolResult(result)
-                conversationHistory.append(.toolResult(
+                turnTranscript.appendToolResult(
                     toolName: parsedCall.name,
                     result: output,
                     toolCallID: parsedCall.id
-                ))
-                transcriptMessages.append(
-                    SwarmTranscriptCodec.encodeMessage(
-                        role: .tool,
-                        content: output,
-                        toolName: parsedCall.name,
-                        toolCallID: parsedCall.id
-                    )
                 )
                 if let activeMemory {
                     await activeMemory.add(.tool(output, toolName: parsedCall.name))
@@ -539,18 +486,10 @@ extension Agent {
                 if configuration.stopOnToolError {
                     throw AgentError.toolExecutionFailed(toolName: parsedCall.name, underlyingError: message)
                 }
-                conversationHistory.append(.toolResult(
+                turnTranscript.appendToolResult(
                     toolName: parsedCall.name,
                     result: AgentTurnKernel.toolFailureConversationText(message: message),
                     toolCallID: parsedCall.id
-                ))
-                transcriptMessages.append(
-                    SwarmTranscriptCodec.encodeMessage(
-                        role: .tool,
-                        content: AgentTurnKernel.toolFailureConversationText(message: message),
-                        toolName: parsedCall.name,
-                        toolCallID: parsedCall.id
-                    )
                 )
                 if let activeMemory {
                     await activeMemory.add(.tool(
@@ -599,36 +538,20 @@ extension Agent {
                     }
                 }
 
-                conversationHistory.append(.toolResult(
+                turnTranscript.appendToolResult(
                     toolName: parsedCall.name,
                     result: toolOutputText,
                     toolCallID: parsedCall.id
-                ))
-                transcriptMessages.append(
-                    SwarmTranscriptCodec.encodeMessage(
-                        role: .tool,
-                        content: toolOutputText,
-                        toolName: parsedCall.name,
-                        toolCallID: parsedCall.id
-                    )
                 )
                 if let activeMemory {
                     await activeMemory.add(.tool(toolOutputText, toolName: parsedCall.name))
                 }
             } else {
                 let errorMessage = outcome.result.errorMessage ?? "Unknown error"
-                conversationHistory.append(.toolResult(
+                turnTranscript.appendToolResult(
                     toolName: parsedCall.name,
                     result: AgentTurnKernel.toolFailureConversationText(message: errorMessage),
                     toolCallID: parsedCall.id
-                ))
-                transcriptMessages.append(
-                    SwarmTranscriptCodec.encodeMessage(
-                        role: .tool,
-                        content: AgentTurnKernel.toolFailureConversationText(message: errorMessage),
-                        toolName: parsedCall.name,
-                        toolCallID: parsedCall.id
-                    )
                 )
                 if let activeMemory {
                     await activeMemory.add(.tool(
@@ -745,8 +668,7 @@ extension Agent {
         response: InferenceResponse,
         toolRegistry: ToolRegistry,
         memory: (any Memory)?,
-        conversationHistory: inout [ConversationMessage],
-        transcriptMessages: inout [MemoryMessage],
+        turnTranscript: inout AgentTurnTranscript,
         resultBuilder: AgentResult.Builder,
         observer: (any AgentObserver)?,
         tracing: TracingHelper?,
@@ -759,13 +681,9 @@ extension Agent {
         )
 
         let assistantContent = AgentTurnKernel.assistantContent(for: response)
-        conversationHistory.append(.assistant(assistantContent, toolCalls: response.toolCalls))
-        transcriptMessages.append(
-            SwarmTranscriptCodec.encodeMessage(
-                role: .assistant,
-                content: assistantContent,
-                toolCalls: response.toolCalls
-            )
+        turnTranscript.appendAssistant(
+            content: assistantContent,
+            toolCalls: response.toolCalls
         )
 
         for parsedCall in response.toolCalls {
@@ -782,8 +700,7 @@ extension Agent {
                         parsedCall: parsedCall,
                         toolRegistry: toolRegistry,
                         memory: memory,
-                        conversationHistory: &conversationHistory,
-                        transcriptMessages: &transcriptMessages,
+                        turnTranscript: &turnTranscript,
                         resultBuilder: resultBuilder,
                         observer: observer,
                         tracing: tracing,
@@ -809,18 +726,10 @@ extension Agent {
                     }
 
                     let toolError = AgentTurnKernel.toolFailureConversationText(message: message)
-                    conversationHistory.append(.toolResult(
+                    turnTranscript.appendToolResult(
                         toolName: parsedCall.name,
                         result: toolError,
                         toolCallID: parsedCall.id
-                    ))
-                    transcriptMessages.append(
-                        SwarmTranscriptCodec.encodeMessage(
-                            role: .tool,
-                            content: toolError,
-                            toolName: parsedCall.name,
-                            toolCallID: parsedCall.id
-                        )
                     )
                     continue
                 }
@@ -839,7 +748,7 @@ extension Agent {
                 await observer?.onHandoff(context: context, fromAgent: self, toAgent: targetAgent)
 
                 // Find the last user message to use as handoff input
-                let lastUserMessage = conversationHistory.last(where: {
+                let lastUserMessage = turnTranscript.conversationMessages.last(where: {
                     if case .user = $0 { return true }
                     return false
                 })
@@ -883,7 +792,7 @@ extension Agent {
                 await preserveExecutionPath(from: context, in: handoffContext)
                 if handoffConfig.nestHandoffHistory {
                     await addNestedHandoffHistory(
-                        conversationHistory,
+                        turnTranscript.conversationMessages,
                         to: handoffContext,
                         skippingToolCallID: parsedCall.id
                     )
@@ -928,18 +837,10 @@ extension Agent {
                     }
                     throw error
                 }
-                conversationHistory.append(.toolResult(
+                turnTranscript.appendToolResult(
                     toolName: parsedCall.name,
                     result: result.output,
                     toolCallID: parsedCall.id
-                ))
-                transcriptMessages.append(
-                    SwarmTranscriptCodec.encodeMessage(
-                        role: .tool,
-                        content: result.output,
-                        toolName: parsedCall.name,
-                        toolCallID: parsedCall.id
-                    )
                 )
 
                 let handoffDuration = ContinuousClock.now - handoffStart
@@ -977,8 +878,7 @@ extension Agent {
                     parsedCall: parsedCall,
                     toolRegistry: toolRegistry,
                     memory: memory,
-                    conversationHistory: &conversationHistory,
-                    transcriptMessages: &transcriptMessages,
+                    turnTranscript: &turnTranscript,
                     resultBuilder: resultBuilder,
                     observer: observer,
                     tracing: tracing,
@@ -1262,15 +1162,14 @@ extension Agent {
         toolRegistry: ToolRegistry,
         memory: (any Memory)?,
         membraneAdapter: (any MembraneAgentAdapter)?,
-        conversationHistory: [ConversationMessage],
-        transcriptMessages: inout [MemoryMessage],
+        turnTranscript: inout AgentTurnTranscript,
         resultBuilder: AgentResult.Builder,
         observer: (any AgentObserver)?,
         tracing: TracingHelper?,
         context: AgentContext,
         startTime: ContinuousClock.Instant
     ) async throws -> ToolLoopOutcome {
-        var history = conversationHistory
+        var history = turnTranscript
         let response = InferenceResponse(
             content: nil,
             toolCalls: [
@@ -1286,8 +1185,7 @@ extension Agent {
             response: response,
             toolRegistry: toolRegistry,
             memory: memory,
-            conversationHistory: &history,
-            transcriptMessages: &transcriptMessages,
+            turnTranscript: &history,
             resultBuilder: resultBuilder,
             observer: observer,
             tracing: tracing,
@@ -1303,38 +1201,7 @@ extension Agent {
         return ToolLoopOutcome(
             output: handoffOutput.content,
             structuredOutput: handoffOutput.structuredOutput,
-            transcriptMessages: transcriptMessages
+            transcriptMessages: history.memoryMessages
         )
-    }
-
-    private func appendOwnedLoopTranscript(
-        _ transcript: [InferenceMessage],
-        finalized: FinalAssistantResponse,
-        to transcriptMessages: inout [MemoryMessage]
-    ) {
-        if transcript.isEmpty {
-            transcriptMessages.append(
-                SwarmTranscriptCodec.encodeMessage(
-                    role: .assistant,
-                    content: finalized.content,
-                    toolCalls: [],
-                    structuredOutput: finalized.structuredOutput
-                )
-            )
-            return
-        }
-
-        var owned = transcript.map(SwarmTranscriptCodec.encode)
-        if let structured = finalized.structuredOutput,
-           let last = owned.indices.last,
-           owned[last].role == .assistant
-        {
-            owned[last] = SwarmTranscriptCodec.encodeMessage(
-                role: .assistant,
-                content: finalized.content,
-                structuredOutput: structured
-            )
-        }
-        transcriptMessages.append(contentsOf: owned)
     }
 }

--- a/Sources/Swarm/Agents/AgentTurnTranscript.swift
+++ b/Sources/Swarm/Agents/AgentTurnTranscript.swift
@@ -1,0 +1,155 @@
+// AgentTurnTranscript.swift
+// Swarm Framework
+
+import Foundation
+
+/// Value-level owner for an agent turn's inference and persistence projections.
+/// Effects remain in the surrounding Agent tool-loop shell.
+struct AgentTurnTranscript: Sendable, Equatable {
+    enum Message: Sendable, Equatable {
+        case system(String)
+        case user(String)
+        case assistant(String, toolCalls: [InferenceResponse.ParsedToolCall] = [])
+        case toolResult(toolName: String, result: String, toolCallID: String? = nil)
+
+        var formatted: String {
+            switch self {
+            case let .system(content):
+                return "[System]: \(content)"
+            case let .user(content):
+                return "[User]: \(content)"
+            case let .assistant(content, toolCalls):
+                if toolCalls.isEmpty { return "[Assistant]: \(content)" }
+                let summary = toolCalls.map { "Calling tool: \($0.name)" }.joined(separator: ", ")
+                if content.isEmpty { return "[Assistant]: \(summary)" }
+                return "[Assistant]: \(content)\n[Assistant Tool Calls]: \(summary)"
+            case let .toolResult(toolName, result, _):
+                return "[Tool Result - \(toolName)]: \(result)"
+            }
+        }
+
+        var inferenceMessage: InferenceMessage {
+            switch self {
+            case let .system(content): return .system(content)
+            case let .user(content): return .user(content)
+            case let .assistant(content, toolCalls):
+                return .assistant(content, toolCalls: toolCalls.map(InferenceMessage.ToolCall.init))
+            case let .toolResult(toolName, result, toolCallID):
+                return .tool(name: toolName, content: result, toolCallID: toolCallID)
+            }
+        }
+
+        init(_ message: InferenceMessage) {
+            switch message.role {
+            case .system: self = .system(message.content)
+            case .user: self = .user(message.content)
+            case .assistant:
+                self = .assistant(
+                    message.content,
+                    toolCalls: message.toolCalls.map {
+                        InferenceResponse.ParsedToolCall(id: $0.id, name: $0.name, arguments: $0.arguments)
+                    }
+                )
+            case .tool:
+                self = .toolResult(
+                    toolName: message.name ?? "previous",
+                    result: message.content,
+                    toolCallID: message.toolCallID
+                )
+            }
+        }
+    }
+
+    struct FinalizedResponse: Sendable, Equatable {
+        let content: String
+        let structuredOutput: StructuredOutputResult?
+
+        init(content: String, structuredOutput: StructuredOutputResult? = nil) {
+            self.content = content
+            self.structuredOutput = structuredOutput
+        }
+    }
+
+    private(set) var conversationMessages: [Message]
+    private(set) var memoryMessages: [MemoryMessage]
+
+    var inferenceMessages: [InferenceMessage] {
+        conversationMessages.map(\.inferenceMessage)
+    }
+
+    init(conversationMessages: [Message] = [], memoryMessages: [MemoryMessage] = []) {
+        self.conversationMessages = conversationMessages
+        self.memoryMessages = memoryMessages
+    }
+
+    mutating func appendAssistant(
+        content: String,
+        toolCalls: [InferenceResponse.ParsedToolCall] = [],
+        structuredOutput: StructuredOutputResult? = nil
+    ) {
+        conversationMessages.append(.assistant(content, toolCalls: toolCalls))
+        memoryMessages.append(
+            SwarmTranscriptCodec.encodeMessage(
+                role: .assistant,
+                content: content,
+                toolCalls: toolCalls,
+                structuredOutput: structuredOutput
+            )
+        )
+    }
+
+    mutating func appendToolResult(toolName: String, result: String, toolCallID: String? = nil) {
+        conversationMessages.append(.toolResult(toolName: toolName, result: result, toolCallID: toolCallID))
+        memoryMessages.append(
+            SwarmTranscriptCodec.encodeMessage(
+                role: .tool,
+                content: result,
+                toolName: toolName,
+                toolCallID: toolCallID
+            )
+        )
+    }
+
+    mutating func appendOwnedLoopTranscript(
+        _ messages: [InferenceMessage],
+        finalizedResponse: FinalizedResponse
+    ) {
+        guard !messages.isEmpty else {
+            appendAssistant(
+                content: finalizedResponse.content,
+                structuredOutput: finalizedResponse.structuredOutput
+            )
+            return
+        }
+
+        var ownedConversation = messages.map(Message.init)
+        var ownedMemory = messages.map(SwarmTranscriptCodec.encode)
+        if let structuredOutput = finalizedResponse.structuredOutput,
+           let last = ownedConversation.indices.last
+        {
+            let toolCalls: [InferenceResponse.ParsedToolCall]
+            if case let .assistant(_, calls) = ownedConversation[last] {
+                toolCalls = calls
+                ownedConversation[last] = .assistant(finalizedResponse.content, toolCalls: calls)
+            } else {
+                toolCalls = []
+            }
+
+            if ownedMemory[last].role == .assistant {
+                let previous = ownedMemory[last]
+                ownedMemory[last] = SwarmTranscriptCodec.encodeMessage(
+                    role: .assistant,
+                    content: finalizedResponse.content,
+                    timestamp: previous.timestamp,
+                    messageID: previous.id,
+                    metadata: previous.metadata,
+                    toolCalls: toolCalls,
+                    structuredOutput: structuredOutput
+                )
+            }
+        }
+
+        conversationMessages.append(contentsOf: ownedConversation)
+        memoryMessages.append(contentsOf: ownedMemory)
+    }
+}

--- a/Tests/SwarmTests/Agents/AgentTurnTranscriptTests.swift
+++ b/Tests/SwarmTests/Agents/AgentTurnTranscriptTests.swift
@@ -33,8 +33,8 @@ struct AgentTurnTranscriptTests {
         ])
         #expect(entries[1].toolName == "weather")
         #expect(entries[1].toolCallID == call.id)
-        #expect(entries[0].metadata["swarm.transcript.entry_id"] == entries[0].messageID.uuidString)
-        #expect(entries[1].metadata["swarm.transcript.entry_id"] == entries[1].messageID.uuidString)
+        #expect(transcript.memoryMessages[0].metadata[SwarmTranscriptCodec.entryIDKey] == entries[0].messageID.uuidString)
+        #expect(transcript.memoryMessages[1].metadata[SwarmTranscriptCodec.entryIDKey] == entries[1].messageID.uuidString)
     }
 
     @Test("Owned provider transcripts retain order, IDs, tool calls, and structured output")

--- a/Tests/SwarmTests/Agents/AgentTurnTranscriptTests.swift
+++ b/Tests/SwarmTests/Agents/AgentTurnTranscriptTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+@testable import Swarm
+import Testing
+
+struct AgentTurnTranscriptTests {
+    @Test("Named append operations keep inference and memory projections aligned")
+    func appendOperationsPreserveRolesAndToolIDs() {
+        let call = InferenceResponse.ParsedToolCall(
+            id: "call-weather",
+            name: "weather",
+            arguments: ["city": .string("Nairobi")]
+        )
+        var transcript = AgentTurnTranscript()
+
+        transcript.appendAssistant(content: "", toolCalls: [call])
+        transcript.appendToolResult(
+            toolName: "weather",
+            result: "sunny",
+            toolCallID: call.id
+        )
+
+        #expect(transcript.inferenceMessages == [
+            .assistant("", toolCalls: [
+                InferenceMessage.ToolCall(id: call.id, name: call.name, arguments: call.arguments),
+            ]),
+            .tool(name: "weather", content: "sunny", toolCallID: "call-weather"),
+        ])
+
+        let entries = transcript.memoryMessages.map { SwarmTranscriptCodec.decodeEntry(from: $0) }
+        #expect(entries.map(\.role) == [.assistant, .tool])
+        #expect(entries[0].toolCalls == [
+            SwarmTranscriptToolCall(id: call.id, name: call.name, arguments: call.arguments),
+        ])
+        #expect(entries[1].toolName == "weather")
+        #expect(entries[1].toolCallID == call.id)
+        #expect(entries[0].metadata["swarm.transcript.entry_id"] == entries[0].messageID.uuidString)
+        #expect(entries[1].metadata["swarm.transcript.entry_id"] == entries[1].messageID.uuidString)
+    }
+
+    @Test("Owned provider transcripts retain order, IDs, tool calls, and structured output")
+    func ownedLoopProjectionPreservesProviderTranscript() {
+        let providerMessages: [InferenceMessage] = [
+            .assistant("", toolCalls: [
+                .init(id: "call-search", name: "search", arguments: [:]),
+            ]),
+            .tool(name: "search", content: "result", toolCallID: "call-search"),
+            .assistant("provider final"),
+        ]
+        let structured = StructuredOutputResult(
+            format: .jsonObject,
+            rawJSON: #"{"answer":"ok"}"#,
+            value: .dictionary(["answer": .string("ok")]),
+            source: .providerNative
+        )
+        var transcript = AgentTurnTranscript()
+
+        transcript.appendOwnedLoopTranscript(
+            providerMessages,
+            finalizedResponse: .init(content: structured.rawJSON, structuredOutput: structured)
+        )
+
+        #expect(transcript.inferenceMessages.map(\.role) == [.assistant, .tool, .assistant])
+        #expect(transcript.inferenceMessages[0].toolCalls.first?.id == "call-search")
+        #expect(transcript.inferenceMessages[1].toolCallID == "call-search")
+        #expect(transcript.inferenceMessages[2].content == structured.rawJSON)
+
+        let entries = transcript.memoryMessages.map { SwarmTranscriptCodec.decodeEntry(from: $0) }
+        #expect(entries.count == 3)
+        #expect(entries[0].toolCalls.first?.id == "call-search")
+        #expect(entries[1].toolCallID == "call-search")
+        #expect(entries[2].structuredOutput?.result == structured)
+        #expect(entries[2].content == structured.rawJSON)
+    }
+
+    @Test("An empty owned transcript becomes one final assistant message")
+    func emptyOwnedLoopAddsFinalAssistant() {
+        let structured = StructuredOutputResult(
+            format: .jsonObject,
+            rawJSON: "[]",
+            value: .array([]),
+            source: .promptFallback
+        )
+        var transcript = AgentTurnTranscript()
+
+        transcript.appendOwnedLoopTranscript(
+            [],
+            finalizedResponse: .init(content: "[]", structuredOutput: structured)
+        )
+
+        #expect(transcript.inferenceMessages == [.assistant("[]")])
+        let entry = transcript.memoryMessages.first.map(SwarmTranscriptCodec.decodeEntry(from:))
+        #expect(entry?.role == .assistant)
+        #expect(entry?.structuredOutput?.result == structured)
+    }
+}


### PR DESCRIPTION
## Summary

Implements architecture ticket T2 from the local functional-evolution spec:
`spec/spec-architecture-functional-evolution-2026-08-28.md`.

- Adds an internal value-level canonical Agent turn transcript.
- Keeps inference and persisted transcript projections aligned across host, Membrane, handoff, failure, and provider-owned paths.
- Preserves transcript codec behavior, IDs, roles, structured output, memory, tracing, and observer effects.
- Adds pure transcript projection tests.

## Validation

- AgentTurnTranscriptTests: pass (3)
- AgentTranscriptContractTests: pass (6)
- ProviderOwnedToolLoopTests: pass (16)
- AgentHandoffRuntimeTests: pass (6)
- AgentToolLoopCharacterizationTests: pass (4)
- Lean Swarm build/test build: pass
- `git diff --check`: pass

## Review

- Fresh first review: APPROVE; fixed reserved metadata assertion at the storage boundary.
- Fresh final review: APPROVE; no actionable findings.
- Review route: `swift-pr-review`
