### PR TITLE
Drive the Agent tool loop from AgentTurnKernel

### DIFF
--- a/Sources/Swarm/Agents/Agent+ToolLoop.swift
+++ b/Sources/Swarm/Agents/Agent+ToolLoop.swift
@@ -273,14 +273,12 @@ extension Agent {
                         return handoffOutcome
                     }
                     if case .ownedLoopTools = turnState.mode {
-                        let agentError = (error as? AgentError)
-                            ?? .generationFailed(reason: error.localizedDescription)
                         switch AgentTurnKernel.transition(
                             turnState,
-                            .ownedLoopInferenceFailed(agentError)
+                            .ownedLoopInferenceFailed(Self.ownedLoopInferenceFailure(from: error))
                         ) {
                         case .fail(let kernelError):
-                            if error is AgentError {
+                            if error is CancellationError || error is AgentError {
                                 throw kernelError
                             }
                             throw error
@@ -357,6 +355,22 @@ extension Agent {
                 throw normalizeCancellation(error)
             }
         }
+    }
+
+    /// Maps an owned-loop inference error to ``AgentError`` for the kernel.
+    ///
+    /// `CancellationError` must stay ``AgentError/cancelled`` (not retryable
+    /// ``AgentError/generationFailed(reason:)``). Other non-`AgentError` values
+    /// keep a generationFailed stand-in so the kernel can classify retry vs
+    /// fail; the shell still rethrows the original error in that case.
+    private static func ownedLoopInferenceFailure(from error: Error) -> AgentError {
+        if error is CancellationError {
+            return .cancelled
+        }
+        if let agentError = error as? AgentError {
+            return agentError
+        }
+        return .generationFailed(reason: error.localizedDescription)
     }
 
     /// Builds the initial conversation history from session history and user input.

--- a/Sources/Swarm/Agents/Agent+ToolLoop.swift
+++ b/Sources/Swarm/Agents/Agent+ToolLoop.swift
@@ -80,17 +80,18 @@ extension Agent {
             iteration: 0,
             maxIterations: configuration.maxIterations
         )
+        var pendingTurnAction = AgentTurnKernel.TurnAction.startNextIteration
 
         while true {
-            // Kernel: admit the next iteration before any per-iteration effects
-            // run (mirrors the previous `while iteration < maxIterations` head).
-            switch AgentTurnKernel.transition(turnState, .startNextIteration) {
+            // Kernel: admit before per-iteration effects. After host tools the
+            // shell feeds `.toolsCompleted` instead of `.startNextIteration`.
+            switch AgentTurnKernel.transition(turnState, pendingTurnAction) {
             case .fail(let error):
                 throw error
             case .performInference(let admitted):
                 turnState = admitted
                 iteration = admitted.iteration
-            default:
+            case .executeTools, .retryOwnedLoopInference, .finish:
                 throw AgentError.internalError(reason: "Unexpected admission transition")
             }
 
@@ -271,6 +272,29 @@ extension Agent {
                         await observer?.onIterationEnd(context: nil, agent: self, number: iteration)
                         return handoffOutcome
                     }
+                    if case .ownedLoopTools = turnState.mode {
+                        let agentError = (error as? AgentError)
+                            ?? .generationFailed(reason: error.localizedDescription)
+                        switch AgentTurnKernel.transition(
+                            turnState,
+                            .ownedLoopInferenceFailed(agentError)
+                        ) {
+                        case .fail(let kernelError):
+                            if error is AgentError {
+                                throw kernelError
+                            }
+                            throw error
+                        case .retryOwnedLoopInference:
+                            // Empty schemas: executeProviderInference already
+                            // applied ownedLoopInferenceRetryPolicy. Honor the
+                            // kernel without admitting or replaying tools.
+                            throw error
+                        case .performInference, .executeTools, .finish:
+                            throw AgentError.internalError(
+                                reason: "Unexpected owned-loop failure transition"
+                            )
+                        }
+                    }
                     throw error
                 }
                 recordUsage(response.usage, on: resultBuilder)
@@ -322,7 +346,10 @@ extension Agent {
                         )
                     }
                     await observer?.onIterationEnd(context: nil, agent: self, number: iteration)
-                default:
+                    pendingTurnAction = .toolsCompleted
+                    continue
+
+                case .performInference, .retryOwnedLoopInference:
                     throw AgentError.internalError(reason: "Unexpected inference transition")
                 }
             } catch {

--- a/Sources/Swarm/Agents/AgentTurnKernel.swift
+++ b/Sources/Swarm/Agents/AgentTurnKernel.swift
@@ -143,9 +143,10 @@ enum AgentTurnKernel: Sendable {
     ///   handoff (the sole admission for that tool round; the shell must not
     ///   also feed ``TurnAction/startNextIteration``)
     /// - ``TurnAction/ownedLoopInferenceFailed(_:)`` classifies owned-loop
-    ///   inference failures. Empty schemas are retry-safe
-    ///   (``TurnTransition/retryOwnedLoopInference``); tools that already ran
-    ///   inside inference fail closed. `executeProviderInference` still applies
+    ///   inference failures. Empty schemas retry only for retryable
+    ///   ``AgentError`` values (``TurnTransition/retryOwnedLoopInference``);
+    ///   cancellation, timeout, and tools that already ran inside inference
+    ///   fail closed. `executeProviderInference` still applies
     ///   ``ownedLoopInferenceRetryPolicy(mode:hasToolSchemas:)`` so retry
     ///   timing is unchanged.
     enum TurnAction: Equatable, Sendable {
@@ -166,8 +167,8 @@ enum AgentTurnKernel: Sendable {
         /// Host tool calls are pending; execute them, then report
         /// `.toolsCompleted`.
         case executeTools(TurnState)
-        /// Owned-loop inference may be retried (empty tool list only; tools
-        /// already ran inside inference).
+        /// Owned-loop inference may be retried (empty retryable failures only;
+        /// cancellation, timeout, and tools already ran inside inference fail).
         case retryOwnedLoopInference(TurnState)
         /// The turn finished with assistant content.
         case finish(content: String)
@@ -208,7 +209,10 @@ enum AgentTurnKernel: Sendable {
             return transition(state, .startNextIteration)
 
         case .ownedLoopInferenceFailed(let error):
-            if case .ownedLoopTools = state.mode, !state.hasToolSchemas {
+            // Empty schemas are retry-safe (no host tools to replay), but only
+            // transient inference failures may retry. Cancellation and timeout
+            // fail closed so they cannot be classified as generationFailed.
+            if case .ownedLoopTools = state.mode, !state.hasToolSchemas, error.isRetryable {
                 return .retryOwnedLoopInference(state)
             }
             return .fail(error)

--- a/Sources/Swarm/Agents/AgentTurnKernel.swift
+++ b/Sources/Swarm/Agents/AgentTurnKernel.swift
@@ -136,13 +136,18 @@ enum AgentTurnKernel: Sendable {
 
     /// Facts the shell reports to the kernel after executing an effect.
     ///
-    /// `Agent.executeToolCallingLoop` currently feeds only
-    /// `.startNextIteration` (loop head) and `.inferenceCompleted`. The
-    /// remaining actions are modeled but not yet wired into the shell:
-    /// `.toolsCompleted` is equivalent to the shell re-entering
-    /// `.startNextIteration` at the loop head, and `.ownedLoopInferenceFailed`
-    /// corresponds to failures the shell currently handles through
-    /// `ownedLoopInferenceRetryPolicy` inside `executeProviderInference`.
+    /// `Agent.executeToolCallingLoop` feeds every action:
+    /// - ``TurnAction/startNextIteration`` admits the first iteration
+    /// - ``TurnAction/inferenceCompleted(_:)`` interprets the provider response
+    /// - ``TurnAction/toolsCompleted`` continues after host tools without a
+    ///   handoff (the sole admission for that tool round; the shell must not
+    ///   also feed ``TurnAction/startNextIteration``)
+    /// - ``TurnAction/ownedLoopInferenceFailed(_:)`` classifies owned-loop
+    ///   inference failures. Empty schemas are retry-safe
+    ///   (``TurnTransition/retryOwnedLoopInference``); tools that already ran
+    ///   inside inference fail closed. `executeProviderInference` still applies
+    ///   ``ownedLoopInferenceRetryPolicy(mode:hasToolSchemas:)`` so retry
+    ///   timing is unchanged.
     enum TurnAction: Equatable, Sendable {
         /// Loop head: request admission of the next iteration.
         case startNextIteration
@@ -197,8 +202,9 @@ enum AgentTurnKernel: Sendable {
             }
 
         case .toolsCompleted:
-            // Continuing the loop re-enters at the loop head, where the
-            // iteration cap is enforced before any per-iteration effects run.
+            // The shell feeds this after host tools without a handoff. It is
+            // the sole continue-admission for that tool round; feeding
+            // `.startNextIteration` as well would double-count.
             return transition(state, .startNextIteration)
 
         case .ownedLoopInferenceFailed(let error):

--- a/Tests/SwarmTests/Agents/AgentToolLoopCharacterizationTests.swift
+++ b/Tests/SwarmTests/Agents/AgentToolLoopCharacterizationTests.swift
@@ -1,15 +1,15 @@
 // AgentToolLoopCharacterizationTests.swift
 // SwarmTests
 //
-// Characterization tests for the Agent tool-calling loop (spec ticket T2, AC-004).
-// They pin the CURRENT public behavior of `Agent.executeToolCallingLoop` and must
-// pass unchanged before and after the turn-kernel transition extraction.
+// Characterization tests for the Agent tool-calling loop (spec T1 AC-001).
+// They pin public `executeToolCallingLoop` behavior: one admission per inference
+// attempt, including after host tools without a handoff.
 
 import Foundation
 @testable import Swarm
 import Testing
 
-@Suite("Tool-calling loop characterization (T2 AC-004)")
+@Suite("Tool-calling loop characterization (T1 AC-001)")
 struct AgentToolLoopCharacterizationTests {
     private static let loopConfiguration = AgentConfiguration.default
         .enableStreaming(false)
@@ -36,7 +36,30 @@ struct AgentToolLoopCharacterizationTests {
         #expect(await tool.callCount == 1)
         // One tool-calling turn plus one final turn.
         #expect(await provider.recordedInferenceCallCount == 2)
+        #expect(result.iterationCount == 2)
         #expect(result.toolCalls.map(\.toolName) == ["weather"])
+    }
+
+    @Test("Two host-tool rounds under a tight cap admit once per inference")
+    func twoHostToolRoundsUnderTightCapDoNotDoubleAdmit() async throws {
+        let tool = SpyTool(name: "step", result: .string("ok"))
+        let provider = await MockInferenceProvider()
+        await provider.configureToolCallingSequence(
+            toolCalls: [("step", [:]), ("step", [:])],
+            finalAnswer: "done"
+        )
+        let agent = try Agent(
+            tools: [tool],
+            configuration: Self.loopConfiguration.maxIterations(3),
+            inferenceProvider: provider
+        )
+
+        let result = try await agent.run("two steps")
+
+        #expect(result.output == "done")
+        #expect(await tool.callCount == 2)
+        #expect(await provider.recordedInferenceCallCount == 3)
+        #expect(result.iterationCount == 3)
     }
 
     @Test("Iteration cap throws maxIterationsExceeded with the configured count")

--- a/Tests/SwarmTests/Agents/AgentTurnKernelTests.swift
+++ b/Tests/SwarmTests/Agents/AgentTurnKernelTests.swift
@@ -236,6 +236,20 @@ struct AgentTurnKernelTests {
         #expect(capped == .fail(.maxIterationsExceeded(iterations: 3)))
     }
 
+    @Test("toolsCompleted already admits, so a second startNextIteration would skip a slot")
+    func toolsCompletedMustNotBeFollowedByStartNextIteration() {
+        let afterHostTools = state(iteration: 1, mode: .hostTools(streaming: false))
+        let continued = AgentTurnKernel.transition(afterHostTools, .toolsCompleted)
+        guard case let .performInference(admitted) = continued else {
+            Issue.record("Expected toolsCompleted to admit the next iteration")
+            return
+        }
+        #expect(admitted.iteration == 2)
+
+        let doubled = AgentTurnKernel.transition(admitted, .startNextIteration)
+        #expect(doubled == .performInference(state(iteration: 3, maxIterations: 3, mode: nil)))
+    }
+
     @Test("Owned-loop inference failure retries only with an empty tool list")
     func ownedLoopInferenceFailureRetryDecision() {
         let transient = AgentError.generationFailed(reason: "transient 503")
@@ -246,6 +260,10 @@ struct AgentTurnKernelTests {
             .ownedLoopInferenceFailed(transient)
         )
         #expect(emptySchemas == .retryOwnedLoopInference(emptySchemasState))
+        guard case let .retryOwnedLoopInference(retryState) = emptySchemas else {
+            return
+        }
+        #expect(retryState.iteration == emptySchemasState.iteration)
 
         let withSchemas = AgentTurnKernel.transition(
             state(iteration: 1, mode: .ownedLoopTools(streaming: false), hasToolSchemas: true),

--- a/Tests/SwarmTests/Agents/AgentTurnKernelTests.swift
+++ b/Tests/SwarmTests/Agents/AgentTurnKernelTests.swift
@@ -260,10 +260,6 @@ struct AgentTurnKernelTests {
             .ownedLoopInferenceFailed(transient)
         )
         #expect(emptySchemas == .retryOwnedLoopInference(emptySchemasState))
-        guard case let .retryOwnedLoopInference(retryState) = emptySchemas else {
-            return
-        }
-        #expect(retryState.iteration == emptySchemasState.iteration)
 
         let withSchemas = AgentTurnKernel.transition(
             state(iteration: 1, mode: .ownedLoopTools(streaming: false), hasToolSchemas: true),
@@ -276,6 +272,26 @@ struct AgentTurnKernelTests {
             .ownedLoopInferenceFailed(transient)
         )
         #expect(hostLoop == .fail(transient))
+    }
+
+    @Test("Owned-loop cancellation and timeout fail closed even with empty schemas")
+    func ownedLoopInferenceFailureDoesNotRetryCancellationOrTimeout() {
+        let emptySchemasState = state(
+            iteration: 1,
+            mode: .ownedLoopTools(streaming: false),
+            hasToolSchemas: false
+        )
+
+        #expect(
+            AgentTurnKernel.transition(emptySchemasState, .ownedLoopInferenceFailed(.cancelled))
+                == .fail(.cancelled)
+        )
+        #expect(
+            AgentTurnKernel.transition(
+                emptySchemasState,
+                .ownedLoopInferenceFailed(.timeout(duration: .seconds(15)))
+            ) == .fail(.timeout(duration: .seconds(15)))
+        )
     }
 
     @Test("Max iterations reached while tool calls are pending fails identically to the loop")

--- a/Tests/SwarmTests/Agents/ProviderOwnedToolLoopTests.swift
+++ b/Tests/SwarmTests/Agents/ProviderOwnedToolLoopTests.swift
@@ -87,6 +87,43 @@ struct ProviderOwnedToolLoopTests {
         let result = try await agent.run("hello")
         #expect(result.output == "recovered")
         #expect(await provider.recordedInferenceCallCount == 2)
+        #expect(result.iterationCount == 1)
+    }
+
+    @Test("Empty-tools owned-loop exhausted retries stay on one iteration")
+    func emptyToolsOwnedLoopExhaustedRetriesDoNotAdmitOrReplay() async throws {
+        let provider = MockOwnedLoopProvider(responses: ["should-not-run"])
+        await provider.setErrorSequence([
+            Self.transient,
+            Self.transient,
+            Self.transient,
+            Self.transient,
+        ])
+        let agent = try Agent(
+            tools: [],
+            instructions: "Be brief.",
+            configuration: AgentConfiguration.default
+                .enableStreaming(false)
+                .timeout(.seconds(15))
+                .resilience(ResilienceConfiguration(
+                    retryPolicy: RetryPolicy(maxAttempts: 3, backoff: .immediate)
+                ))
+                .defaultTracingEnabled(false),
+            inferenceProvider: provider
+        )
+
+        do {
+            _ = try await agent.run("hello")
+            Issue.record("Expected retries to exhaust")
+        } catch is ResilienceError {
+            // executeProviderInference still owns retry timing; the kernel
+            // classifies the failure without a second admission.
+        } catch {
+            Issue.record("Expected ResilienceError.retriesExhausted, got \(error)")
+        }
+
+        // maxAttempts counts retries after the first try: 1 + 3 = 4 calls.
+        #expect(await provider.recordedInferenceCallCount == 4)
     }
 
     @Test("Owned loop persists the InferenceMessage transcript on Session")

--- a/Tests/SwarmTests/Agents/ProviderOwnedToolLoopTests.swift
+++ b/Tests/SwarmTests/Agents/ProviderOwnedToolLoopTests.swift
@@ -115,15 +115,45 @@ struct ProviderOwnedToolLoopTests {
         do {
             _ = try await agent.run("hello")
             Issue.record("Expected retries to exhaust")
-        } catch is ResilienceError {
-            // executeProviderInference still owns retry timing; the kernel
-            // classifies the failure without a second admission.
+        } catch let error as ResilienceError {
+            guard case .retriesExhausted(let attempts, _) = error else {
+                Issue.record("Expected ResilienceError.retriesExhausted, got \(error)")
+                return
+            }
+            #expect(attempts == 4)
         } catch {
             Issue.record("Expected ResilienceError.retriesExhausted, got \(error)")
         }
 
         // maxAttempts counts retries after the first try: 1 + 3 = 4 calls.
         #expect(await provider.recordedInferenceCallCount == 4)
+    }
+
+    @Test("Empty-tools owned-loop CancellationError is cancelled, not generationFailed")
+    func emptyToolsOwnedLoopCancellationIsNotGenerationFailed() async throws {
+        let provider = MockOwnedLoopProvider(responses: ["should-not-run"])
+        await provider.setErrorSequence([CancellationError()])
+        let agent = try Agent(
+            tools: [],
+            instructions: "Be brief.",
+            configuration: AgentConfiguration.default
+                .enableStreaming(false)
+                .timeout(.seconds(15))
+                .resilience(ResilienceConfiguration(retryPolicy: .noRetry))
+                .defaultTracingEnabled(false),
+            inferenceProvider: provider
+        )
+
+        do {
+            _ = try await agent.run("hello")
+            Issue.record("Expected cancellation")
+        } catch let error as AgentError {
+            #expect(error == .cancelled)
+        } catch {
+            Issue.record("Expected AgentError.cancelled, got \(error)")
+        }
+
+        #expect(await provider.recordedInferenceCallCount == 1)
     }
 
     @Test("Owned loop persists the InferenceMessage transcript on Session")


### PR DESCRIPTION
## Summary
- Drive `executeToolCallingLoop` from `AgentTurnKernel.transition` for all four `TurnAction`s so host-tool continue cannot double-admit an iteration.
- Treat owned-loop `CancellationError` as `.cancelled` (not retryable `generationFailed`) and only retry empty-schema owned-loop failures when `error.isRetryable`.
- Package-internal only; public `Agent.run` is unchanged.

Spec: `spec/spec-architecture-functional-evolution.md` ticket **T1**.
Reviews: `swift-pr-review` (first pass, fix allowed) then `swift-pr-review` (final pass, clean).

## Test plan
- [x] `SWARM_OMIT_INTEGRATION_TARGETS=1 swift test --no-parallel --filter 'AgentTurnKernel|AgentToolLoopCharacterization|ProviderOwnedToolLoop'`
- [x] `SWARM_CORE_ONLY=1 swift build`
- [x] `git diff --check`
- [ ] CI lean + Integrations lanes on this PR


Made with [Cursor](https://cursor.com)