### PR TITLE
Batch host-regular tools through ToolExecutionEngine

### DIFF
--- a/Sources/Swarm/Agents/Agent+ToolLoop.swift
+++ b/Sources/Swarm/Agents/Agent+ToolLoop.swift
@@ -542,20 +542,55 @@ extension Agent {
             }
 
         case (.handoff, _), (.regular, _), (.membraneInternal, nil):
-            let engine = ToolExecutionEngine()
-            let outcome = try await executeWithinRemainingTimeout(startTime: startTime) {
-                try await engine.execute(
-                    parsedCall,
-                    registry: toolRegistry,
-                    agent: self,
-                    context: nil,
-                    resultBuilder: resultBuilder,
-                    observer: observer,
-                    tracing: tracing,
-                    stopOnToolError: false
-                )
-            }
+            try await executeRegularToolBatch(
+                calls: [parsedCall],
+                toolRegistry: toolRegistry,
+                memory: memory,
+                turnTranscript: &turnTranscript,
+                resultBuilder: resultBuilder,
+                observer: observer,
+                tracing: tracing,
+                membraneAdapter: membraneAdapter,
+                startTime: startTime
+            )
+        }
+    }
 
+    /// Registry-backed regular tools through ``ToolExecutionEngine/executeBatch``.
+    ///
+    /// Engine is invoked with `stopOnToolError: false`. After transcript and
+    /// memory updates, this throws ``AgentError/toolFailure`` when configured.
+    private func executeRegularToolBatch(
+        calls: [InferenceResponse.ParsedToolCall],
+        toolRegistry: ToolRegistry,
+        memory: (any Memory)?,
+        turnTranscript: inout AgentTurnTranscript,
+        resultBuilder: AgentResult.Builder,
+        observer: (any AgentObserver)?,
+        tracing: TracingHelper?,
+        membraneAdapter: (any MembraneAgentAdapter)?,
+        startTime: ContinuousClock.Instant
+    ) async throws {
+        guard !calls.isEmpty else {
+            return
+        }
+
+        let engine = ToolExecutionEngine()
+        let outcomes = try await executeWithinRemainingTimeout(startTime: startTime) {
+            try await engine.executeBatch(
+                calls,
+                registry: toolRegistry,
+                agent: self,
+                context: nil,
+                resultBuilder: resultBuilder,
+                observer: observer,
+                tracing: tracing,
+                stopOnToolError: false
+            )
+        }
+
+        var firstFailure: (toolName: String, message: String)?
+        for (parsedCall, outcome) in zip(calls, outcomes) {
             if outcome.result.isSuccess {
                 var toolOutputText = Self.toolOutputText(for: outcome.result.output)
                 if let membraneAdapter {
@@ -584,8 +619,8 @@ extension Agent {
                     result: toolOutputText,
                     toolCallID: parsedCall.id
                 )
-                if let activeMemory {
-                    await activeMemory.add(.tool(toolOutputText, toolName: parsedCall.name))
+                if let memory {
+                    await memory.add(.tool(toolOutputText, toolName: parsedCall.name))
                 }
             } else {
                 let errorMessage = outcome.result.errorMessage ?? "Unknown error"
@@ -594,17 +629,24 @@ extension Agent {
                     result: AgentTurnKernel.toolFailureConversationText(message: errorMessage),
                     toolCallID: parsedCall.id
                 )
-                if let activeMemory {
-                    await activeMemory.add(.tool(
+                if let memory {
+                    await memory.add(.tool(
                         AgentTurnKernel.memoryToolErrorText(message: errorMessage),
                         toolName: parsedCall.name
                     ))
                 }
-
-                if configuration.stopOnToolError {
-                    throw AgentError.toolFailure(toolName: parsedCall.name, message: errorMessage, cause: nil)
+                if firstFailure == nil {
+                    firstFailure = (parsedCall.name, errorMessage)
                 }
             }
+        }
+
+        if configuration.stopOnToolError, let firstFailure {
+            throw AgentError.toolFailure(
+                toolName: firstFailure.toolName,
+                message: firstFailure.message,
+                cause: nil
+            )
         }
     }
 
@@ -727,12 +769,18 @@ extension Agent {
             toolCalls: response.toolCalls
         )
 
-        for parsedCall in response.toolCalls {
-            let kind = AgentTurnKernel.hostToolCallKind(
+        let hostKind: (InferenceResponse.ParsedToolCall) -> AgentTurnKernel.HostToolCallKind = { parsedCall in
+            AgentTurnKernel.hostToolCallKind(
                 isHandoffTool: handoffMap[parsedCall.name] != nil,
                 isMembraneInternal: membraneAdapter != nil
                     && MembraneInternalTools.isInternalTool(parsedCall.name)
             )
+        }
+
+        var callIndex = 0
+        while callIndex < response.toolCalls.count {
+            let parsedCall = response.toolCalls[callIndex]
+            let kind = hostKind(parsedCall)
 
             switch kind {
             case .handoff:
@@ -749,6 +797,7 @@ extension Agent {
                         membraneAdapter: membraneAdapter,
                         startTime: startTime
                     )
+                    callIndex += 1
                     continue
                 }
                 if let when = handoffConfig.when, await !when(context, handoffConfig.targetAgent) {
@@ -772,6 +821,7 @@ extension Agent {
                         result: toolError,
                         toolCallID: parsedCall.id
                     )
+                    callIndex += 1
                     continue
                 }
 
@@ -914,7 +964,7 @@ extension Agent {
                 // Return the handoff output to be used as the final result
                 return FinalAssistantResponse(content: result.output, structuredOutput: nil)
 
-            case .membraneInternal, .regular:
+            case .membraneInternal:
                 try await executeSingleToolCall(
                     parsedCall: parsedCall,
                     toolRegistry: toolRegistry,
@@ -927,6 +977,26 @@ extension Agent {
                     membraneAdapter: membraneAdapter,
                     startTime: startTime
                 )
+                callIndex += 1
+
+            case .regular:
+                var end = callIndex + 1
+                while end < response.toolCalls.count,
+                      hostKind(response.toolCalls[end]) == .regular {
+                    end += 1
+                }
+                try await executeRegularToolBatch(
+                    calls: Array(response.toolCalls[callIndex..<end]),
+                    toolRegistry: toolRegistry,
+                    memory: memory,
+                    turnTranscript: &turnTranscript,
+                    resultBuilder: resultBuilder,
+                    observer: observer,
+                    tracing: tracing,
+                    membraneAdapter: membraneAdapter,
+                    startTime: startTime
+                )
+                callIndex = end
             }
         }
 

--- a/Sources/Swarm/Agents/Agent+ToolLoop.swift
+++ b/Sources/Swarm/Agents/Agent+ToolLoop.swift
@@ -558,7 +558,8 @@ extension Agent {
 
     /// Registry-backed regular tools through ``ToolExecutionEngine/executeBatch``.
     ///
-    /// Engine is invoked with `stopOnToolError: false`. After transcript and
+    /// Engine is invoked with `stopOnToolError: false` and
+    /// `allowConcurrent: configuration.parallelToolCalls`. After transcript and
     /// memory updates, this throws ``AgentError/toolFailure`` when configured.
     private func executeRegularToolBatch(
         calls: [InferenceResponse.ParsedToolCall],
@@ -585,7 +586,8 @@ extension Agent {
                 resultBuilder: resultBuilder,
                 observer: observer,
                 tracing: tracing,
-                stopOnToolError: false
+                stopOnToolError: false,
+                allowConcurrent: configuration.parallelToolCalls
             )
         }
 

--- a/Sources/Swarm/Tools/ParallelToolExecutor.swift
+++ b/Sources/Swarm/Tools/ParallelToolExecutor.swift
@@ -144,10 +144,9 @@ public actor ParallelToolExecutor {
             return []
         }
 
-        let eligibility = try await validatedEligibility(for: calls, registry: registry)
+        try await validateToolsExist(in: calls, registry: registry)
         return try await executeCalls(
             calls,
-            eligibility: eligibility,
             using: registry,
             agent: agent,
             context: context,
@@ -277,10 +276,9 @@ public actor ParallelToolExecutor {
     ) async throws -> [ToolExecutionResult] {
         guard !calls.isEmpty else { return [] }
 
-        let eligibility = try await validatedEligibility(for: calls, registry: registry)
+        try await validateToolsExist(in: calls, registry: registry)
         return try await executeCalls(
             calls,
-            eligibility: eligibility,
             using: registry,
             agent: agent,
             context: context,
@@ -288,99 +286,44 @@ public actor ParallelToolExecutor {
         )
     }
 
-    /// Fail-fast validation plus per-tool parallel eligibility from `runtimePolicy()`.
+    /// Fail-fast validation before any Engine invocation.
     ///
-    /// Missing or disabled tools throw before any Engine invocation. A tool that
-    /// is disabled *after* this pre-pass still goes through Engine and surfaces
-    /// as a per-call failure when `stopOnToolError` is false.
-    private func validatedEligibility(
-        for calls: [ToolCall],
+    /// A tool that is disabled *after* this pre-pass still goes through Engine
+    /// and surfaces as a per-call failure when `stopOnToolError` is false.
+    private func validateToolsExist(
+        in calls: [ToolCall],
         registry: ToolRegistry
-    ) async throws -> [Bool] {
-        var eligibility: [Bool] = []
-        eligibility.reserveCapacity(calls.count)
+    ) async throws {
         for call in calls {
             guard let tool = await registry.tool(named: call.toolName), tool.isEnabled else {
                 throw AgentError.toolNotFound(name: call.toolName)
             }
-            eligibility.append(tool.executionSemantics.runtimePolicy().mayRunInParallel)
         }
-        return eligibility
     }
 
     private func executeCalls(
         _ calls: [ToolCall],
-        eligibility: [Bool],
         using registry: ToolRegistry,
         agent: any AgentRuntime,
         context: AgentContext?,
         stopOnToolError: Bool
     ) async throws -> [ToolExecutionResult] {
-        var results: [ToolExecutionResult] = []
-        results.reserveCapacity(calls.count)
-        var index = 0
-        while index < calls.count {
-            if eligibility[index] {
-                var end = index + 1
-                while end < calls.count, eligibility[end] {
-                    end += 1
-                }
-                let concurrentResults = try await executeConcurrent(
-                    Array(calls[index..<end]),
-                    using: registry,
-                    agent: agent,
-                    context: context,
-                    stopOnToolError: stopOnToolError
-                )
-                results.append(contentsOf: concurrentResults)
-                index = end
-            } else {
-                try Task.checkCancellation()
-                let mapped = try await engine.executeMapped(
-                    call: calls[index],
-                    registry: registry,
-                    agent: agent,
-                    context: context,
-                    stopOnToolError: stopOnToolError
-                )
-                results.append(mapped)
-                index += 1
-            }
-        }
-        return results
-    }
-
-    private func executeConcurrent(
-        _ calls: [ToolCall],
-        using registry: ToolRegistry,
-        agent: any AgentRuntime,
-        context: AgentContext?,
-        stopOnToolError: Bool
-    ) async throws -> [ToolExecutionResult] {
-        try await withThrowingTaskGroup(of: (Int, ToolExecutionResult).self) { group in
-            for (index, call) in calls.enumerated() {
-                group.addTask { [engine, registry, agent, context] in
-                    let mapped = try await engine.executeMapped(
-                        call: call,
-                        registry: registry,
-                        agent: agent,
-                        context: context,
-                        stopOnToolError: stopOnToolError
-                    )
-                    return (index, mapped)
-                }
-            }
-
-            var indexedResults: [(Int, ToolExecutionResult)] = []
-            indexedResults.reserveCapacity(calls.count)
-
-            for try await result in group {
-                try Task.checkCancellation()
-                indexedResults.append(result)
-            }
-
-            indexedResults.sort { $0.0 < $1.0 }
-            return indexedResults.map(\.1)
+        let outcomes = try await engine.executeBatch(
+            calls,
+            registry: registry,
+            agent: agent,
+            context: context,
+            resultBuilder: AgentResult.Builder(),
+            observer: nil,
+            tracing: nil,
+            stopOnToolError: stopOnToolError
+        )
+        return zip(calls, outcomes).map { call, outcome in
+            ToolExecutionResult.from(
+                call: call,
+                result: outcome.result,
+                underlyingError: outcome.caughtError
+            )
         }
     }
 }

--- a/Sources/Swarm/Tools/ParallelToolExecutor.swift
+++ b/Sources/Swarm/Tools/ParallelToolExecutor.swift
@@ -316,7 +316,8 @@ public actor ParallelToolExecutor {
             resultBuilder: AgentResult.Builder(),
             observer: nil,
             tracing: nil,
-            stopOnToolError: stopOnToolError
+            stopOnToolError: stopOnToolError,
+            allowConcurrent: true
         )
         return zip(calls, outcomes).map { call, outcome in
             ToolExecutionResult.from(

--- a/Sources/Swarm/Tools/ToolBatchPlan.swift
+++ b/Sources/Swarm/Tools/ToolBatchPlan.swift
@@ -1,0 +1,39 @@
+// ToolBatchPlan.swift
+// Swarm Framework
+//
+// Pure grouping of consecutive parallel-eligible tool calls.
+
+import Foundation
+
+/// One step of a tool batch: overlapping work or a serial singleton.
+enum ToolBatchGroup: Equatable, Sendable {
+    /// Half-open indices into the call list that may overlap.
+    case concurrent(Range<Int>)
+    /// Single index that must not overlap any other call.
+    case serial(Int)
+}
+
+/// Groups a call list from parallel-eligibility flags.
+///
+/// A maximal consecutive `true` run is one concurrent group. Each `false` is
+/// a serial singleton. Empty input yields no groups.
+enum ToolBatchPlan: Sendable {
+    static func groups(eligibility: [Bool]) -> [ToolBatchGroup] {
+        var groups: [ToolBatchGroup] = []
+        var index = 0
+        while index < eligibility.count {
+            if eligibility[index] {
+                var end = index + 1
+                while end < eligibility.count, eligibility[end] {
+                    end += 1
+                }
+                groups.append(.concurrent(index..<end))
+                index = end
+            } else {
+                groups.append(.serial(index))
+                index += 1
+            }
+        }
+        return groups
+    }
+}

--- a/Sources/Swarm/Tools/ToolExecutionEngine.swift
+++ b/Sources/Swarm/Tools/ToolExecutionEngine.swift
@@ -148,6 +148,100 @@ struct ToolExecutionEngine: Sendable {
         )
     }
 
+    /// Executes registry-backed calls using ``ToolBatchPlan``.
+    ///
+    /// Concurrent groups overlap via `withThrowingTaskGroup`. Returned outcomes
+    /// stay in input order. Each call uses ``execute`` (live builder, observer,
+    /// tracing). `stopOnToolError` rethrows the original tool error after
+    /// recording, matching ``executeMapped``.
+    func executeBatch(
+        _ calls: [some ToolCallGoal],
+        registry: ToolRegistry,
+        agent: any AgentRuntime,
+        context: AgentContext?,
+        resultBuilder: AgentResult.Builder,
+        observer: (any AgentObserver)?,
+        tracing: TracingHelper?,
+        stopOnToolError: Bool
+    ) async throws -> [Outcome] {
+        guard !calls.isEmpty else {
+            return []
+        }
+
+        var eligibility: [Bool] = []
+        eligibility.reserveCapacity(calls.count)
+        for call in calls {
+            let tool = await registry.tool(named: call.toolName)
+            eligibility.append(tool?.executionSemantics.runtimePolicy().mayRunInParallel ?? true)
+        }
+
+        var outcomes = [Outcome?](repeating: nil, count: calls.count)
+        for group in ToolBatchPlan.groups(eligibility: eligibility) {
+            switch group {
+            case let .serial(index):
+                try Task.checkCancellation()
+                let outcome = try await execute(
+                    calls[index],
+                    registry: registry,
+                    agent: agent,
+                    context: context,
+                    resultBuilder: resultBuilder,
+                    observer: observer,
+                    tracing: tracing,
+                    stopOnToolError: false
+                )
+                outcomes[index] = outcome
+                if stopOnToolError, let error = outcome.caughtError {
+                    throw error
+                }
+
+            case let .concurrent(range):
+                try await withThrowingTaskGroup(of: (Int, Outcome).self) { taskGroup in
+                    for index in range {
+                        let goal = calls[index]
+                        taskGroup.addTask {
+                            let isolatedBuilder = AgentResult.Builder()
+                            let outcome = try await self.execute(
+                                goal,
+                                registry: registry,
+                                agent: agent,
+                                context: context,
+                                resultBuilder: isolatedBuilder,
+                                observer: observer,
+                                tracing: tracing,
+                                stopOnToolError: false
+                            )
+                            if stopOnToolError, let error = outcome.caughtError {
+                                throw error
+                            }
+                            return (index, outcome)
+                        }
+                    }
+
+                    var collected: [(Int, Outcome)] = []
+                    collected.reserveCapacity(range.count)
+                    for try await item in taskGroup {
+                        try Task.checkCancellation()
+                        collected.append(item)
+                    }
+                    collected.sort { $0.0 < $1.0 }
+                    for (index, outcome) in collected {
+                        _ = resultBuilder.addToolCall(outcome.call)
+                        _ = resultBuilder.addToolResult(outcome.result)
+                        outcomes[index] = outcome
+                    }
+                }
+            }
+        }
+
+        return outcomes.map { outcome in
+            guard let outcome else {
+                preconditionFailure("ToolExecutionEngine.executeBatch missing outcome")
+            }
+            return outcome
+        }
+    }
+
     private func elapsedDuration(since startNanoseconds: UInt64) -> Duration {
         let now = clock.nowNanoseconds()
         let elapsed = now >= startNanoseconds ? now - startNanoseconds : 0

--- a/Sources/Swarm/Tools/ToolExecutionEngine.swift
+++ b/Sources/Swarm/Tools/ToolExecutionEngine.swift
@@ -154,6 +154,14 @@ struct ToolExecutionEngine: Sendable {
     /// stay in input order. Each call uses ``execute`` (live builder, observer,
     /// tracing). `stopOnToolError` rethrows the original tool error after
     /// recording, matching ``executeMapped``.
+    ///
+    /// Concurrent groups are only formed when `allowConcurrent` is true **and**
+    /// the tool's ``ToolExecutionSemantics/runtimePolicy()`` allows overlap.
+    /// Missing tools are treated as parallel-eligible so they fail inside
+    /// ``execute`` rather than forcing a serial split. Isolated builders record
+    /// each overlapping call; results are merged onto `resultBuilder` in input
+    /// order. Observer and tracing callbacks for a concurrent group follow
+    /// completion order.
     func executeBatch(
         _ calls: [some ToolCallGoal],
         registry: ToolRegistry,
@@ -162,7 +170,8 @@ struct ToolExecutionEngine: Sendable {
         resultBuilder: AgentResult.Builder,
         observer: (any AgentObserver)?,
         tracing: TracingHelper?,
-        stopOnToolError: Bool
+        stopOnToolError: Bool,
+        allowConcurrent: Bool
     ) async throws -> [Outcome] {
         guard !calls.isEmpty else {
             return []
@@ -172,7 +181,8 @@ struct ToolExecutionEngine: Sendable {
         eligibility.reserveCapacity(calls.count)
         for call in calls {
             let tool = await registry.tool(named: call.toolName)
-            eligibility.append(tool?.executionSemantics.runtimePolicy().mayRunInParallel ?? true)
+            let mayOverlap = tool?.executionSemantics.runtimePolicy().mayRunInParallel ?? true
+            eligibility.append(allowConcurrent && mayOverlap)
         }
 
         var outcomes = [Outcome?](repeating: nil, count: calls.count)

--- a/Tests/SwarmTests/Agents/AgentHostToolBatchTests.swift
+++ b/Tests/SwarmTests/Agents/AgentHostToolBatchTests.swift
@@ -1,0 +1,238 @@
+// AgentHostToolBatchTests.swift
+// SwarmTests
+//
+// Host-round batching for consecutive regular tools on ToolExecutionEngine.
+
+import Foundation
+@testable import Swarm
+import Testing
+
+@Suite("Agent host tool batch")
+struct AgentHostToolBatchTests {
+    private static let configuration = AgentConfiguration.default
+        .enableStreaming(false)
+        .timeout(.seconds(30))
+        .defaultTracingEnabled(false)
+
+    @Test("Two parallel-eligible regular tools both run; transcript order matches input")
+    func twoRegularToolsBatchInInputOrder() async throws {
+        let handshake = ToolHandshake()
+        let search = HandshakeTool(name: "search", handshake: handshake)
+        let calc = HandshakeTool(name: "calc", handshake: handshake)
+        let provider = MockInferenceProvider()
+        await provider.setToolCallResponses([
+            InferenceResponse(
+                content: nil,
+                toolCalls: [
+                    InferenceResponse.ParsedToolCall(id: "call_search", name: "search", arguments: [:]),
+                    InferenceResponse.ParsedToolCall(id: "call_calc", name: "calc", arguments: [:]),
+                ],
+                finishReason: .toolCall,
+                usage: nil
+            ),
+            InferenceResponse(content: "done", toolCalls: [], finishReason: .completed, usage: nil),
+        ])
+        let agent = try Agent(
+            tools: [search, calc],
+            configuration: Self.configuration,
+            inferenceProvider: provider
+        )
+
+        let result = try await agent.run("search then calc")
+
+        #expect(result.output == "done")
+        #expect(result.toolCalls.map(\.toolName) == ["search", "calc"])
+        #expect(result.toolCalls.map(\.providerCallId) == ["call_search", "call_calc"])
+        #expect(result.toolResults.map(\.isSuccess) == [true, true])
+        #expect(result.toolResults.map(\.output) == [.string("search"), .string("calc")])
+        #expect(await handshake.arrivals == 2)
+    }
+
+    @Test("Successful handoff skips later regular tools")
+    func successfulHandoffSkipsLaterRegularTools() async throws {
+        let search = SpyTool(name: "search", result: .string("hits"))
+        let calc = SpyTool(name: "calc", result: .string("should-not-run"))
+        let provider = MockInferenceProvider()
+        await provider.setToolCallResponses([
+            InferenceResponse(
+                content: nil,
+                toolCalls: [
+                    InferenceResponse.ParsedToolCall(id: "call_search", name: "search", arguments: [:]),
+                    InferenceResponse.ParsedToolCall(
+                        id: "call_handoff",
+                        name: "handoff_to_writer",
+                        arguments: ["reason": .string("write it")]
+                    ),
+                    InferenceResponse.ParsedToolCall(id: "call_calc", name: "calc", arguments: [:]),
+                ],
+                finishReason: .toolCall,
+                usage: nil
+            ),
+        ])
+        let target = HostBatchHandoffReceiver(name: "writer")
+        let agent = try Agent(
+            tools: [search, calc],
+            instructions: "Route to writer.",
+            configuration: AgentConfiguration(name: "source", defaultTracingEnabled: false)
+                .enableStreaming(false)
+                .timeout(.seconds(30)),
+            inferenceProvider: provider,
+            handoffs: [
+                AnyHandoffConfiguration(
+                    HandoffConfiguration(targetAgent: target, toolNameOverride: "handoff_to_writer")
+                ),
+            ]
+        )
+
+        let result = try await agent.run("search then hand off")
+
+        #expect(result.output == "handled search then hand off")
+        #expect(await search.callCount == 1)
+        #expect(await calc.callCount == 0)
+        #expect(await target.handoffCount == 1)
+        #expect(result.toolCalls.map(\.toolName) == ["search", "handoff_to_writer"])
+    }
+
+    @Test("Membrane internal tools do not go through Engine batch")
+    func membraneInternalToolsBypassEngineBatch() async throws {
+        let weather = SpyTool(name: "weather", result: .string("72F"))
+        let adapter = RecordingMembraneAdapter()
+        let provider = MockInferenceProvider()
+        await provider.setToolCallResponses([
+            InferenceResponse(
+                content: nil,
+                toolCalls: [
+                    InferenceResponse.ParsedToolCall(
+                        id: "call_ptr",
+                        name: MembraneInternalToolName.resolvePointer,
+                        arguments: ["pointer_id": .string("ptr_test")]
+                    ),
+                    InferenceResponse.ParsedToolCall(id: "call_weather", name: "weather", arguments: [:]),
+                ],
+                finishReason: .toolCall,
+                usage: nil
+            ),
+            InferenceResponse(content: "It is 72F", toolCalls: [], finishReason: .completed, usage: nil),
+        ])
+        let agent = try Agent(
+            tools: [weather],
+            configuration: Self.configuration,
+            inferenceProvider: provider
+        ).environment(
+            \.membrane,
+            MembraneEnvironment(isEnabled: true, adapter: adapter)
+        )
+
+        let result = try await agent.run("resolve then weather")
+
+        #expect(result.output == "It is 72F")
+        #expect(await adapter.internalCalls == [MembraneInternalToolName.resolvePointer])
+        #expect(await weather.callCount == 1)
+        #expect(result.toolCalls.map(\.toolName) == [MembraneInternalToolName.resolvePointer, "weather"])
+        #expect(result.toolResults.first?.output == .string("internal-ok"))
+        #expect(result.toolResults.last?.output == .string("72F"))
+    }
+}
+
+private actor ToolHandshake {
+    private(set) var arrivals = 0
+    private var waiter: CheckedContinuation<Void, Never>?
+
+    func arrive() async {
+        arrivals += 1
+        if arrivals >= 2 {
+            waiter?.resume()
+            waiter = nil
+        } else {
+            await withCheckedContinuation { continuation in
+                waiter = continuation
+            }
+        }
+    }
+}
+
+private struct HandshakeTool: AnyJSONTool {
+    let name: String
+    let handshake: ToolHandshake
+
+    var description: String { "Handshake tool \(name)" }
+    var parameters: [ToolParameter] { [] }
+    var inputGuardrails: [any ToolInputGuardrail] { [] }
+    var outputGuardrails: [any ToolOutputGuardrail] { [] }
+
+    func execute(arguments _: [String: SendableValue]) async throws -> SendableValue {
+        await handshake.arrive()
+        return .string(name)
+    }
+}
+
+private actor HostBatchHandoffReceiver: HandoffReceiver {
+    nonisolated let tools: [any AnyJSONTool] = []
+    nonisolated let instructions = "Record handoffs"
+    nonisolated let configuration: AgentConfiguration
+    nonisolated let memory: (any Memory)? = nil
+    nonisolated let inferenceProvider: (any InferenceProvider)? = nil
+    nonisolated let tracer: (any Tracer)? = nil
+    nonisolated let inputGuardrails: [any InputGuardrail] = []
+    nonisolated let outputGuardrails: [any OutputGuardrail] = []
+    nonisolated let handoffs: [AnyHandoffConfiguration] = []
+
+    private(set) var handoffCount = 0
+
+    init(name: String) {
+        configuration = AgentConfiguration(name: name, defaultTracingEnabled: false)
+    }
+
+    func run(_ input: String, session _: (any Session)?, observer _: (any AgentObserver)?) async throws -> AgentResult {
+        AgentResult(output: "handled \(input)")
+    }
+
+    nonisolated func stream(
+        _ input: String,
+        session _: (any Session)?,
+        observer _: (any AgentObserver)?
+    ) -> AsyncThrowingStream<AgentEvent, Error> {
+        StreamHelper.makeTrackedStream { continuation in
+            continuation.yield(.lifecycle(.completed(result: AgentResult(output: "handled \(input)"))))
+            continuation.finish()
+        }
+    }
+
+    func cancel() async {}
+
+    func handleHandoff(_ request: HandoffRequest, context _: AgentContext) async throws -> AgentResult {
+        handoffCount += 1
+        return AgentResult(output: "handled \(request.input)")
+    }
+}
+
+private actor RecordingMembraneAdapter: MembraneAgentAdapter {
+    private(set) var internalCalls: [String] = []
+
+    func plan(
+        prompt: String,
+        toolSchemas: [ToolSchema],
+        profile _: ContextProfile
+    ) async throws -> MembranePlannedBoundary {
+        MembranePlannedBoundary(prompt: prompt, toolSchemas: toolSchemas, mode: "test")
+    }
+
+    func transformToolResult(
+        toolName _: String,
+        output: String,
+        profile _: ContextProfile
+    ) async throws -> MembraneToolResultBoundary {
+        MembraneToolResultBoundary(textForConversation: output)
+    }
+
+    func handleInternalToolCall(
+        name: String,
+        arguments _: [String: SendableValue]
+    ) async throws -> String? {
+        internalCalls.append(name)
+        return "internal-ok"
+    }
+
+    func restore(checkpointData _: Data?) async throws {}
+    func snapshotCheckpointData() async throws -> Data? { nil }
+}

--- a/Tests/SwarmTests/Agents/AgentHostToolBatchTests.swift
+++ b/Tests/SwarmTests/Agents/AgentHostToolBatchTests.swift
@@ -14,6 +14,8 @@ struct AgentHostToolBatchTests {
         .timeout(.seconds(30))
         .defaultTracingEnabled(false)
 
+    private static let parallelConfiguration = configuration.parallelToolCalls(true)
+
     @Test("Two parallel-eligible regular tools both run; transcript order matches input")
     func twoRegularToolsBatchInInputOrder() async throws {
         let handshake = ToolHandshake()
@@ -34,7 +36,7 @@ struct AgentHostToolBatchTests {
         ])
         let agent = try Agent(
             tools: [search, calc],
-            configuration: Self.configuration,
+            configuration: Self.parallelConfiguration,
             inferenceProvider: provider
         )
 
@@ -46,6 +48,90 @@ struct AgentHostToolBatchTests {
         #expect(result.toolResults.map(\.isSuccess) == [true, true])
         #expect(result.toolResults.map(\.output) == [.string("search"), .string("calc")])
         #expect(await handshake.arrivals == 2)
+    }
+
+    @Test("Default parallelToolCalls false keeps consecutive regulars serial")
+    func defaultConfigurationSerializesRegulars() async throws {
+        let log = ToolPhaseLog()
+        let first = FunctionTool(name: "search", description: "Search") { _ in
+            await log.record("start-search")
+            await Task.yield()
+            await log.record("end-search")
+            return .string("hits")
+        }
+        let second = FunctionTool(name: "calc", description: "Calc") { _ in
+            await log.record("start-calc")
+            await Task.yield()
+            await log.record("end-calc")
+            return .string("4")
+        }
+        let provider = MockInferenceProvider()
+        await provider.setToolCallResponses([
+            InferenceResponse(
+                content: nil,
+                toolCalls: [
+                    InferenceResponse.ParsedToolCall(id: "call_search", name: "search", arguments: [:]),
+                    InferenceResponse.ParsedToolCall(id: "call_calc", name: "calc", arguments: [:]),
+                ],
+                finishReason: .toolCall,
+                usage: nil
+            ),
+            InferenceResponse(content: "done", toolCalls: [], finishReason: .completed, usage: nil),
+        ])
+        let agent = try Agent(
+            tools: [first, second],
+            configuration: Self.configuration,
+            inferenceProvider: provider
+        )
+
+        let result = try await agent.run("search then calc")
+
+        #expect(result.output == "done")
+        #expect(result.toolCalls.map(\.toolName) == ["search", "calc"])
+        #expect(await log.snapshot() == ["start-search", "end-search", "start-calc", "end-calc"])
+    }
+
+    @Test("stopOnToolError still runs later regulars in the same batch then throws")
+    func stopOnToolErrorRunsLaterRegularsThenThrows() async throws {
+        let failing = MockTool(name: "first") { _ in
+            throw AgentError.toolFailure(toolName: "first", message: "boom", cause: nil)
+        }
+        let succeeding = SpyTool(name: "second", result: .string("ok"))
+        let provider = MockInferenceProvider()
+        await provider.setToolCallResponses([
+            InferenceResponse(
+                content: nil,
+                toolCalls: [
+                    InferenceResponse.ParsedToolCall(id: "call_first", name: "first", arguments: [:]),
+                    InferenceResponse.ParsedToolCall(id: "call_second", name: "second", arguments: [:]),
+                ],
+                finishReason: .toolCall,
+                usage: nil
+            ),
+            InferenceResponse(content: "should not run", toolCalls: [], finishReason: .completed, usage: nil),
+        ])
+        let agent = try Agent(
+            tools: [failing, succeeding],
+            configuration: Self.configuration.stopOnToolError(true),
+            inferenceProvider: provider
+        )
+
+        do {
+            _ = try await agent.run("use both")
+            Issue.record("Expected stopOnToolError to throw")
+        } catch let error as AgentError {
+            switch error {
+            case let .toolFailure(toolName, message, _):
+                #expect(toolName == "first")
+                #expect(message?.contains("boom") == true)
+            default:
+                Issue.record("Expected toolFailure, got \(error)")
+            }
+        } catch {
+            Issue.record("Expected AgentError, got \(error)")
+        }
+
+        #expect(await succeeding.callCount == 1)
     }
 
     @Test("Successful handoff skips later regular tools")

--- a/Tests/SwarmTests/Tools/ToolBatchPlanTests.swift
+++ b/Tests/SwarmTests/Tools/ToolBatchPlanTests.swift
@@ -1,0 +1,39 @@
+// ToolBatchPlanTests.swift
+// SwarmTests
+//
+// Pure grouping table for consecutive parallel-eligible tool calls.
+
+import Foundation
+@testable import Swarm
+import Testing
+
+@Suite("ToolBatchPlan")
+struct ToolBatchPlanTests {
+    @Test("empty eligibility yields no groups")
+    func emptyEligibility() {
+        #expect(ToolBatchPlan.groups(eligibility: []) == [])
+    }
+
+    @Test("all false yields one serial group per index")
+    func allFalseYieldsSerialSingletons() {
+        #expect(ToolBatchPlan.groups(eligibility: [false]) == [.serial(0)])
+        #expect(
+            ToolBatchPlan.groups(eligibility: [false, false, false])
+                == [.serial(0), .serial(1), .serial(2)]
+        )
+    }
+
+    @Test("consecutive true runs collapse to concurrent ranges")
+    func consecutiveTrueRunsAreConcurrent() {
+        #expect(
+            ToolBatchPlan.groups(eligibility: [true, true, false, true])
+                == [.concurrent(0..<2), .serial(2), .concurrent(3..<4)]
+        )
+        #expect(ToolBatchPlan.groups(eligibility: [true]) == [.concurrent(0..<1)])
+        #expect(ToolBatchPlan.groups(eligibility: [true, true]) == [.concurrent(0..<2)])
+        #expect(
+            ToolBatchPlan.groups(eligibility: [false, true, true, false])
+                == [.serial(0), .concurrent(1..<3), .serial(3)]
+        )
+    }
+}

--- a/Tests/SwarmTests/Tools/ToolExecutionEngineTests.swift
+++ b/Tests/SwarmTests/Tools/ToolExecutionEngineTests.swift
@@ -197,6 +197,35 @@ struct ToolExecutionSemanticsEngineTests {
         #expect(outcomeUnique == unique)
     }
 
+    @Test("executeBatch preserves input order for concurrent tools")
+    func executeBatchPreservesInputOrder() async throws {
+        let engine = ToolExecutionEngine()
+        let registry = ToolRegistry()
+        try await registry.register(MockDelayTool(name: "slow", delay: .milliseconds(30), resultValue: .string("first")))
+        try await registry.register(MockDelayTool(name: "fast", delay: .zero, resultValue: .string("second")))
+        let builder = AgentResult.Builder()
+
+        let outcomes = try await engine.executeBatch(
+            [
+                ToolCall(toolName: "slow", arguments: [:]),
+                ToolCall(toolName: "fast", arguments: [:]),
+            ],
+            registry: registry,
+            agent: ParallelTestMockAgent(),
+            context: nil,
+            resultBuilder: builder,
+            observer: nil,
+            tracing: nil,
+            stopOnToolError: false
+        )
+
+        #expect(outcomes.map(\.call.toolName) == ["slow", "fast"])
+        #expect(outcomes.map(\.result.output) == [.string("first"), .string("second")])
+        let recorded = builder.build()
+        #expect(recorded.toolCalls.map(\.toolName) == ["slow", "fast"])
+        #expect(recorded.toolResults.map(\.output) == [.string("first"), .string("second")])
+    }
+
     @Test("execute still wraps stopOnToolError throws with original cause")
     func stopOnToolErrorThrowsWrappedToolFailureWithCause() async throws {
         let unique = UniqueToolError(code: 23)

--- a/Tests/SwarmTests/Tools/ToolExecutionEngineTests.swift
+++ b/Tests/SwarmTests/Tools/ToolExecutionEngineTests.swift
@@ -216,7 +216,8 @@ struct ToolExecutionSemanticsEngineTests {
             resultBuilder: builder,
             observer: nil,
             tracing: nil,
-            stopOnToolError: false
+            stopOnToolError: false,
+            allowConcurrent: true
         )
 
         #expect(outcomes.map(\.call.toolName) == ["slow", "fast"])
@@ -224,6 +225,50 @@ struct ToolExecutionSemanticsEngineTests {
         let recorded = builder.build()
         #expect(recorded.toolCalls.map(\.toolName) == ["slow", "fast"])
         #expect(recorded.toolResults.map(\.output) == [.string("first"), .string("second")])
+    }
+
+    @Test("executeBatch serializes parallel-eligible tools when allowConcurrent is false")
+    func executeBatchSerializesWhenConcurrencyDisallowed() async throws {
+        let log = ToolPhaseLog()
+        let engine = ToolExecutionEngine()
+        let registry = ToolRegistry()
+        try await registry.register(
+            FunctionTool(name: "a", description: "A") { _ in
+                await log.record("start-a")
+                await Task.yield()
+                await log.record("end-a")
+                return .string("a")
+            }
+        )
+        try await registry.register(
+            FunctionTool(name: "b", description: "B") { _ in
+                await log.record("start-b")
+                await Task.yield()
+                await log.record("end-b")
+                return .string("b")
+            }
+        )
+        let builder = AgentResult.Builder()
+
+        let outcomes = try await engine.executeBatch(
+            [
+                ToolCall(toolName: "a", arguments: [:]),
+                ToolCall(toolName: "b", arguments: [:]),
+            ],
+            registry: registry,
+            agent: ParallelTestMockAgent(),
+            context: nil,
+            resultBuilder: builder,
+            observer: nil,
+            tracing: nil,
+            stopOnToolError: false,
+            allowConcurrent: false
+        )
+
+        #expect(outcomes.map(\.call.toolName) == ["a", "b"])
+        #expect(await log.snapshot() == ["start-a", "end-a", "start-b", "end-b"])
+        let recorded = builder.build()
+        #expect(recorded.toolCalls.map(\.toolName) == ["a", "b"])
     }
 
     @Test("execute still wraps stopOnToolError throws with original cause")


### PR DESCRIPTION
## Summary

Consecutive host-regular tools go through a shared pure `ToolBatchPlan` and `ToolExecutionEngine.executeBatch` (live `execute`, not `executeMapped`). `ParallelToolExecutor` uses the same plan. Overlap is off unless `AgentConfiguration.parallelToolCalls` is true (default sequential).

Handoffs stay serial and still end the round. Membrane internals stay off Engine.

This is architecture pipeline ticket **T1** of `spec/spec-architecture-host-tool-batch-and-job-window.md` (local; not in this PR). Discovery: `/swift-functional-codebase-evolution` 2026-09-09, Strong candidate 01.

## Why

#212 put `ParallelToolExecutor` on Engine but the Agent host loop still walked tools one-by-one. `ToolExecutionSemantics.mayRunInParallel` had no production caller on that path.

## Tests

```
SWARM_OMIT_INTEGRATION_TARGETS=1 swift test --filter 'ToolBatchPlanTests|ParallelToolExecutor|AgentToolLoopCharacterizationTests|AgentHostToolBatchTests|ToolExecutionSemanticsEngineTests'
```

54 tests, 7 suites, pass.

## Review

- Size route: `Agent+ToolLoop.swift` 1318 LOC → `swift-pr-review` (review-and-fix, then final pass)
- First review: gated overlap on `parallelToolCalls` (`3b69f4cd`)
- Final pass: APPROVE, no further commit

Independent of T2 (Job window). Do not merge these as one PR.