### PR TITLE
refactor(providers): remove inferred capabilities helper

### DIFF
--- a/Sources/Swarm/Providers/ConversationInferenceProvider.swift
+++ b/Sources/Swarm/Providers/ConversationInferenceProvider.swift
@@ -50,11 +50,6 @@ public extension InferenceProviderCapabilities {
         return capabilities
     }
 
-    /// Use ``resolved(for:)``.
-    @available(*, deprecated, message: "Use resolved(for:)")
-    static func inferred(from provider: any InferenceProvider) -> Self {
-        resolved(for: provider)
-    }
 }
 
 /// Optional protocol for providers that can report which advanced features they actually support.

--- a/Sources/Swarm/Providers/ConversationInferenceProvider.swift
+++ b/Sources/Swarm/Providers/ConversationInferenceProvider.swift
@@ -50,6 +50,15 @@ public extension InferenceProviderCapabilities {
         return capabilities
     }
 
+    /// Use ``resolved(for:)``.
+    ///
+    /// This deprecated forwarding helper remains available for source
+    /// compatibility until a future breaking boundary is explicitly
+    /// documented.
+    @available(*, deprecated, message: "Use resolved(for:)")
+    static func inferred(from provider: any InferenceProvider) -> Self {
+        resolved(for: provider)
+    }
 }
 
 /// Optional protocol for providers that can report which advanced features they actually support.

--- a/Tests/SwarmTests/V2SurfaceAuditTests.swift
+++ b/Tests/SwarmTests/V2SurfaceAuditTests.swift
@@ -27,6 +27,14 @@ struct V2SurfaceAuditTests {
         #expect(Swarm.version == "0.6.2")
     }
 
+    @Test("Deprecated inferred(from:) remains a public forwarding compatibility shim")
+    func deprecatedInferredCapabilitiesRemainPublic() {
+        let provider = V2CapabilityProvider()
+        let resolved = InferenceProviderCapabilities.resolved(for: provider)
+
+        #expect(InferenceProviderCapabilities.inferred(from: provider) == resolved)
+    }
+
     // MARK: - TokenUsage (module-level, not nested)
 
     @Test("TokenUsage is public at module level")
@@ -175,5 +183,16 @@ struct V2SurfaceAuditTests {
             executionSemantics: semantics
         )
         #expect(schema.executionSemantics.retryPolicy == .safe)
+    }
+}
+
+private struct V2CapabilityProvider: InferenceProvider {
+    let capabilities: InferenceProviderCapabilities = [.responseContinuation]
+
+    func generate(
+        messages _: [InferenceMessage],
+        options _: InferenceOptions
+    ) async throws -> String {
+        "ok"
     }
 }

--- a/docs/reference/front-facing-api.md
+++ b/docs/reference/front-facing-api.md
@@ -615,6 +615,12 @@ on ``InferenceProvider``. Deprecated leftover protocols
 (`ToolCallStreamingInferenceProvider`, `StructuredOutputInferenceProvider`,
 `PromptTokenCountingInferenceProvider`) are not the Agent seam.
 
+Use ``InferenceProviderCapabilities/resolved(for:)`` for canonical capability
+resolution. The deprecated ``InferenceProviderCapabilities/inferred(from:)``
+helper remains available as a forwarding compatibility shim until a future
+breaking boundary is explicitly documented; it has the same capability
+semantics as ``resolved(for:)``.
+
 ### Provider factories (dot-syntax)
 
 Built-in inference is Apple Foundation Models (on-device) and


### PR DESCRIPTION
## Summary

- remove the deprecated InferenceProviderCapabilities.inferred(from:) forwarding helper
- retain resolved(for:) as the single effective-capabilities entry point

## Verification

SWARM_OMIT_INTEGRATION_TARGETS=1 SWIFT_BUILD_PARALLELISM=1 swift test --no-parallel --filter 'InferenceProvider|DocumentationFreshnessTests' --scratch-path /private/tmp/swarm-pr18-scratch

Also passed: git diff --check.