### PR TITLE
Share context-window fit between PromptEnvelope and SlidingWindowMemory

### DIFF
--- a/Sources/Swarm/Core/PromptEnvelope.swift
+++ b/Sources/Swarm/Core/PromptEnvelope.swift
@@ -137,6 +137,40 @@ enum ContextWindow {
         return best
     }
 
+    /// Synchronous counterpart of ``longestPrefix(of:maxTokens:minimum:countTokens:)``
+    /// for callers that cannot suspend (actor-isolated mutation).
+    static func longestPrefix(
+        of text: String,
+        maxTokens: Int,
+        minimum: String = "",
+        countTokens: (String) -> Int
+    ) -> String {
+        guard maxTokens > 0 else {
+            return minimum
+        }
+
+        if countTokens(text) <= maxTokens {
+            return text
+        }
+
+        var lower = minimum.count
+        var upper = text.count
+        var best = minimum
+
+        while lower <= upper {
+            let mid = (lower + upper) / 2
+            let candidate = String(text.prefix(mid))
+            if countTokens(candidate) <= maxTokens {
+                best = candidate
+                lower = mid + 1
+            } else {
+                upper = mid - 1
+            }
+        }
+
+        return best
+    }
+
     /// Keep-newest eviction: drop oldest messages until the additive token sum
     /// fits, always leaving at least one message.
     static func evictOldest<Message: Sendable>(
@@ -148,21 +182,44 @@ enum ContextWindow {
             return messages
         }
 
-        var remaining = messages
         var tokenCounts: [Int] = []
-        tokenCounts.reserveCapacity(remaining.count)
-        var total = 0
-        for message in remaining {
-            let tokens = await tokensOf(message)
-            tokenCounts.append(tokens)
-            total += tokens
+        tokenCounts.reserveCapacity(messages.count)
+        for message in messages {
+            tokenCounts.append(await tokensOf(message))
+        }
+        return evictOldest(from: messages, maxTokens: maxTokens, tokenCounts: tokenCounts)
+    }
+
+    /// Synchronous counterpart of ``evictOldest(from:maxTokens:tokensOf:)`` for
+    /// callers that cannot suspend (actor-isolated mutation).
+    static func evictOldest<Message>(
+        from messages: [Message],
+        maxTokens: Int,
+        tokensOf: (Message) -> Int
+    ) -> [Message] {
+        evictOldest(
+            from: messages,
+            maxTokens: maxTokens,
+            tokenCounts: messages.map(tokensOf)
+        )
+    }
+
+    private static func evictOldest<Message>(
+        from messages: [Message],
+        maxTokens: Int,
+        tokenCounts: [Int]
+    ) -> [Message] {
+        guard !messages.isEmpty else {
+            return messages
         }
 
+        var remaining = messages
+        var counts = tokenCounts
+        var total = counts.reduce(0, +)
         while total > maxTokens, remaining.count > 1 {
             remaining.removeFirst()
-            total -= tokenCounts.removeFirst()
+            total -= counts.removeFirst()
         }
-
         return remaining
     }
 

--- a/Sources/Swarm/Core/PromptEnvelope.swift
+++ b/Sources/Swarm/Core/PromptEnvelope.swift
@@ -8,9 +8,9 @@ import Foundation
 /// Roles stay; this is windowing, not flattening to a single user string.
 enum ContextWindow {
     struct Policy: Equatable, Sendable {
-        var maxTokens: Int
-        var protectLeadingSystem: Bool
-        var alwaysKeepLast: Bool
+        let maxTokens: Int
+        let protectLeadingSystem: Bool
+        let alwaysKeepLast: Bool
 
         static func strict4k(_ profile: ContextProfile) -> Policy {
             Policy(
@@ -22,10 +22,17 @@ enum ContextWindow {
     }
 
     /// Drops oldest unprotected messages until the conversation fits `policy.maxTokens`.
-    /// The latest message is kept when `alwaysKeepLast` is true. A leading `.system`
+    ///
+    /// Token counts are measured on ``InferenceMessage/flattenPrompt(_:)``. The injected
+    /// counter receives that labeled string, not raw message bodies.
+    ///
+    /// When `alwaysKeepLast` is true, the latest message is kept. A leading `.system`
     /// message is kept when `protectLeadingSystem` is true; if system + last still
     /// overflow, last (and if needed system text) is truncated so a non-empty system
     /// remains.
+    ///
+    /// When `alwaysKeepLast` is false, eviction is drop-oldest only (no truncation).
+    /// At least one message is always retained.
     static func fit(
         messages: [InferenceMessage],
         policy: Policy,
@@ -142,14 +149,18 @@ enum ContextWindow {
         }
 
         var remaining = messages
+        var tokenCounts: [Int] = []
+        tokenCounts.reserveCapacity(remaining.count)
         var total = 0
         for message in remaining {
-            total += await tokensOf(message)
+            let tokens = await tokensOf(message)
+            tokenCounts.append(tokens)
+            total += tokens
         }
 
         while total > maxTokens, remaining.count > 1 {
-            let removed = remaining.removeFirst()
-            total -= await tokensOf(removed)
+            remaining.removeFirst()
+            total -= tokenCounts.removeFirst()
         }
 
         return remaining
@@ -163,7 +174,8 @@ enum ContextWindow {
     ) async -> [InferenceMessage] {
         var remaining = messages
         let protectedCount = (protectLeadingSystem && remaining.first?.role == .system) ? 1 : 0
-        while remaining.count > protectedCount,
+        let floorCount = max(protectedCount, 1)
+        while remaining.count > floorCount,
             await tokenCount(of: remaining, countTokens: countTokens) > maxTokens
         {
             remaining.remove(at: protectedCount)

--- a/Sources/Swarm/Core/PromptEnvelope.swift
+++ b/Sources/Swarm/Core/PromptEnvelope.swift
@@ -1,24 +1,57 @@
 import Foundation
 
-/// Enforces context-envelope limits for provider prompts.
-enum PromptEnvelope {
-    /// Drops oldest non-system messages until the conversation fits the profile budget.
-    /// Roles stay. The latest message is always kept. A leading `.system` message is
-    /// never dropped; if system + last still overflow, last (and if needed system
-    /// text) is truncated so a non-empty system remains.
-    static func enforce(messages: [InferenceMessage], profile: ContextProfile) async -> [InferenceMessage] {
-        guard profile.preset == .strict4k, !messages.isEmpty else {
+/// Package-internal context-window decisions shared by ``PromptEnvelope`` and
+/// ``SlidingWindowMemory``.
+///
+/// Callers inject a token counter so the same fit/truncate policy can run
+/// against a provider counter, ``EstimatedPromptTokenCounter``, or a test fake.
+/// Roles stay; this is windowing, not flattening to a single user string.
+enum ContextWindow {
+    struct Policy: Equatable, Sendable {
+        var maxTokens: Int
+        var protectLeadingSystem: Bool
+        var alwaysKeepLast: Bool
+
+        static func strict4k(_ profile: ContextProfile) -> Policy {
+            Policy(
+                maxTokens: profile.budget.maxInputTokens,
+                protectLeadingSystem: true,
+                alwaysKeepLast: true
+            )
+        }
+    }
+
+    /// Drops oldest unprotected messages until the conversation fits `policy.maxTokens`.
+    /// The latest message is kept when `alwaysKeepLast` is true. A leading `.system`
+    /// message is kept when `protectLeadingSystem` is true; if system + last still
+    /// overflow, last (and if needed system text) is truncated so a non-empty system
+    /// remains.
+    static func fit(
+        messages: [InferenceMessage],
+        policy: Policy,
+        countTokens: @Sendable (String) async -> Int
+    ) async -> [InferenceMessage] {
+        guard !messages.isEmpty else {
             return messages
         }
 
-        let maxTokens = profile.budget.maxInputTokens
-        if await tokenCount(of: messages) <= maxTokens {
+        let maxTokens = policy.maxTokens
+        if await tokenCount(of: messages, countTokens: countTokens) <= maxTokens {
             return messages
+        }
+
+        if !policy.alwaysKeepLast {
+            return await dropOldest(
+                messages,
+                maxTokens: maxTokens,
+                protectLeadingSystem: policy.protectLeadingSystem,
+                countTokens: countTokens
+            )
         }
 
         let lastIndex = messages.count - 1
         let last = messages[lastIndex]
-        let hasProtectedSystem = messages[0].role == .system
+        let hasProtectedSystem = policy.protectLeadingSystem && messages[0].role == .system
         let protectedSystem = hasProtectedSystem ? messages[0] : nil
         let lastIsProtectedSystem = lastIndex == 0 && hasProtectedSystem
 
@@ -35,7 +68,7 @@ enum PromptEnvelope {
                 last: last,
                 lastIsProtectedSystem: lastIsProtectedSystem
             )
-            if await tokenCount(of: next) <= maxTokens {
+            if await tokenCount(of: next, countTokens: countTokens) <= maxTokens {
                 kept.insert(candidate, at: 0)
             } else {
                 break
@@ -48,7 +81,7 @@ enum PromptEnvelope {
             last: last,
             lastIsProtectedSystem: lastIsProtectedSystem
         )
-        if await tokenCount(of: windowed) <= maxTokens {
+        if await tokenCount(of: windowed, countTokens: countTokens) <= maxTokens {
             return windowed
         }
 
@@ -56,12 +89,93 @@ enum PromptEnvelope {
             protectedSystem,
             last: last,
             lastIsProtectedSystem: lastIsProtectedSystem,
-            maxTokens: maxTokens
+            maxTokens: maxTokens,
+            countTokens: countTokens
         )
     }
 
-    private static func tokenCount(of messages: [InferenceMessage]) async -> Int {
-        await PromptTokenBudgeting.countTokens(in: InferenceMessage.flattenPrompt(messages))
+    /// Longest character prefix of `text` whose token count is within `maxTokens`.
+    ///
+    /// If even `minimum` overflows, `minimum` is returned so callers can keep a
+    /// non-empty protected system head.
+    static func longestPrefix(
+        of text: String,
+        maxTokens: Int,
+        minimum: String = "",
+        countTokens: @Sendable (String) async -> Int
+    ) async -> String {
+        guard maxTokens > 0 else {
+            return minimum
+        }
+
+        if await countTokens(text) <= maxTokens {
+            return text
+        }
+
+        var lower = minimum.count
+        var upper = text.count
+        var best = minimum
+
+        while lower <= upper {
+            let mid = (lower + upper) / 2
+            let candidate = String(text.prefix(mid))
+            if await countTokens(candidate) <= maxTokens {
+                best = candidate
+                lower = mid + 1
+            } else {
+                upper = mid - 1
+            }
+        }
+
+        return best
+    }
+
+    /// Keep-newest eviction: drop oldest messages until the additive token sum
+    /// fits, always leaving at least one message.
+    static func evictOldest<Message: Sendable>(
+        from messages: [Message],
+        maxTokens: Int,
+        tokensOf: @Sendable (Message) async -> Int
+    ) async -> [Message] {
+        guard !messages.isEmpty else {
+            return messages
+        }
+
+        var remaining = messages
+        var total = 0
+        for message in remaining {
+            total += await tokensOf(message)
+        }
+
+        while total > maxTokens, remaining.count > 1 {
+            let removed = remaining.removeFirst()
+            total -= await tokensOf(removed)
+        }
+
+        return remaining
+    }
+
+    private static func dropOldest(
+        _ messages: [InferenceMessage],
+        maxTokens: Int,
+        protectLeadingSystem: Bool,
+        countTokens: @Sendable (String) async -> Int
+    ) async -> [InferenceMessage] {
+        var remaining = messages
+        let protectedCount = (protectLeadingSystem && remaining.first?.role == .system) ? 1 : 0
+        while remaining.count > protectedCount,
+            await tokenCount(of: remaining, countTokens: countTokens) > maxTokens
+        {
+            remaining.remove(at: protectedCount)
+        }
+        return remaining
+    }
+
+    private static func tokenCount(
+        of messages: [InferenceMessage],
+        countTokens: @Sendable (String) async -> Int
+    ) async -> Int {
+        await countTokens(InferenceMessage.flattenPrompt(messages))
     }
 
     private static func assemble(
@@ -86,10 +200,17 @@ enum PromptEnvelope {
         _ protectedSystem: InferenceMessage?,
         last: InferenceMessage,
         lastIsProtectedSystem: Bool,
-        maxTokens: Int
+        maxTokens: Int,
+        countTokens: @Sendable (String) async -> Int
     ) async -> [InferenceMessage] {
         if lastIsProtectedSystem, let system = protectedSystem {
-            return [await truncatedMessage(system, prefixedBy: [], maxTokens: maxTokens, keepNonEmpty: true)]
+            return [await truncatedMessage(
+                system,
+                prefixedBy: [],
+                maxTokens: maxTokens,
+                keepNonEmpty: true,
+                countTokens: countTokens
+            )]
         }
 
         if let system = protectedSystem {
@@ -97,10 +218,11 @@ enum PromptEnvelope {
                 last,
                 prefixedBy: [system],
                 maxTokens: maxTokens,
-                keepNonEmpty: false
+                keepNonEmpty: false,
+                countTokens: countTokens
             )
             let withFullSystem = [system, clippedLast]
-            if await tokenCount(of: withFullSystem) <= maxTokens {
+            if await tokenCount(of: withFullSystem, countTokens: countTokens) <= maxTokens {
                 return withFullSystem
             }
 
@@ -112,46 +234,48 @@ enum PromptEnvelope {
                 system,
                 prefixedBy: [],
                 maxTokens: headShare,
-                keepNonEmpty: true
+                keepNonEmpty: true,
+                countTokens: countTokens
             )
             let fittedLast = await truncatedMessage(
                 last,
                 prefixedBy: [clippedSystem],
                 maxTokens: maxTokens,
-                keepNonEmpty: false
+                keepNonEmpty: false,
+                countTokens: countTokens
             )
             return [clippedSystem, fittedLast]
         }
 
-        return [await truncatedMessage(last, prefixedBy: [], maxTokens: maxTokens, keepNonEmpty: false)]
+        return [await truncatedMessage(
+            last,
+            prefixedBy: [],
+            maxTokens: maxTokens,
+            keepNonEmpty: false,
+            countTokens: countTokens
+        )]
     }
 
     private static func truncatedMessage(
         _ message: InferenceMessage,
         prefixedBy prefix: [InferenceMessage],
         maxTokens: Int,
-        keepNonEmpty: Bool
+        keepNonEmpty: Bool,
+        countTokens: @Sendable (String) async -> Int
     ) async -> InferenceMessage {
         let minimum = keepNonEmpty && !message.content.isEmpty
             ? String(message.content.prefix(1))
             : ""
-        var lower = minimum.count
-        var upper = message.content.count
-        var best = minimum
-
-        while lower <= upper {
-            let mid = (lower + upper) / 2
-            let candidate = String(message.content.prefix(mid))
-            let next = prefix + [replacingContent(of: message, with: candidate)]
-            if await tokenCount(of: next) <= maxTokens {
-                best = candidate
-                lower = mid + 1
-            } else {
-                upper = mid - 1
+        let clipped = await longestPrefix(
+            of: message.content,
+            maxTokens: maxTokens,
+            minimum: minimum,
+            countTokens: { candidate in
+                let next = prefix + [replacingContent(of: message, with: candidate)]
+                return await countTokens(InferenceMessage.flattenPrompt(next))
             }
-        }
-
-        return replacingContent(of: message, with: best)
+        )
+        return replacingContent(of: message, with: clipped)
     }
 
     private static func replacingContent(of message: InferenceMessage, with content: String) -> InferenceMessage {
@@ -161,6 +285,28 @@ enum PromptEnvelope {
             name: message.name,
             toolCallID: message.toolCallID,
             toolCalls: message.toolCalls
+        )
+    }
+}
+
+/// Enforces context-envelope limits for provider prompts.
+enum PromptEnvelope {
+    /// Drops oldest non-system messages until the conversation fits the profile budget.
+    /// Roles stay. The latest message is always kept. A leading `.system` message is
+    /// never dropped; if system + last still overflow, last (and if needed system
+    /// text) is truncated so a non-empty system remains.
+    ///
+    /// Non-``.strict4k`` presets are a no-op. The shared ``ContextWindow`` core is
+    /// still callable with an explicit budget independent of this gate.
+    static func enforce(messages: [InferenceMessage], profile: ContextProfile) async -> [InferenceMessage] {
+        guard profile.preset == .strict4k, !messages.isEmpty else {
+            return messages
+        }
+
+        return await ContextWindow.fit(
+            messages: messages,
+            policy: .strict4k(profile),
+            countTokens: { await PromptTokenBudgeting.countTokens(in: $0) }
         )
     }
 }

--- a/Sources/Swarm/Core/PromptTokenCounter.swift
+++ b/Sources/Swarm/Core/PromptTokenCounter.swift
@@ -82,28 +82,9 @@ enum PromptTokenBudgeting {
         maxTokens: Int,
         using counter: (any PromptTokenCounter)? = nil
     ) async -> String {
-        guard maxTokens > 0 else { return "" }
-
-        if await countTokens(in: text, using: counter) <= maxTokens {
-            return text
+        await ContextWindow.longestPrefix(of: text, maxTokens: maxTokens, minimum: "") { candidate in
+            await countTokens(in: candidate, using: counter)
         }
-
-        var lower = 0
-        var upper = text.count
-        var best = ""
-
-        while lower <= upper {
-            let mid = (lower + upper) / 2
-            let candidate = prefix(text, maxCharacters: mid)
-            if await countTokens(in: candidate, using: counter) <= maxTokens {
-                best = candidate
-                lower = mid + 1
-            } else {
-                upper = mid - 1
-            }
-        }
-
-        return best
     }
 
     static func suffix(
@@ -133,13 +114,6 @@ enum PromptTokenBudgeting {
         }
 
         return best
-    }
-
-    private static func prefix(_ text: String, maxCharacters: Int) -> String {
-        guard maxCharacters > 0 else { return "" }
-        guard text.count > maxCharacters else { return text }
-        let end = text.index(text.startIndex, offsetBy: maxCharacters)
-        return String(text[..<end])
     }
 
     private static func suffix(_ text: String, maxCharacters: Int) -> String {

--- a/Sources/Swarm/Memory/SlidingWindowMemory.swift
+++ b/Sources/Swarm/Memory/SlidingWindowMemory.swift
@@ -69,28 +69,24 @@ public actor SlidingWindowMemory: Memory {
     ) {
         self.maxTokens = max(100, maxTokens)
         self.tokenEstimator = tokenEstimator
-        self.tokenCounter = EstimatedPromptTokenCounter(estimator: tokenEstimator)
     }
 
     // MARK: - AgentMemory Conformance
 
     public func add(_ message: MemoryMessage) async {
-        let counter = tokenCounter
+        // Evict and truncate without awaiting so concurrent `add` calls cannot
+        // interleave and overwrite `messages`. TokenEstimator is synchronous and
+        // matches ``EstimatedPromptTokenCounter`` for the same estimator.
         messages.append(message)
-        messages = await ContextWindow.evictOldest(
+        messages = ContextWindow.evictOldest(
             from: messages,
             maxTokens: maxTokens,
-            tokensOf: { candidate in
-                await PromptTokenBudgeting.countTokens(
-                    in: candidate.formattedContent,
-                    using: counter
-                )
-            }
+            tokensOf: { tokenEstimator.estimateTokens(for: $0.formattedContent) }
         )
         recalibrateTokenCount()
 
         if currentTokenCount > maxTokens, let latest = messages.last {
-            let truncated = await truncate(latest, toFit: maxTokens)
+            let truncated = truncate(latest, toFit: maxTokens)
             messages[messages.count - 1] = truncated
             currentTokenCount = tokenEstimator.estimateTokens(for: truncated.formattedContent)
         }
@@ -118,22 +114,21 @@ public actor SlidingWindowMemory: Memory {
         operationsSinceRecalibration = 0
     }
 
-    private func truncate(_ message: MemoryMessage, toFit tokenLimit: Int) async -> MemoryMessage {
-        let counter = tokenCounter
-        let identity = message
-        let clipped = await ContextWindow.longestPrefix(
+    private func truncate(_ message: MemoryMessage, toFit tokenLimit: Int) -> MemoryMessage {
+        let clipped = ContextWindow.longestPrefix(
             of: message.content,
             maxTokens: tokenLimit,
             minimum: ""
         ) { candidate in
-            let formatted = MemoryMessage(
-                id: identity.id,
-                role: identity.role,
-                content: candidate,
-                timestamp: identity.timestamp,
-                metadata: identity.metadata
-            ).formattedContent
-            return await PromptTokenBudgeting.countTokens(in: formatted, using: counter)
+            tokenEstimator.estimateTokens(
+                for: MemoryMessage(
+                    id: message.id,
+                    role: message.role,
+                    content: candidate,
+                    timestamp: message.timestamp,
+                    metadata: message.metadata
+                ).formattedContent
+            )
         }
 
         return MemoryMessage(
@@ -149,9 +144,6 @@ public actor SlidingWindowMemory: Memory {
 
     /// Token estimator for counting.
     private let tokenEstimator: any TokenEstimator
-
-    /// ``TokenEstimator`` adapted to the shared ``PromptTokenCounter`` seam.
-    private let tokenCounter: EstimatedPromptTokenCounter
 
     /// Internal message storage.
     private var messages: [MemoryMessage] = []

--- a/Sources/Swarm/Memory/SlidingWindowMemory.swift
+++ b/Sources/Swarm/Memory/SlidingWindowMemory.swift
@@ -69,25 +69,28 @@ public actor SlidingWindowMemory: Memory {
     ) {
         self.maxTokens = max(100, maxTokens)
         self.tokenEstimator = tokenEstimator
+        self.tokenCounter = EstimatedPromptTokenCounter(estimator: tokenEstimator)
     }
 
     // MARK: - AgentMemory Conformance
 
     public func add(_ message: MemoryMessage) async {
-        let messageTokens = tokenEstimator.estimateTokens(for: message.formattedContent)
-
+        let counter = tokenCounter
         messages.append(message)
-        currentTokenCount += messageTokens
-
-        // Remove oldest messages until within budget
-        while currentTokenCount > maxTokens, messages.count > 1 {
-            let removed = messages.removeFirst()
-            let removedTokens = tokenEstimator.estimateTokens(for: removed.formattedContent)
-            currentTokenCount -= removedTokens
-        }
+        messages = await ContextWindow.evictOldest(
+            from: messages,
+            maxTokens: maxTokens,
+            tokensOf: { candidate in
+                await PromptTokenBudgeting.countTokens(
+                    in: candidate.formattedContent,
+                    using: counter
+                )
+            }
+        )
+        recalibrateTokenCount()
 
         if currentTokenCount > maxTokens, let latest = messages.last {
-            let truncated = truncate(latest, toFit: maxTokens)
+            let truncated = await truncate(latest, toFit: maxTokens)
             messages[messages.count - 1] = truncated
             currentTokenCount = tokenEstimator.estimateTokens(for: truncated.formattedContent)
         }
@@ -115,34 +118,28 @@ public actor SlidingWindowMemory: Memory {
         operationsSinceRecalibration = 0
     }
 
-    private func truncate(_ message: MemoryMessage, toFit tokenLimit: Int) -> MemoryMessage {
-        var lowerBound = 0
-        var upperBound = message.content.count
-        var bestContent = ""
-
-        while lowerBound <= upperBound {
-            let midpoint = (lowerBound + upperBound) / 2
-            let candidateContent = String(message.content.prefix(midpoint))
-            let candidate = MemoryMessage(
-                id: message.id,
-                role: message.role,
-                content: candidateContent,
-                timestamp: message.timestamp,
-                metadata: message.metadata
-            )
-
-            if tokenEstimator.estimateTokens(for: candidate.formattedContent) <= tokenLimit {
-                bestContent = candidateContent
-                lowerBound = midpoint + 1
-            } else {
-                upperBound = midpoint - 1
-            }
+    private func truncate(_ message: MemoryMessage, toFit tokenLimit: Int) async -> MemoryMessage {
+        let counter = tokenCounter
+        let identity = message
+        let clipped = await ContextWindow.longestPrefix(
+            of: message.content,
+            maxTokens: tokenLimit,
+            minimum: ""
+        ) { candidate in
+            let formatted = MemoryMessage(
+                id: identity.id,
+                role: identity.role,
+                content: candidate,
+                timestamp: identity.timestamp,
+                metadata: identity.metadata
+            ).formattedContent
+            return await PromptTokenBudgeting.countTokens(in: formatted, using: counter)
         }
 
         return MemoryMessage(
             id: message.id,
             role: message.role,
-            content: bestContent,
+            content: clipped,
             timestamp: message.timestamp,
             metadata: message.metadata
         )
@@ -152,6 +149,9 @@ public actor SlidingWindowMemory: Memory {
 
     /// Token estimator for counting.
     private let tokenEstimator: any TokenEstimator
+
+    /// ``TokenEstimator`` adapted to the shared ``PromptTokenCounter`` seam.
+    private let tokenCounter: EstimatedPromptTokenCounter
 
     /// Internal message storage.
     private var messages: [MemoryMessage] = []

--- a/Tests/SwarmTests/Core/PromptEnvelopeContextWindowTests.swift
+++ b/Tests/SwarmTests/Core/PromptEnvelopeContextWindowTests.swift
@@ -212,6 +212,24 @@ struct PromptEnvelopeContextWindowTests {
         #expect(kept == [50])
     }
 
+    @Test("synchronous evictOldest matches the async keep-newest result")
+    func synchronousEvictOldestMatchesAsync() async {
+        let messages = [10, 20, 30, 40]
+        let asyncKept = await ContextWindow.evictOldest(
+            from: messages,
+            maxTokens: 70,
+            tokensOf: { $0 }
+        )
+        let syncKept = ContextWindow.evictOldest(
+            from: messages,
+            maxTokens: 70,
+            tokensOf: { $0 }
+        )
+
+        #expect(syncKept == asyncKept)
+        #expect(syncKept == [30, 40])
+    }
+
     @Test("strict4k enforce matches ContextWindow.fit with the same counter")
     func enforceMatchesSharedFit() async {
         let padding = String(repeating: "x", count: 80)

--- a/Tests/SwarmTests/Core/PromptEnvelopeContextWindowTests.swift
+++ b/Tests/SwarmTests/Core/PromptEnvelopeContextWindowTests.swift
@@ -1,0 +1,177 @@
+import Foundation
+@testable import Swarm
+import Testing
+
+@Suite("PromptEnvelope ContextWindow")
+struct PromptEnvelopeContextWindowTests {
+    @Test("fit drops oldest history and keeps a protected system plus the last turn")
+    func fitKeepsProtectedSystemAndLast() async throws {
+        let system = InferenceMessage.system("Stay")
+        let oldest = InferenceMessage.user("old-user")
+        let last = InferenceMessage.user("needle-latest")
+        let messages = [system, oldest, last]
+        let budget = flattenCharacterCount([system, last])
+        try #require(flattenCharacterCount(messages) > budget)
+
+        let fitted = await ContextWindow.fit(
+            messages: messages,
+            policy: ContextWindow.Policy(
+                maxTokens: budget,
+                protectLeadingSystem: true,
+                alwaysKeepLast: true
+            ),
+            countTokens: characterCount
+        )
+
+        #expect(fitted == [system, last])
+        #expect(flattenCharacterCount(fitted) <= budget)
+    }
+
+    @Test("fit honors an explicit budget without a strict4k profile")
+    func fitUsesExplicitBudgetIndependentOfPreset() async {
+        let messages = [
+            InferenceMessage.system("sys"),
+            .user("old"),
+            .user("new"),
+        ]
+        let budget = flattenCharacterCount([.system("sys"), .user("new")])
+
+        let fitted = await ContextWindow.fit(
+            messages: messages,
+            policy: ContextWindow.Policy(
+                maxTokens: budget,
+                protectLeadingSystem: true,
+                alwaysKeepLast: true
+            ),
+            countTokens: characterCount
+        )
+
+        #expect(fitted.map(\.content) == ["sys", "new"])
+        #expect(fitted.map(\.role) == [.system, .user])
+    }
+
+    @Test("fit can drop a leading system when protection is off")
+    func fitDropsUnprotectedLeadingSystem() async throws {
+        let system = InferenceMessage.system("SYSTEM-LONG")
+        let last = InferenceMessage.user("x")
+        let budget = flattenCharacterCount([last])
+        try #require(flattenCharacterCount([system, last]) > budget)
+
+        let fitted = await ContextWindow.fit(
+            messages: [system, last],
+            policy: ContextWindow.Policy(
+                maxTokens: budget,
+                protectLeadingSystem: false,
+                alwaysKeepLast: true
+            ),
+            countTokens: characterCount
+        )
+
+        #expect(fitted == [last])
+    }
+
+    @Test("fit truncates an oversized last turn instead of dropping it")
+    func fitTruncatesLastTurnToBudget() async {
+        let last = InferenceMessage.user(String(repeating: "u", count: 40))
+        let budget = 20
+
+        let fitted = await ContextWindow.fit(
+            messages: [last],
+            policy: ContextWindow.Policy(
+                maxTokens: budget,
+                protectLeadingSystem: false,
+                alwaysKeepLast: true
+            ),
+            countTokens: characterCount
+        )
+
+        #expect(fitted.count == 1)
+        #expect(fitted[0].role == .user)
+        #expect(fitted[0].content.isEmpty == false)
+        #expect(flattenCharacterCount(fitted) <= budget)
+        #expect(fitted[0].content.count < last.content.count)
+    }
+
+    @Test("fit keeps a non-empty protected system when last overflows")
+    func fitTruncatesLastBeforeClippingProtectedSystem() async throws {
+        let system = InferenceMessage.system("You are the system.")
+        let last = InferenceMessage.user(String(repeating: "u", count: 80))
+        let budget = flattenCharacterCount([system, .user("")]) + 8
+        try #require(flattenCharacterCount([system, last]) > budget)
+
+        let fitted = await ContextWindow.fit(
+            messages: [system, last],
+            policy: ContextWindow.Policy(
+                maxTokens: budget,
+                protectLeadingSystem: true,
+                alwaysKeepLast: true
+            ),
+            countTokens: characterCount
+        )
+
+        #expect(fitted.count == 2)
+        #expect(fitted[0].role == .system)
+        #expect(fitted[0].content == system.content)
+        #expect(fitted[1].role == .user)
+        #expect(fitted[1].content.isEmpty == false)
+        #expect(flattenCharacterCount(fitted) <= budget)
+    }
+
+    @Test("longestPrefix uses the injected counter")
+    func longestPrefixHonorsFakeCounter() async {
+        let clipped = await ContextWindow.longestPrefix(
+            of: "abcdefghij",
+            maxTokens: 4,
+            countTokens: characterCount
+        )
+
+        #expect(clipped == "abcd")
+    }
+
+    @Test("evictOldest keeps newest messages under an additive budget")
+    func evictOldestKeepsNewest() async {
+        let kept = await ContextWindow.evictOldest(
+            from: [10, 20, 30, 40],
+            maxTokens: 70,
+            tokensOf: { $0 }
+        )
+
+        #expect(kept == [30, 40])
+    }
+
+    @Test("strict4k enforce matches ContextWindow.fit with the same counter")
+    func enforceMatchesSharedFit() async {
+        let padding = String(repeating: "x", count: 80)
+        var messages: [InferenceMessage] = [.system("Stay concise.")]
+        for index in 0 ..< 12 {
+            messages.append(.user("old-user-\(index) \(padding)"))
+            messages.append(.assistant("old-assistant-\(index) \(padding)"))
+        }
+        messages.append(.user("needle-latest"))
+
+        let viaEnvelope = await PromptEnvelope.enforce(messages: messages, profile: .strict4k)
+        let viaFit = await ContextWindow.fit(
+            messages: messages,
+            policy: .strict4k(.strict4k),
+            countTokens: { await PromptTokenBudgeting.countTokens(in: $0) }
+        )
+
+        #expect(viaEnvelope == viaFit)
+    }
+}
+
+private func characterCount(_ text: String) async -> Int {
+    (try? await CharacterCountTokenCounter().countTokens(in: text)) ?? text.count
+}
+
+private func flattenCharacterCount(_ messages: [InferenceMessage]) -> Int {
+    InferenceMessage.flattenPrompt(messages).count
+}
+
+/// Deterministic fake ``PromptTokenCounter``: one token per character.
+/// Used to exercise ``ContextWindow`` without constructing Agent or Memory.
+private struct CharacterCountTokenCounter: PromptTokenCounter {
+    func countTokens(in text: String) async throws -> Int {
+        text.count
+    }
+}

--- a/Tests/SwarmTests/Core/PromptEnvelopeContextWindowTests.swift
+++ b/Tests/SwarmTests/Core/PromptEnvelopeContextWindowTests.swift
@@ -70,6 +70,68 @@ struct PromptEnvelopeContextWindowTests {
         #expect(fitted == [last])
     }
 
+    @Test("fit with alwaysKeepLast false drops oldest history first")
+    func fitWithoutKeepingLastDropsOldest() async throws {
+        let oldest = InferenceMessage.user("old-user")
+        let newest = InferenceMessage.user("new-user")
+        let budget = flattenCharacterCount([newest])
+        try #require(flattenCharacterCount([oldest, newest]) > budget)
+
+        let fitted = await ContextWindow.fit(
+            messages: [oldest, newest],
+            policy: ContextWindow.Policy(
+                maxTokens: budget,
+                protectLeadingSystem: false,
+                alwaysKeepLast: false
+            ),
+            countTokens: characterCount
+        )
+
+        #expect(fitted == [newest])
+        #expect(flattenCharacterCount(fitted) <= budget)
+    }
+
+    @Test("fit with alwaysKeepLast false retains an oversized sole message")
+    func fitWithoutKeepingLastRetainsAtLeastOneMessage() async throws {
+        let last = InferenceMessage.user(String(repeating: "u", count: 40))
+        let budget = 4
+        try #require(flattenCharacterCount([last]) > budget)
+
+        let fitted = await ContextWindow.fit(
+            messages: [last],
+            policy: ContextWindow.Policy(
+                maxTokens: budget,
+                protectLeadingSystem: false,
+                alwaysKeepLast: false
+            ),
+            countTokens: characterCount
+        )
+
+        #expect(fitted == [last])
+        #expect(flattenCharacterCount(fitted) > budget)
+    }
+
+    @Test("fit with alwaysKeepLast false keeps a protected system and may drop the last turn")
+    func fitWithoutKeepingLastProtectsLeadingSystem() async throws {
+        let system = InferenceMessage.system("Stay")
+        let last = InferenceMessage.user("needle-latest")
+        let budget = flattenCharacterCount([system])
+        try #require(flattenCharacterCount([system, last]) > budget)
+
+        let fitted = await ContextWindow.fit(
+            messages: [system, last],
+            policy: ContextWindow.Policy(
+                maxTokens: budget,
+                protectLeadingSystem: true,
+                alwaysKeepLast: false
+            ),
+            countTokens: characterCount
+        )
+
+        #expect(fitted == [system])
+        #expect(flattenCharacterCount(fitted) <= budget)
+    }
+
     @Test("fit truncates an oversized last turn instead of dropping it")
     func fitTruncatesLastTurnToBudget() async {
         let last = InferenceMessage.user(String(repeating: "u", count: 40))
@@ -139,6 +201,17 @@ struct PromptEnvelopeContextWindowTests {
         #expect(kept == [30, 40])
     }
 
+    @Test("evictOldest keeps a single oversized message")
+    func evictOldestKeepsSingleOversized() async {
+        let kept = await ContextWindow.evictOldest(
+            from: [50],
+            maxTokens: 10,
+            tokensOf: { $0 }
+        )
+
+        #expect(kept == [50])
+    }
+
     @Test("strict4k enforce matches ContextWindow.fit with the same counter")
     func enforceMatchesSharedFit() async {
         let padding = String(repeating: "x", count: 80)
@@ -161,7 +234,12 @@ struct PromptEnvelopeContextWindowTests {
 }
 
 private func characterCount(_ text: String) async -> Int {
-    (try? await CharacterCountTokenCounter().countTokens(in: text)) ?? text.count
+    do {
+        return try await CharacterCountTokenCounter().countTokens(in: text)
+    } catch {
+        Issue.record("CharacterCountTokenCounter is not expected to throw")
+        return text.count
+    }
 }
 
 private func flattenCharacterCount(_ messages: [InferenceMessage]) -> Int {

--- a/Tests/SwarmTests/Memory/SlidingWindowMemoryTests.swift
+++ b/Tests/SwarmTests/Memory/SlidingWindowMemoryTests.swift
@@ -88,6 +88,40 @@ struct SlidingWindowMemoryTests {
         #expect(remaining.last?.content.contains("unique-marker-40") == true)
     }
 
+    @Test("Concurrent adds under budget keep every message")
+    func concurrentAddsUnderBudgetKeepEveryMessage() async {
+        let memory = SlidingWindowMemory(maxTokens: 50_000)
+        let total = 40
+
+        await withTaskGroup(of: Void.self) { group in
+            for index in 1 ... total {
+                group.addTask {
+                    await memory.add(.user("concurrent-marker-\(index)"))
+                }
+            }
+        }
+
+        let remaining = await memory.allMessages()
+        #expect(remaining.count == total)
+        #expect(Set(remaining.map(\.content)).count == total)
+    }
+
+    @Test("Concurrent overflowing adds stay within the token budget")
+    func concurrentOverflowStaysWithinBudget() async {
+        let memory = SlidingWindowMemory(maxTokens: 200)
+
+        await withTaskGroup(of: Void.self) { group in
+            for index in 1 ... 40 {
+                group.addTask {
+                    await memory.add(.user("overflow-marker-\(index) with extra padding"))
+                }
+            }
+        }
+
+        #expect(await memory.count >= 1)
+        #expect(await memory.tokenCount <= 200)
+    }
+
     @Test("Keeps at least one message")
     func keepsAtLeastOneMessage() async {
         let memory = SlidingWindowMemory(maxTokens: 100)

--- a/Tests/SwarmTests/Memory/SlidingWindowMemoryTests.swift
+++ b/Tests/SwarmTests/Memory/SlidingWindowMemoryTests.swift
@@ -83,7 +83,7 @@ struct SlidingWindowMemoryTests {
 
         let remaining = await memory.allMessages()
         #expect(remaining.contains(where: { $0.content.contains("unique-marker-40") }))
-        #expect(!remaining.contains(where: { $0.content.contains("unique-marker-1") }))
+        #expect(remaining.contains(where: { $0.content.contains("unique-marker-1") }) == false)
         #expect(await memory.tokenCount <= 100)
         #expect(remaining.last?.content.contains("unique-marker-40") == true)
     }

--- a/Tests/SwarmTests/Memory/SlidingWindowMemoryTests.swift
+++ b/Tests/SwarmTests/Memory/SlidingWindowMemoryTests.swift
@@ -73,6 +73,21 @@ struct SlidingWindowMemoryTests {
         #expect(tokenCount <= 200)
     }
 
+    @Test("Keep-newest eviction drops the oldest marker and retains the latest")
+    func keepNewestEvictionDropsOldestMarker() async {
+        let memory = SlidingWindowMemory(maxTokens: 100)
+
+        for index in 1 ... 40 {
+            await memory.add(.user("unique-marker-\(index)"))
+        }
+
+        let remaining = await memory.allMessages()
+        #expect(remaining.contains(where: { $0.content.contains("unique-marker-40") }))
+        #expect(!remaining.contains(where: { $0.content.contains("unique-marker-1") }))
+        #expect(await memory.tokenCount <= 100)
+        #expect(remaining.last?.content.contains("unique-marker-40") == true)
+    }
+
     @Test("Keeps at least one message")
     func keepsAtLeastOneMessage() async {
         let memory = SlidingWindowMemory(maxTokens: 100)
@@ -82,6 +97,7 @@ struct SlidingWindowMemoryTests {
         await memory.add(.user(longContent))
 
         #expect(await memory.count >= 1)
+        #expect(await memory.tokenCount <= 100)
     }
 
     @Test("Near capacity flag works correctly")


### PR DESCRIPTION
## Summary
- Extract a package-internal `ContextWindow` used by `PromptEnvelope.enforce` and `SlidingWindowMemory` eviction/truncate so budget math is not duplicated.
- Keep the `.strict4k` no-op gate in the envelope shell; `fit` takes an explicit budget.
- Keep at least one message when `dropOldest` would otherwise return an empty window.

Spec: `spec/spec-architecture-functional-evolution.md` ticket **T3**.
Reviews: `swift-pr-review` (first pass, fix allowed) then `swift-pr-review` (final pass, clean).

## Test plan
- [x] `SWARM_OMIT_INTEGRATION_TARGETS=1 swift test --no-parallel --filter 'PromptEnvelope|Strict4kPromptEnvelope|SlidingWindowMemory'`
- [x] `SWARM_CORE_ONLY=1 swift build`
- [x] `git diff --check`
- [ ] CI lean + Integrations lanes on this PR


Made with [Cursor](https://cursor.com)