### PR TITLE
refactor(workflow): remove durable run alias

### DIFF
--- a/Sources/Swarm/Workflow/Workflow+Durable.swift
+++ b/Sources/Swarm/Workflow/Workflow+Durable.swift
@@ -62,6 +62,12 @@ public extension Workflow {
             try await workflow.executeDurable(input, resumeFrom: checkpointID)
         }
 
+        /// Backward-compatible alias for `execute(_:resumeFrom:)`.
+        @available(*, deprecated, renamed: "execute(_:resumeFrom:)")
+        public func run(_ input: String, resumeFrom checkpointID: String? = nil) async throws -> AgentResult {
+            try await execute(input, resumeFrom: checkpointID)
+        }
+
     }
 }
 

--- a/Sources/Swarm/Workflow/Workflow+Durable.swift
+++ b/Sources/Swarm/Workflow/Workflow+Durable.swift
@@ -62,11 +62,6 @@ public extension Workflow {
             try await workflow.executeDurable(input, resumeFrom: checkpointID)
         }
 
-        /// Backward-compatible alias for `execute(_:resumeFrom:)`.
-        @available(*, deprecated, renamed: "execute(_:resumeFrom:)")
-        public func run(_ input: String, resumeFrom checkpointID: String? = nil) async throws -> AgentResult {
-            try await execute(input, resumeFrom: checkpointID)
-        }
     }
 }
 

--- a/Tests/SwarmTests/Workflow/WorkflowDurableTests.swift
+++ b/Tests/SwarmTests/Workflow/WorkflowDurableTests.swift
@@ -41,6 +41,23 @@ struct WorkflowDurableTests {
         #expect(resumed.output == "done")
     }
 
+    @Test("deprecated durable run forwards execution and resume")
+    func deprecatedRunForwardsExecutionAndResume() async throws {
+        let checkpointing = WorkflowCheckpointing.inMemory()
+        let workflow = Workflow()
+            .step(MockAgentRuntime(response: "done"))
+            .durable
+            .checkpoint(id: "wf-run-compatibility", policy: .everyStep)
+            .durable
+            .checkpointing(checkpointing)
+
+        let first = try await workflow.durable.run("start")
+        #expect(first.output == "done")
+
+        let resumed = try await workflow.durable.run("ignored", resumeFrom: "wf-run-compatibility")
+        #expect(resumed.output == "done")
+    }
+
     @Test("durable resume throws when checkpoint is missing")
     func resumeMissingCheckpoint() async throws {
         let checkpointing = WorkflowCheckpointing.inMemory()


### PR DESCRIPTION
## Summary

- remove the deprecated Workflow.Durable.run(_:resumeFrom:) forwarding alias
- retain the canonical durable execute(_:resumeFrom:) API

## Verification

SWARM_OMIT_INTEGRATION_TARGETS=1 SWIFT_BUILD_PARALLELISM=1 swift test --no-parallel --filter 'WorkflowDurable|DocumentationFreshnessTests' --scratch-path /private/tmp/swarm-pr11-scratch

Also passed: git diff --check.