### PR TITLE
refactor(observability): remove legacy tracer initializer

### DIFF
--- a/Sources/Swarm/Observability/AgentTracer.swift
+++ b/Sources/Swarm/Observability/AgentTracer.swift
@@ -117,16 +117,6 @@ package actor CompositeTracer: Tracer {
         self.shouldExecuteInParallel = shouldExecuteInParallel
     }
 
-    /// Creates a composite tracer.
-    ///
-    /// - Parameters:
-    ///   - tracers: The child tracers to forward events to.
-    ///   - parallel: Whether to forward events in parallel.
-    @available(*, deprecated, message: "Use shouldExecuteInParallel instead of parallel")
-    package init(tracers: [any Tracer], parallel: Bool) {
-        self.init(tracers: tracers, minimumLevel: .trace, shouldExecuteInParallel: parallel)
-    }
-
     package func trace(_ event: TraceEvent) async {
         // Filter events below minimum level
         guard event.level >= minimumLevel else { return }

--- a/docs/reference/api-catalog.md
+++ b/docs/reference/api-catalog.md
@@ -2056,7 +2056,6 @@ Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for
 | 72 | func | public | Tracer.flush() | `public func flush() async` |
 | 101 | class | public | CompositeTracer | `public actor CompositeTracer` |
 | 110 | func | public | CompositeTracer.init(tracers:minimumLevel:shouldExecuteInParallel:) | `public init(tracers: [any Tracer], minimumLevel: EventLevel = .trace, shouldExecuteInParallel: Bool = true)` |
-| 126 | func | public | CompositeTracer.init(tracers:parallel:) | `public convenience init(tracers: [any Tracer], parallel: Bool)` _(Availability: * (deprecated); Use shouldExecuteInParallel instead of parallel)_ |
 | 130 | func | public | CompositeTracer.trace(_:) | `public func trace(_ event: TraceEvent) async` |
 | 151 | func | public | CompositeTracer.flush() | `public func flush() async` |
 | 196 | class | public | NoOpTracer | `public actor NoOpTracer` |


### PR DESCRIPTION
## Summary

- remove the deprecated package CompositeTracer initializer using the parallel label
- retain the canonical shouldExecuteInParallel initializer
- remove the stale catalog entry

## Verification

SWARM_OMIT_INTEGRATION_TARGETS=1 SWIFT_BUILD_PARALLELISM=1 swift test --no-parallel --filter 'Tracer|DocumentationFreshnessTests' --scratch-path /private/tmp/swarm-pr12-scratch

Also passed: git diff --check.