### PR TITLE
Unify parallel tool execution on ToolExecutionEngine

### DIFF
--- a/Sources/Swarm/Tools/ParallelToolExecutor.swift
+++ b/Sources/Swarm/Tools/ParallelToolExecutor.swift
@@ -70,8 +70,11 @@ import Foundation
 /// - All tools are validated for existence before any execution begins
 /// - Duration is measured by the shared tool execution engine's injectable clock
 /// - Failed tools do not block successful ones from completing
-/// - Tools with explicit ``ToolSideEffectLevel/externalMutation`` serialize;
-///   ``ToolExecutionSemantics/automatic`` remains parallel-eligible
+/// - Consecutive tools that ``ToolExecutionSemantics/runtimePolicy()`` marks
+///   parallel-eligible still run concurrently; each explicit
+///   ``ToolSideEffectLevel/externalMutation`` is its own serial step so it
+///   does not overlap any other call. ``ToolExecutionSemantics/automatic``
+///   remains parallel-eligible.
 public actor ParallelToolExecutor {
     // MARK: Public
 
@@ -310,28 +313,36 @@ public actor ParallelToolExecutor {
         context: AgentContext?,
         stopOnToolError: Bool
     ) async throws -> [ToolExecutionResult] {
-        if eligibility.allSatisfy({ $0 }) {
-            return try await executeConcurrent(
-                calls,
-                using: registry,
-                agent: agent,
-                context: context,
-                stopOnToolError: stopOnToolError
-            )
-        }
-
         var results: [ToolExecutionResult] = []
         results.reserveCapacity(calls.count)
-        for call in calls {
-            try Task.checkCancellation()
-            let mapped = try await engine.executeMapped(
-                call: call,
-                registry: registry,
-                agent: agent,
-                context: context,
-                stopOnToolError: stopOnToolError
-            )
-            results.append(mapped)
+        var index = 0
+        while index < calls.count {
+            if eligibility[index] {
+                var end = index + 1
+                while end < calls.count, eligibility[end] {
+                    end += 1
+                }
+                let concurrentResults = try await executeConcurrent(
+                    Array(calls[index..<end]),
+                    using: registry,
+                    agent: agent,
+                    context: context,
+                    stopOnToolError: stopOnToolError
+                )
+                results.append(contentsOf: concurrentResults)
+                index = end
+            } else {
+                try Task.checkCancellation()
+                let mapped = try await engine.executeMapped(
+                    call: calls[index],
+                    registry: registry,
+                    agent: agent,
+                    context: context,
+                    stopOnToolError: stopOnToolError
+                )
+                results.append(mapped)
+                index += 1
+            }
         }
         return results
     }

--- a/Sources/Swarm/Tools/ParallelToolExecutor.swift
+++ b/Sources/Swarm/Tools/ParallelToolExecutor.swift
@@ -68,15 +68,24 @@ import Foundation
 /// ## Performance Considerations
 ///
 /// - All tools are validated for existence before any execution begins
-/// - Execution uses `ContinuousClock` for precise timing measurements
+/// - Duration is measured by the shared tool execution engine's injectable clock
 /// - Failed tools do not block successful ones from completing
+/// - Tools with explicit ``ToolSideEffectLevel/externalMutation`` serialize;
+///   ``ToolExecutionSemantics/automatic`` remains parallel-eligible
 public actor ParallelToolExecutor {
     // MARK: Public
 
     // MARK: - Initialization
 
-    /// Creates a new parallel tool executor.
-    public init() {}
+    /// Creates a new parallel tool executor using the live Engine clock.
+    public init() {
+        engine = ToolExecutionEngine()
+    }
+
+    /// Creates an executor that runs every call through the given Engine.
+    init(engine: ToolExecutionEngine) {
+        self.engine = engine
+    }
 
     // MARK: - Public Methods
 
@@ -130,64 +139,15 @@ public actor ParallelToolExecutor {
             return []
         }
 
-        // 1. Validate all tools exist BEFORE starting any execution.
-        // This is a fast-fail optimization: if any tool is missing or disabled at the
-        // start of the batch, throw before launching N tasks. ToolRegistry.execute()
-        // re-validates per call inside the task group below, so a tool that gets
-        // disabled *after* this pre-pass surfaces as a `ToolExecutionResult.failure`
-        // for that single call rather than a fast-throw — consistent with how the
-        // parallel error strategies (`.failFast`, `.collectErrors`, `.continueOnError`)
-        // expect to handle per-tool failures.
-        for call in calls {
-            guard let tool = await registry.tool(named: call.toolName), tool.isEnabled else {
-                throw AgentError.toolNotFound(name: call.toolName)
-            }
-        }
-
-        // 2. Execute with structured concurrency - PRESERVE ORDER via index
-        return try await withThrowingTaskGroup(of: (Int, ToolExecutionResult).self) { group in
-            for (index, call) in calls.enumerated() {
-                group.addTask { [registry, agent, context] in
-                    let startTime = ContinuousClock.now
-                    do {
-                        let result = try await registry.execute(
-                            toolNamed: call.toolName,
-                            arguments: call.arguments,
-                            agent: agent,
-                            context: context
-                        )
-                        let duration = ContinuousClock.now - startTime
-                        return (index, ToolExecutionResult.success(
-                            toolName: call.toolName,
-                            arguments: call.arguments,
-                            value: result,
-                            duration: duration
-                        ))
-                    } catch {
-                        let duration = ContinuousClock.now - startTime
-                        return (index, ToolExecutionResult.failure(
-                            toolName: call.toolName,
-                            arguments: call.arguments,
-                            error: error,
-                            duration: duration
-                        ))
-                    }
-                }
-            }
-
-            // 3. Collect all results with cancellation support
-            var indexedResults: [(Int, ToolExecutionResult)] = []
-            indexedResults.reserveCapacity(calls.count)
-
-            for try await result in group {
-                try Task.checkCancellation()
-                indexedResults.append(result)
-            }
-
-            // 4. Sort by index to restore original order
-            indexedResults.sort { $0.0 < $1.0 }
-            return indexedResults.map(\.1)
-        }
+        let eligibility = try await validatedEligibility(for: calls, registry: registry)
+        return try await executeCalls(
+            calls,
+            eligibility: eligibility,
+            using: registry,
+            agent: agent,
+            context: context,
+            stopOnToolError: false
+        )
     }
 
     /// Executes multiple tool calls in parallel with an error handling strategy.
@@ -295,12 +255,14 @@ public actor ParallelToolExecutor {
 
     // MARK: Private
 
+    private let engine: ToolExecutionEngine
+
     // MARK: - Private Methods
 
     /// Executes tools with true fail-fast cancellation.
     ///
-    /// Unlike the standard parallel execution, this method cancels all remaining
-    /// tasks immediately when the first failure is detected, saving resources.
+    /// Unlike the standard parallel execution, this method cancels remaining
+    /// work when the first Engine invocation throws.
     private func executeWithFailFast(
         _ calls: [ToolCall],
         using registry: ToolRegistry,
@@ -309,36 +271,92 @@ public actor ParallelToolExecutor {
     ) async throws -> [ToolExecutionResult] {
         guard !calls.isEmpty else { return [] }
 
-        // Validate all tools exist and are enabled before any execution starts.
+        let eligibility = try await validatedEligibility(for: calls, registry: registry)
+        return try await executeCalls(
+            calls,
+            eligibility: eligibility,
+            using: registry,
+            agent: agent,
+            context: context,
+            stopOnToolError: true
+        )
+    }
+
+    /// Fail-fast validation plus per-tool parallel eligibility from `runtimePolicy()`.
+    ///
+    /// Missing or disabled tools throw before any Engine invocation. A tool that
+    /// is disabled *after* this pre-pass still goes through Engine and surfaces
+    /// as a per-call failure when `stopOnToolError` is false.
+    private func validatedEligibility(
+        for calls: [ToolCall],
+        registry: ToolRegistry
+    ) async throws -> [Bool] {
+        var eligibility: [Bool] = []
+        eligibility.reserveCapacity(calls.count)
         for call in calls {
             guard let tool = await registry.tool(named: call.toolName), tool.isEnabled else {
                 throw AgentError.toolNotFound(name: call.toolName)
             }
+            eligibility.append(tool.executionSemantics.runtimePolicy().mayRunInParallel)
+        }
+        return eligibility
+    }
+
+    private func executeCalls(
+        _ calls: [ToolCall],
+        eligibility: [Bool],
+        using registry: ToolRegistry,
+        agent: any AgentRuntime,
+        context: AgentContext?,
+        stopOnToolError: Bool
+    ) async throws -> [ToolExecutionResult] {
+        if eligibility.allSatisfy({ $0 }) {
+            return try await executeConcurrent(
+                calls,
+                using: registry,
+                agent: agent,
+                context: context,
+                stopOnToolError: stopOnToolError
+            )
         }
 
-        // Execute with early cancellation on first failure
-        return try await withThrowingTaskGroup(of: (Int, ToolExecutionResult).self) { group in
+        var results: [ToolExecutionResult] = []
+        results.reserveCapacity(calls.count)
+        for call in calls {
+            try Task.checkCancellation()
+            let mapped = try await engine.executeMapped(
+                call: call,
+                registry: registry,
+                agent: agent,
+                context: context,
+                stopOnToolError: stopOnToolError
+            )
+            results.append(mapped)
+        }
+        return results
+    }
+
+    private func executeConcurrent(
+        _ calls: [ToolCall],
+        using registry: ToolRegistry,
+        agent: any AgentRuntime,
+        context: AgentContext?,
+        stopOnToolError: Bool
+    ) async throws -> [ToolExecutionResult] {
+        try await withThrowingTaskGroup(of: (Int, ToolExecutionResult).self) { group in
             for (index, call) in calls.enumerated() {
-                group.addTask { [registry, agent, context] in
-                    let startTime = ContinuousClock.now
-                    // Let errors propagate for fail-fast behavior
-                    let result = try await registry.execute(
-                        toolNamed: call.toolName,
-                        arguments: call.arguments,
+                group.addTask { [engine, registry, agent, context] in
+                    let mapped = try await engine.executeMapped(
+                        call: call,
+                        registry: registry,
                         agent: agent,
-                        context: context
+                        context: context,
+                        stopOnToolError: stopOnToolError
                     )
-                    let duration = ContinuousClock.now - startTime
-                    return (index, ToolExecutionResult.success(
-                        toolName: call.toolName,
-                        arguments: call.arguments,
-                        value: result,
-                        duration: duration
-                    ))
+                    return (index, mapped)
                 }
             }
 
-            // Collect results, throwing on first error (which cancels remaining tasks)
             var indexedResults: [(Int, ToolExecutionResult)] = []
             indexedResults.reserveCapacity(calls.count)
 
@@ -347,7 +365,6 @@ public actor ParallelToolExecutor {
                 indexedResults.append(result)
             }
 
-            // Sort by index to restore original order
             indexedResults.sort { $0.0 < $1.0 }
             return indexedResults.map(\.1)
         }

--- a/Sources/Swarm/Tools/ParallelToolExecutor.swift
+++ b/Sources/Swarm/Tools/ParallelToolExecutor.swift
@@ -95,8 +95,10 @@ public actor ParallelToolExecutor {
     /// Executes multiple tool calls in parallel.
     ///
     /// This method validates all tools exist in the registry before starting
-    /// any execution, then runs all tools concurrently. Results are returned
-    /// in the same order as the input calls, regardless of completion order.
+    /// any execution, then runs consecutive parallel-eligible tools concurrently.
+    /// Each explicit ``ToolSideEffectLevel/externalMutation`` is a serial step
+    /// so it does not overlap any other call. Results are returned in the same
+    /// order as the input calls, regardless of completion order.
     ///
     /// Individual tool failures are captured as `ToolExecutionResult.failure`
     /// entries rather than throwing. This allows the caller to handle partial
@@ -171,8 +173,9 @@ public actor ParallelToolExecutor {
     ///
     /// ## Error Strategies
     ///
-    /// - **`.failFast`**: Throws the first error found in the results.
-    ///   All tools still execute, but the first failure causes a throw.
+    /// - **`.failFast`**: Throws the first tool error and cancels remaining
+    ///   work in the current concurrent group; later serial or concurrent
+    ///   groups never start.
     ///
     /// - **`.collectErrors`**: Throws a composite error if any tool failed.
     ///   The error message includes all failure descriptions.

--- a/Sources/Swarm/Tools/ToolExecutionEngine.swift
+++ b/Sources/Swarm/Tools/ToolExecutionEngine.swift
@@ -5,6 +5,26 @@
 
 import Foundation
 
+// MARK: - ToolClock
+
+/// Nanosecond clock used by ``ToolExecutionEngine`` for duration measurement.
+///
+/// Matches the `SwarmClock.nowNanoseconds()` shape so tests can inject a
+/// scripted source of time without sleeping. Sleep is not part of this seam;
+/// tool bodies remain responsible for their own suspension.
+protocol ToolClock: Sendable {
+    func nowNanoseconds() -> UInt64
+}
+
+/// Live adapter over ``LiveSwarmClock`` so Engine defaults match wall-monotonic time.
+struct LiveToolClock: ToolClock {
+    static let live = LiveToolClock()
+
+    func nowNanoseconds() -> UInt64 {
+        LiveSwarmClock.live.nowNanoseconds()
+    }
+}
+
 /// Centralized tool-call execution path.
 ///
 /// This standardizes:
@@ -12,8 +32,16 @@ import Foundation
 /// - AgentResult.Builder recording
 /// - AgentObserver emission
 /// - ToolRegistry execution wiring
+///
+/// Duration is measured from an injectable ``ToolClock`` so tests can pin
+/// elapsed time without `Task.sleep`. ``init()`` keeps compiling as
+/// `ToolExecutionEngine()` from the Agent host loop.
 struct ToolExecutionEngine: Sendable {
-    init() {}
+    private let clock: any ToolClock
+
+    init(clock: some ToolClock = LiveToolClock()) {
+        self.clock = clock
+    }
 
     struct Outcome: Sendable {
         let call: ToolCall
@@ -39,7 +67,7 @@ struct ToolExecutionEngine: Sendable {
 
         let spanId: UUID? = if let tracing { await tracing.traceToolCall(name: toolName, arguments: arguments) } else { nil }
 
-        let startTime = ContinuousClock.now
+        let startTime = clock.nowNanoseconds()
         do {
             let output = try await registry.execute(
                 toolNamed: toolName,
@@ -49,22 +77,22 @@ struct ToolExecutionEngine: Sendable {
                 observer: observer
             )
 
-            let duration = ContinuousClock.now - startTime
-            let result = ToolResult.success(callId: call.id, output: output, duration: duration)
+            let measured = elapsedDuration(since: startTime)
+            let result = ToolResult.success(callId: call.id, output: output, duration: measured)
             _ = resultBuilder.addToolResult(result)
 
             if let tracing, let spanId {
-                await tracing.traceToolResult(spanId: spanId, name: toolName, result: output.description, duration: duration)
+                await tracing.traceToolResult(spanId: spanId, name: toolName, result: output.description, duration: measured)
             }
 
             await observer?.onToolEnd(context: context, agent: agent, result: result)
 
             return Outcome(call: call, result: result)
         } catch {
-            let duration = ContinuousClock.now - startTime
+            let measured = elapsedDuration(since: startTime)
             let errorMessage = (error as? AgentError)?.localizedDescription ?? error.localizedDescription
 
-            let result = ToolResult.failure(callId: call.id, error: errorMessage, duration: duration)
+            let result = ToolResult.failure(callId: call.id, error: errorMessage, duration: measured)
             _ = resultBuilder.addToolResult(result)
 
             if let tracing, let spanId {
@@ -79,5 +107,34 @@ struct ToolExecutionEngine: Sendable {
 
             return Outcome(call: call, result: result)
         }
+    }
+
+    /// Registry execution + duration + ``ToolExecutionResult`` mapping for the public façade.
+    func executeMapped(
+        call: ToolCall,
+        registry: ToolRegistry,
+        agent: any AgentRuntime,
+        context: AgentContext?,
+        stopOnToolError: Bool
+    ) async throws -> ToolExecutionResult {
+        let outcome = try await execute(
+            toolName: call.toolName,
+            arguments: call.arguments,
+            providerCallId: call.providerCallId,
+            registry: registry,
+            agent: agent,
+            context: context,
+            resultBuilder: AgentResult.Builder(),
+            observer: nil,
+            tracing: nil,
+            stopOnToolError: stopOnToolError
+        )
+        return ToolExecutionResult.from(call: call, result: outcome.result)
+    }
+
+    private func elapsedDuration(since startNanoseconds: UInt64) -> Duration {
+        let now = clock.nowNanoseconds()
+        let elapsed = now >= startNanoseconds ? now - startNanoseconds : 0
+        return Duration(swarmNanoseconds: elapsed)
     }
 }

--- a/Sources/Swarm/Tools/ToolExecutionEngine.swift
+++ b/Sources/Swarm/Tools/ToolExecutionEngine.swift
@@ -46,6 +46,11 @@ struct ToolExecutionEngine: Sendable {
     struct Outcome: Sendable {
         let call: ToolCall
         let result: ToolResult
+        /// Original tool error when ``result`` is a failure; `nil` on success.
+        ///
+        /// ``ToolResult`` only stores a message string. The façade keeps this
+        /// instance so continue-on-error and fail-fast can preserve error identity.
+        let caughtError: (any Error)?
     }
 
     func execute(
@@ -87,7 +92,7 @@ struct ToolExecutionEngine: Sendable {
 
             await observer?.onToolEnd(context: context, agent: agent, result: result)
 
-            return Outcome(call: call, result: result)
+            return Outcome(call: call, result: result, caughtError: nil)
         } catch {
             let measured = elapsedDuration(since: startTime)
             let errorMessage = (error as? AgentError)?.localizedDescription ?? error.localizedDescription
@@ -105,11 +110,15 @@ struct ToolExecutionEngine: Sendable {
                 throw AgentError.toolFailure(toolName: toolName, message: errorMessage, cause: error)
             }
 
-            return Outcome(call: call, result: result)
+            return Outcome(call: call, result: result, caughtError: error)
         }
     }
 
     /// Registry execution + duration + ``ToolExecutionResult`` mapping for the public façade.
+    ///
+    /// Always records through ``execute`` with `stopOnToolError: false` so duration
+    /// stays on ``Outcome``. Fail-fast rethrows the original tool error; continue-on-error
+    /// stores that same instance on ``ToolExecutionResult``.
     func executeMapped(
         call: ToolCall,
         registry: ToolRegistry,
@@ -127,9 +136,16 @@ struct ToolExecutionEngine: Sendable {
             resultBuilder: AgentResult.Builder(),
             observer: nil,
             tracing: nil,
-            stopOnToolError: stopOnToolError
+            stopOnToolError: false
         )
-        return ToolExecutionResult.from(call: call, result: outcome.result)
+        if stopOnToolError, let error = outcome.caughtError {
+            throw error
+        }
+        return ToolExecutionResult.from(
+            call: call,
+            result: outcome.result,
+            underlyingError: outcome.caughtError
+        )
     }
 
     private func elapsedDuration(since startNanoseconds: UInt64) -> Duration {

--- a/Sources/Swarm/Tools/ToolExecutionResult.swift
+++ b/Sources/Swarm/Tools/ToolExecutionResult.swift
@@ -208,6 +208,26 @@ public struct ToolExecutionResult: Sendable {
             timestamp: timestamp
         )
     }
+
+    /// Maps an Engine ``ToolResult`` onto the public parallel-executor result.
+    static func from(call: ToolCall, result: ToolResult) -> ToolExecutionResult {
+        switch result.outcome {
+        case let .success(value):
+            return .success(
+                toolName: call.toolName,
+                arguments: call.arguments,
+                value: value,
+                duration: result.duration
+            )
+        case let .failure(message):
+            return .failure(
+                toolName: call.toolName,
+                arguments: call.arguments,
+                error: AgentError.toolFailure(toolName: call.toolName, message: message, cause: nil),
+                duration: result.duration
+            )
+        }
+    }
 }
 
 // MARK: CustomStringConvertible

--- a/Sources/Swarm/Tools/ToolExecutionResult.swift
+++ b/Sources/Swarm/Tools/ToolExecutionResult.swift
@@ -210,7 +210,16 @@ public struct ToolExecutionResult: Sendable {
     }
 
     /// Maps an Engine ``ToolResult`` onto the public parallel-executor result.
-    static func from(call: ToolCall, result: ToolResult) -> ToolExecutionResult {
+    ///
+    /// When ``underlyingError`` is present (the Engine still has the thrown
+    /// instance), that error is stored so callers can inspect type and cause.
+    /// String-only ``ToolResult`` failures synthesize ``AgentError/toolFailure``
+    /// with no cause.
+    static func from(
+        call: ToolCall,
+        result: ToolResult,
+        underlyingError: (any Error)? = nil
+    ) -> ToolExecutionResult {
         switch result.outcome {
         case let .success(value):
             return .success(
@@ -220,10 +229,15 @@ public struct ToolExecutionResult: Sendable {
                 duration: result.duration
             )
         case let .failure(message):
+            let error = underlyingError ?? AgentError.toolFailure(
+                toolName: call.toolName,
+                message: message,
+                cause: nil
+            )
             return .failure(
                 toolName: call.toolName,
                 arguments: call.arguments,
-                error: AgentError.toolFailure(toolName: call.toolName, message: message, cause: nil),
+                error: error,
                 duration: result.duration
             )
         }

--- a/Sources/Swarm/Tools/ToolExecutionSemantics.swift
+++ b/Sources/Swarm/Tools/ToolExecutionSemantics.swift
@@ -51,4 +51,42 @@ public struct ToolExecutionSemantics: Codable, Sendable, Equatable {
     }
 
     public static let automatic = ToolExecutionSemantics()
+
+    /// Governance bits derived from declared semantics.
+    ///
+    /// Consumed by ``ToolExecutionEngine`` and ``ParallelToolExecutor``. The
+    /// Agent host loop does not add approval gates from these values.
+    public struct RuntimePolicy: Equatable, Sendable {
+        /// Whether an orchestrator may retry this tool without caller intervention.
+        public var mayRetryAutomatically: Bool
+        /// Whether a higher layer should require approval before running the tool.
+        public var requiresApproval: Bool
+        /// Whether the tool may share a concurrent batch with other calls.
+        public var mayRunInParallel: Bool
+    }
+
+    /// Pure runtime decision for retry, approval, and parallel eligibility.
+    ///
+    /// ``automatic`` preserves today's Engine behavior: automatic retry is
+    /// allowed, approval is not required, and the tool may run in parallel.
+    /// Explicit ``ToolSideEffectLevel/externalMutation`` is not parallel-eligible.
+    public func runtimePolicy() -> RuntimePolicy {
+        let mayRetryAutomatically: Bool = switch retryPolicy {
+        case .automatic, .safe: true
+        case .unsafe, .callerManaged: false
+        }
+        let requiresApproval: Bool = switch approvalRequirement {
+        case .automatic, .never: false
+        case .always: true
+        }
+        let mayRunInParallel: Bool = switch sideEffectLevel {
+        case .unspecified, .readOnly, .localMutation: true
+        case .externalMutation: false
+        }
+        return RuntimePolicy(
+            mayRetryAutomatically: mayRetryAutomatically,
+            requiresApproval: requiresApproval,
+            mayRunInParallel: mayRunInParallel
+        )
+    }
 }

--- a/Sources/Swarm/Tools/ToolExecutionSemantics.swift
+++ b/Sources/Swarm/Tools/ToolExecutionSemantics.swift
@@ -59,11 +59,11 @@ public struct ToolExecutionSemantics: Codable, Sendable, Equatable {
     /// The Engine host path does not add approval or retry gates from these values.
     public struct RuntimePolicy: Equatable, Sendable {
         /// Whether an orchestrator may retry this tool without caller intervention.
-        public var mayRetryAutomatically: Bool
+        public let mayRetryAutomatically: Bool
         /// Whether a higher layer should require approval before running the tool.
-        public var requiresApproval: Bool
+        public let requiresApproval: Bool
         /// Whether the tool may share a concurrent batch with other calls.
-        public var mayRunInParallel: Bool
+        public let mayRunInParallel: Bool
     }
 
     /// Pure runtime decision for retry, approval, and parallel eligibility.

--- a/Sources/Swarm/Tools/ToolExecutionSemantics.swift
+++ b/Sources/Swarm/Tools/ToolExecutionSemantics.swift
@@ -54,8 +54,9 @@ public struct ToolExecutionSemantics: Codable, Sendable, Equatable {
 
     /// Governance bits derived from declared semantics.
     ///
-    /// Consumed by ``ToolExecutionEngine`` and ``ParallelToolExecutor``. The
-    /// Agent host loop does not add approval gates from these values.
+    /// ``ParallelToolExecutor`` uses ``mayRunInParallel`` so explicit
+    /// ``ToolSideEffectLevel/externalMutation`` does not overlap other calls.
+    /// The Engine host path does not add approval or retry gates from these values.
     public struct RuntimePolicy: Equatable, Sendable {
         /// Whether an orchestrator may retry this tool without caller intervention.
         public var mayRetryAutomatically: Bool

--- a/Tests/SwarmTests/DocumentationFreshnessTests.swift
+++ b/Tests/SwarmTests/DocumentationFreshnessTests.swift
@@ -152,6 +152,11 @@ struct DocumentationFreshnessTests {
         #expect(toolSemantics.contains("public var resultDurability: ToolResultDurability"))
         #expect(toolSemantics.contains("public init("))
         #expect(toolSemantics.contains("public static let automatic"))
+        #expect(toolSemantics.contains("public struct RuntimePolicy"))
+        #expect(toolSemantics.contains("public func runtimePolicy()"))
+        #expect(toolSemantics.contains("public let mayRetryAutomatically: Bool"))
+        #expect(toolSemantics.contains("public let requiresApproval: Bool"))
+        #expect(toolSemantics.contains("public let mayRunInParallel: Bool"))
     }
 
     @Test("public memory docs do not advertise removed builder APIs")

--- a/Tests/SwarmTests/Tools/ParallelToolExecutorTests+Advanced.swift
+++ b/Tests/SwarmTests/Tools/ParallelToolExecutorTests+Advanced.swift
@@ -132,6 +132,74 @@ struct ParallelToolExecutorAdvancedTests {
 
     // MARK: - Same Tool Multiple Calls Tests
 
+    @Test("executeInParallel measures duration through the Engine clock")
+    func executeInParallelMeasuresDurationThroughEngineClock() async throws {
+        let clock = ScriptedToolClock(readings: [UInt64(0), UInt64(25_000_000)])
+        let tool = MockDelayTool(name: "instant", delay: .zero, resultValue: .string("ok"))
+        let registry = try await createRegistry(tools: [tool])
+        let executor = ParallelToolExecutor(engine: ToolExecutionEngine(clock: clock))
+        let agent = ParallelTestMockAgent()
+
+        let results = try await executor.executeInParallel(
+            [ToolCall(toolName: "instant", arguments: [:])],
+            using: registry,
+            agent: agent,
+            context: nil
+        )
+
+        #expect(results.count == 1)
+        #expect(results[0].isSuccess == true)
+        #expect(results[0].duration == Duration(swarmNanoseconds: UInt64(25_000_000)))
+    }
+
+    @Test("explicit externalMutation tools serialize in input order")
+    func explicitExternalMutationToolsSerializeInInputOrder() async throws {
+        let log = ToolPhaseLog()
+        let semantics = ToolExecutionSemantics(sideEffectLevel: .externalMutation)
+        let first = FunctionTool(
+            name: "mutate_a",
+            description: "First mutation",
+            executionSemantics: semantics
+        ) { _ in
+            await log.record("start-a")
+            await Task.yield()
+            await log.record("end-a")
+            return .string("a")
+        }
+        let second = FunctionTool(
+            name: "mutate_b",
+            description: "Second mutation",
+            executionSemantics: semantics
+        ) { _ in
+            await log.record("start-b")
+            await Task.yield()
+            await log.record("end-b")
+            return .string("b")
+        }
+
+        let registry = try await createRegistry(tools: [first, second])
+        let executor = ParallelToolExecutor()
+        let agent = ParallelTestMockAgent()
+
+        let results = try await executor.executeInParallel(
+            [
+                ToolCall(toolName: "mutate_a", arguments: [:]),
+                ToolCall(toolName: "mutate_b", arguments: [:])
+            ],
+            using: registry,
+            agent: agent,
+            context: nil
+        )
+
+        #expect(results.count == 2)
+        #expect(results[0].toolName == "mutate_a")
+        #expect(results[1].toolName == "mutate_b")
+        #expect(results[0].isSuccess == true)
+        #expect(results[1].isSuccess == true)
+        let events = await log.snapshot()
+        #expect(events == ["start-a", "end-a", "start-b", "end-b"])
+    }
+
     @Test("Same tool can be called multiple times")
     func sameToolMultipleCalls() async throws {
         let tool = MockDelayTool(name: "reusable", delay: .zero, resultValue: .string("result"))

--- a/Tests/SwarmTests/Tools/ParallelToolExecutorTests+Advanced.swift
+++ b/Tests/SwarmTests/Tools/ParallelToolExecutorTests+Advanced.swift
@@ -200,6 +200,158 @@ struct ParallelToolExecutorAdvancedTests {
         #expect(events == ["start-a", "end-a", "start-b", "end-b"])
     }
 
+    @Test("mixed batch keeps consecutive parallel-eligible tools concurrent")
+    func mixedBatchKeepsParallelEligibleToolsConcurrent() async throws {
+        let log = ToolPhaseLog()
+        let gate = ToolOverlapGate(expected: 2)
+        let readSemantics = ToolExecutionSemantics(sideEffectLevel: .readOnly)
+        let mutateSemantics = ToolExecutionSemantics(sideEffectLevel: .externalMutation)
+
+        let readA = FunctionTool(
+            name: "read_a",
+            description: "Read A",
+            executionSemantics: readSemantics
+        ) { _ in
+            await log.record("start-a")
+            await gate.arrive()
+            await log.record("end-a")
+            return .string("a")
+        }
+        let readB = FunctionTool(
+            name: "read_b",
+            description: "Read B",
+            executionSemantics: readSemantics
+        ) { _ in
+            await log.record("start-b")
+            await gate.arrive()
+            await log.record("end-b")
+            return .string("b")
+        }
+        let mutate = FunctionTool(
+            name: "mutate",
+            description: "Mutate",
+            executionSemantics: mutateSemantics
+        ) { _ in
+            await log.record("start-m")
+            await log.record("end-m")
+            return .string("m")
+        }
+
+        let registry = try await createRegistry(tools: [readA, readB, mutate])
+        let executor = ParallelToolExecutor()
+        let agent = ParallelTestMockAgent()
+
+        let results = try await executor.executeInParallel(
+            [
+                ToolCall(toolName: "read_a", arguments: [:]),
+                ToolCall(toolName: "read_b", arguments: [:]),
+                ToolCall(toolName: "mutate", arguments: [:])
+            ],
+            using: registry,
+            agent: agent,
+            context: nil
+        )
+
+        #expect(results.map(\.toolName) == ["read_a", "read_b", "mutate"])
+        #expect(results.allSatisfy { $0.isSuccess })
+
+        let events = await log.snapshot()
+        let startA = try #require(events.firstIndex(of: "start-a"))
+        let startB = try #require(events.firstIndex(of: "start-b"))
+        let endA = try #require(events.firstIndex(of: "end-a"))
+        let endB = try #require(events.firstIndex(of: "end-b"))
+        let startM = try #require(events.firstIndex(of: "start-m"))
+        #expect(max(startA, startB) < min(endA, endB))
+        #expect(max(endA, endB) < startM)
+    }
+
+    @Test("continueOnError preserves original error identity")
+    func continueOnErrorPreservesOriginalErrorIdentity() async throws {
+        let unique = UniqueToolError(code: 7)
+        let successTool = MockDelayTool(name: "ok", delay: .zero, resultValue: .string("ok"))
+        let errorTool = MockErrorTool(name: "boom", error: unique)
+        let registry = try await createRegistry(tools: [successTool, errorTool])
+        let executor = ParallelToolExecutor()
+        let agent = ParallelTestMockAgent()
+
+        let results = try await executor.executeInParallel(
+            [
+                ToolCall(toolName: "ok", arguments: [:]),
+                ToolCall(toolName: "boom", arguments: [:])
+            ],
+            using: registry,
+            agent: agent,
+            context: nil,
+            errorStrategy: .continueOnError
+        )
+
+        #expect(results.count == 2)
+        #expect(results[0].isSuccess == true)
+        #expect(results[1].isSuccess == false)
+        let agentError = try #require(results[1].error as? AgentError)
+        guard case let .toolFailure(toolName, _, cause) = agentError else {
+            Issue.record("expected toolFailure, got \(agentError)")
+            return
+        }
+        #expect(toolName == "boom")
+        let captured = try #require(cause as? UniqueToolError)
+        #expect(captured == unique)
+    }
+
+    @Test("continueOnError keeps AgentError thrown by the tool")
+    func continueOnErrorKeepsAgentErrorThrownByTheTool() async throws {
+        let original = AgentError.toolFailure(
+            toolName: "boom",
+            message: "specific-message",
+            cause: nil
+        )
+        let errorTool = MockErrorTool(name: "boom", error: original)
+        let registry = try await createRegistry(tools: [errorTool])
+        let executor = ParallelToolExecutor()
+        let agent = ParallelTestMockAgent()
+
+        let results = try await executor.executeInParallel(
+            [ToolCall(toolName: "boom", arguments: [:])],
+            using: registry,
+            agent: agent,
+            context: nil,
+            errorStrategy: .continueOnError
+        )
+
+        let agentError = try #require(results[0].error as? AgentError)
+        #expect(agentError == original)
+    }
+
+    @Test("failFast throws the original tool error")
+    func failFastThrowsTheOriginalToolError() async throws {
+        let unique = UniqueToolError(code: 11)
+        let errorTool = MockErrorTool(name: "boom", error: unique)
+        let registry = try await createRegistry(tools: [errorTool])
+        let executor = ParallelToolExecutor()
+        let agent = ParallelTestMockAgent()
+
+        do {
+            _ = try await executor.executeInParallel(
+                [ToolCall(toolName: "boom", arguments: [:])],
+                using: registry,
+                agent: agent,
+                context: nil,
+                errorStrategy: .failFast
+            )
+            Issue.record("expected toolFailure to be thrown")
+        } catch let error as AgentError {
+            guard case let .toolFailure(toolName, _, cause) = error else {
+                Issue.record("expected toolFailure, got \(error)")
+                return
+            }
+            #expect(toolName == "boom")
+            let captured = try #require(cause as? UniqueToolError)
+            #expect(captured == unique)
+        } catch {
+            Issue.record("expected AgentError.toolFailure, got \(error)")
+        }
+    }
+
     @Test("Same tool can be called multiple times")
     func sameToolMultipleCalls() async throws {
         let tool = MockDelayTool(name: "reusable", delay: .zero, resultValue: .string("result"))

--- a/Tests/SwarmTests/Tools/ParallelToolExecutorTests+Mocks.swift
+++ b/Tests/SwarmTests/Tools/ParallelToolExecutorTests+Mocks.swift
@@ -157,3 +157,38 @@ struct DisabledTestTool: AnyJSONTool, Sendable {
         .string("unused")
     }
 }
+
+// MARK: - ScriptedToolClock
+
+/// Deterministic `ToolClock` that returns scripted nanosecond readings in order.
+///
+/// Used to prove Engine/façade duration measurement without `Task.sleep`.
+final class ScriptedToolClock: ToolClock, @unchecked Sendable {
+    private let lock = NSLock()
+    private var readings: [UInt64]
+
+    init(readings: [UInt64]) {
+        self.readings = readings
+    }
+
+    func nowNanoseconds() -> UInt64 {
+        lock.withLock {
+            guard !readings.isEmpty else { return 0 }
+            return readings.removeFirst()
+        }
+    }
+}
+
+// MARK: - ToolPhaseLog
+
+actor ToolPhaseLog {
+    private var events: [String] = []
+
+    func record(_ event: String) {
+        events.append(event)
+    }
+
+    func snapshot() -> [String] {
+        events
+    }
+}

--- a/Tests/SwarmTests/Tools/ParallelToolExecutorTests+Mocks.swift
+++ b/Tests/SwarmTests/Tools/ParallelToolExecutorTests+Mocks.swift
@@ -158,11 +158,20 @@ struct DisabledTestTool: AnyJSONTool, Sendable {
     }
 }
 
+// MARK: - UniqueToolError
+
+/// Distinct error type used to prove façade mapping does not erase identity.
+struct UniqueToolError: Error, Equatable {
+    let code: Int
+}
+
 // MARK: - ScriptedToolClock
 
 /// Deterministic `ToolClock` that returns scripted nanosecond readings in order.
 ///
 /// Used to prove Engine/façade duration measurement without `Task.sleep`.
+/// All mutable state is guarded by a single `NSLock`, so the class is safely
+/// usable across concurrency domains (`@unchecked Sendable`).
 final class ScriptedToolClock: ToolClock, @unchecked Sendable {
     private let lock = NSLock()
     private var readings: [UInt64]
@@ -175,6 +184,27 @@ final class ScriptedToolClock: ToolClock, @unchecked Sendable {
         lock.withLock {
             guard !readings.isEmpty else { return 0 }
             return readings.removeFirst()
+        }
+    }
+}
+
+// MARK: - ToolOverlapGate
+
+/// Waits until `expected` tools have arrived, or gives up after a bounded yield
+/// spin so a serial batch fails the overlap assertion instead of hanging.
+actor ToolOverlapGate {
+    private var remaining: Int
+
+    init(expected: Int) {
+        remaining = expected
+    }
+
+    func arrive() async {
+        remaining -= 1
+        var spins = 0
+        while remaining > 0, spins < 10_000 {
+            await Task.yield()
+            spins += 1
         }
     }
 }

--- a/Tests/SwarmTests/Tools/ToolExecutionEngineTests.swift
+++ b/Tests/SwarmTests/Tools/ToolExecutionEngineTests.swift
@@ -151,4 +151,87 @@ struct ToolExecutionSemanticsEngineTests {
             Issue.record("expected toolFailure, got \(String(describing: mapped.error))")
         }
     }
+
+    @Test("executeMapped continue-on-error preserves original error identity")
+    func executeMappedContinueOnErrorPreservesOriginalErrorIdentity() async throws {
+        let unique = UniqueToolError(code: 19)
+        let engine = ToolExecutionEngine()
+        let registry = ToolRegistry()
+        try await registry.register(MockErrorTool(name: "boom", error: unique))
+
+        let mapped = try await engine.executeMapped(
+            call: ToolCall(toolName: "boom", arguments: [:]),
+            registry: registry,
+            agent: ParallelTestMockAgent(),
+            context: nil,
+            stopOnToolError: false
+        )
+
+        #expect(mapped.isSuccess == false)
+        let agentError = try #require(mapped.error as? AgentError)
+        guard case let .toolFailure(toolName, _, cause) = agentError else {
+            Issue.record("expected toolFailure, got \(String(describing: mapped.error))")
+            return
+        }
+        #expect(toolName == "boom")
+        let captured = try #require(cause as? UniqueToolError)
+        #expect(captured == unique)
+
+        let outcome = try await engine.execute(
+            toolName: "boom",
+            arguments: [:],
+            registry: registry,
+            agent: ParallelTestMockAgent(),
+            context: nil,
+            resultBuilder: AgentResult.Builder(),
+            observer: nil,
+            tracing: nil,
+            stopOnToolError: false
+        )
+        let outcomeError = try #require(outcome.caughtError as? AgentError)
+        guard case let .toolFailure(_, _, outcomeCause) = outcomeError else {
+            Issue.record("expected caught toolFailure, got \(outcomeError)")
+            return
+        }
+        let outcomeUnique = try #require(outcomeCause as? UniqueToolError)
+        #expect(outcomeUnique == unique)
+    }
+
+    @Test("execute still wraps stopOnToolError throws with original cause")
+    func stopOnToolErrorThrowsWrappedToolFailureWithCause() async throws {
+        let unique = UniqueToolError(code: 23)
+        let engine = ToolExecutionEngine()
+        let registry = ToolRegistry()
+        try await registry.register(MockErrorTool(name: "boom", error: unique))
+
+        do {
+            _ = try await engine.execute(
+                toolName: "boom",
+                arguments: [:],
+                registry: registry,
+                agent: ParallelTestMockAgent(),
+                context: nil,
+                resultBuilder: AgentResult.Builder(),
+                observer: nil,
+                tracing: nil,
+                stopOnToolError: true
+            )
+            Issue.record("expected toolFailure to be thrown")
+        } catch let error as AgentError {
+            guard case let .toolFailure(toolName, _, cause) = error else {
+                Issue.record("expected toolFailure, got \(error)")
+                return
+            }
+            #expect(toolName == "boom")
+            let registryError = try #require(cause as? AgentError)
+            guard case let .toolFailure(_, _, innerCause) = registryError else {
+                Issue.record("expected registry toolFailure cause, got \(registryError)")
+                return
+            }
+            let captured = try #require(innerCause as? UniqueToolError)
+            #expect(captured == unique)
+        } catch {
+            Issue.record("expected AgentError.toolFailure, got \(error)")
+        }
+    }
 }

--- a/Tests/SwarmTests/Tools/ToolExecutionEngineTests.swift
+++ b/Tests/SwarmTests/Tools/ToolExecutionEngineTests.swift
@@ -1,0 +1,154 @@
+// ToolExecutionEngineTests.swift
+// SwarmTests
+//
+// Clock injection and default-preserving Engine behavior.
+
+import Foundation
+@testable import Swarm
+import Testing
+
+@Suite("ToolExecutionSemantics Engine")
+struct ToolExecutionSemanticsEngineTests {
+    @Test("injected clock supplies success duration")
+    func injectedClockSuppliesSuccessDuration() async throws {
+        let clock = ScriptedToolClock(readings: [UInt64(1_000), UInt64(1_042)])
+        let engine = ToolExecutionEngine(clock: clock)
+        let registry = ToolRegistry()
+        try await registry.register(MockDelayTool(name: "echo", delay: .zero, resultValue: .string("ok")))
+
+        let outcome = try await engine.execute(
+            toolName: "echo",
+            arguments: [:],
+            registry: registry,
+            agent: ParallelTestMockAgent(),
+            context: nil,
+            resultBuilder: AgentResult.Builder(),
+            observer: nil,
+            tracing: nil,
+            stopOnToolError: false
+        )
+
+        #expect(outcome.result.isSuccess == true)
+        #expect(outcome.result.output == .string("ok"))
+        #expect(outcome.result.duration == Duration(swarmNanoseconds: UInt64(42)))
+    }
+
+    @Test("injected clock supplies failure duration")
+    func injectedClockSuppliesFailureDuration() async throws {
+        let clock = ScriptedToolClock(readings: [UInt64(10), UInt64(17)])
+        let engine = ToolExecutionEngine(clock: clock)
+        let registry = ToolRegistry()
+        try await registry.register(MockErrorTool(name: "boom"))
+
+        let outcome = try await engine.execute(
+            toolName: "boom",
+            arguments: [:],
+            registry: registry,
+            agent: ParallelTestMockAgent(),
+            context: nil,
+            resultBuilder: AgentResult.Builder(),
+            observer: nil,
+            tracing: nil,
+            stopOnToolError: false
+        )
+
+        #expect(outcome.result.isSuccess == false)
+        #expect(outcome.result.duration == Duration(swarmNanoseconds: UInt64(7)))
+    }
+
+    @Test("automatic semantics do not add an approval throw")
+    func automaticSemanticsDoNotAddAnApprovalThrow() async throws {
+        let engine = ToolExecutionEngine()
+        let registry = ToolRegistry()
+        try await registry.register(
+            FunctionTool(
+                name: "echo",
+                description: "Echo",
+                executionSemantics: .automatic
+            ) { _ in .string("ok") }
+        )
+
+        let outcome = try await engine.execute(
+            toolName: "echo",
+            arguments: [:],
+            registry: registry,
+            agent: ParallelTestMockAgent(),
+            context: nil,
+            resultBuilder: AgentResult.Builder(),
+            observer: nil,
+            tracing: nil,
+            stopOnToolError: false
+        )
+
+        #expect(outcome.result.isSuccess == true)
+    }
+
+    @Test("always approval still executes on the Engine host path")
+    func alwaysApprovalStillExecutesOnTheEngineHostPath() async throws {
+        let engine = ToolExecutionEngine()
+        let registry = ToolRegistry()
+        try await registry.register(
+            FunctionTool(
+                name: "gated",
+                description: "Gated",
+                executionSemantics: ToolExecutionSemantics(approvalRequirement: .always)
+            ) { _ in .string("ran") }
+        )
+
+        let outcome = try await engine.execute(
+            toolName: "gated",
+            arguments: [:],
+            registry: registry,
+            agent: ParallelTestMockAgent(),
+            context: nil,
+            resultBuilder: AgentResult.Builder(),
+            observer: nil,
+            tracing: nil,
+            stopOnToolError: false
+        )
+
+        #expect(outcome.result.isSuccess == true)
+        #expect(outcome.result.output == .string("ran"))
+    }
+
+    @Test("maps ToolResult success onto ToolExecutionResult")
+    func mapsToolResultSuccessOntoToolExecutionResult() {
+        let call = ToolCall(toolName: "echo", arguments: ["x": .int(1)])
+        let toolResult = ToolResult.success(
+            callId: call.id,
+            output: .string("ok"),
+            duration: .milliseconds(3)
+        )
+
+        let mapped = ToolExecutionResult.from(call: call, result: toolResult)
+
+        #expect(mapped.isSuccess == true)
+        #expect(mapped.toolName == "echo")
+        #expect(mapped.value == .string("ok"))
+        #expect(mapped.duration == .milliseconds(3))
+        #expect(mapped.arguments["x"] == .int(1))
+    }
+
+    @Test("maps ToolResult failure onto ToolExecutionResult")
+    func mapsToolResultFailureOntoToolExecutionResult() {
+        let call = ToolCall(toolName: "boom", arguments: [:])
+        let toolResult = ToolResult.failure(
+            callId: call.id,
+            error: "nope",
+            duration: .milliseconds(2)
+        )
+
+        let mapped = ToolExecutionResult.from(call: call, result: toolResult)
+
+        #expect(mapped.isSuccess == false)
+        #expect(mapped.toolName == "boom")
+        #expect(mapped.duration == .milliseconds(2))
+        if let agentError = mapped.error as? AgentError,
+           case let .toolFailure(toolName, message, _) = agentError {
+            #expect(toolName == "boom")
+            #expect(message == "nope")
+        } else {
+            Issue.record("expected toolFailure, got \(String(describing: mapped.error))")
+        }
+    }
+}

--- a/Tests/SwarmTests/Tools/ToolExecutionSemanticsTests.swift
+++ b/Tests/SwarmTests/Tools/ToolExecutionSemanticsTests.swift
@@ -1,0 +1,73 @@
+// ToolExecutionSemanticsTests.swift
+// SwarmTests
+//
+// Pure `runtimePolicy()` decisions for tool governance.
+
+import Foundation
+@testable import Swarm
+import Testing
+
+@Suite("ToolExecutionSemantics runtimePolicy")
+struct ToolExecutionSemanticsTests {
+    @Test("automatic preserves host-loop defaults")
+    func automaticPreservesHostLoopDefaults() {
+        let policy = ToolExecutionSemantics.automatic.runtimePolicy()
+        #expect(policy.mayRetryAutomatically == true)
+        #expect(policy.requiresApproval == false)
+        #expect(policy.mayRunInParallel == true)
+    }
+
+    @Test("unspecified side effects stay parallel-eligible")
+    func unspecifiedSideEffectsStayParallelEligible() {
+        let policy = ToolExecutionSemantics(sideEffectLevel: .unspecified).runtimePolicy()
+        #expect(policy.mayRunInParallel == true)
+        #expect(policy.requiresApproval == false)
+    }
+
+    @Test("explicit externalMutation is not parallel-eligible")
+    func explicitExternalMutationIsNotParallelEligible() {
+        let policy = ToolExecutionSemantics(sideEffectLevel: .externalMutation).runtimePolicy()
+        #expect(policy.mayRunInParallel == false)
+        #expect(policy.requiresApproval == false)
+        #expect(policy.mayRetryAutomatically == true)
+    }
+
+    @Test("readOnly and localMutation remain parallel-eligible")
+    func readOnlyAndLocalMutationRemainParallelEligible() {
+        #expect(ToolExecutionSemantics(sideEffectLevel: .readOnly).runtimePolicy().mayRunInParallel == true)
+        #expect(ToolExecutionSemantics(sideEffectLevel: .localMutation).runtimePolicy().mayRunInParallel == true)
+    }
+
+    @Test("unsafe retry policy is not automatically retryable")
+    func unsafeRetryPolicyIsNotAutomaticallyRetryable() {
+        let policy = ToolExecutionSemantics(retryPolicy: .unsafe).runtimePolicy()
+        #expect(policy.mayRetryAutomatically == false)
+        #expect(policy.requiresApproval == false)
+        #expect(policy.mayRunInParallel == true)
+    }
+
+    @Test("safe retry policy may retry automatically")
+    func safeRetryPolicyMayRetryAutomatically() {
+        #expect(ToolExecutionSemantics(retryPolicy: .safe).runtimePolicy().mayRetryAutomatically == true)
+    }
+
+    @Test("caller-managed retry is not automatically retryable")
+    func callerManagedRetryIsNotAutomaticallyRetryable() {
+        #expect(
+            ToolExecutionSemantics(retryPolicy: .callerManaged).runtimePolicy().mayRetryAutomatically == false
+        )
+    }
+
+    @Test("always approval requires approval without changing parallel defaults")
+    func alwaysApprovalRequiresApproval() {
+        let policy = ToolExecutionSemantics(approvalRequirement: .always).runtimePolicy()
+        #expect(policy.requiresApproval == true)
+        #expect(policy.mayRunInParallel == true)
+        #expect(policy.mayRetryAutomatically == true)
+    }
+
+    @Test("never approval does not require approval")
+    func neverApprovalDoesNotRequireApproval() {
+        #expect(ToolExecutionSemantics(approvalRequirement: .never).runtimePolicy().requiresApproval == false)
+    }
+}

--- a/Tests/SwarmTests/V2SurfaceAuditTests.swift
+++ b/Tests/SwarmTests/V2SurfaceAuditTests.swift
@@ -162,6 +162,11 @@ struct V2SurfaceAuditTests {
         let automatic: ToolExecutionSemantics = .automatic
         #expect(automatic == ToolExecutionSemantics())
 
+        let automaticPolicy = automatic.runtimePolicy()
+        #expect(automaticPolicy.requiresApproval == false)
+        #expect(automaticPolicy.mayRunInParallel == true)
+        #expect(automaticPolicy.mayRetryAutomatically == true)
+
         let tool = FunctionTool(
             name: "echo",
             description: "Echo",

--- a/docs/reference/api-catalog.md
+++ b/docs/reference/api-catalog.md
@@ -1216,12 +1216,25 @@ Refresh the header counts with `scripts/ci/refresh-api-catalog-header.sh`. That 
 
 | Line | Kind | Access | Name | Signature |
 |------|------|--------|------|-----------|
-| 73 | class | public | ParallelToolExecutor | `public actor ParallelToolExecutor` |
-| 79 | func | public | ParallelToolExecutor.init() | `public init()` |
-| 122 | func | public | ParallelToolExecutor.executeInParallel(_:using:agent:context:) | `public func executeInParallel(_ calls: [ToolCall], using registry: ToolRegistry, agent: any AgentRuntime, context: AgentContext?) async throws -> [ToolExecutionResult]` |
-| 237 | func | public | ParallelToolExecutor.executeInParallel(_:using:agent:context:errorStrategy:) | `public func executeInParallel(_ calls: [ToolCall], using registry: ToolRegistry, agent: any AgentRuntime, context: AgentContext?, errorStrategy: ParallelExecutionErrorStrategy) async throws -> [ToolExecutionResult]` |
-| 365 | func | public | ParallelToolExecutor.executeAllCapturingErrors(_:using:agent:context:) | `public func executeAllCapturingErrors(_ calls: [ToolCall], using registry: ToolRegistry, agent: any AgentRuntime, context: AgentContext? = nil) async throws -> [ToolExecutionResult]` |
-| 393 | func | public | ParallelToolExecutor.executeAllOrFail(_:using:agent:context:) | `public func executeAllOrFail(_ calls: [ToolCall], using registry: ToolRegistry, agent: any AgentRuntime, context: AgentContext? = nil) async throws -> [ToolExecutionResult]` |
+| 78 | class | public | ParallelToolExecutor | `public actor ParallelToolExecutor` |
+| 84 | func | public | ParallelToolExecutor.init() | `public init()` |
+| 136 | func | public | ParallelToolExecutor.executeInParallel(_:using:agent:context:) | `public func executeInParallel(_ calls: [ToolCall], using registry: ToolRegistry, agent: any AgentRuntime, context: AgentContext?) async throws -> [ToolExecutionResult]` |
+| 210 | func | public | ParallelToolExecutor.executeInParallel(_:using:agent:context:errorStrategy:) | `public func executeInParallel(_ calls: [ToolCall], using registry: ToolRegistry, agent: any AgentRuntime, context: AgentContext?, errorStrategy: ParallelExecutionErrorStrategy) async throws -> [ToolExecutionResult]` |
+| 404 | func | public | ParallelToolExecutor.executeAllCapturingErrors(_:using:agent:context:) | `public func executeAllCapturingErrors(_ calls: [ToolCall], using registry: ToolRegistry, agent: any AgentRuntime, context: AgentContext? = nil) async throws -> [ToolExecutionResult]` |
+| 432 | func | public | ParallelToolExecutor.executeAllOrFail(_:using:agent:context:) | `public func executeAllOrFail(_ calls: [ToolCall], using registry: ToolRegistry, agent: any AgentRuntime, context: AgentContext? = nil) async throws -> [ToolExecutionResult]` |
+
+### Tools/ToolExecutionSemantics.swift
+
+| Line | Kind | Access | Name | Signature |
+|------|------|--------|------|-----------|
+| 4 | enum | public | ToolSideEffectLevel | `public enum ToolSideEffectLevel` |
+| 12 | enum | public | ToolRetryPolicy | `public enum ToolRetryPolicy` |
+| 20 | enum | public | ToolApprovalRequirement | `public enum ToolApprovalRequirement` |
+| 27 | enum | public | ToolResultDurability | `public enum ToolResultDurability` |
+| 35 | struct | public | ToolExecutionSemantics | `public struct ToolExecutionSemantics` |
+| 53 | var | public | ToolExecutionSemantics.automatic | `public static let automatic: ToolExecutionSemantics` |
+| 60 | struct | public | ToolExecutionSemantics.RuntimePolicy | `public struct RuntimePolicy` |
+| 74 | func | public | ToolExecutionSemantics.runtimePolicy() | `public func runtimePolicy() -> RuntimePolicy` |
 
 ### Tools/SemanticCompactorTool.swift
 

--- a/docs/reference/front-facing-api.md
+++ b/docs/reference/front-facing-api.md
@@ -278,6 +278,12 @@ let greet = FunctionTool(
 }
 ```
 
+`ToolExecutionSemantics.runtimePolicy()` is the public derivation of retry,
+approval, and parallel eligibility. ``ToolExecutionSemantics/automatic`` stays
+approval-free and parallel-eligible. `ParallelToolExecutor` serializes each
+explicit `externalMutation` so it does not overlap another call; consecutive
+parallel-eligible tools still run concurrently.
+
 ### `@ToolBuilder` result builder
 
 Used as the trailing closure in the canonical `Agent` init. No brackets, no commas:


### PR DESCRIPTION
## Summary
- Run `ParallelToolExecutor` through `ToolExecutionEngine` with an injectable clock (`ToolExecutionEngine()` stays valid from Agent).
- Add public `ToolExecutionSemantics.runtimePolicy()`; `.automatic` stays approval-free and parallel-eligible; explicit `externalMutation` serializes that tool only.
- Keep original tool error identity on continue-on-error and fail-fast instead of rebuilding `AgentError` from the result string.

Spec: `spec/spec-architecture-functional-evolution.md` ticket **T2**.
Reviews: `swift-pr-review` (first pass, fix allowed) then `swift-pr-review` (final pass, clean).

## Test plan
- [x] `SWARM_OMIT_INTEGRATION_TARGETS=1 swift test --no-parallel --filter 'ParallelToolExecutor|ToolExecutionSemantics|V2SurfaceAudit|ToolExecutionEngine'`
- [x] `SWARM_CORE_ONLY=1 swift build`
- [x] `git diff --check`
- [ ] CI lean + Integrations lanes on this PR


Made with [Cursor](https://cursor.com)