### PR TITLE
fix(resilience): use supported continuous clock instant API

### DIFF
--- a/Sources/Swarm/Resilience/ClockSupport.swift
+++ b/Sources/Swarm/Resilience/ClockSupport.swift
@@ -11,18 +11,19 @@ import Foundation
 /// Default `SwarmClock` backed by Swift's sleep-inclusive continuous clock and
 /// task suspension.
 ///
-/// `nowNanoseconds()` reads `ContinuousClock.Instant.durationSinceReference`,
-/// so elapsed time includes system sleep and remains monotonic without being
-/// tied to wall-clock calendar time.
+/// `nowNanoseconds()` measures from a stored `ContinuousClock.Instant`, so
+/// elapsed time includes system sleep and remains monotonic without being tied
+/// to wall-clock calendar time.
 /// `sleep(nanoseconds:)` suspends via `Task.sleep`, propagating cancellation
 /// as `CancellationError`. Durations beyond `Int64.max` nanoseconds
 /// (~292 years) saturate instead of trapping.
 struct LiveSwarmClock: SwarmClock {
     /// Shared instance; `LiveSwarmClock` is stateless and value-semantic.
     static let live = LiveSwarmClock()
+    private static let reference = ContinuousClock.now
 
     func nowNanoseconds() -> UInt64 {
-        ContinuousClock.now.durationSinceReference.swarmNanoseconds
+        Self.reference.duration(to: ContinuousClock.now).swarmNanoseconds
     }
 
     func sleep(nanoseconds: UInt64) async throws {

--- a/Tests/SwarmTests/Resilience/TestClocks.swift
+++ b/Tests/SwarmTests/Resilience/TestClocks.swift
@@ -256,13 +256,15 @@ private struct DurationNanosecondConversionTests {
 
 @Suite("LiveSwarmClock Tests")
 private struct LiveSwarmClockTests {
-    @Test("Reads monotonic uptime")
-    func readsMonotonicUptime() {
+    @Test("Reads nonnegative monotonic time across suspension")
+    func readsNonnegativeMonotonicTimeAcrossSuspension() async throws {
         let clock = LiveSwarmClock()
         let first = clock.nowNanoseconds()
-        let second = clock.nowNanoseconds()
 
-        #expect(first > 0)
+        try await Task.sleep(nanoseconds: 1_000_000)
+
+        let second = clock.nowNanoseconds()
+        #expect(first >= 0)
         #expect(second >= first)
     }
 


### PR DESCRIPTION
Fixes the merged resilience clock implementation by replacing the unavailable `durationSinceReference` API with a stored `ContinuousClock.Instant` reference and supported `duration(to:)` calculation. Updates the monotonicity regression test.

Verified with Swift 6.2.4: `swift build --target Swarm` and focused `LiveSwarmClockTests` (2 tests).`