### PR TITLE
refactor(context): remove legacy typed storage shim

### DIFF
--- a/Sources/Swarm/Core/Execution/AgentContext.swift
+++ b/Sources/Swarm/Core/Execution/AgentContext.swift
@@ -41,53 +41,6 @@ public enum AgentContextKey: String, Sendable {
     case metadata
 }
 
-// MARK: - AgentContextProviding
-
-/// A protocol for providing typed context to agents and tools.
-///
-/// - Deprecated: Store typed values with ``ContextKey`` instead. Define a
-/// `ContextKey<Value>` for your value type and use
-/// ``AgentContext/setTyped(_:value:)`` /
-/// ``AgentContext/getTyped(_:)``, which pair keys and values at compile
-/// time. This protocol remains functional over the unified context store
-/// but will be removed in a future release.
-///
-/// - Migration hazard: `ContextKey<Value>` writes live in a namespace
-/// separate from untyped string storage. Values written through the typed
-/// API are no longer visible to raw reads such as
-/// ``AgentContext/get(_:)`` or string-keyed snapshot entries, so any code
-/// still reading a migrated value by its raw string must switch to
-/// ``AgentContext/getTyped(_:)`` with the same key name.
-///
-/// Example:
-/// ```swift
-/// extension ContextKey where Value == String {
-///     static let userContext = ContextKey("user_context")
-/// }
-///
-/// struct UserContext: Codable, Sendable {
-///     let userId: String
-///     let isAdmin: Bool
-/// }
-///
-/// // Store:
-/// await context.setTyped(.userContext, value: UserContext(userId: "123", isAdmin: true))
-///
-/// // Retrieve:
-/// if let user = await context.getTyped(.userContext) {
-///     print(user.userId)
-/// }
-/// ```
-@available(
-    *,
-    deprecated,
-    message: "Use ContextKey<Value> with setTyped(_:value:)/getTyped(_:) instead"
-)
-public protocol AgentContextProviding: Sendable {
-    /// The key used to store this context in the key-value storage.
-    static var contextKey: String { get }
-}
-
 // MARK: - AgentContext
 
 /// Thread-safe shared context for multi-agent orchestration.
@@ -384,8 +337,7 @@ public actor AgentContext {
         // Merge typed value slots so reads through `getTyped(_:)` observe
         // merged state. Snapshot already projects those slots by name; they
         // are not copied into the raw namespace, matching `setTyped` and
-        // `copy(additionalValues:)`. Provided slots are intentionally not
-        // merged; they were historically instance-specific.
+        // `copy(additionalValues:)`.
         slots.mergeValueSlots(from: otherSlots, overwrite: overwrite)
 
         // Merge messages
@@ -427,8 +379,7 @@ public actor AgentContext {
         }
 
         // Carry typed value slots so reads through `getTyped(_:)` observe
-        // copied state. Provided slots are intentionally not copied; they
-        // are instance-specific.
+        // copied state.
         let newContext = AgentContext(
             input: originalInput,
             initialValues: copiedValues,
@@ -440,43 +391,6 @@ public actor AgentContext {
         // If needed, use merge() after creating the copy.
 
         return newContext
-    }
-
-    // MARK: - Typed Context (deprecated shim)
-
-    /// Stores a typed context object.
-    ///
-    /// The context is stored in the unified slot store keyed by its concrete
-    /// type and `contextKey`, and can be retrieved using `typed(_:)`.
-    ///
-    /// - Parameter context: The typed context to store.
-    public func setTyped<T: AgentContextProviding>(_ context: T) {
-        slots.setProvided(context)
-    }
-
-    /// Retrieves a typed context object.
-    ///
-    /// - Parameter type: The type of context to retrieve.
-    /// - Returns: The stored context, or nil if not found.
-    public func typed<T: AgentContextProviding>(_: T.Type) -> T? {
-        slots.provided(of: T.self)
-    }
-
-    /// Removes a typed context.
-    ///
-    /// - Parameter type: The type of context to remove.
-    /// - Returns: The removed context, or nil if not found.
-    @discardableResult
-    public func removeTyped<T: AgentContextProviding>(_: T.Type) -> T? {
-        slots.removeProvided(of: T.self)
-    }
-
-    /// Returns true if a typed context of the given type is stored.
-    ///
-    /// - Parameter type: The type to check for.
-    /// - Returns: Whether a context of this type exists.
-    public func hasTyped<T: AgentContextProviding>(_: T.Type) -> Bool {
-        slots.containsProvided(of: T.self)
     }
 
     // MARK: - Slot Storage Bridge (package-internal)
@@ -562,9 +476,8 @@ public actor AgentContext {
     /// List of agent names that have executed.
     private var executionPath: [String]
 
-    /// Unified typed slot storage shared by `ContextKey<Value>` accessors
-    /// and the deprecated `AgentContextProviding` shim. See
-    /// `ContextSlotStore`.
+    /// Unified typed slot storage used by `ContextKey<Value>` accessors.
+    /// See `ContextSlotStore`.
     private var slots: ContextSlotStore
 }
 

--- a/Sources/Swarm/Core/Execution/AgentContext.swift
+++ b/Sources/Swarm/Core/Execution/AgentContext.swift
@@ -41,6 +41,48 @@ public enum AgentContextKey: String, Sendable {
     case metadata
 }
 
+// MARK: - AgentContextProviding
+
+/// A protocol for providing typed context to agents and tools.
+///
+/// - Deprecated: Store typed values with ``ContextKey`` instead. Define a
+///   `ContextKey<Value>` for your value type and use
+///   ``AgentContext/setTyped(_:value:)`` /
+///   ``AgentContext/getTyped(_:)``, which pair keys and values at compile
+///   time. This protocol remains functional over the unified context store
+///   until the documented 0.7.0 breaking boundary.
+///
+/// - Migration hazard: `ContextKey<Value>` writes live in a namespace
+///   separate from untyped string storage. Values written through the typed
+///   API are no longer visible to raw reads such as
+///   ``AgentContext/get(_:)`` or string-keyed snapshot entries, so any code
+///   still reading a migrated value by its raw string must switch to
+///   ``AgentContext/getTyped(_:)`` with the same key name.
+///
+/// - Example:
+/// ```swift
+/// struct UserContext: Codable, Sendable {
+///     let userId: String
+///     let isAdmin: Bool
+/// }
+///
+/// extension UserContext: AgentContextProviding {
+///     static let contextKey = "user_context"
+/// }
+///
+/// await context.setTyped(UserContext(userId: "123", isAdmin: true))
+/// let user = await context.typed(UserContext.self)
+/// ```
+@available(
+    *,
+    deprecated,
+    message: "Use ContextKey<Value> with setTyped(_:value:)/getTyped(_:) instead; this protocol will be removed in 0.7.0."
+)
+public protocol AgentContextProviding: Sendable {
+    /// The key used to identify this context in the legacy typed storage.
+    static var contextKey: String { get }
+}
+
 // MARK: - AgentContext
 
 /// Thread-safe shared context for multi-agent orchestration.
@@ -337,7 +379,8 @@ public actor AgentContext {
         // Merge typed value slots so reads through `getTyped(_:)` observe
         // merged state. Snapshot already projects those slots by name; they
         // are not copied into the raw namespace, matching `setTyped` and
-        // `copy(additionalValues:)`.
+        // `copy(additionalValues:)`. Provided slots remain instance-specific,
+        // as they were historically.
         slots.mergeValueSlots(from: otherSlots, overwrite: overwrite)
 
         // Merge messages
@@ -379,7 +422,8 @@ public actor AgentContext {
         }
 
         // Carry typed value slots so reads through `getTyped(_:)` observe
-        // copied state.
+        // copied state. Provided slots are intentionally not copied; they
+        // are instance-specific.
         let newContext = AgentContext(
             input: originalInput,
             initialValues: copiedValues,
@@ -391,6 +435,47 @@ public actor AgentContext {
         // If needed, use merge() after creating the copy.
 
         return newContext
+    }
+
+    // MARK: - Typed Context (deprecated shim)
+
+    /// Stores a typed context object.
+    ///
+    /// The context is stored in legacy typed storage keyed by its concrete
+    /// type and `contextKey`, and can be retrieved using `typed(_:)`.
+    ///
+    /// - Parameter context: The typed context to store.
+    @available(*, deprecated, message: "Use ContextKey<Value> with setTyped(_:value:) instead; this overload will be removed in 0.7.0.")
+    public func setTyped<T: AgentContextProviding>(_ context: T) {
+        slots.setProvided(context)
+    }
+
+    /// Retrieves a typed context object.
+    ///
+    /// - Parameter type: The type of context to retrieve.
+    /// - Returns: The stored context, or nil if not found.
+    @available(*, deprecated, message: "Use ContextKey<Value> with getTyped(_:) instead; this overload will be removed in 0.7.0.")
+    public func typed<T: AgentContextProviding>(_: T.Type) -> T? {
+        slots.provided(of: T.self)
+    }
+
+    /// Removes a typed context.
+    ///
+    /// - Parameter type: The type of context to remove.
+    /// - Returns: The removed context, or nil if not found.
+    @available(*, deprecated, message: "Use ContextKey<Value> with removeTyped(_:) instead; this overload will be removed in 0.7.0.")
+    @discardableResult
+    public func removeTyped<T: AgentContextProviding>(_: T.Type) -> T? {
+        slots.removeProvided(of: T.self)
+    }
+
+    /// Returns true if a typed context of the given type is stored.
+    ///
+    /// - Parameter type: The type to check for.
+    /// - Returns: Whether a context of this type exists.
+    @available(*, deprecated, message: "Use ContextKey<Value> with hasTyped(_:) instead; this overload will be removed in 0.7.0.")
+    public func hasTyped<T: AgentContextProviding>(_: T.Type) -> Bool {
+        slots.containsProvided(of: T.self)
     }
 
     // MARK: - Slot Storage Bridge (package-internal)
@@ -476,8 +561,8 @@ public actor AgentContext {
     /// List of agent names that have executed.
     private var executionPath: [String]
 
-    /// Unified typed slot storage used by `ContextKey<Value>` accessors.
-    /// See `ContextSlotStore`.
+    /// Unified typed slot storage used by `ContextKey<Value>` accessors and
+    /// the deprecated `AgentContextProviding` shim. See `ContextSlotStore`.
     private var slots: ContextSlotStore
 }
 

--- a/Sources/Swarm/Core/Execution/ContextSlotStore.swift
+++ b/Sources/Swarm/Core/Execution/ContextSlotStore.swift
@@ -61,13 +61,19 @@ struct ContextSlotEntry {
 /// The single unified store for `AgentContext` typed values.
 ///
 /// `ContextKey<Value>` writes land in value slots keyed by
-/// `(Value type identity, key name)`. Untyped string access remains a separate
-/// raw `[String: SendableValue]` namespace owned by `AgentContext`.
+/// `(Value type identity, key name)`; the deprecated
+/// `AgentContextProviding` shim stores instances in provided slots keyed by
+/// `(concrete type identity, contextKey)`. Untyped string access remains a
+/// separate raw `[String: SendableValue]` namespace owned by `AgentContext`.
 struct ContextSlotStore {
     // MARK: Private
 
     /// Typed value slots keyed by value-type identity plus key name.
     private var valueSlots: [ContextSlotID: ContextSlotEntry] = [:]
+
+    /// Deprecated `AgentContextProviding` instances keyed by concrete type
+    /// identity plus the conformer's `contextKey`.
+    private var providedSlots: [ContextSlotID: any AgentContextProviding] = [:]
 
     /// Source of monotonically increasing write stamps.
     private var nextWriteStamp = 0
@@ -217,9 +223,56 @@ struct ContextSlotStore {
         valueSlots.contains { $0.key.name == name }
     }
 
+    // MARK: - Provided Slots (deprecated shim)
+
+    /// Stores `instance` in the slot identified by its concrete type and
+    /// `AgentContextProviding.contextKey`.
+    ///
+    /// - Parameter instance: The typed context instance to store.
+    mutating func setProvided<T: AgentContextProviding>(_ instance: T) {
+        let id = ContextSlotID(valueType: T.self, name: T.contextKey)
+        providedSlots[id] = instance
+    }
+
+    /// Returns the stored instance for `type`, if any.
+    ///
+    /// The slot identifier pins the concrete type, so the single existential
+    /// crossing below can neither fail nor produce a wrong-typed value; a
+    /// mismatched request simply addresses an empty slot and returns nil.
+    ///
+    /// - Parameter type: The concrete context type to retrieve.
+    /// - Returns: The stored instance, or nil when absent.
+    func provided<T: AgentContextProviding>(of type: T.Type) -> T? {
+        extract(type, from: providedSlots[ContextSlotID(valueType: T.self, name: T.contextKey)])
+    }
+
+    /// Removes and returns the stored instance for `type`, if any.
+    ///
+    /// - Parameter type: The concrete context type to remove.
+    /// - Returns: The removed instance, or nil when absent.
+    @discardableResult
+    mutating func removeProvided<T: AgentContextProviding>(of type: T.Type) -> T? {
+        extract(type, from: providedSlots.removeValue(forKey: ContextSlotID(
+            valueType: T.self,
+            name: T.contextKey
+        )))
+    }
+
+    /// Returns whether a provided slot exists for `type`.
+    ///
+    /// - Parameter type: The concrete context type to look up.
+    /// - Returns: True when an instance is stored.
+    func containsProvided<T: AgentContextProviding>(of type: T.Type) -> Bool {
+        providedSlots[ContextSlotID(valueType: T.self, name: T.contextKey)] != nil
+    }
+
     // MARK: - Copying
 
-    /// Creates a copy holding the value slots.
+    /// Creates a copy holding only value slots, dropping provided slots.
+    ///
+    /// Provided slots are deliberately excluded: `copy(additionalValues:)`
+    /// historically duplicated only the string-keyed values that typed
+    /// `ContextKey` writes produced, never `AgentContextProviding` instances.
     ///
     /// - Returns: A store whose value slots match this store's.
     func copyingValueSlots() -> ContextSlotStore {
@@ -235,6 +288,19 @@ struct ContextSlotStore {
             )
         }
         return copy
+    }
+
+    // MARK: Private
+
+    /// Crosses the `any AgentContextProviding` existential boundary after
+    /// slot identity already established the stored instance has type
+    /// `Value`.
+    private func extract<Value: AgentContextProviding>(
+        _ type: Value.Type,
+        from slot: (any AgentContextProviding)?
+    ) -> Value? {
+        guard let slot else { return nil }
+        return slot as? Value
     }
 
 }

--- a/Sources/Swarm/Core/Execution/ContextSlotStore.swift
+++ b/Sources/Swarm/Core/Execution/ContextSlotStore.swift
@@ -61,19 +61,13 @@ struct ContextSlotEntry {
 /// The single unified store for `AgentContext` typed values.
 ///
 /// `ContextKey<Value>` writes land in value slots keyed by
-/// `(Value type identity, key name)`; the deprecated `AgentContextProviding`
-/// shim stores instances in provided slots keyed by
-/// `(concrete type identity, contextKey)`. Untyped string access remains a
-/// separate raw `[String: SendableValue]` namespace owned by `AgentContext`.
+/// `(Value type identity, key name)`. Untyped string access remains a separate
+/// raw `[String: SendableValue]` namespace owned by `AgentContext`.
 struct ContextSlotStore {
     // MARK: Private
 
     /// Typed value slots keyed by value-type identity plus key name.
     private var valueSlots: [ContextSlotID: ContextSlotEntry] = [:]
-
-    /// Deprecated `AgentContextProviding` instances keyed by concrete type
-    /// identity plus the conformer's `contextKey`.
-    private var providedSlots: [ContextSlotID: any AgentContextProviding] = [:]
 
     /// Source of monotonically increasing write stamps.
     private var nextWriteStamp = 0
@@ -223,56 +217,9 @@ struct ContextSlotStore {
         valueSlots.contains { $0.key.name == name }
     }
 
-    // MARK: - Provided Slots (deprecated shim)
-
-    /// Stores `instance` in the slot identified by its concrete type and
-    /// `AgentContextProviding.contextKey`.
-    ///
-    /// - Parameter instance: The typed context instance to store.
-    mutating func setProvided<T: AgentContextProviding>(_ instance: T) {
-        let id = ContextSlotID(valueType: T.self, name: T.contextKey)
-        providedSlots[id] = instance
-    }
-
-    /// Returns the stored instance for `type`, if any.
-    ///
-    /// The slot identifier pins the concrete type, so the single existential
-    /// crossing below can neither fail nor produce a wrong-typed value; a
-    /// mismatched request simply addresses an empty slot and returns nil.
-    ///
-    /// - Parameter type: The concrete context type to retrieve.
-    /// - Returns: The stored instance, or nil when absent.
-    func provided<T: AgentContextProviding>(of type: T.Type) -> T? {
-        extract(type, from: providedSlots[ContextSlotID(valueType: T.self, name: T.contextKey)])
-    }
-
-    /// Removes and returns the stored instance for `type`, if any.
-    ///
-    /// - Parameter type: The concrete context type to remove.
-    /// - Returns: The removed instance, or nil when absent.
-    @discardableResult
-    mutating func removeProvided<T: AgentContextProviding>(of type: T.Type) -> T? {
-        extract(type, from: providedSlots.removeValue(forKey: ContextSlotID(
-            valueType: T.self,
-            name: T.contextKey
-        )))
-    }
-
-    /// Returns whether a provided slot exists for `type`.
-    ///
-    /// - Parameter type: The concrete context type to look up.
-    /// - Returns: True when an instance of this type is stored.
-    func containsProvided<T: AgentContextProviding>(of type: T.Type) -> Bool {
-        providedSlots[ContextSlotID(valueType: T.self, name: T.contextKey)] != nil
-    }
-
     // MARK: - Copying
 
-    /// Creates a copy holding only value slots, dropping provided slots.
-    ///
-    /// Provided slots are deliberately excluded: `copy(additionalValues:)`
-    /// historically duplicated only the string-keyed values that typed
-    /// `ContextKey` writes produced, never `AgentContextProviding` instances.
+    /// Creates a copy holding the value slots.
     ///
     /// - Returns: A store whose value slots match this store's.
     func copyingValueSlots() -> ContextSlotStore {
@@ -290,22 +237,4 @@ struct ContextSlotStore {
         return copy
     }
 
-    // MARK: Private
-
-    /// Crosses the `any AgentContextProviding` existential boundary after
-    /// slot identity already established the stored instance has type
-    /// `Value`.
-    ///
-    /// This is not a speculative runtime check like the removed string-keyed
-    /// lookup: the slot identifier pins the concrete conformer type, so the
-    /// conversion below can neither fail nor produce a wrong-typed value. It
-    /// exists only because Swift has no way to recover a concrete type from
-    /// an existential without one checked conversion at the storage boundary.
-    private func extract<Value: AgentContextProviding>(
-        _ type: Value.Type,
-        from slot: (any AgentContextProviding)?
-    ) -> Value? {
-        guard let slot else { return nil }
-        return slot as? Value
-    }
 }

--- a/Tests/SwarmTests/APIAuditTests.swift
+++ b/Tests/SwarmTests/APIAuditTests.swift
@@ -22,6 +22,25 @@ private struct DisabledTool: AnyJSONTool {
     }
 }
 
+// MARK: - TestUserContext
+
+/// A typed context for testing `AgentContextProviding`.
+private struct TestUserContext: AgentContextProviding {
+    static let contextKey = "test_user_context"
+
+    let userId: String
+    let isAdmin: Bool
+}
+
+// MARK: - TestSessionContext
+
+/// A second typed context to test multiple typed contexts.
+private struct TestSessionContext: AgentContextProviding {
+    static let contextKey = "test_session_context"
+
+    let sessionId: String
+}
+
 // MARK: - APIAuditTests
 
 final class APIAuditTests: XCTestCase {
@@ -418,6 +437,80 @@ final class APIAuditTests: XCTestCase {
         XCTAssertNil(handoff.transform)
         XCTAssertNil(handoff.when)
         XCTAssertFalse(handoff.nestHandoffHistory)
+    }
+
+    // MARK: - AgentContextProviding Tests
+
+    func testSetTypedAndRetrieveTyped() async {
+        let context = AgentContext(input: "test")
+        let userContext = TestUserContext(userId: "user_123", isAdmin: true)
+
+        await context.setTyped(userContext)
+        let retrieved: TestUserContext? = await context.typed(TestUserContext.self)
+
+        XCTAssertNotNil(retrieved)
+        XCTAssertEqual(retrieved?.userId, "user_123")
+        XCTAssertEqual(retrieved?.isAdmin, true)
+    }
+
+    func testTypedReturnsNilWhenNotSet() async {
+        let context = AgentContext(input: "test")
+        let retrieved: TestUserContext? = await context.typed(TestUserContext.self)
+        XCTAssertNil(retrieved)
+    }
+
+    func testHasTypedReturnsTrueWhenSet() async {
+        let context = AgentContext(input: "test")
+        await context.setTyped(TestUserContext(userId: "u1", isAdmin: false))
+
+        let hasIt = await context.hasTyped(TestUserContext.self)
+        XCTAssertTrue(hasIt)
+    }
+
+    func testHasTypedReturnsFalseWhenNotSet() async {
+        let context = AgentContext(input: "test")
+        let hasIt = await context.hasTyped(TestUserContext.self)
+        XCTAssertFalse(hasIt)
+    }
+
+    func testRemoveTypedRemovesContext() async {
+        let context = AgentContext(input: "test")
+        await context.setTyped(TestUserContext(userId: "u1", isAdmin: false))
+
+        let removed: TestUserContext? = await context.removeTyped(TestUserContext.self)
+        XCTAssertNotNil(removed)
+        XCTAssertEqual(removed?.userId, "u1")
+
+        let afterRemoval: TestUserContext? = await context.typed(TestUserContext.self)
+        XCTAssertNil(afterRemoval)
+    }
+
+    func testRemoveTypedReturnsNilWhenNotSet() async {
+        let context = AgentContext(input: "test")
+        let removed: TestUserContext? = await context.removeTyped(TestUserContext.self)
+        XCTAssertNil(removed)
+    }
+
+    func testMultipleTypedContextsCoexist() async {
+        let context = AgentContext(input: "test")
+        await context.setTyped(TestUserContext(userId: "u1", isAdmin: true))
+        await context.setTyped(TestSessionContext(sessionId: "s1"))
+
+        let user: TestUserContext? = await context.typed(TestUserContext.self)
+        let session: TestSessionContext? = await context.typed(TestSessionContext.self)
+
+        XCTAssertEqual(user?.userId, "u1")
+        XCTAssertEqual(session?.sessionId, "s1")
+    }
+
+    func testSetTypedOverwritesPrevious() async {
+        let context = AgentContext(input: "test")
+        await context.setTyped(TestUserContext(userId: "u1", isAdmin: false))
+        await context.setTyped(TestUserContext(userId: "u2", isAdmin: true))
+
+        let retrieved: TestUserContext? = await context.typed(TestUserContext.self)
+        XCTAssertEqual(retrieved?.userId, "u2")
+        XCTAssertEqual(retrieved?.isAdmin, true)
     }
 
     // MARK: - AgentContext Basic Tests

--- a/Tests/SwarmTests/APIAuditTests.swift
+++ b/Tests/SwarmTests/APIAuditTests.swift
@@ -22,25 +22,6 @@ private struct DisabledTool: AnyJSONTool {
     }
 }
 
-// MARK: - TestUserContext
-
-/// A typed context for testing `AgentContextProviding`.
-private struct TestUserContext: AgentContextProviding {
-    static let contextKey = "test_user_context"
-
-    let userId: String
-    let isAdmin: Bool
-}
-
-// MARK: - TestSessionContext
-
-/// A second typed context to test multiple typed contexts.
-private struct TestSessionContext: AgentContextProviding {
-    static let contextKey = "test_session_context"
-
-    let sessionId: String
-}
-
 // MARK: - APIAuditTests
 
 final class APIAuditTests: XCTestCase {
@@ -437,80 +418,6 @@ final class APIAuditTests: XCTestCase {
         XCTAssertNil(handoff.transform)
         XCTAssertNil(handoff.when)
         XCTAssertFalse(handoff.nestHandoffHistory)
-    }
-
-    // MARK: - AgentContextProviding Tests
-
-    func testSetTypedAndRetrieveTyped() async {
-        let context = AgentContext(input: "test")
-        let userContext = TestUserContext(userId: "user_123", isAdmin: true)
-
-        await context.setTyped(userContext)
-        let retrieved: TestUserContext? = await context.typed(TestUserContext.self)
-
-        XCTAssertNotNil(retrieved)
-        XCTAssertEqual(retrieved?.userId, "user_123")
-        XCTAssertEqual(retrieved?.isAdmin, true)
-    }
-
-    func testTypedReturnsNilWhenNotSet() async {
-        let context = AgentContext(input: "test")
-        let retrieved: TestUserContext? = await context.typed(TestUserContext.self)
-        XCTAssertNil(retrieved)
-    }
-
-    func testHasTypedReturnsTrueWhenSet() async {
-        let context = AgentContext(input: "test")
-        await context.setTyped(TestUserContext(userId: "u1", isAdmin: false))
-
-        let hasIt = await context.hasTyped(TestUserContext.self)
-        XCTAssertTrue(hasIt)
-    }
-
-    func testHasTypedReturnsFalseWhenNotSet() async {
-        let context = AgentContext(input: "test")
-        let hasIt = await context.hasTyped(TestUserContext.self)
-        XCTAssertFalse(hasIt)
-    }
-
-    func testRemoveTypedRemovesContext() async {
-        let context = AgentContext(input: "test")
-        await context.setTyped(TestUserContext(userId: "u1", isAdmin: false))
-
-        let removed: TestUserContext? = await context.removeTyped(TestUserContext.self)
-        XCTAssertNotNil(removed)
-        XCTAssertEqual(removed?.userId, "u1")
-
-        let afterRemoval: TestUserContext? = await context.typed(TestUserContext.self)
-        XCTAssertNil(afterRemoval)
-    }
-
-    func testRemoveTypedReturnsNilWhenNotSet() async {
-        let context = AgentContext(input: "test")
-        let removed: TestUserContext? = await context.removeTyped(TestUserContext.self)
-        XCTAssertNil(removed)
-    }
-
-    func testMultipleTypedContextsCoexist() async {
-        let context = AgentContext(input: "test")
-        await context.setTyped(TestUserContext(userId: "u1", isAdmin: true))
-        await context.setTyped(TestSessionContext(sessionId: "s1"))
-
-        let user: TestUserContext? = await context.typed(TestUserContext.self)
-        let session: TestSessionContext? = await context.typed(TestSessionContext.self)
-
-        XCTAssertEqual(user?.userId, "u1")
-        XCTAssertEqual(session?.sessionId, "s1")
-    }
-
-    func testSetTypedOverwritesPrevious() async {
-        let context = AgentContext(input: "test")
-        await context.setTyped(TestUserContext(userId: "u1", isAdmin: false))
-        await context.setTyped(TestUserContext(userId: "u2", isAdmin: true))
-
-        let retrieved: TestUserContext? = await context.typed(TestUserContext.self)
-        XCTAssertEqual(retrieved?.userId, "u2")
-        XCTAssertEqual(retrieved?.isAdmin, true)
     }
 
     // MARK: - AgentContext Basic Tests

--- a/Tests/SwarmTests/Core/AgentContextKeySurfaceTests.swift
+++ b/Tests/SwarmTests/Core/AgentContextKeySurfaceTests.swift
@@ -7,6 +7,18 @@ import Foundation
 @testable import Swarm
 import Testing
 
+// MARK: - Collision Contexts
+
+private struct ContextTypeA: AgentContextProviding {
+    static let contextKey = "same"
+    let n: Int
+}
+
+private struct ContextTypeB: AgentContextProviding {
+    static let contextKey = "same"
+    let n: Int
+}
+
 // MARK: - AgentContextKeySurfaceTests
 
 @Suite("AgentContext key surfaces")
@@ -130,6 +142,21 @@ struct AgentContextKeySurfaceTests {
         await context.set("original_input", value: .string("raw-original"))
         #expect(await context.get(.originalInput) == "raw-original")
         #expect(await context.snapshot["original_input"] == .string("raw-original"))
+    }
+
+    // MARK: - Type-Indexed Typed Contexts (REQ-006, AC-003)
+
+    @Test("two AgentContextProviding types that share contextKey both persist")
+    func sharedContextKeyTypesBothPersist() async {
+        let context = AgentContext(input: "seed")
+        await context.setTyped(ContextTypeA(n: 1))
+        await context.setTyped(ContextTypeB(n: 2))
+
+        #expect(ContextTypeA.contextKey == ContextTypeB.contextKey)
+        #expect(await context.typed(ContextTypeA.self)?.n == 1)
+        #expect(await context.typed(ContextTypeB.self)?.n == 2)
+        #expect(await context.hasTyped(ContextTypeA.self))
+        #expect(await context.hasTyped(ContextTypeB.self))
     }
 
 }

--- a/Tests/SwarmTests/Core/AgentContextKeySurfaceTests.swift
+++ b/Tests/SwarmTests/Core/AgentContextKeySurfaceTests.swift
@@ -7,18 +7,6 @@ import Foundation
 @testable import Swarm
 import Testing
 
-// MARK: - Collision Contexts
-
-private struct ContextTypeA: AgentContextProviding {
-    static let contextKey = "same"
-    let n: Int
-}
-
-private struct ContextTypeB: AgentContextProviding {
-    static let contextKey = "same"
-    let n: Int
-}
-
 // MARK: - AgentContextKeySurfaceTests
 
 @Suite("AgentContext key surfaces")
@@ -144,18 +132,4 @@ struct AgentContextKeySurfaceTests {
         #expect(await context.snapshot["original_input"] == .string("raw-original"))
     }
 
-    // MARK: - Type-Indexed Typed Contexts (REQ-006, AC-003)
-
-    @Test("two AgentContextProviding types that share contextKey both persist")
-    func sharedContextKeyTypesBothPersist() async {
-        let context = AgentContext(input: "seed")
-        await context.setTyped(ContextTypeA(n: 1))
-        await context.setTyped(ContextTypeB(n: 2))
-
-        #expect(ContextTypeA.contextKey == ContextTypeB.contextKey)
-        #expect(await context.typed(ContextTypeA.self)?.n == 1)
-        #expect(await context.typed(ContextTypeB.self)?.n == 2)
-        #expect(await context.hasTyped(ContextTypeA.self))
-        #expect(await context.hasTyped(ContextTypeB.self))
-    }
 }

--- a/Tests/SwarmTests/Core/ContextStoreUnificationTests.swift
+++ b/Tests/SwarmTests/Core/ContextStoreUnificationTests.swift
@@ -16,6 +16,21 @@ private struct UserProfile: Codable, Equatable, Sendable {
     let score: Double
 }
 
+/// A deprecated-protocol conformer used to prove the shim still functions.
+private struct LegacyUserContext: AgentContextProviding {
+    static let contextKey = "legacy_user_context"
+
+    let userId: String
+    let isAdmin: Bool
+}
+
+/// A second deprecated-protocol conformer used to prove shim coexistence.
+private struct LegacySessionContext: AgentContextProviding {
+    static let contextKey = "legacy_session_context"
+
+    let sessionId: String
+}
+
 /// An enum with associated values used to exercise codec round-trips that
 /// must not corrupt case payloads.
 private enum AssociatedValueEnum: Codable, Equatable, Sendable {
@@ -337,6 +352,52 @@ struct ContextStoreUnificationTests {
         #expect(await branch.snapshot["recency_name"] == .string("newest"))
         #expect(await branch.getTyped(ContextKey<String>("recency_name")) == "newest")
         #expect(await branch.getTyped(ContextKey<Int>("recency_name")) == 1)
+    }
+
+    // MARK: - Deprecated AgentContextProviding Shim
+
+    @Test("deprecated AgentContextProviding shim stores and retrieves instances")
+    func providedShimStillFunctions() async throws {
+        let context = AgentContext(input: "test")
+
+        await context.setTyped(LegacyUserContext(userId: "u-42", isAdmin: true))
+        let retrieved = await context.typed(LegacyUserContext.self)
+        #expect(retrieved?.userId == "u-42")
+        #expect(retrieved?.isAdmin == true)
+    }
+
+    @Test("deprecated shim supports has, overwrite, removal, and coexistence")
+    func providedShimHasRemoveCoexist() async throws {
+        let context = AgentContext(input: "test")
+
+        #expect(await context.hasTyped(LegacyUserContext.self) == false)
+        #expect(await context.removeTyped(LegacyUserContext.self) == nil)
+        #expect(await context.typed(LegacyUserContext.self) == nil)
+
+        await context.setTyped(LegacyUserContext(userId: "first", isAdmin: false))
+        await context.setTyped(LegacyUserContext(userId: "second", isAdmin: true))
+        let overwritten = await context.typed(LegacyUserContext.self)
+        #expect(overwritten?.userId == "second")
+
+        await context.setTyped(LegacySessionContext(sessionId: "s-1"))
+        let user = await context.typed(LegacyUserContext.self)
+        let session = await context.typed(LegacySessionContext.self)
+        #expect(user?.userId == "second")
+        #expect(session?.sessionId == "s-1")
+
+        let removed = await context.removeTyped(LegacyUserContext.self)
+        #expect(removed?.userId == "second")
+        #expect(await context.hasTyped(LegacyUserContext.self) == false)
+        #expect(await context.hasTyped(LegacySessionContext.self))
+    }
+
+    @Test("deprecated shim instances do not appear in snapshots")
+    func providedShimStaysOutOfSnapshots() async throws {
+        let context = AgentContext(input: "test")
+        await context.setTyped(LegacyUserContext(userId: "u-1", isAdmin: false))
+
+        let snap = await context.snapshot
+        #expect(snap["legacy_user_context"] == nil)
     }
 
     // MARK: - Codec Edge Cases

--- a/Tests/SwarmTests/Core/ContextStoreUnificationTests.swift
+++ b/Tests/SwarmTests/Core/ContextStoreUnificationTests.swift
@@ -2,8 +2,7 @@
 // SwarmTests
 //
 // Tests for the unified phantom-typed AgentContext store: slot identity,
-// round-trip exactness, namespace separation, snapshot/merge/copy behavior,
-// and the deprecated AgentContextProviding shim.
+// round-trip exactness, namespace separation, and snapshot/merge/copy behavior.
 
 import Foundation
 import Testing
@@ -15,21 +14,6 @@ import Testing
 private struct UserProfile: Codable, Equatable, Sendable {
     let id: String
     let score: Double
-}
-
-/// A deprecated-protocol conformer used to prove the shim still functions.
-private struct LegacyUserContext: AgentContextProviding {
-    static let contextKey = "legacy_user_context"
-
-    let userId: String
-    let isAdmin: Bool
-}
-
-/// A second deprecated-protocol conformer used to prove shim coexistence.
-private struct LegacySessionContext: AgentContextProviding {
-    static let contextKey = "legacy_session_context"
-
-    let sessionId: String
 }
 
 /// An enum with associated values used to exercise codec round-trips that
@@ -353,52 +337,6 @@ struct ContextStoreUnificationTests {
         #expect(await branch.snapshot["recency_name"] == .string("newest"))
         #expect(await branch.getTyped(ContextKey<String>("recency_name")) == "newest")
         #expect(await branch.getTyped(ContextKey<Int>("recency_name")) == 1)
-    }
-
-    // MARK: - Deprecated AgentContextProviding Shim
-
-    @Test("deprecated AgentContextProviding shim stores and retrieves instances")
-    func providedShimStillFunctions() async throws {
-        let context = AgentContext(input: "test")
-
-        await context.setTyped(LegacyUserContext(userId: "u-42", isAdmin: true))
-        let retrieved = await context.typed(LegacyUserContext.self)
-        #expect(retrieved?.userId == "u-42")
-        #expect(retrieved?.isAdmin == true)
-    }
-
-    @Test("deprecated shim supports has, overwrite, removal, and coexistence")
-    func providedShimHasRemoveCoexist() async throws {
-        let context = AgentContext(input: "test")
-
-        #expect(await context.hasTyped(LegacyUserContext.self) == false)
-        #expect(await context.removeTyped(LegacyUserContext.self) == nil)
-        #expect(await context.typed(LegacyUserContext.self) == nil)
-
-        await context.setTyped(LegacyUserContext(userId: "first", isAdmin: false))
-        await context.setTyped(LegacyUserContext(userId: "second", isAdmin: true))
-        let overwritten = await context.typed(LegacyUserContext.self)
-        #expect(overwritten?.userId == "second")
-
-        await context.setTyped(LegacySessionContext(sessionId: "s-1"))
-        let user = await context.typed(LegacyUserContext.self)
-        let session = await context.typed(LegacySessionContext.self)
-        #expect(user?.userId == "second")
-        #expect(session?.sessionId == "s-1")
-
-        let removed = await context.removeTyped(LegacyUserContext.self)
-        #expect(removed?.userId == "second")
-        #expect(await context.hasTyped(LegacyUserContext.self) == false)
-        #expect(await context.hasTyped(LegacySessionContext.self))
-    }
-
-    @Test("deprecated shim instances do not appear in snapshots")
-    func providedShimStaysOutOfSnapshots() async throws {
-        let context = AgentContext(input: "test")
-        await context.setTyped(LegacyUserContext(userId: "u-1", isAdmin: false))
-
-        let snap = await context.snapshot
-        #expect(snap["legacy_user_context"] == nil)
     }
 
     // MARK: - Codec Edge Cases

--- a/docs/reference/api-catalog.md
+++ b/docs/reference/api-catalog.md
@@ -555,8 +555,6 @@ Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for
 | 35 | case | public | AgentContextKey.executionPath | `public case executionPath` |
 | 38 | case | public | AgentContextKey.startTime | `public case startTime` |
 | 41 | case | public | AgentContextKey.metadata | `public case metadata` |
-| 86 | protocol | public | AgentContextProviding | `public protocol AgentContextProviding : Sendable` _(Availability: * (deprecated); Use ContextKey<Value> with setTyped(_:value:)/getTyped(_:) instead)_ |
-| 88 | var | public | AgentContextProviding.contextKey | `public static var contextKey: String { get }` |
 | 118 | class | public | AgentContext | `public actor AgentContext` |
 | 122 | var | public | AgentContext.originalInput | `public nonisolated let originalInput: String` |
 | 125 | var | public | AgentContext.executionId | `public nonisolated let executionId: UUID` |
@@ -578,10 +576,6 @@ Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for
 | 347 | func | public | AgentContext.getPreviousOutput() | `public func getPreviousOutput() -> String?` |
 | 367 | func | public | AgentContext.merge(from:overwrite:) | `public func merge(from other: AgentContext, overwrite: Bool = false) async` |
 | 421 | func | public | AgentContext.copy(additionalValues:) | `public func copy(additionalValues: [String : SendableValue] = [:]) -> AgentContext` |
-| 453 | func | public | AgentContext.setTyped(_:) | `public func setTyped<T>(_ context: T) where T : AgentContextProviding` |
-| 461 | func | public | AgentContext.typed(_:) | `public func typed<T>(_: T.Type) -> T? where T : AgentContextProviding` |
-| 470 | func | public | AgentContext.removeTyped(_:) | `public @discardableResult func removeTyped<T>(_: T.Type) -> T? where T : AgentContextProviding` |
-| 478 | func | public | AgentContext.hasTyped(_:) | `public func hasTyped<T>(_: T.Type) -> Bool where T : AgentContextProviding` |
 | 574 | var | public | AgentContext.description | `public nonisolated var description: String { get }` |
 | 588 | var | public | AgentContext.debugDescription | `public nonisolated var debugDescription: String { get }` |
 

--- a/docs/reference/api-catalog.md
+++ b/docs/reference/api-catalog.md
@@ -555,6 +555,8 @@ Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for
 | 35 | case | public | AgentContextKey.executionPath | `public case executionPath` |
 | 38 | case | public | AgentContextKey.startTime | `public case startTime` |
 | 41 | case | public | AgentContextKey.metadata | `public case metadata` |
+| 81 | protocol | public | AgentContextProviding | `public protocol AgentContextProviding : Sendable` _(Availability: * (deprecated); Use ContextKey<Value> with setTyped(_:value:)/getTyped(_:) instead; this protocol will be removed in 0.7.0.)_ |
+| 83 | var | public | AgentContextProviding.contextKey | `public static var contextKey: String { get }` |
 | 118 | class | public | AgentContext | `public actor AgentContext` |
 | 122 | var | public | AgentContext.originalInput | `public nonisolated let originalInput: String` |
 | 125 | var | public | AgentContext.executionId | `public nonisolated let executionId: UUID` |
@@ -576,6 +578,10 @@ Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for
 | 347 | func | public | AgentContext.getPreviousOutput() | `public func getPreviousOutput() -> String?` |
 | 367 | func | public | AgentContext.merge(from:overwrite:) | `public func merge(from other: AgentContext, overwrite: Bool = false) async` |
 | 421 | func | public | AgentContext.copy(additionalValues:) | `public func copy(additionalValues: [String : SendableValue] = [:]) -> AgentContext` |
+| 449 | func | public | AgentContext.setTyped(_:) | `public func setTyped<T>(_ context: T) where T : AgentContextProviding` _(Availability: * (deprecated); Use ContextKey<Value> with setTyped(_:value:) instead; this overload will be removed in 0.7.0.)_ |
+| 458 | func | public | AgentContext.typed(_:) | `public func typed<T>(_: T.Type) -> T? where T : AgentContextProviding` _(Availability: * (deprecated); Use ContextKey<Value> with getTyped(_:) instead; this overload will be removed in 0.7.0.)_ |
+| 468 | func | public | AgentContext.removeTyped(_:) | `public @discardableResult func removeTyped<T>(_: T.Type) -> T? where T : AgentContextProviding` _(Availability: * (deprecated); Use ContextKey<Value> with removeTyped(_:) instead; this overload will be removed in 0.7.0.)_ |
+| 477 | func | public | AgentContext.hasTyped(_:) | `public func hasTyped<T>(_: T.Type) -> Bool where T : AgentContextProviding` _(Availability: * (deprecated); Use ContextKey<Value> with hasTyped(_:) instead; this overload will be removed in 0.7.0.)_ |
 | 574 | var | public | AgentContext.description | `public nonisolated var description: String { get }` |
 | 588 | var | public | AgentContext.debugDescription | `public nonisolated var debugDescription: String { get }` |
 

--- a/docs/reference/front-facing-api.md
+++ b/docs/reference/front-facing-api.md
@@ -449,8 +449,7 @@ public protocol OutputGuardrail: Sendable {
 statics. Prefer `set(.originalInput, "…")` / `get(.originalInput)` over the
 deprecated `AgentContextKey` get/set. Typed `ContextKey` writes stay in the
 slot store introduced with the unified context; `snapshot` still projects
-those names. `AgentContextProviding` remains a deprecated shim keyed by
-concrete type plus `contextKey`.
+those names.
 
 ## 9) Memory factories
 

--- a/docs/reference/front-facing-api.md
+++ b/docs/reference/front-facing-api.md
@@ -449,7 +449,14 @@ public protocol OutputGuardrail: Sendable {
 statics. Prefer `set(.originalInput, "…")` / `get(.originalInput)` over the
 deprecated `AgentContextKey` get/set. Typed `ContextKey` writes stay in the
 slot store introduced with the unified context; `snapshot` still projects
-those names.
+those names. The deprecated `AgentContextProviding` protocol remains
+functional for compatibility: conformers provide a `contextKey`, then use
+`setTyped(_:)`, `typed(_:)`, `removeTyped(_:)`, and `hasTyped(_:)`. These
+type-indexed methods use a separate legacy namespace and do not appear in
+string-keyed snapshots. Migrate new code to `ContextKey<Value>` and the
+`setTyped(_:value:)` / `getTyped(_:)` accessors. The deprecated
+`AgentContextKey` overloads of `get(_:)` and `set(_:value:)` remain available
+for existing string-keyed callers until the 0.7.0 breaking boundary.
 
 ## 9) Memory factories
 


### PR DESCRIPTION
## Summary
- remove the deprecated `AgentContextProviding` protocol and object-based typed accessors
- remove the parallel existential `providedSlots` store and its helpers
- retain the Codable `ContextKey<Value>` slot store, snapshots, merge/copy semantics, and orchestration keys

## Verification
- `SWARM_OMIT_INTEGRATION_TARGETS=1 SWIFT_BUILD_PARALLELISM=1 swift test --no-parallel --filter AgentContextKeySurfaceTests|ContextStoreUnificationTests|APIAuditTests|DocumentationFreshnessTests --scratch-path /private/tmp/swarm-pr4-scratch`
- `git diff --check`

This PR is independent of the other simplification branches.