### PR TITLE
fix(docs): restore freshness contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,8 +207,7 @@ To configure one provider globally for the default graph:
 await Swarm.configure(provider: myProvider)
 ```
 
-The default Swarm graph is CI-tested on Ubuntu with Swift 6.2. Apple-only
-features such as Foundation Models, SwiftData, OSLog require supported Apple
+The default Swarm graph is CI-tested on Ubuntu with Swift 6.2. Apple-only features such as Foundation Models, SwiftData, OSLog require supported Apple
 platforms; on Linux and in CI, use an OpenAI-compatible provider or inject a
 mock.
 

--- a/README.md
+++ b/README.md
@@ -201,6 +201,17 @@ Foundation Models and some memory and platform integrations are Apple-only.
 On Linux and in CI, use an OpenAI-compatible provider, inject a mock, or run
 the deterministic examples.
 
+To configure one provider globally for the default graph:
+
+```swift
+await Swarm.configure(provider: myProvider)
+```
+
+The default Swarm graph is CI-tested on Ubuntu with Swift 6.2. Apple-only
+features such as Foundation Models, SwiftData, OSLog require supported Apple
+platforms; on Linux and in CI, use an OpenAI-compatible provider or inject a
+mock.
+
 ## Documentation
 
 | Guide | Covers |

--- a/Tests/SwarmTests/DocumentationFreshnessTests.swift
+++ b/Tests/SwarmTests/DocumentationFreshnessTests.swift
@@ -185,7 +185,7 @@ struct DocumentationFreshnessTests {
 
         #expect(agent.contains("private var toolRegistry"))
         #expect(!agent.contains("enum ConversationMessage"))
-        #expect(loop.contains("private enum ConversationMessage"))
+        #expect(loop.contains("private typealias ConversationMessage = AgentTurnTranscript.Message"))
         #expect(loop.contains("dependencies: AgentTurnDependencies"))
         #expect(loop.contains("AgentTurnKernel."))
         #expect(!loop.contains("struct ToolLoopEngine"))

--- a/docs/reference/api-catalog.md
+++ b/docs/reference/api-catalog.md
@@ -3,7 +3,7 @@
 Generated from `Sources/Swarm/` on 2026-04-30; source-verified and refreshed for high-risk public rows on 2026-07-28 (Conduit hard-removed in 0.6). MCP client rows refreshed 2026-08-14. OpenAI-compatible provider rows added 2026-08-14.
 
 - Scope: all `.swift` files under `Sources/Swarm/`, excluding `Internal/GraphRuntime/`
-- Source files scanned: 194
+- Source files scanned: 196
 - Public/open symbols cataloged: 2325
 
 ## 1. Swarm (entry point)

--- a/docs/reference/front-facing-api.md
+++ b/docs/reference/front-facing-api.md
@@ -647,6 +647,13 @@ Built-in inference is Apple Foundation Models (on-device) and
 ``InferenceProvider`` and are passed explicitly (or via
 `await Swarm.configure(provider:)`).
 
+Prompt-string methods remain for one minor so existing backends compile. Agent
+and tests call the messages methods only. Prompt-string methods default to
+wrapping `prompt` as a user message. Capability bits and the structured-message
+methods are the live dispatch surface. Deprecated marker protocols remain
+available for source compatibility: `PromptTokenCountingInferenceProvider`,
+`StructuredOutputInferenceProvider`, and `ToolCallStreamingInferenceProvider`.
+
 ```swift
 .foundationModels()                 // On-device first-class provider
 .foundationModels(profile: profile) // Dynamic profile re-resolved each turn


### PR DESCRIPTION
Restores the public documentation contracts enforced by DocumentationFreshnessTests after the PR merge sweep. Updates provider compatibility wording, global configuration and Linux platform guidance, the API catalog source count, and the transcript refactor expectation.

Verified: DocumentationFreshness suite, 32 tests passed.