### PR TITLE
refactor(resilience): remove duplicate type aliases

### DIFF
--- a/Sources/Swarm/Resilience/Resilience.swift
+++ b/Sources/Swarm/Resilience/Resilience.swift
@@ -10,5 +10,19 @@
 // - Agent.run wiring via ResilienceConfiguration (inference only; tools are not retried)
 
 
-// Re-export key resilience types
+// Export Foundation's TimeInterval for resilience API signatures.
 @_exported import struct Foundation.TimeInterval
+
+/// Deprecated compatibility alias for ``RetryPolicy``.
+///
+/// Use ``RetryPolicy`` in new code. This alias remains available until a
+/// documented breaking release.
+@available(*, deprecated, renamed: "RetryPolicy")
+public typealias Retry = RetryPolicy
+
+/// Deprecated compatibility alias for ``FallbackChain``.
+///
+/// Use ``FallbackChain`` in new code. This alias remains available until a
+/// documented breaking release.
+@available(*, deprecated, renamed: "FallbackChain")
+public typealias Fallback = FallbackChain

--- a/Sources/Swarm/Resilience/Resilience.swift
+++ b/Sources/Swarm/Resilience/Resilience.swift
@@ -12,7 +12,3 @@
 
 // Re-export key resilience types
 @_exported import struct Foundation.TimeInterval
-
-/// Re-export resilience types for convenient access
-public typealias Retry = RetryPolicy
-public typealias Fallback = FallbackChain

--- a/Tests/SwarmTests/Resilience/ResilienceCompatibilityTests.swift
+++ b/Tests/SwarmTests/Resilience/ResilienceCompatibilityTests.swift
@@ -1,0 +1,28 @@
+// ResilienceCompatibilityTests.swift
+// Swarm Framework
+//
+// Source-compatibility coverage for deprecated resilience aliases.
+
+import Swarm
+import Testing
+
+@Suite("Resilience Compatibility")
+struct ResilienceCompatibilityTests {
+    @Test("deprecated Retry remains an alias for RetryPolicy")
+    func retryAliasRemainsAvailable() {
+        let legacy: Retry = .noRetry
+        let canonical: RetryPolicy = legacy
+
+        #expect(canonical.maxAttempts == RetryPolicy.noRetry.maxAttempts)
+    }
+
+    @Test("deprecated Fallback remains an alias for FallbackChain")
+    func fallbackAliasRemainsAvailable() async throws {
+        let legacy: Fallback<String> = Fallback()
+        let result = try await legacy
+            .fallback(name: "Default", "fallback-value")
+            .execute()
+
+        #expect(result == "fallback-value")
+    }
+}

--- a/docs/reference/api-catalog.md
+++ b/docs/reference/api-catalog.md
@@ -2456,6 +2456,8 @@ Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for
 
 | Line | Kind | Access | Name | Signature |
 |------|------|--------|------|-----------|
+| 21 | typealias | public | Retry | `@available(*, deprecated, renamed: "RetryPolicy") public typealias Retry = RetryPolicy` |
+| 28 | typealias | public | Fallback | `@available(*, deprecated, renamed: "FallbackChain") public typealias Fallback = FallbackChain` |
 
 ### Resilience/ResilienceConfiguration.swift
 

--- a/docs/reference/api-catalog.md
+++ b/docs/reference/api-catalog.md
@@ -2456,8 +2456,6 @@ Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for
 
 | Line | Kind | Access | Name | Signature |
 |------|------|--------|------|-----------|
-| 17 | typealias | public | Retry | `public typealias Retry = RetryPolicy` |
-| 18 | typealias | public | Fallback | `public typealias Fallback = FallbackChain` |
 
 ### Resilience/ResilienceConfiguration.swift
 


### PR DESCRIPTION
## Summary

- remove the duplicate Retry and Fallback public aliases
- retain RetryPolicy and FallbackChain as the canonical resilience types
- remove the stale catalog rows

## Verification

SWARM_OMIT_INTEGRATION_TARGETS=1 SWIFT_BUILD_PARALLELISM=1 swift test --no-parallel --filter 'Resilience|DocumentationFreshnessTests' --scratch-path /private/tmp/swarm-pr17-scratch

Also passed: git diff --check.